### PR TITLE
Use /dev/fast branding in Review Desktop

### DIFF
--- a/apps/review-desktop/README.md
+++ b/apps/review-desktop/README.md
@@ -97,7 +97,7 @@ packaging script but no distribution. Signed builds auto-update from
 SKIP_NOTARIZE=1 pnpm --filter @dev-fast/review-desktop app:package:macos
 ```
 
-builds an unsigned `VSCode-darwin-arm64/dev.fast Review.app` and skips
+builds an unsigned `VSCode-darwin-arm64/Review.app` and skips
 signing, notarization, and artifact creation. A full run needs the signing
 environment and produces `dist/Review-darwin-arm64-<version>.zip` (the
 Squirrel update payload) and the matching `.dmg`, both notarized and stapled:

--- a/apps/review-desktop/code-oss/build/darwin/create-dmg.ts
+++ b/apps/review-desktop/code-oss/build/darwin/create-dmg.ts
@@ -156,7 +156,7 @@ async function main(buildDir?: string, outDir?: string): Promise<void> {
 	}
 
 	const appRoot = path.join(buildDir, `VSCode-darwin-${arch}`);
-	const appName = product.nameLong + '.app';
+	const appName = product.nameShort + '.app';
 	const appPath = path.join(appRoot, appName);
 	const dmgName = `VSCode-darwin-${arch}`;
 	const artifactPath = path.join(outDir, `${dmgName}.dmg`);
@@ -197,7 +197,7 @@ async function main(buildDir?: string, outDir?: string): Promise<void> {
 		.replace('{{BADGE_ICON}}', JSON.stringify(diskIconPath))
 		.replace('{{BACKGROUND}}', JSON.stringify(backgroundPath))
 		.replace('{{APP_PATH}}', JSON.stringify(appPath))
-		.replace('{{APP_NAME}}', JSON.stringify(product.nameLong + '.app'));
+		.replace('{{APP_NAME}}', JSON.stringify(appName));
 	fs.writeFileSync(settingsFile, settingsContent);
 
 	try {

--- a/apps/review-desktop/code-oss/build/darwin/create-universal-app.ts
+++ b/apps/review-desktop/code-oss/build/darwin/create-universal-app.ts
@@ -42,7 +42,7 @@ async function main(buildDir?: string) {
 	}
 
 	const product = JSON.parse(fs.readFileSync(path.join(root, 'product.json'), 'utf8'));
-	const appName = product.nameLong + '.app';
+	const appName = product.nameShort + '.app';
 	const x64AppPath = path.join(buildDir, 'VSCode-darwin-x64', appName);
 	const arm64AppPath = path.join(buildDir, 'VSCode-darwin-arm64', appName);
 	const asarRelativePath = path.join('Contents', 'Resources', 'app', 'node_modules.asar');

--- a/apps/review-desktop/code-oss/build/darwin/sign.ts
+++ b/apps/review-desktop/code-oss/build/darwin/sign.ts
@@ -108,7 +108,7 @@ async function main(buildDir?: string): Promise<void> {
 	}
 
 	const appRoot = path.join(buildDir, `VSCode-darwin-${arch}`);
-	const appName = product.nameLong + '.app';
+	const appName = product.nameShort + '.app';
 	const appPath = path.join(appRoot, appName);
 	const infoPlistPath = path.resolve(appPath, 'Contents', 'Info.plist');
 

--- a/apps/review-desktop/code-oss/build/lib/electron.ts
+++ b/apps/review-desktop/code-oss/build/lib/electron.ts
@@ -141,14 +141,16 @@ const electronAssetResolver = electronFeed
 
 export const config = {
 	version: electronVersion,
-	productAppName: product.nameLong,
+	// Keep the bundle directory filesystem-safe. The branded name contains a
+	// slash, so it belongs in display metadata rather than in a path.
+	productAppName: product.nameShort,
 	// CFBundleDisplayName, which is what titles the macOS application menu. The
 	// window chrome carries no wordmark, so the brand lives here instead. The
 	// bundle file name still comes from productAppName and the executable from
-	// darwinExecutable, so packaging paths are unaffected.
-	productDisplayName: '/dev/fast',
-	companyName: 'dev.fast',
-	copyright: 'Copyright (C) 2026 dev.fast',
+	// darwinExecutable, so packaging paths stay filesystem-safe.
+	productDisplayName: product.nameLong,
+	companyName: '/dev/fast',
+	copyright: 'Copyright (C) 2026 /dev/fast',
 	darwinExecutable: product.nameShort,
 	darwinIcon: 'resources/darwin/code.icns',
 	darwinBundleIdentifier: product.darwinBundleIdentifier,

--- a/apps/review-desktop/code-oss/extensions/review-themes/package.json
+++ b/apps/review-desktop/code-oss/extensions/review-themes/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "review-themes",
 	"displayName": "Review Themes",
-	"description": "Themes for dev.fast Review.",
+	"description": "Themes for /dev/fast Review.",
 	"categories": [
 		"Themes"
 	],

--- a/apps/review-desktop/code-oss/product.json
+++ b/apps/review-desktop/code-oss/product.json
@@ -1,6 +1,6 @@
 {
 	"nameShort": "Review",
-	"nameLong": "dev.fast Review",
+	"nameLong": "/dev/fast Review",
 	"reviewVersion": "0.0.23",
 	"applicationName": "review",
 	"dataFolderName": ".dev-fast-review",
@@ -15,8 +15,8 @@
 	"serverApplicationName": "code-server-oss",
 	"serverDataFolderName": ".vscode-server-oss",
 	"tunnelApplicationName": "code-tunnel-oss",
-	"win32DirName": "dev.fast Review",
-	"win32NameVersion": "dev.fast Review",
+	"win32DirName": "Review",
+	"win32NameVersion": "/dev/fast Review",
 	"win32RegValueName": "Review",
 	"win32x64AppId": "{{B35E642E-885D-48BC-8386-C06377164CC5}",
 	"win32arm64AppId": "{{6854770A-F656-4CAC-9F4C-A50D0B97F241}",

--- a/apps/review-desktop/code-oss/scripts/chat-simulation/common/utils.js
+++ b/apps/review-desktop/code-oss/scripts/chat-simulation/common/utils.js
@@ -62,7 +62,7 @@ function getRepoRoot(electronPath) {
 function getElectronPath() {
 	const product = require(path.join(ROOT, 'product.json'));
 	if (process.platform === 'darwin') {
-		return path.join(ROOT, '.build', 'electron', `${product.nameLong}.app`, 'Contents', 'MacOS', product.nameShort);
+		return path.join(ROOT, '.build', 'electron', `${product.nameShort}.app`, 'Contents', 'MacOS', product.nameShort);
 	} else if (process.platform === 'linux') {
 		return path.join(ROOT, '.build', 'electron', product.applicationName);
 	} else {

--- a/apps/review-desktop/code-oss/scripts/chat-simulation/test-chat-perf-regression.js
+++ b/apps/review-desktop/code-oss/scripts/chat-simulation/test-chat-perf-regression.js
@@ -219,7 +219,7 @@ function buildProductionBuild() {
 	/** @type {string} */
 	let electronPath;
 	if (platform === 'darwin') {
-		electronPath = path.join(destDir, `${product.nameLong}.app`, 'Contents', 'MacOS', product.nameShort);
+		electronPath = path.join(destDir, `${product.nameShort}.app`, 'Contents', 'MacOS', product.nameShort);
 	} else if (platform === 'linux') {
 		electronPath = path.join(destDir, product.applicationName);
 	} else {
@@ -241,7 +241,7 @@ function buildProductionBuild() {
 		/** @type {string} */
 		let appDir;
 		if (platform === 'darwin') {
-			appDir = path.join(destDir, `${product.nameLong}.app`, 'Contents', 'Resources', 'app');
+			appDir = path.join(destDir, `${product.nameShort}.app`, 'Contents', 'Resources', 'app');
 		} else {
 			appDir = path.join(destDir, 'resources', 'app');
 		}

--- a/apps/review-desktop/code-oss/scripts/code-cli.sh
+++ b/apps/review-desktop/code-oss/scripts/code-cli.sh
@@ -11,7 +11,7 @@ function code() {
 	cd $ROOT
 
 	if [[ "$OSTYPE" == "darwin"* ]]; then
-		NAME=`node -p "require('./product.json').nameLong"`
+		NAME=`node -p "require('./product.json').nameShort"`
 		EXE_NAME=`node -p "require('./product.json').nameShort"`
 		CODE="./.build/electron/$NAME.app/Contents/MacOS/$EXE_NAME"
 	else

--- a/apps/review-desktop/code-oss/scripts/code.sh
+++ b/apps/review-desktop/code-oss/scripts/code.sh
@@ -17,7 +17,7 @@ function code() {
 	cd "$ROOT"
 
 	if [[ "$OSTYPE" == "darwin"* ]]; then
-		NAME=`node -p "require('./product.json').nameLong"`
+		NAME=`node -p "require('./product.json').nameShort"`
 		EXE_NAME=`node -p "require('./product.json').nameShort"`
 		CODE="./.build/electron/$NAME.app/Contents/MacOS/$EXE_NAME"
 	else

--- a/apps/review-desktop/code-oss/scripts/node-electron.sh
+++ b/apps/review-desktop/code-oss/scripts/node-electron.sh
@@ -10,7 +10,7 @@ fi
 pushd $ROOT
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	NAME=`node -p "require('./product.json').nameLong"`
+	NAME=`node -p "require('./product.json').nameShort"`
 	EXE_NAME=`node -p "require('./product.json').nameShort"`
 	CODE="$ROOT/.build/electron/$NAME.app/Contents/MacOS/$EXE_NAME"
 else

--- a/apps/review-desktop/code-oss/scripts/test.sh
+++ b/apps/review-desktop/code-oss/scripts/test.sh
@@ -11,7 +11,7 @@ fi
 cd $ROOT
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	NAME=`node -p "require('./product.json').nameLong"`
+	NAME=`node -p "require('./product.json').nameShort"`
 	EXE_NAME=`node -p "require('./product.json').nameShort"`
 	CODE="./.build/electron/$NAME.app/Contents/MacOS/$EXE_NAME"
 else

--- a/apps/review-desktop/code-oss/src/vs/review/electron-main/reviewMenubar.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/electron-main/reviewMenubar.ts
@@ -103,7 +103,7 @@ export class ReviewMenubarMainService
       // macOS prints this in parentheses after the version. The commit is what
       // the update feed matches on, so it is the build identity that matters.
       version: commit ? commit.substring(0, 10) : "",
-      copyright: localize("review.about.copyright", "Copyright © 2026 dev.fast"),
+      copyright: localize("review.about.copyright", "Copyright © 2026 /dev/fast"),
       credits: localize("review.about.codeOss", "Code OSS {0}", version),
     });
   }

--- a/apps/review-desktop/code-oss/test/automation/src/electron.ts
+++ b/apps/review-desktop/code-oss/test/automation/src/electron.ts
@@ -153,7 +153,7 @@ export function getDevElectronPath(): string {
 
 	switch (process.platform) {
 		case 'darwin':
-			return join(buildPath, 'electron', `${product.nameLong}.app`, 'Contents', 'MacOS', `${product.nameShort}`);
+			return join(buildPath, 'electron', `${product.nameShort}.app`, 'Contents', 'MacOS', `${product.nameShort}`);
 		case 'linux':
 			return join(buildPath, 'electron', `${product.applicationName}`);
 		case 'win32':

--- a/apps/review-desktop/scripts/build.sh
+++ b/apps/review-desktop/scripts/build.sh
@@ -45,7 +45,7 @@ else
 fi
 if [[ "${REVIEW_DESKTOP_COMPILE_ONLY:-0}" != "1" ]]; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    PRODUCT_APP="$(node -p "require('./product.json').nameLong")"
+    PRODUCT_APP="$(node -p "require('./product.json').nameShort")"
     PRODUCT_EXE="$(node -p "require('./product.json').nameShort")"
     EXPECTED_BINARY="$CHECKOUT/.build/electron/$PRODUCT_APP.app/Contents/MacOS/$PRODUCT_EXE"
   else

--- a/apps/review-desktop/scripts/desktop-branding.test.mjs
+++ b/apps/review-desktop/scripts/desktop-branding.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const readSource = (relativePath) =>
+  readFile(new URL(relativePath, import.meta.url), "utf8");
+
+const product = JSON.parse(await readSource("../code-oss/product.json"));
+const electronBuild = await readSource("../code-oss/build/lib/electron.ts");
+const aboutPanel = await readSource(
+  "../code-oss/src/vs/review/electron-main/reviewMenubar.ts",
+);
+const themePackage = JSON.parse(
+  await readSource("../code-oss/extensions/review-themes/package.json"),
+);
+const canvasShell = await readSource(
+  "../../../packages/progressive-review/app/src/desktop-entry.tsx",
+);
+const bugReportDialog = await readSource(
+  "../../../packages/progressive-review/app/src/bug-report-dialog.tsx",
+);
+
+test("uses slash-form branding in Review Desktop display surfaces", () => {
+  assert.equal(product.nameLong, "/dev/fast Review");
+  assert.equal(product.win32NameVersion, "/dev/fast Review");
+  assert.equal(themePackage.description, "Themes for /dev/fast Review.");
+
+  assert.match(electronBuild, /productDisplayName: product\.nameLong/);
+  assert.match(electronBuild, /companyName: '\/dev\/fast'/);
+  assert.match(electronBuild, /Copyright \(C\) 2026 \/dev\/fast/);
+  assert.match(aboutPanel, /Copyright © 2026 \/dev\/fast/);
+  assert.match(canvasShell, />\/dev\/fast Review<\/div>/);
+  assert.match(
+    bugReportDialog,
+    /Reports are sent securely to \/dev\/fast\. Only authorized\s+\/dev\/fast team members/,
+  );
+});
+
+test("keeps compatibility-sensitive Desktop identifiers unchanged", () => {
+  assert.equal(product.darwinBundleIdentifier, "dev.fast.review");
+  assert.equal(product.updateUrl, "https://update.dev.fast");
+  assert.equal(product.urlProtocol, "dev-fast-review");
+  assert.equal(product.dataFolderName, ".dev-fast-review");
+  assert.equal(product.sharedDataFolderName, ".dev-fast-review-shared");
+});
+
+test("uses Review.app instead of putting the branded name in paths", async () => {
+  assert.equal(product.nameShort, "Review");
+  assert.equal(product.win32DirName, "Review");
+  assert.match(electronBuild, /productAppName: product\.nameShort/);
+
+  const bundlePathSources = await Promise.all(
+    [
+      "../code-oss/build/darwin/create-dmg.ts",
+      "../code-oss/build/darwin/create-universal-app.ts",
+      "../code-oss/build/darwin/sign.ts",
+      "../code-oss/scripts/code.sh",
+      "../code-oss/scripts/code-cli.sh",
+      "../code-oss/scripts/node-electron.sh",
+      "../code-oss/scripts/test.sh",
+      "../code-oss/scripts/chat-simulation/common/utils.js",
+      "../code-oss/scripts/chat-simulation/test-chat-perf-regression.js",
+      "../code-oss/test/automation/src/electron.ts",
+      "./build.sh",
+      "./run.sh",
+      "./package-macos.sh",
+      "./notarize-macos.sh",
+      "./smoke-launch-packaged.mjs",
+      "./validate-release-artifacts.mjs",
+    ].map(readSource),
+  );
+
+  for (const source of bundlePathSources) {
+    assert.doesNotMatch(source, /dev\.fast Review\.app/);
+    assert.doesNotMatch(source, /product\.nameLong\s*\+\s*['"]\.app['"]/);
+    assert.doesNotMatch(source, /\$\{product\.nameLong\}\.app/);
+  }
+
+  assert.match(await readSource("./package-macos.sh"), /Review\.app/);
+  assert.match(await readSource("./notarize-macos.sh"), /Review\.app/);
+  assert.match(await readSource("./smoke-launch-packaged.mjs"), /Review\.app/);
+  assert.match(
+    await readSource("./validate-release-artifacts.mjs"),
+    /Review\.app/,
+  );
+});

--- a/apps/review-desktop/scripts/notarize-macos.sh
+++ b/apps/review-desktop/scripts/notarize-macos.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 MONOREPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
 APP_DIR="$MONOREPO_ROOT/apps/review-desktop"
 CHECKOUT="$APP_DIR/code-oss"
-PACKAGED_APP="$APP_DIR/VSCode-darwin-arm64/dev.fast Review.app"
+PACKAGED_APP="$APP_DIR/VSCode-darwin-arm64/Review.app"
 VERSION="$(node -p "require('$APP_DIR/package.json').version")"
 ARTIFACT_DIR="${DEV_FAST_REVIEW_ARTIFACT_DIR:-$APP_DIR/dist}"
 UPDATE_ZIP="$ARTIFACT_DIR/Review-darwin-arm64-$VERSION.zip"
@@ -139,10 +139,10 @@ mkdir -p "$ARTIFACT_DIR"
 rm -f -- "$UPDATE_ZIP" "$DMG"
 
 mkdir -p "$DMG_STAGE"
-ditto "$PACKAGED_APP" "$DMG_STAGE/dev.fast Review.app"
+ditto "$PACKAGED_APP" "$DMG_STAGE/Review.app"
 ln -s /Applications "$DMG_STAGE/Applications"
 hdiutil create \
-  -volname "dev.fast Review" \
+  -volname "Review" \
   -srcfolder "$DMG_STAGE" \
   -ov \
   -format UDZO \

--- a/apps/review-desktop/scripts/package-macos.sh
+++ b/apps/review-desktop/scripts/package-macos.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 MONOREPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
 APP_DIR="$MONOREPO_ROOT/apps/review-desktop"
 CHECKOUT="$APP_DIR/code-oss"
-PACKAGED_APP="$APP_DIR/VSCode-darwin-arm64/dev.fast Review.app"
+PACKAGED_APP="$APP_DIR/VSCode-darwin-arm64/Review.app"
 
 # shellcheck source=darwin-payload-manifest.sh
 source "$APP_DIR/scripts/darwin-payload-manifest.sh"

--- a/apps/review-desktop/scripts/packaged-runtime.test.mjs
+++ b/apps/review-desktop/scripts/packaged-runtime.test.mjs
@@ -68,7 +68,7 @@ test("production build configurations include the Review entrypoint and CSS", as
 test("canvas targets are derived from fixed output locations", () => {
   const fakeAppRoot = path.resolve("/tmp/review desktop");
   const packagedRoot = path.resolve("/tmp/review package");
-  const packagedMacRoot = path.resolve("/tmp/dev.fast Review.app");
+  const packagedMacRoot = path.resolve("/tmp/Review.app");
 
   assert.deepEqual(canvasTargets([], fakeAppRoot), [
     path.join(fakeAppRoot, "code-oss/out/vs/review/canvas"),

--- a/apps/review-desktop/scripts/run.sh
+++ b/apps/review-desktop/scripts/run.sh
@@ -30,7 +30,7 @@ if [[ -n "$PACKAGED_ROOT" ]]; then
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   CODE_APP_NAME="$(
     cd "$CHECKOUT"
-    node -p "require('./product.json').nameLong"
+    node -p "require('./product.json').nameShort"
   )"
   CODE_EXE_NAME="$(
     cd "$CHECKOUT"

--- a/apps/review-desktop/scripts/smoke-launch-packaged.mjs
+++ b/apps/review-desktop/scripts/smoke-launch-packaged.mjs
@@ -27,11 +27,7 @@ import path from "node:path";
 import { parseArgs } from "node:util";
 
 const APP_DIR = path.resolve(import.meta.dirname, "..");
-const DEFAULT_APP = path.join(
-  APP_DIR,
-  "VSCode-darwin-arm64",
-  "dev.fast Review.app",
-);
+const DEFAULT_APP = path.join(APP_DIR, "VSCode-darwin-arm64", "Review.app");
 const POLL_INTERVAL_MS = 500;
 const SERVER_READY_PATTERN = /\[Review Desktop\] server ready at https?:\/\//;
 

--- a/apps/review-desktop/scripts/validate-release-artifacts.mjs
+++ b/apps/review-desktop/scripts/validate-release-artifacts.mjs
@@ -104,7 +104,7 @@ function main() {
   const artifactDir = path.resolve(
     values["artifact-dir"] ?? path.join(APP_DIR, "dist"),
   );
-  const app = path.join(APP_DIR, "VSCode-darwin-arm64", "dev.fast Review.app");
+  const app = path.join(APP_DIR, "VSCode-darwin-arm64", "Review.app");
   const zip = path.join(artifactDir, `Review-darwin-arm64-${version}.zip`);
   const dmg = path.join(artifactDir, `Review-darwin-arm64-${version}.dmg`);
 

--- a/packages/progressive-review/app/src/bug-report-dialog.tsx
+++ b/packages/progressive-review/app/src/bug-report-dialog.tsx
@@ -169,8 +169,9 @@ export function BugReportControl() {
                 </label>
               </fieldset>
               <p className="bug-report-privacy">
-                Reports are sent securely to dev.fast. Only authorized dev.fast
-                team members can access them. Reports are deleted after 90 days.
+                Reports are sent securely to /dev/fast. Only authorized
+                /dev/fast team members can access them. Reports are deleted
+                after 90 days.
               </p>
               <div className="bug-report-actions">
                 <button type="button" onClick={cancel} disabled={sending}>

--- a/packages/progressive-review/app/src/desktop-entry.tsx
+++ b/packages/progressive-review/app/src/desktop-entry.tsx
@@ -270,7 +270,7 @@ function CanvasShell({
 }) {
   return (
     <main className="review-canvas-shell">
-      <div className="review-shell-brand">dev.fast Review</div>
+      <div className="review-shell-brand">/dev/fast Review</div>
       <h1>{title}</h1>
       {children}
     </main>


### PR DESCRIPTION
## Summary

- use /dev/fast anywhere Review Desktop refers to the company in user-facing product copy and metadata
- keep the displayed /dev/fast Review name separate from the filesystem-safe Review.app bundle name
- preserve URLs, package scopes, bundle IDs, storage keys, and other compatibility-sensitive identifiers
- add regression coverage for the display identity and bundle-path separation

## Verification

- REVIEW_DESKTOP_CI_FAST=1 pnpm run ci
- pnpm lint
- pnpm --filter @dev.fast/review typecheck
- unsigned macOS package produced VSCode-darwin-arm64/Review.app
- packaged runtime opened a renderer and started the Review server
- native macOS menu and About panel displayed /dev/fast Review and /dev/fast copyright