### PR TITLE
Sync Review trace and authoring updates

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
@@ -798,10 +798,21 @@ export interface ReviewCanvasInstallContent {
   apply(request: {
     targets: readonly ReviewCliInstallTarget[];
     shim?: boolean;
+    fff?: boolean;
+    trace?:
+      | true
+      | {
+          endpoint?: string;
+          bucket?: string;
+          key?: string;
+          secret?: string;
+        };
   }): Promise<ReviewCliInstallStatus>;
   remove(request: {
     targets: readonly ReviewCliInstallTarget[];
     shim?: boolean;
+    fff?: boolean;
+    trace?: true;
   }): Promise<ReviewCliInstallStatus>;
   decline(): Promise<ReviewCliInstallStatus>;
   skip(): Promise<ReviewCliInstallStatus>;
@@ -1052,7 +1063,7 @@ export const ReviewStatusSchema = z.enum([
 ]);
 
 export const ReviewSourceIdentitySchema = z.strictObject({
-  kind: z.enum(["git-branch", "jj-bookmark", "jj-change"]),
+  kind: z.enum(["git-branch", "git-commit", "jj-bookmark", "jj-change"]),
   name: requiredString,
 });
 export type ReviewSourceIdentity = z.infer<typeof ReviewSourceIdentitySchema>;
@@ -1300,11 +1311,27 @@ export type ReviewListResponse = z.infer<typeof ReviewListResponseSchema>;
 export type ReviewListError = ReviewListResponse["errors"][number];
 
 export const ReviewCliInstallTargetSchema = z.enum(
-  ["claude", "codex", "cursor"],
-  { error: "must be claude, codex, or cursor" },
+  ["claude", "codex", "cursor", "pi"],
+  { error: "must be claude, codex, cursor, or pi" },
 );
 export type ReviewCliInstallTarget = z.infer<
   typeof ReviewCliInstallTargetSchema
+>;
+
+export const ReviewFffInstallTargetSchema = z.enum(["claude", "codex", "pi"], {
+  error: "must be claude, codex, or pi",
+});
+export type ReviewFffInstallTarget = z.infer<
+  typeof ReviewFffInstallTargetSchema
+>;
+
+export const ReviewFffManagedRegistrationSchema = z.strictObject({
+  target: ReviewFffInstallTargetSchema,
+  command: requiredString,
+  args: z.array(requiredString),
+});
+export type ReviewFffManagedRegistration = z.infer<
+  typeof ReviewFffManagedRegistrationSchema
 >;
 
 export const ReviewCliInstallStampSchema = z.strictObject({
@@ -1314,6 +1341,8 @@ export const ReviewCliInstallStampSchema = z.strictObject({
   fingerprint: requiredString.optional(),
   targets: z.array(ReviewCliInstallTargetSchema).optional(),
   shimPath: requiredString.optional(),
+  fffRegistrations: z.array(ReviewFffManagedRegistrationSchema).optional(),
+  traceManaged: z.boolean().optional(),
   updatedAt: requiredString,
 });
 export type ReviewCliInstallStamp = z.infer<typeof ReviewCliInstallStampSchema>;
@@ -1330,6 +1359,30 @@ export const ReviewCliInstallStatusSchema = z.strictObject({
   stamp: ReviewCliInstallStampSchema.nullable(),
   stale: z.boolean(),
   shim: z.strictObject({ path: requiredString, onPath: z.boolean() }),
+  fff: z.strictObject({
+    serverName: z.literal("fff"),
+    corpusRoot: requiredString,
+    binary: z.strictObject({ path: requiredString, installed: z.boolean() }),
+    registrations: z.array(
+      z.strictObject({
+        target: ReviewFffInstallTargetSchema,
+        present: z.boolean(),
+        managed: z.boolean(),
+      }),
+    ),
+  }),
+  trace: z.strictObject({
+    enabled: z.boolean(),
+    configured: z.boolean(),
+    autoActivateRepositories: z.boolean(),
+    envPath: requiredString,
+    settingsPath: requiredString,
+    endpoint: requiredString.optional(),
+    bucket: requiredString.optional(),
+    accessKeyIdPrefix: requiredString.optional(),
+    verifiedAt: requiredString.optional(),
+    error: requiredString.optional(),
+  }),
   // Null when the serving package has no built CLI (a source-run dev server).
   cli: z
     .strictObject({ path: requiredString, version: requiredString })
@@ -1339,17 +1392,34 @@ export type ReviewCliInstallStatus = z.infer<
   typeof ReviewCliInstallStatusSchema
 >;
 
-// Skills are per-agent; the review terminal command is per-machine. The two
-// install independently: `targets` may be empty for a command-only install,
-// and the command is only ever written when `shim` is explicitly true.
+// Skills and FFF integrations are per-agent. The review command, FFF binary,
+// and trace configuration are per-machine. Silent app updates omit `fff` and
+// `trace`, so they do not run an installer or contact R2.
 export const ReviewCliInstallApplyRequestSchema = z
   .strictObject({
     targets: z.array(ReviewCliInstallTargetSchema),
     shim: z.boolean().optional(),
+    fff: z.boolean().optional(),
+    trace: z
+      .union([
+        z.literal(true),
+        z.strictObject({
+          endpoint: requiredString.optional(),
+          bucket: requiredString.optional(),
+          key: requiredString.optional(),
+          secret: requiredString.optional(),
+        }),
+      ])
+      .optional(),
   })
-  .refine((request) => request.targets.length > 0 || request.shim === true, {
-    message: "must install skills for at least one agent or the command",
-  });
+  .refine(
+    (request) =>
+      request.targets.length > 0 ||
+      request.shim === true ||
+      request.fff === true ||
+      request.trace !== undefined,
+    { message: "must install skills, the command, FFF, or trace capture" },
+  );
 export type ReviewCliInstallApplyRequest = z.infer<
   typeof ReviewCliInstallApplyRequestSchema
 >;
@@ -1931,6 +2001,89 @@ export const ReviewSurfaceEventSchema = z.discriminatedUnion("event", [
 ]);
 export type ReviewSurfaceEvent = z.infer<typeof ReviewSurfaceEventSchema>;
 
+// --- Agent trace view & trace quotes ----------------------------------------
+
+export const ReviewAgentTraceEventSchema = z.discriminatedUnion("kind", [
+  z.strictObject({
+    kind: z.literal("user"),
+    text: stringAllowEmpty,
+    at: z.string().optional(),
+  }),
+  z.strictObject({
+    kind: z.literal("assistant"),
+    markdown: stringAllowEmpty,
+    thinking: z.boolean().optional(),
+    at: z.string().optional(),
+  }),
+  z.strictObject({
+    kind: z.literal("tool"),
+    tool: requiredString,
+    verb: requiredString,
+    title: stringAllowEmpty,
+    filePath: z.string().optional(),
+    additions: z.number().optional(),
+    deletions: z.number().optional(),
+    command: z.string().optional(),
+    input: z.string().optional(),
+    output: z.string().optional(),
+    error: z.boolean().optional(),
+    at: z.string().optional(),
+  }),
+  z.strictObject({
+    kind: z.literal("separator"),
+    label: requiredString,
+  }),
+]);
+export type ReviewAgentTraceEvent = z.infer<typeof ReviewAgentTraceEventSchema>;
+
+export const ReviewAgentTraceSessionSchema = z.strictObject({
+  sessionId: requiredString,
+  harness: z.enum(["claude-code", "codex", "pi", "unknown"]),
+  available: z.boolean(),
+  source: z.enum(["r2"]).nullable(),
+  notSynced: z.boolean().optional(),
+  subagents: z.array(requiredString).optional(),
+  commits: z.array(
+    z.strictObject({ sha: requiredString, subject: stringAllowEmpty }),
+  ),
+});
+export type ReviewAgentTraceSession = z.infer<
+  typeof ReviewAgentTraceSessionSchema
+>;
+
+export const ReviewAgentTraceListResponseSchema = z.discriminatedUnion("ok", [
+  z.strictObject({
+    ok: z.literal(true),
+    configured: z.boolean().default(true),
+    sessions: z.array(ReviewAgentTraceSessionSchema),
+  }),
+  ReviewErrorResponseSchema,
+]);
+export type ReviewAgentTraceListResponse = z.infer<
+  typeof ReviewAgentTraceListResponseSchema
+>;
+
+export const ReviewAgentTraceResponseSchema = z.discriminatedUnion("ok", [
+  z.strictObject({
+    ok: z.literal(true),
+    parserVersion: requiredString,
+    session: ReviewAgentTraceSessionSchema,
+    trace: stringAllowEmpty.nullable().optional(),
+    subagents: z.array(requiredString).default([]),
+    title: z.string().nullable(),
+    startedAt: z.string().nullable(),
+    endedAt: z.string().nullable(),
+    activeMs: z.number().nullable(),
+    userTurns: z.number(),
+    toolCalls: z.number(),
+    events: z.array(ReviewAgentTraceEventSchema),
+  }),
+  ReviewErrorResponseSchema,
+]);
+export type ReviewAgentTraceResponse = z.infer<
+  typeof ReviewAgentTraceResponseSchema
+>;
+
 export function parseReviewRuntimeConfig(value: unknown): ReviewRuntimeConfig {
   return parseContract(ReviewRuntimeConfigSchema, value);
 }
@@ -2085,6 +2238,30 @@ export function parseReviewDesktopState(value: unknown): ReviewDesktopState {
 
 export function parseReviewRange(value: unknown): ReviewRangeWire {
   return parseContract(ReviewRangeSchema, value);
+}
+
+export function parseReviewAgentTraceEvent(
+  value: unknown,
+): ReviewAgentTraceEvent {
+  return parseContract(ReviewAgentTraceEventSchema, value);
+}
+
+export function parseReviewAgentTraceSession(
+  value: unknown,
+): ReviewAgentTraceSession {
+  return parseContract(ReviewAgentTraceSessionSchema, value);
+}
+
+export function parseReviewAgentTraceListResponse(
+  value: unknown,
+): ReviewAgentTraceListResponse {
+  return parseContract(ReviewAgentTraceListResponseSchema, value);
+}
+
+export function parseReviewAgentTraceResponse(
+  value: unknown,
+): ReviewAgentTraceResponse {
+  return parseContract(ReviewAgentTraceResponseSchema, value);
 }
 
 function parseContract<T>(schema: z.ZodType<T>, value: unknown): T {

--- a/apps/review-desktop/code-oss/src/vs/review/contrib/install/reviewCliInstall.contribution.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/install/reviewCliInstall.contribution.ts
@@ -30,6 +30,7 @@ const TARGET_LABELS: Readonly<Record<ReviewCliInstallTarget, string>> = {
 	claude: 'Claude Code',
 	codex: 'Codex',
 	cursor: 'Cursor',
+	pi: 'Pi',
 };
 
 function formatTargets(targets: readonly ReviewCliInstallTarget[]): string {
@@ -116,6 +117,8 @@ class UninstallReviewDesktopAction extends Action2 {
 		const targets = status.agents
 			.filter(agent => agent.installed)
 			.map(agent => agent.target);
+		const fffTargets = status.stamp?.fffRegistrations?.map(registration => registration.target) ?? [];
+		const removalTargets = [...new Set([...targets, ...fffTargets])];
 		const detail = [
 			targets.length > 0
 				? localize('review.uninstall.skills', "Removes the Review skills for {0}.", formatTargets(targets))
@@ -123,6 +126,12 @@ class UninstallReviewDesktopAction extends Action2 {
 			status.stamp?.shimPath
 				? localize('review.uninstall.shim', "Removes the review terminal command at {0}.", status.stamp.shimPath)
 				: localize('review.uninstall.noShim', "The review terminal command is not installed."),
+			fffTargets.length > 0
+				? localize('review.uninstall.fff', "Removes unchanged fff registrations that Review created. The shared FFF binary stays installed.")
+				: localize('review.uninstall.noFff', "No fff registrations are managed by Review."),
+			status.stamp?.traceManaged
+				? localize('review.uninstall.trace', "Disables trace capture and restores hook paths for known repositories. R2 credentials stay on disk.")
+				: localize('review.uninstall.noTrace', "Trace capture is not managed by Review."),
 			localize('review.uninstall.tutorial', "Removes the bundled tutorial repository and Review."),
 			localize('review.uninstall.keepsData', "Your reviews and their history stay on disk."),
 		].join('\n');
@@ -145,7 +154,12 @@ class UninstallReviewDesktopAction extends Action2 {
 			tutorialError = error;
 		}
 		try {
-			await sessionService.removeCliInstall({ targets, shim: true });
+			await sessionService.removeCliInstall({
+				targets: removalTargets,
+				shim: true,
+				fff: true,
+				...(status.stamp?.traceManaged ? { trace: true } : {}),
+			});
 			await sessionService.resetCliInstallPrompts();
 			if (tutorialError) {
 				await dialogService.error(

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
@@ -105,10 +105,14 @@ export interface IReviewSessionService {
 	applyCliInstall(request: {
 		targets: readonly ReviewCliInstallTarget[];
 		shim?: boolean;
+		fff?: boolean;
+		trace?: true | { endpoint?: string; bucket?: string; key?: string; secret?: string };
 	}): Promise<ReviewCliInstallApplyResponse>;
 	removeCliInstall(request: {
 		targets: readonly ReviewCliInstallTarget[];
 		shim?: boolean;
+		fff?: boolean;
+		trace?: true;
 	}): Promise<void>;
 	declineCliInstall(): Promise<void>;
 	skipCliInstallPrompts(): Promise<void>;
@@ -480,6 +484,8 @@ export class ReviewSessionService
 	async applyCliInstall(request: {
 		targets: readonly ReviewCliInstallTarget[];
 		shim?: boolean;
+		fff?: boolean;
+		trace?: true | { endpoint?: string; bucket?: string; key?: string; secret?: string };
 	}): Promise<ReviewCliInstallApplyResponse> {
 		await this.initialize();
 		const response = await fetch(`${this.serverUrl}/install/apply`, {
@@ -491,6 +497,8 @@ export class ReviewSessionService
 			body: JSON.stringify({
 				targets: request.targets,
 				...(request.shim ? { shim: true } : {}),
+				...(request.fff ? { fff: true } : {}),
+				...(request.trace !== undefined ? { trace: request.trace } : {}),
 			}),
 			signal: AbortSignal.timeout(120_000),
 		});
@@ -511,6 +519,8 @@ export class ReviewSessionService
 	async removeCliInstall(request: {
 		targets: readonly ReviewCliInstallTarget[];
 		shim?: boolean;
+		fff?: boolean;
+		trace?: true;
 	}): Promise<void> {
 		await this.initialize();
 		const response = await fetch(`${this.serverUrl}/install/remove`, {
@@ -522,6 +532,8 @@ export class ReviewSessionService
 			body: JSON.stringify({
 				targets: request.targets,
 				...(request.shim ? { shim: true } : {}),
+				...(request.fff ? { fff: true } : {}),
+				...(request.trace ? { trace: true } : {}),
 			}),
 			signal: AbortSignal.timeout(30_000),
 		});

--- a/apps/review-desktop/scripts/package-linux.sh
+++ b/apps/review-desktop/scripts/package-linux.sh
@@ -46,6 +46,7 @@ for artifact in \
   "$PACKAGED_ROOT/resources/app/review-runtime/dist/cli.js" \
   "$PACKAGED_ROOT/resources/app/review-runtime/skills/dev-review/SKILL.md" \
   "$PACKAGED_ROOT/resources/app/review-runtime/skills/dev-review-map/SKILL.md" \
+  "$PACKAGED_ROOT/resources/app/review-runtime/skills/trace-archaeology/SKILL.md" \
   "$PACKAGED_ROOT/resources/app/review-runtime/tutorial/review.mdx" \
   "$PACKAGED_ROOT/resources/app/review-runtime/tutorial/data.ts" \
   "$PACKAGED_ROOT/resources/app/review-runtime/tutorial/software-map.ts" \

--- a/apps/review-desktop/scripts/package-macos.sh
+++ b/apps/review-desktop/scripts/package-macos.sh
@@ -94,6 +94,7 @@ for artifact in \
   "$PACKAGED_APP/Contents/Resources/app/review-runtime/dist/cli.js" \
   "$PACKAGED_APP/Contents/Resources/app/review-runtime/skills/dev-review/SKILL.md" \
   "$PACKAGED_APP/Contents/Resources/app/review-runtime/skills/dev-review-map/SKILL.md" \
+  "$PACKAGED_APP/Contents/Resources/app/review-runtime/skills/trace-archaeology/SKILL.md" \
   "$PACKAGED_APP/Contents/Resources/app/review-runtime/tutorial/review.mdx" \
   "$PACKAGED_APP/Contents/Resources/app/review-runtime/tutorial/data.ts" \
   "$PACKAGED_APP/Contents/Resources/app/review-runtime/tutorial/software-map.ts" \

--- a/apps/review-desktop/scripts/stage-review-runtime.mjs
+++ b/apps/review-desktop/scripts/stage-review-runtime.mjs
@@ -58,6 +58,7 @@ const REQUIRED_ENTRIES = [
   "app/src",
   "skills/dev-review/SKILL.md",
   "skills/dev-review-map/SKILL.md",
+  "skills/trace-archaeology/SKILL.md",
   "tutorial/review.mdx",
   "tutorial/data.ts",
   "tutorial/software-map.ts",

--- a/packages/local-vcs/src/index.test.ts
+++ b/packages/local-vcs/src/index.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { mkdirSync, realpathSync, writeFileSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -114,9 +114,19 @@ describe("local vcs", () => {
     writeFileSync(path.join(rootPath, "src/app.ts"), "export const app = 1;\n");
     execFileSync("git", ["add", "src/app.ts"], { cwd: rootPath });
     execFileSync("git", ["commit", "-m", "initial"], { cwd: rootPath });
+    const commit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
+    const branch = execGitOutput(rootPath, ["symbolic-ref", "--short", "HEAD"]);
 
     expect(detectLocalVcsSync(rootPath)).toMatchObject({ kind: "git" });
     expect(listTrackedFilesSync({ rootPath })).toEqual(["src/app.ts"]);
+    await expect(changeIdentityForRevision(rootPath, branch)).resolves.toEqual({
+      kind: "git-branch",
+      name: branch,
+    });
+    await expect(changeIdentityForRevision(rootPath, commit)).resolves.toEqual({
+      kind: "git-commit",
+      name: commit,
+    });
   });
 
   it("limits git diffs to requested paths", async () => {
@@ -366,6 +376,34 @@ describe("local vcs", () => {
     ).resolves.toMatchObject({
       kind: "jj-change",
       name: expect.stringMatching(new RegExp(`^${headRef}`)),
+    });
+  });
+
+  it("binds a Git-only commit by its exact commit id in a colocated jj repo", async () => {
+    if (!commandExists("jj")) return;
+
+    const rootPath = await mkdtemp(
+      path.join(tmpdir(), "local-vcs-jj-git-sha-"),
+    );
+    execJj(rootPath, ["git", "init", "--colocate"]);
+    execGit(rootPath, ["config", "user.email", "test@example.com"]);
+    execGit(rootPath, ["config", "user.name", "Test User"]);
+    writeFileSync(path.join(rootPath, "git-only.txt"), "git only\n");
+    execGit(rootPath, ["add", "git-only.txt"]);
+    const tree = execGitOutput(rootPath, ["write-tree"]);
+    const commit = execFileSync("git", ["-C", rootPath, "commit-tree", tree], {
+      input: "git-only commit\n",
+      encoding: "utf8",
+    }).trim();
+
+    expect(() =>
+      execFileSync("jj", ["-R", rootPath, "log", "--no-graph", "-r", commit], {
+        stdio: ["ignore", "pipe", "ignore"],
+      }),
+    ).toThrow(/./);
+    await expect(changeIdentityForRevision(rootPath, commit)).resolves.toEqual({
+      kind: "git-commit",
+      name: commit,
     });
   });
 

--- a/packages/local-vcs/src/index.ts
+++ b/packages/local-vcs/src/index.ts
@@ -427,7 +427,7 @@ export async function currentHead(
 }
 
 export interface LocalChangeIdentity {
-  kind: "jj-bookmark" | "jj-change" | "git-branch";
+  kind: "jj-bookmark" | "jj-change" | "git-branch" | "git-commit";
   name: string;
 }
 
@@ -482,16 +482,49 @@ export async function changeIdentityForRevision(
   if (!vcs) return null;
   if (vcs.kind === "git") {
     const resolved = await vcs.resolveRevision(revision);
-    return resolved ? { kind: "git-branch", name: revision } : null;
+    if (!resolved) return null;
+    const branch = await gitRevisionBranch(rootPath, revision);
+    return branch
+      ? { kind: "git-branch", name: branch }
+      : { kind: "git-commit", name: resolved.commit };
   }
   const summaries = await jjChangeSummary(rootPath, revision);
-  if (summaries.length !== 1) return null;
-  const subject = summaries[0]!;
-  const bookmark = subject.bookmarks[0];
-  if (bookmark) return { kind: "jj-bookmark", name: bookmark };
-  return subject.changeId
-    ? { kind: "jj-change", name: subject.changeId }
-    : null;
+  if (summaries.length === 1) {
+    const subject = summaries[0]!;
+    const bookmark = subject.bookmarks[0];
+    if (bookmark) return { kind: "jj-bookmark", name: bookmark };
+    return subject.changeId
+      ? { kind: "jj-change", name: subject.changeId }
+      : null;
+  }
+  if (summaries.length > 1 || !canUseGitFallbackSync(rootPath, vcs.kind)) {
+    return null;
+  }
+
+  // A colocated repository can contain a Git commit that jj has not imported,
+  // such as an exact pull-request SHA with no local ref. The commit is still a
+  // valid immutable Review binding. Do not substitute the current jj change.
+  const resolved = await resolveGitRevisionCommit(rootPath, revision).catch(
+    () => null,
+  );
+  return resolved ? { kind: "git-commit", name: resolved } : null;
+}
+
+async function gitRevisionBranch(
+  rootPath: string,
+  revision: string,
+): Promise<string | null> {
+  const symbolic = await commandOutput("git", [
+    "-C",
+    rootPath,
+    "rev-parse",
+    "--symbolic-full-name",
+    revision,
+  ]).catch(() => "");
+  for (const prefix of ["refs/heads/", "refs/remotes/"]) {
+    if (symbolic.startsWith(prefix)) return symbolic.slice(prefix.length);
+  }
+  return null;
 }
 
 interface JjChangeSummary {

--- a/packages/local-vcs/src/notes.test.ts
+++ b/packages/local-vcs/src/notes.test.ts
@@ -630,6 +630,31 @@ describe("notes config and rewrite handling", () => {
     expect(enabledSpecs).toEqual([DEV_FAST_NOTES_FETCH_REFSPEC]);
   });
 
+  it("installs the fetch refspec on the configured notes remote", async () => {
+    const rootPath = await initGitRepo();
+    commit(rootPath, "one");
+    const origin = await mkdtemp(path.join(tmpdir(), "notes-origin-"));
+    const fork = await mkdtemp(path.join(tmpdir(), "notes-fork-"));
+    git(origin, ["init", "-q", "--bare"]);
+    git(fork, ["init", "-q", "--bare"]);
+    git(rootPath, ["remote", "add", "origin", origin]);
+    git(rootPath, ["remote", "add", "fork", fork]);
+    git(rootPath, ["config", "devFast.notesRemote", "fork"]);
+
+    await ensureNotesConfig({ rootPath });
+
+    expect(
+      git(rootPath, ["config", "--get-all", "remote.fork.fetch"])
+        .split("\n")
+        .filter((line) => line.includes("dev-fast")),
+    ).toEqual([DEV_FAST_NOTES_FETCH_REFSPEC]);
+    expect(
+      git(rootPath, ["config", "--get-all", "remote.origin.fetch"])
+        .split("\n")
+        .filter((line) => line.includes("dev-fast")),
+    ).toEqual([]);
+  });
+
   it("notes.rewriteRef carries a note across git commit --amend", async () => {
     const rootPath = await initGitRepo();
     const original = commit(rootPath, "will amend");
@@ -656,6 +681,26 @@ describe("notes config and rewrite handling", () => {
 });
 
 describe("notes sharing", () => {
+  it("uses devFast.notesRemote when no remote override is supplied", async () => {
+    const publisher = await initGitRepo();
+    const head = commit(publisher, "shared through fork");
+    const fork = await mkdtemp(path.join(tmpdir(), "notes-fork-"));
+    git(fork, ["init", "-q", "--bare"]);
+    git(publisher, ["remote", "add", "fork", fork]);
+    git(publisher, ["config", "devFast.notesRemote", "fork"]);
+    await writeNote({
+      rootPath: publisher,
+      ref: MAP_REF,
+      commit: head,
+      content: "fork map",
+    });
+
+    const pushed = await pushNotes({ rootPath: publisher, refs: [MAP_REF] });
+
+    expect(pushed).toMatchObject({ ok: true, pushed: [MAP_REF] });
+    expect(git(fork, ["ls-remote", ".", MAP_REF])).toContain(MAP_REF);
+  });
+
   it("pushes and fetches notes through a bare origin into the remote namespace", async () => {
     const publisher = await initGitRepo();
     const head = commit(publisher, "shared");

--- a/packages/local-vcs/src/notes.ts
+++ b/packages/local-vcs/src/notes.ts
@@ -522,6 +522,46 @@ export const DEV_FAST_NOTES_GLOB = "refs/notes/dev-fast/*";
 export const DEV_FAST_REMOTE_NOTES_PREFIX = "refs/notes/dev-fast/remote/";
 export const DEV_FAST_NOTES_FETCH_REFSPEC =
   "+refs/notes/dev-fast/*:refs/notes/dev-fast/remote/*";
+export const DEV_FAST_NOTES_REMOTE_CONFIG = "devFast.notesRemote";
+
+export async function notesRemote(
+  rootPath: string,
+  explicitRemote?: string,
+): Promise<string> {
+  const explicit = explicitRemote?.trim();
+  if (explicit) return explicit;
+  const configured = await git(
+    rootPath,
+    ["config", "--get", DEV_FAST_NOTES_REMOTE_CONFIG],
+    { allowFailure: true },
+  );
+  return configured.ok && configured.stdout.trim()
+    ? configured.stdout.trim()
+    : "origin";
+}
+
+export function notesRemoteSync(
+  rootPath: string,
+  explicitRemote?: string,
+): string {
+  const explicit = explicitRemote?.trim();
+  if (explicit) return explicit;
+  try {
+    return (
+      execFileSync(
+        "git",
+        gitArgsSync(rootPath, [
+          "config",
+          "--get",
+          DEV_FAST_NOTES_REMOTE_CONFIG,
+        ]),
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+      ).trim() || "origin"
+    );
+  } catch {
+    return "origin";
+  }
+}
 
 /** Local notes ref → the remote/* namespace it fetches into. */
 export function remoteNotesRef(localRef: string): string {
@@ -548,7 +588,7 @@ export async function pushNotes(input: {
   remote?: string;
   refs: readonly string[];
 }): Promise<{ ok: boolean; pushed: string[]; error?: string }> {
-  const remote = input.remote ?? "origin";
+  const remote = await notesRemote(input.rootPath, input.remote);
   const pushed: string[] = [];
   const errors: string[] = [];
   for (const ref of input.refs) {
@@ -693,7 +733,7 @@ export async function fetchNotes(input: {
   if (await notesFetchDisabled(input.rootPath)) {
     return { ok: true, skipped: true };
   }
-  const remote = input.remote ?? "origin";
+  const remote = await notesRemote(input.rootPath, input.remote);
   const fetched = await git(
     input.rootPath,
     ["fetch", remote, DEV_FAST_NOTES_FETCH_REFSPEC],
@@ -744,15 +784,17 @@ const notesConfigEnsured = new Set<string>();
  * Idempotently configure a repo for dev-fast notes:
  * - notes.rewriteRef / notes.rewriteMode so git-native rebases and amends
  *   carry notes forward,
- * - a fetch refspec on origin so ordinary fetches receive teammates' notes
- *   into the remote/* namespace.
+ * - a fetch refspec on the selected notes remote so ordinary fetches receive
+ *   teammates' notes into the remote/* namespace.
  */
 export async function ensureNotesConfig(input: {
   rootPath: string;
 }): Promise<void> {
   const gitDir = await gitCommonDir(input.rootPath);
   if (!gitDir) return;
-  if (notesConfigEnsured.has(gitDir)) return;
+  const remote = await notesRemote(input.rootPath);
+  const cacheKey = `${gitDir}\0${remote}`;
+  if (notesConfigEnsured.has(cacheKey)) return;
 
   const rewriteRef = await git(
     input.rootPath,
@@ -775,20 +817,25 @@ export async function ensureNotesConfig(input: {
   // the switch. Don't memoize while disabled: flipping the switch back on
   // must let a later call install the refspec.
   if (await notesFetchDisabled(input.rootPath)) return;
-  notesConfigEnsured.add(gitDir);
+  notesConfigEnsured.add(cacheKey);
 
-  const origin = await git(
+  const remoteFetch = await git(
     input.rootPath,
-    ["config", "--get-all", "remote.origin.fetch"],
+    ["config", "--get-all", `remote.${remote}.fetch`],
     { allowFailure: true },
   );
   if (
-    origin.ok &&
-    !origin.stdout.split("\n").includes(DEV_FAST_NOTES_FETCH_REFSPEC)
+    remoteFetch.ok &&
+    !remoteFetch.stdout.split("\n").includes(DEV_FAST_NOTES_FETCH_REFSPEC)
   ) {
     await git(
       input.rootPath,
-      ["config", "--add", "remote.origin.fetch", DEV_FAST_NOTES_FETCH_REFSPEC],
+      [
+        "config",
+        "--add",
+        `remote.${remote}.fetch`,
+        DEV_FAST_NOTES_FETCH_REFSPEC,
+      ],
       { allowFailure: true },
     );
   }
@@ -797,7 +844,9 @@ export async function ensureNotesConfig(input: {
 export function ensureNotesConfigSync(input: { rootPath: string }): void {
   const gitDir = gitCommonDirSync(input.rootPath);
   if (!gitDir) return;
-  if (notesConfigEnsured.has(gitDir)) return;
+  const remote = notesRemoteSync(input.rootPath);
+  const cacheKey = `${gitDir}\0${remote}`;
+  if (notesConfigEnsured.has(cacheKey)) return;
   const config = (args: string[]) => {
     try {
       return execFileSync(
@@ -823,13 +872,13 @@ export function ensureNotesConfigSync(input: { rootPath: string }): void {
   // See ensureNotesConfig: skip refspec install (and memoization) while the
   // kill-switch is on.
   if (notesFetchDisabledSync(input.rootPath)) return;
-  notesConfigEnsured.add(gitDir);
-  const originFetch = config(["--get-all", "remote.origin.fetch"]);
+  notesConfigEnsured.add(cacheKey);
+  const remoteFetch = config(["--get-all", `remote.${remote}.fetch`]);
   if (
-    originFetch.trim() !== "" &&
-    !originFetch.split("\n").includes(DEV_FAST_NOTES_FETCH_REFSPEC)
+    remoteFetch.trim() !== "" &&
+    !remoteFetch.split("\n").includes(DEV_FAST_NOTES_FETCH_REFSPEC)
   ) {
-    config(["--add", "remote.origin.fetch", DEV_FAST_NOTES_FETCH_REFSPEC]);
+    config(["--add", `remote.${remote}.fetch`, DEV_FAST_NOTES_FETCH_REFSPEC]);
   }
 }
 

--- a/packages/progressive-review/README.md
+++ b/packages/progressive-review/README.md
@@ -68,9 +68,10 @@ Use `review app pick --review <uuid>` to select a specific Review. Bare
 `review app --review <uuid>` form remains an alias for `review app pick`.
 
 `review scaffold` creates one new UUID directory and prints its JSONL `info`
-event. `review info` is read-only: it lists active Reviews for the current
-worktree, or every worktree in the repository with `--all`; an unmatched
-lookup returns an empty `reviews` list.
+event. `review info` is read-only: it lists active Reviews bound to the current
+worktree, or every worktree in the repository with `--all`. Each result has a
+`matchesCheckout` field. It is true when the checkout equals or descends from
+the Review change.
 
 `review scaffold` materializes the pinned head and base worktrees. It runs each
 configured `devfast.prepare` command in those worktrees. This setup gives
@@ -78,12 +79,45 @@ Review Desktop language services the dependencies and build output they need.
 Source ranges do not need an indexer. `review publish` reads each range from
 its pinned worktree and rejects paths or line numbers that are not valid.
 
-Review Desktop is the primary install path for Claude Code, Codex, and other
-coding agents. On startup it detects known local skill locations, offers to
+Review Desktop is the primary install path for Claude Code, Codex, Cursor, Pi,
+and other coding agents. On startup it detects installed agents, offers to
 install the CLI and skills, and re-syncs both after each app update. It also
 writes a `review` shim to `~/.local/bin` that always resolves to the app's
 bundled CLI. `review install` remains for headless environments; a standalone
 CLI defers to the app's bundled copy whenever Review Desktop is running.
+
+Explicit agent setup installs FFF. It registers the standard `fff` MCP server
+for Claude and Codex, and installs `npm:@ff-labs/pi-fff` for Pi. The MCP
+registration points FFF at `~/.dev/trace-search`. Review accepts existing FFF
+integrations without changes. Silent app-update synchronization never runs an
+FFF installer.
+
+The same setup page configures R2 and enables trace capture for the machine.
+Each agent session activates its current repository. Git receives a managed
+hook dispatcher that chains the repository's prior hooks. Jujutsu receives a
+repository commit-trailer template. A target repository needs no Review files.
+
+Use `review trace status` to inspect the machine and current repository. Use
+`review trace enable`, `review trace disable`, or `review trace repair` only
+when you need to manage the current repository manually.
+
+For a missing registration, setup runs the equivalent commands:
+
+```sh
+curl -L https://dmtrkovalenko.dev/install-fff-mcp.sh | bash
+claude mcp add -s user fff -- "$HOME/.local/bin/fff-mcp" "$HOME/.dev/trace-search"
+codex mcp add fff -- "$HOME/.local/bin/fff-mcp" "$HOME/.dev/trace-search"
+pi install npm:@ff-labs/pi-fff
+```
+
+Trace search uses this local flow:
+
+```text
+R2 raw trace
+  → temporary download
+  → normalized JSONL in ~/.dev/trace-search
+  → FFF, review trace show, Review UI, and quote validation
+```
 
 The app-managed command starts the exact macOS bundle that installed it. The
 bundle does not need to be under `/Applications`. A repository or standalone

--- a/packages/progressive-review/app/desktop.vite.config.ts
+++ b/packages/progressive-review/app/desktop.vite.config.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import path from "node:path";
 
 import react from "@vitejs/plugin-react";
@@ -8,6 +9,12 @@ import {
   hardenLibavoidForTrustedTypes,
   isLibavoidBrowserModule,
 } from "./desktop-trusted-types";
+
+const require = createRequire(import.meta.url);
+const decodeNamedCharacterReferenceIndex = path.join(
+  path.dirname(require.resolve("decode-named-character-reference")),
+  "index.js",
+);
 
 export default defineConfig({
   root: __dirname,
@@ -40,7 +47,12 @@ export default defineConfig({
       },
     },
   ],
-  resolve: { dedupe: ["react", "react-dom"] },
+  resolve: {
+    dedupe: ["react", "react-dom"],
+    alias: {
+      "decode-named-character-reference": decodeNamedCharacterReferenceIndex,
+    },
+  },
   build: {
     copyPublicDir: false,
     emptyOutDir: true,

--- a/packages/progressive-review/app/src/App.test.ts
+++ b/packages/progressive-review/app/src/App.test.ts
@@ -864,14 +864,21 @@ describe("review app light theme", () => {
     // The composer is bare until focused; controls appear while composing.
     expect(threadCardSource).toContain("thread-reply-row");
     expect(threadCardSource).toContain("setComposing(true)");
+    // Portaling the popover to the app lets it cross the document scroller's
+    // clipping edge and paint above an open side peek.
+    expect(annotationsSource).toContain(
+      'import { createPortal } from "react-dom"',
+    );
+    expect(annotationsSource).toContain("createPortal(");
+    expect(annotationsSource).toContain("reviewRoots?.appRef.current");
     // Popover geometry is owned by popoverStyle() so the rendered width and the
     // POPOVER_WIDTH the placement clamps use cannot drift apart again.
     const popoverRule = /\.thread-popover\s*{([^}]*)}/s.exec(styles)?.[1] ?? "";
-    expect(popoverRule).toContain("z-index: 40;");
+    expect(popoverRule).toContain("z-index: 60;");
     expect(popoverRule).not.toMatch(/\bwidth:/);
     expect(popoverRule).not.toMatch(/\bposition:/);
     expect(annotationsSource).toContain(
-      "width: `min(${POPOVER_WIDTH}px, calc(100vw - 32px))`",
+      "width: `min(${POPOVER_WIDTH}px, calc(100% - 24px))`",
     );
     // A clamped compact body says so, rather than trailing off into an ellipsis.
     expect(threadCardSource).toContain("thread-expand-hint");

--- a/packages/progressive-review/app/src/App.tsx
+++ b/packages/progressive-review/app/src/App.tsx
@@ -84,6 +84,7 @@ import {
   useReviewViewStateSync,
 } from "./review-view-state";
 import { ReviewCommitsView } from "./ReviewCommitsView";
+import { ReviewTraceView, type TraceSelection } from "./ReviewTraceView";
 import { useRightPanelResize } from "./side-panel-resizer";
 import { selectActiveSoftwareMapModel } from "./software-map-selection";
 import type {
@@ -200,6 +201,9 @@ function ReviewLayout({
   const appRef = useRef<HTMLDivElement | null>(null);
   const shellRef = useRef<HTMLElement | null>(null);
   const scrollRegionRef = useRef<HTMLElement | null>(null);
+  const [traceSelection, setTraceSelection] = useState<
+    TraceSelection | undefined
+  >(undefined);
   const roots = useMemo(
     () => ({ appRef, shellRef, scrollRegionRef, articleRef }),
     [],
@@ -222,6 +226,7 @@ function ReviewLayout({
               key={document.routePath}
               documentRoute={document.routePath}
               softwareMapEnabled={softwareMapEnabled}
+              openTraceSession={(sel) => setTraceSelection(sel)}
             >
               <ReviewPanelProvider detailRevision={document.Component}>
                 <ReviewLayoutContent
@@ -245,6 +250,7 @@ function ReviewLayout({
                   softwareMapEnabled={softwareMapEnabled}
                   range={range}
                   commits={commits}
+                  traceSelection={traceSelection}
                 />
               </ReviewPanelProvider>
             </ReviewProvider>
@@ -269,6 +275,7 @@ function ReviewLayoutContent({
   softwareMapEnabled,
   range,
   commits,
+  traceSelection,
 }: {
   appRef: RefObject<HTMLDivElement | null>;
   shellRef: RefObject<HTMLElement | null>;
@@ -285,6 +292,7 @@ function ReviewLayoutContent({
   softwareMapEnabled: boolean;
   range: ReviewCanvasRange;
   commits: readonly ReviewCommitSummary[];
+  traceSelection?: TraceSelection;
 }): ReactElement {
   const session = useReviewSession();
   const review = useReview();
@@ -331,6 +339,28 @@ function ReviewLayoutContent({
     reviewFind?.setReviewActive(activeView === "review");
   }, [activeView, reviewFind]);
   const initialDiffStats = useReviewInitialData()?.diffStats;
+  const [hasTraceSessions, setHasTraceSessions] = useState(false);
+  useEffect(() => {
+    const controller = new AbortController();
+    session
+      .fetch("/agent-traces", { signal: controller.signal })
+      .then(async (res) => {
+        if (!res.ok) return;
+        const data = (await res.json()) as {
+          ok?: boolean;
+          sessions?: unknown[];
+        };
+        if (
+          data.ok &&
+          Array.isArray(data.sessions) &&
+          data.sessions.length > 0
+        ) {
+          setHasTraceSessions(true);
+        }
+      })
+      .catch(() => {});
+    return () => controller.abort();
+  }, [session]);
   const diffFiles = useReviewDiffFiles();
   const filesTabFileCount = diffScope
     ? diffScope.fileCount
@@ -341,6 +371,7 @@ function ReviewLayoutContent({
     "review",
     ...(hasChangeRange ? (["commits", "diff"] as const) : []),
     ...(softwareMapEnabled ? (["map"] as const) : []),
+    ...(hasTraceSessions ? (["trace"] as const) : []),
   ];
   const applyReviewView = (view: ReviewView) => {
     const normalizedView = normalizeReviewView(
@@ -384,6 +415,12 @@ function ReviewLayoutContent({
       }),
     [closeThread, session],
   );
+  useEffect(() => {
+    if (traceSelection) {
+      applyReviewView("trace");
+    }
+  }, [traceSelection]);
+
   useEffect(() => {
     if (!softwareMapEnabled || !review.softwareMapFocusRequest) return;
     applyReviewView("map");
@@ -675,6 +712,9 @@ function ReviewLayoutContent({
                 scope={diffScope ? { commit: diffScope.commit } : undefined}
               />
             </div>
+          )}
+          {activeView === "trace" && (
+            <ReviewTraceView initialSelection={traceSelection} />
           )}
         </section>
         <TutorialChecklist />

--- a/packages/progressive-review/app/src/ReviewTraceView.test.tsx
+++ b/packages/progressive-review/app/src/ReviewTraceView.test.tsx
@@ -1,0 +1,322 @@
+// @vitest-environment jsdom
+
+import type {
+  ReviewAgentTraceListResponse,
+  ReviewAgentTraceResponse,
+  ReviewCanvasBridge,
+} from "@dev.fast/review-protocol";
+import { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ReviewSessionProvider } from "./host/review-session";
+import { testReviewSession } from "./review-session-test-utils";
+import { ReviewTraceView } from "./ReviewTraceView";
+import { clearAgentTraceCache } from "./use-agent-trace";
+
+const mockListResponse: Extract<ReviewAgentTraceListResponse, { ok: true }> = {
+  ok: true,
+  configured: true,
+  sessions: [
+    {
+      sessionId: "session-1",
+      harness: "unknown",
+      available: true,
+      source: "r2",
+      commits: [{ sha: "commit-1", subject: "Initial commit subject" }],
+      subagents: ["sub-1"],
+    },
+  ],
+};
+
+const mockTraceDetail: Extract<ReviewAgentTraceResponse, { ok: true }> = {
+  ok: true,
+  parserVersion: "1.0",
+  session: {
+    sessionId: "session-1",
+    harness: "pi",
+    available: true,
+    source: "r2",
+    commits: [{ sha: "commit-1", subject: "Initial commit subject" }],
+  },
+  title: "Upgraded Trace Title",
+  subagents: ["sub-1"],
+  startedAt: "2025-01-01T00:00:00Z",
+  endedAt: "2025-01-01T00:01:00Z",
+  activeMs: 60000,
+  userTurns: 1,
+  toolCalls: 1,
+  events: [
+    {
+      kind: "user",
+      text: "User turn text",
+      at: "2025-01-01T00:00:00Z",
+    },
+  ],
+};
+
+let root: Root | null = null;
+let container: HTMLDivElement;
+
+describe("ReviewTraceView", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    clearAgentTraceCache();
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root?.unmount());
+      root = null;
+    }
+    document.body.replaceChildren();
+    clearAgentTraceCache();
+    vi.restoreAllMocks();
+  });
+
+  it("loads session list and active trace detail without getting stuck in loading state", async () => {
+    const requestMock = vi
+      .fn<ReviewCanvasBridge["request"]>()
+      .mockImplementation((url) => {
+        if (url.includes("/agent-traces/session-1")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(mockTraceDetail), { status: 200 }),
+          );
+        }
+        if (url.includes("/agent-traces")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(mockListResponse), { status: 200 }),
+          );
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+
+    const session = testReviewSession({}, { request: requestMock });
+
+    await act(async () => {
+      root?.render(
+        <ReviewSessionProvider session={session}>
+          <ReviewTraceView />
+        </ReviewSessionProvider>,
+      );
+    });
+
+    // Wait for microtasks
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    // Should display the trace title and content, not "Loading trace…"
+    expect(container.textContent).toContain("Upgraded Trace Title");
+    expect(container.textContent).toContain("User turn text");
+    expect(container.textContent).not.toContain("Loading trace…");
+  });
+
+  it("upgrades picker trigger and dropdown labels from cached trace metadata", async () => {
+    const requestMock = vi
+      .fn<ReviewCanvasBridge["request"]>()
+      .mockImplementation((url) => {
+        if (url.includes("/agent-traces/session-1")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(mockTraceDetail), { status: 200 }),
+          );
+        }
+        if (url.includes("/agent-traces")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(mockListResponse), { status: 200 }),
+          );
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+
+    const session = testReviewSession({}, { request: requestMock });
+
+    await act(async () => {
+      root?.render(
+        <ReviewSessionProvider session={session}>
+          <ReviewTraceView />
+        </ReviewSessionProvider>,
+      );
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    // Trigger button should show upgraded title and harness
+    const trigger = container.querySelector(".review-trace-picker-trigger");
+    expect(
+      trigger?.querySelector(".review-trace-picker-harness")?.textContent,
+    ).toBe("PI");
+    expect(
+      trigger?.querySelector(".review-trace-picker-title")?.textContent,
+    ).toBe("Upgraded Trace Title");
+
+    // Open dropdown picker menu
+    act(() => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const items = container.querySelectorAll(".review-trace-picker-item");
+    expect(items.length).toBe(2);
+    // Main session item should show upgraded PI harness and Upgraded Trace Title
+    expect(
+      items[0]?.querySelector(".review-trace-picker-item-harness")?.textContent,
+    ).toBe("PI");
+    expect(
+      items[0]?.querySelector(".review-trace-picker-item-title")?.textContent,
+    ).toBe("Upgraded Trace Title");
+  });
+
+  it("shows unconfigured state when list returns configured: false", async () => {
+    const unconfiguredList: Extract<
+      ReviewAgentTraceListResponse,
+      { ok: true }
+    > = {
+      ok: true,
+      configured: false,
+      sessions: [],
+    };
+
+    const requestMock = vi
+      .fn<ReviewCanvasBridge["request"]>()
+      .mockImplementation((url) => {
+        if (url.includes("/agent-traces")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(unconfiguredList), { status: 200 }),
+          );
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+
+    const session = testReviewSession({}, { request: requestMock });
+
+    await act(async () => {
+      root?.render(
+        <ReviewSessionProvider session={session}>
+          <ReviewTraceView />
+        </ReviewSessionProvider>,
+      );
+    });
+
+    expect(container.textContent).toContain("Agent traces are not configured");
+  });
+
+  it("renders thinking events collapsed by default under a Thinking tool section", async () => {
+    const traceWithThinking: Extract<ReviewAgentTraceResponse, { ok: true }> = {
+      ok: true,
+      parserVersion: "1.0",
+      session: {
+        sessionId: "session-1",
+        harness: "pi",
+        available: true,
+        source: "r2",
+        commits: [{ sha: "commit-1", subject: "Initial commit subject" }],
+      },
+      title: "Trace with Thinking",
+      subagents: [],
+      startedAt: "2025-01-01T00:00:00Z",
+      endedAt: "2025-01-01T00:01:00Z",
+      activeMs: 60000,
+      userTurns: 1,
+      toolCalls: 1,
+      events: [
+        {
+          kind: "user",
+          text: "What is the plan?",
+          at: "2025-01-01T00:00:00Z",
+        },
+        {
+          kind: "assistant",
+          thinking: true,
+          markdown: "Let me think about how to solve this problem...",
+          at: "2025-01-01T00:00:05Z",
+        },
+        {
+          kind: "tool",
+          tool: "bash",
+          verb: "Ran",
+          title: "pnpm test",
+          command: "pnpm test",
+          output: "All tests pass",
+          at: "2025-01-01T00:00:10Z",
+        },
+        {
+          kind: "assistant",
+          thinking: false,
+          markdown: "Here is the result.",
+          at: "2025-01-01T00:00:15Z",
+        },
+      ],
+    };
+
+    const requestMock = vi
+      .fn<ReviewCanvasBridge["request"]>()
+      .mockImplementation((url) => {
+        if (url.includes("/agent-traces/session-1")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(traceWithThinking), { status: 200 }),
+          );
+        }
+        if (url.includes("/agent-traces")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(mockListResponse), { status: 200 }),
+          );
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+
+    const session = testReviewSession({}, { request: requestMock });
+
+    await act(async () => {
+      root?.render(
+        <ReviewSessionProvider session={session}>
+          <ReviewTraceView />
+        </ReviewSessionProvider>,
+      );
+    });
+
+    // Wait for microtasks
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    // Expand the turn's worked section
+    const workedDetails = container.querySelector(
+      "details.review-trace-worked",
+    ) as HTMLDetailsElement;
+    expect(workedDetails).not.toBeNull();
+    act(() => {
+      workedDetails.open = true;
+    });
+
+    // Find the thinking details element
+    const thinkingDetails = Array.from(
+      container.querySelectorAll("details.review-trace-tool--expandable"),
+    ).find(
+      (el) =>
+        el.querySelector(".review-trace-tool-verb")?.textContent === "Thinking",
+    ) as HTMLDetailsElement | undefined;
+
+    expect(thinkingDetails).toBeDefined();
+    // Should be collapsed by default
+    expect(thinkingDetails?.open).toBe(false);
+    expect(
+      thinkingDetails?.querySelector(".review-trace-tool-verb")?.textContent,
+    ).toBe("Thinking");
+    expect(
+      thinkingDetails?.querySelector(".review-trace-figure-head")?.textContent,
+    ).toBe("Thinking");
+    expect(
+      thinkingDetails?.querySelector(".review-trace-figure-body--thinking")
+        ?.textContent,
+    ).toContain("Let me think about how to solve this problem...");
+  });
+});

--- a/packages/progressive-review/app/src/ReviewTraceView.tsx
+++ b/packages/progressive-review/app/src/ReviewTraceView.tsx
@@ -1,0 +1,430 @@
+import {
+  type ReviewAgentTraceEvent,
+  type ReviewAgentTraceSession,
+  parseReviewAgentTraceListResponse,
+} from "@dev.fast/review-protocol";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+
+import { useReviewSession } from "./host/review-session";
+import {
+  ChevronIcon,
+  type IndexedTraceTurnGroup,
+  TraceDocument,
+  type TraceTurnEvent,
+  formatDuration,
+} from "./trace-document";
+import {
+  type LoadedAgentTrace,
+  getAgentTraceCache,
+  makeAgentTraceKey,
+  makeTraceKey,
+  useAgentTrace,
+} from "./use-agent-trace";
+
+export {
+  TraceDocument,
+  TraceTurn,
+  TraceToolGroup,
+  TraceToolRow,
+  TraceEvent,
+  ElidedMessage,
+  TraceGapChip,
+  ChevronIcon,
+  toolIcon,
+  toolGroupLabel,
+  timeLabel,
+  formatDuration,
+  applyLensPicks,
+  buildLensDisplay,
+  elideByKeep,
+  extractEventText,
+  buildIndexedTraceTurns,
+  buildTraceTurns,
+  groupIndexedWorkEvents,
+  type TraceTurnEvent,
+  type TraceTurnGroup,
+  type IndexedTraceTurnEvent,
+  type IndexedTraceTurnGroup,
+  type IndexedTraceToolItem,
+  type LensPick,
+  type LensPickEvent,
+  type LensPickRange,
+  type LensDisplayItem,
+  type ElidedSegment,
+  type TraceDocumentProps,
+  type TraceDocumentOptions,
+} from "./trace-document";
+export { HighlightedText } from "./highlighted-text";
+
+/**
+ * The Trace tab shows the raw agent traces behind a review, resolved from
+ * `Agent-Session:` commit trailers and fetched from the shared R2 trace store.
+ */
+
+type TraceListState =
+  | { status: "loading" }
+  | { status: "error"; error: string }
+  | {
+      status: "loaded";
+      configured: boolean;
+      sessions: ReviewAgentTraceSession[];
+    };
+
+export interface TraceSelection {
+  sessionId: string;
+  trace?: string;
+  eventIndex?: number;
+}
+
+export function ReviewTraceView({
+  initialSelection,
+}: {
+  initialSelection?: TraceSelection;
+}) {
+  const session = useReviewSession();
+  const reviewFetch = session.fetch;
+  const [list, setList] = useState<TraceListState>({ status: "loading" });
+  const [selectedKey, setSelectedKey] = useState<string | null>(() =>
+    initialSelection
+      ? makeTraceKey(initialSelection.sessionId, initialSelection.trace)
+      : null,
+  );
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const pickerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setPickerOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleOutsideClick);
+    return () => document.removeEventListener("mousedown", handleOutsideClick);
+  }, [pickerOpen]);
+
+  useEffect(() => {
+    if (initialSelection) {
+      setSelectedKey(
+        makeTraceKey(initialSelection.sessionId, initialSelection.trace),
+      );
+    }
+  }, [initialSelection]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    reviewFetch("/agent-traces", { signal: controller.signal })
+      .then(async (response) => {
+        const result = parseReviewAgentTraceListResponse(await response.json());
+        if (!response.ok || !result.ok) {
+          throw new Error(
+            result.ok ? "Unable to load agent traces." : result.error,
+          );
+        }
+        if (controller.signal.aborted) return;
+        setList({
+          status: "loaded",
+          configured: result.configured !== false,
+          sessions: result.sessions,
+        });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setList({
+          status: "error",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    return () => controller.abort();
+  }, [reviewFetch]);
+
+  const sessions = list.status === "loaded" ? list.sessions : [];
+
+  // Build flat trace targets (main trace + each subagent)
+  const targets = useMemo(() => {
+    const result: Array<{
+      key: string;
+      sessionId: string;
+      trace?: string;
+      title: string;
+      harness: ReviewAgentTraceSession["harness"];
+      isSubagent?: boolean;
+      available: boolean;
+      notSynced?: boolean;
+      commits: ReviewAgentTraceSession["commits"];
+    }> = [];
+
+    for (const s of sessions) {
+      const title = s.commits[0]?.subject || "Agent session";
+      result.push({
+        key: s.sessionId,
+        sessionId: s.sessionId,
+        title,
+        harness: s.harness,
+        available: s.available,
+        notSynced: s.notSynced,
+        commits: s.commits,
+      });
+      for (const sub of s.subagents ?? []) {
+        const key = `${s.sessionId}:${sub}`;
+        result.push({
+          key,
+          sessionId: s.sessionId,
+          trace: sub,
+          title: sub,
+          harness: s.harness,
+          isSubagent: true,
+          available: s.available,
+          commits: s.commits,
+        });
+      }
+    }
+    return result;
+  }, [sessions]);
+
+  const activeTarget = useMemo(
+    () =>
+      targets.find((t) => t.key === selectedKey) ??
+      targets.find((t) => t.available) ??
+      targets[0] ??
+      null,
+    [targets, selectedKey],
+  );
+
+  const activeKey = activeTarget?.key ?? null;
+
+  const detail = useAgentTrace(activeTarget?.sessionId, activeTarget?.trace);
+
+  const activeCached = activeTarget
+    ? getAgentTraceCache(
+        session,
+        makeAgentTraceKey(activeTarget.sessionId, activeTarget.trace),
+      )
+    : undefined;
+  const activeHarness =
+    activeCached?.session.harness ?? activeTarget?.harness ?? "unknown";
+  const activeTitle = activeCached?.title ?? activeTarget?.title ?? "";
+
+  return (
+    <div className="review-trace-view">
+      <div className="review-trace-column">
+        {list.status === "loading" && (
+          <p className="review-trace-note">Resolving agent sessions…</p>
+        )}
+        {list.status === "error" && (
+          <p className="review-trace-note review-trace-note--error">
+            {list.error}
+          </p>
+        )}
+        {list.status === "loaded" && !list.configured && (
+          <div className="review-trace-unconfigured">
+            <span className="review-trace-kicker">Agent trace</span>
+            <p>Agent traces are not configured.</p>
+            <p className="review-trace-note">
+              Open Agent Setup in Review Desktop to enable trace capture.
+            </p>
+          </div>
+        )}
+        {list.status === "loaded" &&
+          list.configured &&
+          sessions.length === 0 && (
+            <div className="review-trace-empty">
+              <span className="review-trace-kicker">Agent trace</span>
+              <p>No agent sessions are recorded for this change range.</p>
+              <p className="review-trace-note">
+                Sessions attach automatically through{" "}
+                <code>Agent-Session:</code> commit trailers when an agent
+                commits with repository hooks installed.
+              </p>
+            </div>
+          )}
+        {targets.length > 1 && activeTarget && (
+          <div className="review-trace-picker" ref={pickerRef}>
+            <button
+              type="button"
+              className="review-trace-picker-trigger"
+              aria-haspopup="listbox"
+              aria-expanded={pickerOpen}
+              onClick={() => setPickerOpen((open) => !open)}
+            >
+              <span className="review-trace-picker-harness">
+                {harnessTag(activeHarness, activeTarget.isSubagent)}
+              </span>
+              <span className="review-trace-picker-title">{activeTitle}</span>
+              <span className="review-trace-picker-chevron">
+                <ChevronIcon />
+              </span>
+            </button>
+            {pickerOpen && (
+              <div className="review-trace-picker-menu" role="listbox">
+                {targets.map((target) => {
+                  const isActive = target.key === activeKey;
+                  const cached = getAgentTraceCache(
+                    session,
+                    makeAgentTraceKey(target.sessionId, target.trace),
+                  );
+                  const targetHarness =
+                    cached?.session.harness ?? target.harness;
+                  const itemTitle = cached?.title ?? target.title;
+                  return (
+                    <button
+                      key={target.key}
+                      type="button"
+                      role="option"
+                      aria-selected={isActive}
+                      className={
+                        isActive
+                          ? "review-trace-picker-item review-trace-picker-item--active"
+                          : target.isSubagent
+                            ? "review-trace-picker-item review-trace-picker-item--subagent"
+                            : "review-trace-picker-item"
+                      }
+                      disabled={!target.available}
+                      onClick={() => {
+                        setSelectedKey(target.key);
+                        setPickerOpen(false);
+                      }}
+                    >
+                      <div className="review-trace-picker-item-left">
+                        <span className="review-trace-picker-item-harness">
+                          {harnessTag(targetHarness, target.isSubagent)}
+                        </span>
+                        <span className="review-trace-picker-item-title">
+                          {itemTitle}
+                        </span>
+                      </div>
+                      {target.notSynced ? (
+                        <span className="review-trace-picker-item-badge">
+                          not synced
+                        </span>
+                      ) : isActive ? (
+                        <span className="review-trace-picker-item-check">
+                          ✓
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+        {detail.status === "loading" && (
+          <p className="review-trace-note">Loading trace…</p>
+        )}
+        {detail.status === "error" && (
+          <p className="review-trace-note review-trace-note--error">
+            {detail.error}
+          </p>
+        )}
+        {detail.status === "loaded" && (
+          <ReviewTraceDocument
+            trace={detail.trace}
+            session={
+              sessions.find(
+                (s) => s.sessionId === detail.trace.session.sessionId,
+              ) ?? detail.trace.session
+            }
+            targetEventIndex={
+              initialSelection &&
+              makeTraceKey(
+                initialSelection.sessionId,
+                initialSelection.trace,
+              ) === activeKey
+                ? initialSelection.eventIndex
+                : undefined
+            }
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function harnessLabel(harness: ReviewAgentTraceSession["harness"]): string {
+  if (harness === "claude-code") return "claude";
+  if (harness === "codex") return "codex";
+  if (harness === "pi") return "pi";
+  return "agent";
+}
+
+function harnessTag(
+  harness: ReviewAgentTraceSession["harness"],
+  isSubagent?: boolean,
+): string {
+  if (isSubagent) {
+    if (harness === "pi") return "PI SUB";
+    if (harness === "claude-code") return "CLAUDE SUB";
+    if (harness === "codex") return "CODEX SUB";
+    return "SUBAGENT";
+  }
+  if (harness === "pi") return "PI";
+  if (harness === "claude-code") return "CLAUDE";
+  if (harness === "codex") return "CODEX";
+  return "AGENT";
+}
+
+export function ReviewTraceDocument({
+  trace,
+  session,
+  targetEventIndex,
+  highlightQuote,
+}: {
+  trace: LoadedAgentTrace;
+  session: ReviewAgentTraceSession;
+  targetEventIndex?: number;
+  highlightQuote?: string;
+}) {
+  const duration =
+    trace.activeMs !== null
+      ? formatDuration(trace.activeMs)
+      : trace.startedAt && trace.endedAt
+        ? formatDuration(
+            Date.parse(trace.endedAt) - Date.parse(trace.startedAt),
+          )
+        : null;
+  return (
+    <>
+      <header className="review-trace-header">
+        <span className="review-trace-kicker">Agent trace</span>
+        <h2 className="review-trace-title">
+          {trace.title ??
+            firstCommitSubject(session) ??
+            (trace.trace ? `Subagent: ${trace.trace}` : "Agent session")}
+        </h2>
+        <div className="review-trace-meta">
+          <span>{harnessLabel(trace.session.harness)}</span>
+          <span className="review-trace-meta-sep">·</span>
+          <span>{trace.session.sessionId.slice(0, 8)}</span>
+          {trace.trace && (
+            <>
+              <span className="review-trace-meta-sep">·</span>
+              <span>{trace.trace}</span>
+            </>
+          )}
+          <span className="review-trace-meta-sep">·</span>
+          <span>
+            {trace.userTurns} {trace.userTurns === 1 ? "turn" : "turns"}
+          </span>
+          <span className="review-trace-meta-sep">·</span>
+          <span>{trace.toolCalls} tool calls</span>
+          {duration && (
+            <>
+              <span className="review-trace-meta-sep">·</span>
+              <span>worked {duration}</span>
+            </>
+          )}
+        </div>
+      </header>
+      <TraceDocument
+        events={trace.events}
+        targetEventIndex={targetEventIndex}
+        highlightQuote={highlightQuote}
+      />
+    </>
+  );
+}
+
+function firstCommitSubject(session: ReviewAgentTraceSession): string | null {
+  return session.commits[0]?.subject ?? null;
+}

--- a/packages/progressive-review/app/src/agent-logos.tsx
+++ b/packages/progressive-review/app/src/agent-logos.tsx
@@ -58,8 +58,28 @@ export function CursorLogo(): ReactElement {
   );
 }
 
+export function PiLogo(): ReactElement {
+  return (
+    <svg
+      aria-hidden="true"
+      className="review-agent-logo review-agent-logo--pi"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M4 6h16M8 6v12M16 6v12"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="2.25"
+      />
+    </svg>
+  );
+}
+
 export const AGENT_LOGOS = {
   claude: ClaudeCodeLogo,
   codex: CodexLogo,
   cursor: CursorLogo,
+  pi: PiLogo,
 } as const;

--- a/packages/progressive-review/app/src/agent-markdown.test.tsx
+++ b/packages/progressive-review/app/src/agent-markdown.test.tsx
@@ -76,4 +76,27 @@ describe("agent markdown", () => {
       '<code class="agent-markdown-code-reference">styles.css</code>',
     );
   });
+
+  it("highlights quote spans inside markdown paragraphs and inline code", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentMarkdown, {
+        source: "We should optimize database queries to avoid latency.",
+        highlightQuote: "optimize database queries",
+      }),
+    );
+
+    expect(html).toContain(
+      '<mark class="review-trace-quote-mark">optimize database queries</mark>',
+    );
+  });
+
+  it("decodes named character references without using DOM innerHTML", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentMarkdown, {
+        source: "a &amp; b &gt; c",
+      }),
+    );
+
+    expect(html).toContain("a &amp; b &gt; c");
+  });
 });

--- a/packages/progressive-review/app/src/agent-markdown.tsx
+++ b/packages/progressive-review/app/src/agent-markdown.tsx
@@ -13,6 +13,7 @@ import {
 } from "react";
 
 import { RenderedCodeBlock } from "./code-block";
+import { HighlightedText } from "./highlighted-text";
 import { newTabLinkProps } from "./link-props";
 
 interface MarkdownNode {
@@ -33,9 +34,11 @@ interface MarkdownNode {
 export function AgentMarkdown({
   source,
   className,
+  highlightQuote,
 }: {
   source: string;
   className?: string;
+  highlightQuote?: string;
 }): ReactElement {
   const tree = fromMarkdown(source, {
     extensions: [gfm()],
@@ -43,7 +46,7 @@ export function AgentMarkdown({
   }) as MarkdownNode;
   return (
     <div className={["agent-markdown", className].filter(Boolean).join(" ")}>
-      {renderMarkdownChildren(tree.children ?? [], "root")}
+      {renderMarkdownChildren(tree.children ?? [], "root", highlightQuote)}
     </div>
   );
 }
@@ -77,41 +80,68 @@ export function markdownExcerpt(source: string): string {
 function renderMarkdownChildren(
   children: MarkdownNode[],
   keyPrefix: string,
+  highlightQuote?: string,
 ): ReactNode {
   return children.map((child, index) =>
-    renderMarkdownNode(child, `${keyPrefix}:${index}`),
+    renderMarkdownNode(child, `${keyPrefix}:${index}`, highlightQuote),
   );
 }
 
-function renderMarkdownNode(node: MarkdownNode, key: string): ReactNode {
+function renderMarkdownNode(
+  node: MarkdownNode,
+  key: string,
+  highlightQuote?: string,
+): ReactNode {
   switch (node.type) {
     case "root":
       return (
         <Fragment key={key}>
-          {renderMarkdownChildren(node.children ?? [], key)}
+          {renderMarkdownChildren(node.children ?? [], key, highlightQuote)}
         </Fragment>
       );
     case "paragraph":
       return (
-        <p key={key}>{renderMarkdownChildren(node.children ?? [], key)}</p>
+        <p key={key}>
+          {renderMarkdownChildren(node.children ?? [], key, highlightQuote)}
+        </p>
       );
     case "text":
+      if (highlightQuote) {
+        return (
+          <HighlightedText
+            key={key}
+            text={node.value ?? ""}
+            quote={highlightQuote}
+          />
+        );
+      }
       return node.value ?? "";
     case "emphasis":
       return (
-        <em key={key}>{renderMarkdownChildren(node.children ?? [], key)}</em>
+        <em key={key}>
+          {renderMarkdownChildren(node.children ?? [], key, highlightQuote)}
+        </em>
       );
     case "strong":
       return (
         <strong key={key}>
-          {renderMarkdownChildren(node.children ?? [], key)}
+          {renderMarkdownChildren(node.children ?? [], key, highlightQuote)}
         </strong>
       );
     case "delete":
       return (
-        <del key={key}>{renderMarkdownChildren(node.children ?? [], key)}</del>
+        <del key={key}>
+          {renderMarkdownChildren(node.children ?? [], key, highlightQuote)}
+        </del>
       );
     case "inlineCode":
+      if (highlightQuote) {
+        return (
+          <code key={key}>
+            <HighlightedText text={node.value ?? ""} quote={highlightQuote} />
+          </code>
+        );
+      }
       return <code key={key}>{node.value ?? ""}</code>;
     case "code":
       return (
@@ -130,12 +160,12 @@ function renderMarkdownNode(node: MarkdownNode, key: string): ReactNode {
       return createElement(
         headingTag(node.depth),
         { key },
-        renderMarkdownChildren(node.children ?? [], key),
+        renderMarkdownChildren(node.children ?? [], key, highlightQuote),
       );
     case "blockquote":
       return (
         <blockquote key={key}>
-          {renderMarkdownChildren(node.children ?? [], key)}
+          {renderMarkdownChildren(node.children ?? [], key, highlightQuote)}
         </blockquote>
       );
     case "list": {
@@ -143,7 +173,7 @@ function renderMarkdownNode(node: MarkdownNode, key: string): ReactNode {
       return createElement(
         Tag,
         { key, start: node.ordered ? (node.start ?? undefined) : undefined },
-        renderMarkdownChildren(node.children ?? [], key),
+        renderMarkdownChildren(node.children ?? [], key, highlightQuote),
       );
     }
     case "listItem":
@@ -152,11 +182,15 @@ function renderMarkdownNode(node: MarkdownNode, key: string): ReactNode {
           {node.checked !== null && node.checked !== undefined && (
             <input type="checkbox" checked={node.checked} readOnly />
           )}
-          {renderMarkdownChildren(node.children ?? [], key)}
+          {renderMarkdownChildren(node.children ?? [], key, highlightQuote)}
         </li>
       );
     case "link": {
-      const children = renderMarkdownChildren(node.children ?? [], key);
+      const children = renderMarkdownChildren(
+        node.children ?? [],
+        key,
+        highlightQuote,
+      );
       if (isLocalFilesystemHref(node.url)) {
         return (
           <code key={key} className="agent-markdown-code-reference">

--- a/packages/progressive-review/app/src/agent-setup-card.test.tsx
+++ b/packages/progressive-review/app/src/agent-setup-card.test.tsx
@@ -123,8 +123,50 @@ describe("AgentSetupCard", () => {
       buttons.find((button) => button.textContent === "Install")?.click();
     });
 
-    expect(apply).toHaveBeenCalledExactlyOnceWith({ targets: ["codex"] });
+    expect(apply).toHaveBeenCalledExactlyOnceWith({
+      targets: ["codex"],
+      fff: true,
+    });
     expect(onStatusChange).toHaveBeenCalledExactlyOnceWith(grantedStatus);
+  });
+
+  it("enables trace capture through the shared install action", async () => {
+    const traceStatus: ReviewCliInstallStatus = {
+      ...grantedStatus,
+      trace: {
+        ...grantedStatus.trace,
+        configured: true,
+        endpoint: "https://account.r2.cloudflarestorage.com",
+        bucket: "review-traces",
+        accessKeyIdPrefix: "key-id",
+      },
+    };
+    const apply = vi.fn<ReviewCanvasInstallContent["apply"]>(
+      async () => traceStatus,
+    );
+    const install: ReviewCanvasInstallContent = {
+      status: traceStatus,
+      apply,
+      remove: vi.fn<ReviewCanvasInstallContent["remove"]>(),
+      decline: vi.fn<ReviewCanvasInstallContent["decline"]>(),
+      skip: vi.fn<ReviewCanvasInstallContent["skip"]>(),
+      enablePrompts: vi.fn<ReviewCanvasInstallContent["enablePrompts"]>(),
+    };
+
+    await act(async () => root.render(<AgentSetupCard install={install} />));
+    await act(async () => {
+      [...container.querySelectorAll<HTMLButtonElement>("button")]
+        .find((button) => button.textContent === "Enable")
+        ?.click();
+    });
+
+    expect(apply).toHaveBeenCalledExactlyOnceWith({
+      targets: [],
+      trace: {
+        endpoint: "https://account.r2.cloudflarestorage.com",
+        bucket: "review-traces",
+      },
+    });
   });
 });
 
@@ -134,6 +176,19 @@ const status: ReviewCliInstallStatus = {
   stamp: null,
   stale: false,
   shim: { path: "/tmp/review", onPath: false },
+  fff: {
+    serverName: "fff",
+    corpusRoot: "/tmp/trace-search",
+    binary: { path: "/tmp/fff-mcp", installed: false },
+    registrations: [{ target: "codex", present: false, managed: false }],
+  },
+  trace: {
+    enabled: false,
+    configured: false,
+    autoActivateRepositories: false,
+    envPath: "/tmp/trace-env",
+    settingsPath: "/tmp/trace-settings.json",
+  },
   cli: { path: "/tmp/cli.js", version: "0.0.1" },
 };
 

--- a/packages/progressive-review/app/src/agent-setup-card.tsx
+++ b/packages/progressive-review/app/src/agent-setup-card.tsx
@@ -11,6 +11,7 @@ export const TARGET_LABELS: Record<ReviewCliInstallTarget, string> = {
   claude: "Claude Code",
   codex: "Codex",
   cursor: "Cursor",
+  pi: "Pi",
 };
 
 /**
@@ -43,6 +44,14 @@ export function AgentSetupCard({
   const [status, setStatus] = useState<ReviewCliInstallStatus>(install.status);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [traceEndpoint, setTraceEndpoint] = useState(
+    install.status.trace.endpoint ?? "",
+  );
+  const [traceBucket, setTraceBucket] = useState(
+    install.status.trace.bucket ?? "",
+  );
+  const [traceKey, setTraceKey] = useState("");
+  const [traceSecret, setTraceSecret] = useState("");
 
   const run = async (
     key: string,
@@ -72,6 +81,26 @@ export function AgentSetupCard({
   const presentTargets = status.agents
     .filter((agent) => agent.present)
     .map((agent) => agent.target);
+  const fffTargets = status.agents
+    .filter(
+      (agent) =>
+        supportsFff(agent.target) &&
+        (agent.present ||
+          agent.installed ||
+          status.fff.registrations.some(
+            (registration) =>
+              registration.target === agent.target && registration.present,
+          )),
+    )
+    .map((agent) => agent.target);
+  const fffReady =
+    fffTargets.length > 0 &&
+    fffTargets.every((target) =>
+      status.fff.registrations.some(
+        (registration) =>
+          registration.target === target && registration.present,
+      ),
+    );
   const firstRun = !status.stamp || status.stamp.consent === "skipped";
 
   return (
@@ -99,6 +128,13 @@ export function AgentSetupCard({
               : "No coding agents were detected on this machine. You can still install the "}
             <code>review</code> terminal command.
           </p>
+          {fffTargets.length > 0 ? (
+            <p>
+              This action also installs FFF when needed. It registers the
+              standard <code>fff</code> server for Claude and Codex, and
+              installs the Pi FFF extension.
+            </p>
+          ) : null}
           <div className="review-agent-setup-firstrun-actions">
             <button
               type="button"
@@ -106,7 +142,12 @@ export function AgentSetupCard({
               disabled={busy !== null}
               onClick={() =>
                 void run("firstrun", () =>
-                  install.apply({ targets: presentTargets, shim: true }),
+                  install.apply({
+                    targets: presentTargets,
+                    shim: true,
+                    fff: fffTargets.length > 0,
+                    ...(status.trace.configured ? { trace: true } : {}),
+                  }),
                 )
               }
             >
@@ -189,7 +230,10 @@ export function AgentSetupCard({
                   disabled={busy !== null}
                   onClick={() =>
                     void run(`remove-${agent.target}`, () =>
-                      install.remove({ targets: [agent.target] }),
+                      install.remove({
+                        targets: [agent.target],
+                        ...(supportsFff(agent.target) ? { fff: true } : {}),
+                      }),
                     )
                   }
                 >
@@ -203,7 +247,10 @@ export function AgentSetupCard({
                 disabled={busy !== null}
                 onClick={() =>
                   void run(agent.target, () =>
-                    install.apply({ targets: [agent.target] }),
+                    install.apply({
+                      targets: [agent.target],
+                      ...(supportsFff(agent.target) ? { fff: true } : {}),
+                    }),
                   )
                 }
               >
@@ -217,6 +264,147 @@ export function AgentSetupCard({
           );
         })}
       </ul>
+      <div className="review-agent-setup-terminal">
+        <div className="review-agent-setup-terminal-info">
+          <span className="review-agent-setup-name">Trace search</span>
+          <span
+            className="review-agent-setup-state"
+            data-installed={fffReady}
+            title={`${status.fff.binary.path} · ${status.fff.corpusRoot}`}
+          >
+            {fffReady
+              ? "ready"
+              : status.fff.binary.installed
+                ? "registration needed"
+                : "not installed"}
+          </span>
+          <span className="review-agent-setup-cli">
+            FFF MCP binary:{" "}
+            {status.fff.binary.installed ? "installed" : "not managed here"} ·{" "}
+            {status.fff.registrations
+              .map(
+                (registration) =>
+                  `${TARGET_LABELS[registration.target]}: ${registration.present ? (registration.target === "pi" ? "installed" : "registered") : "missing"}`,
+              )
+              .join(" · ")}
+          </span>
+          <span className="review-agent-setup-cli">
+            Existing FFF integrations stay unchanged. Open a new agent session
+            after setup.
+          </span>
+        </div>
+        <button
+          type="button"
+          disabled={busy !== null || fffTargets.length === 0}
+          onClick={() =>
+            void run("fff", () =>
+              install.apply({ targets: fffTargets, fff: true }),
+            )
+          }
+        >
+          {busy === "fff" ? "Installing…" : fffReady ? "Repair" : "Install"}
+        </button>
+      </div>
+      <div className="review-agent-setup-terminal review-agent-setup-trace">
+        <div className="review-agent-setup-terminal-info">
+          <span className="review-agent-setup-name">Trace capture</span>
+          <span
+            className="review-agent-setup-state"
+            data-installed={status.trace.enabled}
+            title={status.trace.envPath}
+          >
+            {status.trace.enabled
+              ? status.trace.error
+                ? "enabled, storage check failed"
+                : "enabled"
+              : status.trace.configured
+                ? "ready to enable"
+                : "not configured"}
+          </span>
+          <span className="review-agent-setup-cli">
+            Session hooks activate each Git or Jujutsu repository when an agent
+            session starts.
+          </span>
+        </div>
+        <div className="review-agent-setup-trace-fields">
+          <input
+            aria-label="R2 endpoint URL"
+            placeholder="R2 endpoint URL"
+            value={traceEndpoint}
+            onChange={(event) => setTraceEndpoint(event.currentTarget.value)}
+          />
+          <input
+            aria-label="R2 bucket"
+            placeholder="R2 bucket"
+            value={traceBucket}
+            onChange={(event) => setTraceBucket(event.currentTarget.value)}
+          />
+          <input
+            aria-label="R2 access key ID"
+            placeholder={
+              status.trace.accessKeyIdPrefix
+                ? `Access key (${status.trace.accessKeyIdPrefix}…)`
+                : "R2 access key ID"
+            }
+            value={traceKey}
+            onChange={(event) => setTraceKey(event.currentTarget.value)}
+          />
+          <input
+            aria-label="R2 secret access key"
+            type="password"
+            placeholder={
+              status.trace.configured
+                ? "Secret key (unchanged)"
+                : "R2 secret access key"
+            }
+            value={traceSecret}
+            onChange={(event) => setTraceSecret(event.currentTarget.value)}
+          />
+        </div>
+        {status.trace.enabled ? (
+          <button
+            type="button"
+            className="review-agent-setup-subtle"
+            disabled={busy !== null}
+            onClick={() =>
+              void run("trace-remove", () =>
+                install.remove({ targets: [], trace: true }),
+              )
+            }
+          >
+            {busy === "trace-remove" ? "Disabling…" : "Disable"}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          disabled={busy !== null}
+          onClick={() =>
+            void run(
+              "trace",
+              () =>
+                install.apply({
+                  targets: [],
+                  trace: {
+                    ...(traceEndpoint ? { endpoint: traceEndpoint } : {}),
+                    ...(traceBucket ? { bucket: traceBucket } : {}),
+                    ...(traceKey ? { key: traceKey } : {}),
+                    ...(traceSecret ? { secret: traceSecret } : {}),
+                  },
+                }),
+              () => {
+                setTraceKey("");
+                setTraceSecret("");
+              },
+            )
+          }
+        >
+          {busy === "trace"
+            ? "Checking…"
+            : status.trace.enabled
+              ? "Repair"
+              : "Enable"}
+        </button>
+      </div>
       {status.cli ? (
         <div className="review-agent-setup-terminal">
           <div className="review-agent-setup-terminal-info">
@@ -281,4 +469,8 @@ export function AgentSetupCard({
       {error ? <p className="review-agent-setup-error">{error}</p> : null}
     </section>
   );
+}
+
+function supportsFff(target: ReviewCliInstallTarget): boolean {
+  return target === "claude" || target === "codex" || target === "pi";
 }

--- a/packages/progressive-review/app/src/authoring-contract.test.tsx
+++ b/packages/progressive-review/app/src/authoring-contract.test.tsx
@@ -20,8 +20,7 @@ import {
   softwareMapPropsSchema,
 } from "../../src/authoring";
 import { validatedCodePeekInputFromRef } from "./CodePeek";
-import { DatabaseLens, DbRead, DbUseCase, DbWrite } from "./database-lens";
-import { SequenceDiagram, createSequence } from "./diagrams";
+import { createSequence } from "./diagrams";
 import { reviewAuthoringComponents } from "./review-authoring-components";
 import { createTestReviewDefinitionSession } from "./review-definition-test-utils";
 import { ReviewDocumentContent } from "./review-document-surface";
@@ -52,6 +51,9 @@ const stores = defineStores({
       reviews: {
         schema: {
           id: { type: "text" },
+          path: { type: "text" },
+          schema: { type: "text" },
+          storeId: { type: "text" },
           metadata: {
             author: { type: "text" },
           },
@@ -68,11 +70,14 @@ const stores = defineStores({
 });
 
 const actorKeyInference = actors.browser;
-const fieldKeyInference: TargetRef = stores.app.tables.reviews.id;
+const collectionKeyInference: TargetRef = stores.app.tables.reviews;
+const fieldKeyInference: TargetRef = stores.app.tables.reviews.fields.id;
 const nestedFieldKeyInference: TargetRef =
-  stores.app.tables.reviews.metadata.author;
+  stores.app.tables.reviews.fields.metadata.fields.author;
 const leafSchemaKeyInference: TargetRef =
-  stores.app.tables.reviews.payload.status;
+  stores.app.tables.reviews.fields.payload.fields.status;
+const reservedNameFieldInference: TargetRef =
+  stores.app.tables.reviews.fields.path;
 
 // These compile-time assertions make drift in the public authoring contract a
 // failure of the package typecheck, while the Vitest assertion below protects
@@ -84,7 +89,7 @@ void anchors.missing;
 // @ts-expect-error defineStores must retain collection keys.
 void stores.app.tables.users;
 // @ts-expect-error defineStores must retain field keys.
-void stores.app.tables.reviews.missing;
+void stores.app.tables.reviews.fields.missing;
 
 const validCodePeek: CodePeekProps = {
   file: "src/review.ts",
@@ -180,6 +185,7 @@ describe("review authoring contract", () => {
       "DbWrite",
       "ReviewSection",
       "SequenceDiagram",
+      "TraceQuote",
       "TutorialKeymapPicker",
     ]);
   });
@@ -200,12 +206,36 @@ describe("review authoring contract", () => {
       id: "browser",
       label: "Browser",
     });
+    expect(collectionKeyInference).toMatchObject({
+      __kind: "db-target-ref",
+      path: [],
+    });
     expect(fieldKeyInference).toMatchObject({
       __kind: "db-target-ref",
       path: ["id"],
     });
     expect(nestedFieldKeyInference.path).toEqual(["metadata", "author"]);
     expect(leafSchemaKeyInference.path).toEqual(["payload", "status"]);
+    expect(reservedNameFieldInference.path).toEqual(["path"]);
+  });
+
+  it("accepts exact collection and field targets for database operations", () => {
+    expect(
+      dbOperationPropsSchema.parse({
+        from: stores.app.tables.reviews,
+        to: actors.browser,
+        label: "Read reviews",
+        anchor: anchors.request,
+      }),
+    ).toMatchObject({ from: { path: [] } });
+    expect(
+      dbOperationPropsSchema.parse({
+        from: actors.api,
+        to: stores.app.tables.reviews.fields.path,
+        label: "Write path",
+        anchor: anchors.request,
+      }),
+    ).toMatchObject({ to: { path: ["path"] } });
   });
 
   it.each([
@@ -252,7 +282,7 @@ describe("review authoring contract", () => {
       dbOperationPropsSchema,
       {
         from: actors.browser,
-        to: stores.app.tables.reviews.id,
+        to: stores.app.tables.reviews.fields.id,
         label: "Read",
         anchor: anchors.request,
         extra: true,
@@ -263,7 +293,7 @@ describe("review authoring contract", () => {
       dbOperationPropsSchema,
       {
         from: actors.api,
-        to: stores.app.tables.reviews.id,
+        to: stores.app.tables.reviews.fields.id,
         label: "Write",
         anchor: anchors.request,
         extra: true,

--- a/packages/progressive-review/app/src/database-lens.test.ts
+++ b/packages/progressive-review/app/src/database-lens.test.ts
@@ -130,7 +130,7 @@ describe("software map backed database lenses", () => {
       dataStoreKind: "database",
       softwareMapPath: "product.appDb",
     });
-    expect(stores.appDb.tables?.reviews.id).toMatchObject({
+    expect(stores.appDb.tables?.reviews.fields.id).toMatchObject({
       storeDataStoreKind: "database",
       storeSoftwareMapPath: "product.appDb",
     });
@@ -179,7 +179,7 @@ describe("software map backed database lenses", () => {
     const stores = defineSoftwareStores(model, {
       graphDb: { path: "product.graphDb" },
     });
-    const fieldRef = stores.graphDb.tables?.nodes.label;
+    const fieldRef = stores.graphDb.tables?.nodes.fields.label;
     expect(fieldRef).toMatchObject({
       __kind: "db-target-ref",
       path: ["label"],
@@ -190,7 +190,7 @@ describe("software map backed database lenses", () => {
       id: "reader",
       label: "Reader",
     };
-    const target = stores.graphDb.tables?.nodes.label;
+    const target = stores.graphDb.tables?.nodes.fields.label;
     const snapshot = databaseC4Snapshot({
       useCase: {
         id: "inspect",
@@ -269,23 +269,23 @@ describe("software map backed database lenses", () => {
         operation: {
           kind: "write",
           from: actor,
-          to: stores.graphDb.tables?.nodes.id,
+          to: stores.graphDb.tables?.nodes.fields.id,
           label: "writes node ids",
           anchor: { id: "writeNodes", title: "Write nodes" },
         },
         actor,
-        target: stores.graphDb.tables?.nodes.id,
+        target: stores.graphDb.tables?.nodes.fields.id,
       },
       {
         operation: {
           kind: "write",
           from: actor,
-          to: stores.graphDb.tables?.edges.from_id,
+          to: stores.graphDb.tables?.edges.fields.from_id,
           label: "writes edge endpoints",
           anchor: { id: "writeEdges", title: "Write edges" },
         },
         actor,
-        target: stores.graphDb.tables?.edges.from_id,
+        target: stores.graphDb.tables?.edges.fields.from_id,
       },
     ] as never;
     const snapshot = databaseC4Snapshot({
@@ -392,24 +392,24 @@ describe("software map backed database lenses", () => {
       {
         operation: {
           kind: "read",
-          from: stores.graphDb.tables?.nodes.id,
+          from: stores.graphDb.tables?.nodes.fields.id,
           to: actor,
           label: "reads node ids",
           anchor: { id: "readNodes", title: "Read nodes" },
         },
         actor,
-        target: stores.graphDb.tables?.nodes.id,
+        target: stores.graphDb.tables?.nodes.fields.id,
       },
       {
         operation: {
           kind: "read",
-          from: stores.graphDb.tables?.edges.from_id,
+          from: stores.graphDb.tables?.edges.fields.from_id,
           to: actor,
           label: "reads edge endpoints",
           anchor: { id: "readEdges", title: "Read edges" },
         },
         actor,
-        target: stores.graphDb.tables?.edges.from_id,
+        target: stores.graphDb.tables?.edges.fields.from_id,
       },
     ] as never;
     const highlightInputs = [

--- a/packages/progressive-review/app/src/database-lens.tsx
+++ b/packages/progressive-review/app/src/database-lens.tsx
@@ -840,7 +840,7 @@ function softwareMapCollectionNode({
   return {
     id: storeCollectionNodeIdForStore(store, collectionKind, collectionId),
     type: "dataStoreCollection",
-    label: collection.__collectionLabel,
+    label: collection.collectionLabel,
     path: store.softwareMapPath
       ? `${store.softwareMapPath}.${collectionKind}.${collectionId}`
       : undefined,
@@ -850,8 +850,8 @@ function softwareMapCollectionNode({
       {
         id: `${kind}:${collectionId}`,
         kind,
-        label: collection.__collectionLabel,
-        key: collection.__collectionKey,
+        label: collection.collectionLabel,
+        key: collection.collectionKey,
         rows: softwareMapSchemaRowsForCollection({
           store,
           collectionKind,
@@ -928,8 +928,8 @@ function softwareMapSchemaRowsForCollection({
         storeSoftwareMapPath: store.softwareMapPath,
         collectionKind,
         collectionId,
-        collectionLabel: collection.__collectionLabel,
-        collectionKey: collection.__collectionKey,
+        collectionLabel: collection.collectionLabel,
+        collectionKey: collection.collectionKey,
         path: row.path,
       },
       row.path,

--- a/packages/progressive-review/app/src/default-review.mdx
+++ b/packages/progressive-review/app/src/default-review.mdx
@@ -89,14 +89,14 @@ backed by the external `~/.dev` software map for this repository.
   <DbUseCase id="publish-review" label="Publish review">
     <DbWrite
       from={actors.reviewRuntime}
-      to={stores.appDb.tables.reviews.status}
+      to={stores.appDb.tables.reviews.fields.status}
       label="write submitted status"
       anchor={anchors.publishReview}
     />
   </DbUseCase>
   <DbUseCase id="inspect-review" label="Inspect review">
     <DbRead
-      from={stores.appDb.tables.reviews.status}
+      from={stores.appDb.tables.reviews.fields.status}
       to={actors.reviewUi}
       label="read current status"
       anchor={anchors.inspectReview}

--- a/packages/progressive-review/app/src/desktop-entry.tsx
+++ b/packages/progressive-review/app/src/desktop-entry.tsx
@@ -24,6 +24,7 @@ import {
 import { SettingsPage } from "./settings-page";
 import { TutorialProvider } from "./tutorial-context";
 import { captureClientError, captureUiEvent } from "./ui-telemetry";
+import { clearAgentTraceCache } from "./use-agent-trace";
 import { WelcomePage } from "./welcome-page";
 
 import "./styles.css";
@@ -359,6 +360,7 @@ export function mountReviewCanvas(
   return {
     update(next) {
       if (disposed) return;
+      if (session) clearAgentTraceCache(session);
       content = next;
       render();
     },

--- a/packages/progressive-review/app/src/diagrams.tsx
+++ b/packages/progressive-review/app/src/diagrams.tsx
@@ -108,18 +108,10 @@ export interface SequenceRef {
 
 export function createSequence(input: UncheckedSequenceInput): SequenceRef {
   sequenceDiagramPropsSchema.parse(input);
-  const messages = normalizeSequenceMessages(input);
+  const messages = uniqueSequenceMessageAnchors(
+    normalizeSequenceMessages(input),
+  );
   const id = `sequence-${slugSequenceActorLabel(input.label)}`;
-  const seenAnchors = new Set<string>();
-  for (const [index, message] of messages.entries()) {
-    if (seenAnchors.has(message.anchor.id)) {
-      throwAuthoringIssue(
-        ["messages", index, "anchor"],
-        "Anchor must be used only once within this diagram",
-      );
-    }
-    seenAnchors.add(message.anchor.id);
-  }
   const participants = participantsForMessages(messages);
   validateSequenceTargetPaths(input.label, participants, messages);
   return Object.freeze({
@@ -137,6 +129,31 @@ export function createSequence(input: UncheckedSequenceInput): SequenceRef {
         code: message.code,
       }),
     ),
+  });
+}
+
+function uniqueSequenceMessageAnchors(
+  messages: readonly SequenceMessage[],
+): SequenceMessage[] {
+  const reservedIds = new Set(messages.map((message) => message.anchor.id));
+  const usedIds = new Set<string>();
+  return messages.map((message, index) => {
+    if (!usedIds.has(message.anchor.id)) {
+      usedIds.add(message.anchor.id);
+      return message;
+    }
+    const prefix = `${message.anchor.id}--sequence-use-${index + 1}`;
+    let id = prefix;
+    let suffix = 2;
+    while (reservedIds.has(id) || usedIds.has(id)) {
+      id = `${prefix}-${suffix}`;
+      suffix += 1;
+    }
+    usedIds.add(id);
+    return {
+      ...message,
+      anchor: Object.freeze({ ...message.anchor, id }),
+    };
   });
 }
 

--- a/packages/progressive-review/app/src/highlighted-text.test.tsx
+++ b/packages/progressive-review/app/src/highlighted-text.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { findWhitespaceNormalizedSpan } from "./highlighted-text";
+
+describe("findWhitespaceNormalizedSpan", () => {
+  it("finds exact substring match", () => {
+    const text = "Hello world from trace";
+    const span = findWhitespaceNormalizedSpan(text, "world from");
+    expect(span).toEqual({ start: 6, end: 16 });
+    expect(text.slice(span!.start, span!.end)).toBe("world from");
+  });
+
+  it("finds match across newlines and multiple spaces without shifting indices", () => {
+    const text = "\n  First line\n\n  Second   line with details\n";
+    const span = findWhitespaceNormalizedSpan(text, "Second line with");
+    expect(span).not.toBeNull();
+    // Must extract exact slice from original text preserving original whitespace
+    expect(text.slice(span!.start, span!.end)).toBe("Second   line with");
+  });
+
+  it("finds match when quote contains newlines", () => {
+    const text = "Start here and then continue to the end.";
+    const span = findWhitespaceNormalizedSpan(text, "and\nthen\ncontinue");
+    expect(span).not.toBeNull();
+    expect(text.slice(span!.start, span!.end)).toBe("and then continue");
+  });
+
+  it("returns null for non-matching quote", () => {
+    const text = "Some completely different text";
+    const span = findWhitespaceNormalizedSpan(text, "nonexistent quote");
+    expect(span).toBeNull();
+  });
+});

--- a/packages/progressive-review/app/src/highlighted-text.tsx
+++ b/packages/progressive-review/app/src/highlighted-text.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from "react";
+
+export function findWhitespaceNormalizedSpan(
+  text: string,
+  quote: string,
+): { start: number; end: number } | null {
+  const trimmedQuote = quote.trim();
+  if (!trimmedQuote || !text) return null;
+  const normQuote = trimmedQuote.replace(/\s+/g, " ");
+
+  let normText = "";
+  const normToOriginalStart: number[] = [];
+  const normToOriginalEnd: number[] = [];
+
+  let i = 0;
+  while (i < text.length) {
+    if (/\s/.test(text[i])) {
+      const spaceStart = i;
+      while (i < text.length && /\s/.test(text[i])) {
+        i++;
+      }
+      normToOriginalStart.push(spaceStart);
+      normToOriginalEnd.push(i);
+      normText += " ";
+    } else {
+      normToOriginalStart.push(i);
+      normToOriginalEnd.push(i + 1);
+      normText += text[i];
+      i++;
+    }
+  }
+
+  const matchIdx = normText.indexOf(normQuote);
+  if (matchIdx === -1) {
+    return null;
+  }
+
+  const origStart = normToOriginalStart[matchIdx];
+  const origEnd = normToOriginalEnd[matchIdx + normQuote.length - 1];
+  return { start: origStart, end: origEnd };
+}
+
+export function HighlightedText({
+  text,
+  quote,
+}: {
+  text: string;
+  quote: string;
+}): ReactNode {
+  const span = findWhitespaceNormalizedSpan(text, quote);
+  if (!span) {
+    return text;
+  }
+  return (
+    <>
+      {text.slice(0, span.start)}
+      <mark className="review-trace-quote-mark">
+        {text.slice(span.start, span.end)}
+      </mark>
+      {text.slice(span.end)}
+    </>
+  );
+}

--- a/packages/progressive-review/app/src/host/review-session.tsx
+++ b/packages/progressive-review/app/src/host/review-session.tsx
@@ -84,8 +84,12 @@ export function ReviewSessionProvider({
   );
 }
 
+export function useOptionalReviewSession(): ReviewSession | null {
+  return useContext(ReviewSessionContext);
+}
+
 export function useReviewSession(): ReviewSession {
-  const session = useContext(ReviewSessionContext);
+  const session = useOptionalReviewSession();
   if (!session) {
     throw new Error(
       "useReviewSession must be used within ReviewSessionProvider",

--- a/packages/progressive-review/app/src/review-authoring-components.tsx
+++ b/packages/progressive-review/app/src/review-authoring-components.tsx
@@ -4,6 +4,7 @@ import { ReviewCodePeek } from "./CodePeek";
 import { DatabaseLens, DbRead, DbUseCase, DbWrite } from "./database-lens";
 import { SequenceDiagram } from "./diagrams";
 import { AnchorLink, ReviewSection } from "./review-components";
+import { TraceQuote } from "./trace-quote";
 import { TutorialKeymapPicker } from "./tutorial-keymap-picker";
 
 export const reviewAuthoringComponents = {
@@ -16,5 +17,6 @@ export const reviewAuthoringComponents = {
   DbWrite,
   ReviewSection,
   SequenceDiagram,
+  TraceQuote,
   TutorialKeymapPicker,
 } satisfies ReviewAuthoringComponentRegistry;

--- a/packages/progressive-review/app/src/review-components.tsx
+++ b/packages/progressive-review/app/src/review-components.tsx
@@ -1,3 +1,4 @@
+import { type ReviewAgentTraceEvent } from "@dev.fast/review-protocol";
 import type {
   CSSProperties,
   ComponentPropsWithoutRef,
@@ -11,6 +12,7 @@ import {
   isValidElement,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -32,11 +34,15 @@ import {
   validatedCodePeekInputFromRef,
 } from "./CodePeek";
 import { chipPositionClearOf } from "./document-selection";
-import { useReviewSession } from "./host/review-session";
+import { findWhitespaceNormalizedSpan } from "./highlighted-text";
+import {
+  useOptionalReviewSession,
+  useReviewSession,
+} from "./host/review-session";
 import { CloseIcon, CommentIcon, MapPinIcon, TerminalIcon } from "./icons";
 import { newTabLinkProps } from "./link-props";
 import { createClientId, useReview } from "./review-context";
-import { useReviewPanel } from "./review-panel";
+import { useOptionalReviewPanelStore, useReviewPanel } from "./review-panel";
 import {
   type ThreadPanel,
   selectActiveReviewPanel,
@@ -58,7 +64,13 @@ import {
 import { buildAnchorTextTarget, targetKey } from "./target-fingerprint";
 import { ThreadComposer } from "./thread-card";
 import { useThreadTargetState } from "./thread-target-model";
+import {
+  TraceDocument,
+  buildTraceTurns,
+  extractEventText,
+} from "./trace-document";
 import { captureUiEvent } from "./ui-telemetry";
+import { useAgentTrace } from "./use-agent-trace";
 
 const TOUR_ACTIVE_TOP_SLACK_PX = 18;
 
@@ -324,14 +336,72 @@ function reviewSectionSummaryLabel(summary: ReviewSectionSummary): string {
   return parts.join(" · ");
 }
 
+export interface ProsePeekAnchorProps {
+  href: string;
+  isOpen: boolean;
+  onOpen: () => void;
+  onAlreadyOpen?: () => void;
+  className?: string;
+  anchorId?: string;
+  locator?: string;
+  inertFallback?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * Shared prose side-peek anchor primitive for AnchorLink and TraceQuote.
+ * Renders an inline anchor with open-state styling, telemetry, and visibility retention.
+ */
+export function ProsePeekAnchor({
+  href,
+  isOpen,
+  onOpen,
+  onAlreadyOpen,
+  className,
+  anchorId,
+  locator,
+  inertFallback,
+  children,
+}: ProsePeekAnchorProps) {
+  const panelStore = useOptionalReviewPanelStore();
+  const session = useOptionalReviewSession();
+
+  if (!panelStore && inertFallback !== undefined) {
+    return <>{inertFallback}</>;
+  }
+
+  return (
+    <a
+      href={href}
+      className={className}
+      data-review-anchor-id={anchorId}
+      data-review-anchor-open={isOpen ? "true" : undefined}
+      data-review-locator={locator}
+      onClick={(event) => {
+        event.preventDefault();
+        if (isOpen && onAlreadyOpen) {
+          onAlreadyOpen();
+          return;
+        }
+        if (session) {
+          captureUiEvent(session, "peek_opened", { via: "prose_link" });
+        }
+        onOpen();
+        keepAnchorLinkVisible(event.currentTarget);
+      }}
+    >
+      {children}
+    </a>
+  );
+}
+
 export function AnchorLink(props: AnchorLinkProps) {
-  const session = useReviewSession();
   const { anchor, children } = anchorLinkPropsSchema.parse(props);
   const input = validatedCodePeekInputFromRef(anchor.peek);
   const openPeek = useReviewPanel((state) => state.openPeek);
   const peekOpen = useReviewPanel((state) => {
     const active = selectActiveReviewPanel(state);
-    return active?.kind === "peek" && active.anchor.id === anchor.id;
+    return active?.kind === "peek" && active.anchor?.id === anchor.id;
   });
   const target = buildAnchorTextTarget({
     anchorId: anchor.id,
@@ -339,20 +409,17 @@ export function AnchorLink(props: AnchorLinkProps) {
     text: anchor.title,
   });
   return (
-    <a
+    <ProsePeekAnchor
       href={`#review-anchor-${anchor.id}`}
-      data-review-anchor-id={anchor.id}
-      data-review-anchor-open={peekOpen ? "true" : undefined}
-      data-review-locator={targetKey(target)}
-      onClick={(event) => {
-        event.preventDefault();
-        captureUiEvent(session, "peek_opened", { via: "prose_link" });
+      anchorId={anchor.id}
+      isOpen={peekOpen}
+      locator={targetKey(target)}
+      onOpen={() => {
         openPeek(anchor, { kind: "resolved-code", input });
-        keepAnchorLinkVisible(event.currentTarget);
       }}
     >
       {children}
-    </a>
+    </ProsePeekAnchor>
   );
 }
 
@@ -376,7 +443,7 @@ export function a({
  * which can push the clicked anchor link out of the viewport. Once the panel
  * has slid in, scroll the link back into view if the reflow moved it away.
  */
-function keepAnchorLinkVisible(link: HTMLElement) {
+export function keepAnchorLinkVisible(link: HTMLElement) {
   window.setTimeout(() => {
     const rect = link.getBoundingClientRect();
     const visible =
@@ -565,7 +632,14 @@ function PanelSelectionCommentButton({
 
 export type ReviewPeekContent =
   | { kind: "resolved-code"; input: ValidatedCodePeekInput }
-  | { kind: "inline-code"; language?: string; text: string };
+  | { kind: "inline-code"; language?: string; text: string }
+  | {
+      kind: "trace-quote";
+      sessionId: string;
+      trace?: string;
+      event?: number;
+      quote: string;
+    };
 
 export interface GuidedTourStop {
   anchor: AnchorRef;
@@ -647,13 +721,195 @@ function CommitFileDiffPanel({
   );
 }
 
+function TraceQuotePeekPanel({
+  sessionId,
+  trace,
+  event,
+  quote,
+  onClose,
+}: {
+  sessionId: string;
+  trace?: string;
+  event?: number;
+  quote: string;
+  onClose: () => void;
+}) {
+  const review = useReview();
+  const data = useAgentTrace(sessionId, trace);
+
+  const traceEvents = data.status === "loaded" ? data.trace.events : undefined;
+
+  const targetEventIndex = useMemo(() => {
+    if (!traceEvents) return -1;
+    if (event !== undefined && event >= 0 && event < traceEvents.length) {
+      const e = traceEvents[event];
+      const text = extractEventText(e);
+      if (findWhitespaceNormalizedSpan(text, quote)) {
+        return event;
+      }
+    }
+    for (let i = 0; i < traceEvents.length; i++) {
+      const text = extractEventText(traceEvents[i]);
+      if (findWhitespaceNormalizedSpan(text, quote)) {
+        return i;
+      }
+    }
+    return -1;
+  }, [traceEvents, event, quote]);
+
+  const picks = useMemo(() => {
+    if (!traceEvents || targetEventIndex === -1) return undefined;
+    let turnStart = 0;
+    for (let index = targetEventIndex; index >= 0; index -= 1) {
+      if (traceEvents[index].kind === "user") {
+        turnStart = index;
+        break;
+      }
+    }
+    let nextUserIndex = -1;
+    for (
+      let index = targetEventIndex + 1;
+      index < traceEvents.length;
+      index += 1
+    ) {
+      if (traceEvents[index].kind === "user") {
+        nextUserIndex = index;
+        break;
+      }
+    }
+    const turnEnd =
+      nextUserIndex === -1 ? traceEvents.length - 1 : nextUserIndex - 1;
+    return [
+      {
+        events: [turnStart, turnEnd] as [number, number],
+      },
+    ];
+  }, [traceEvents, targetEventIndex]);
+
+  if (data.status === "loading" || data.status === "idle") {
+    return (
+      <ReviewPanelFrame
+        className="side-peek trace-quote-panel"
+        label="Agent trace"
+        title={
+          trace ? `${sessionId.slice(0, 8)} · ${trace}` : sessionId.slice(0, 8)
+        }
+        onClose={onClose}
+        closeLabel="Close side peek"
+      >
+        <div className="side-peek-body">
+          <p className="review-trace-note">Loading trace…</p>
+        </div>
+      </ReviewPanelFrame>
+    );
+  }
+
+  if (data.status === "error") {
+    return (
+      <ReviewPanelFrame
+        className="side-peek trace-quote-panel"
+        label="Agent trace"
+        title={sessionId.slice(0, 8)}
+        onClose={onClose}
+        closeLabel="Close side peek"
+      >
+        <div className="side-peek-body">
+          <p className="review-trace-note review-trace-note--error">
+            {data.error}
+          </p>
+        </div>
+      </ReviewPanelFrame>
+    );
+  }
+
+  const loadedTrace = data.trace;
+  const events = loadedTrace.events;
+
+  const headerAccessory = (
+    <button
+      type="button"
+      className="review-trace-peek-open-full"
+      onClick={() => {
+        review.openTraceSession?.({
+          sessionId,
+          trace,
+          eventIndex: targetEventIndex >= 0 ? targetEventIndex : undefined,
+        });
+        onClose();
+      }}
+    >
+      Full Trace ↗
+    </button>
+  );
+
+  return (
+    <ReviewPanelFrame
+      className="side-peek trace-quote-panel"
+      label="Agent trace"
+      title={
+        loadedTrace.title ??
+        (trace ? `${sessionId.slice(0, 8)} · ${trace}` : sessionId.slice(0, 8))
+      }
+      titleAccessory={headerAccessory}
+      onClose={onClose}
+      closeLabel="Close side peek"
+    >
+      <div className="side-peek-body">
+        {targetEventIndex === -1 ? (
+          <p className="review-trace-note">
+            Quote not found in this session transcript.
+          </p>
+        ) : (
+          <TraceDocument
+            key={`${sessionId}-${trace ?? ""}-${targetEventIndex}-${quote}`}
+            events={events}
+            targetEventIndex={targetEventIndex}
+            highlightQuote={quote}
+            picks={picks}
+            className="review-trace-events--scoped"
+          />
+        )}
+      </div>
+    </ReviewPanelFrame>
+  );
+}
+
 export function ReviewPeekPanel({
   anchor,
   content,
   onClose,
 }: {
-  anchor: AnchorRef;
+  anchor?: AnchorRef;
   content: ReviewPeekContent;
+  onClose: () => void;
+}) {
+  if (content.kind === "trace-quote") {
+    return (
+      <TraceQuotePeekPanel
+        sessionId={content.sessionId}
+        trace={content.trace}
+        event={content.event}
+        quote={content.quote}
+        onClose={onClose}
+      />
+    );
+  }
+  if (!anchor) return null;
+  return (
+    <CodeReviewPeekPanel anchor={anchor} content={content} onClose={onClose} />
+  );
+}
+
+function CodeReviewPeekPanel({
+  anchor,
+  content,
+  onClose,
+}: {
+  anchor: AnchorRef;
+  content: Extract<
+    ReviewPeekContent,
+    { kind: "resolved-code" | "inline-code" }
+  >;
   onClose: () => void;
 }) {
   const review = useReview();
@@ -1156,30 +1412,37 @@ export function ReviewPeekContentView({
   active,
   onNativeFocus,
 }: {
-  anchor: AnchorRef;
+  anchor?: AnchorRef;
   content: ReviewPeekContent;
   active?: boolean;
   onNativeFocus?: () => void;
 }) {
-  return content.kind === "resolved-code" ? (
-    <CodePeekCard
-      input={content.input}
-      active={active}
-      heightMode="content"
-      onNativeFocus={onNativeFocus}
-      commentAnchor={anchor}
-    />
-  ) : (
-    <PanelAuthoredCodeSurface
-      anchor={anchor}
-      code={content.text}
-      language={content.language}
-      selectionStamp={panelSelectionStamp({
-        anchorId: anchor.id,
-        field: "code",
-      })}
-    />
-  );
+  if (content.kind === "resolved-code") {
+    return (
+      <CodePeekCard
+        input={content.input}
+        active={active}
+        heightMode="content"
+        onNativeFocus={onNativeFocus}
+        commentAnchor={anchor}
+      />
+    );
+  }
+  if (content.kind === "inline-code") {
+    if (!anchor) return null;
+    return (
+      <PanelAuthoredCodeSurface
+        anchor={anchor}
+        code={content.text}
+        language={content.language}
+        selectionStamp={panelSelectionStamp({
+          anchorId: anchor.id,
+          field: "code",
+        })}
+      />
+    );
+  }
+  return null;
 }
 
 /**

--- a/packages/progressive-review/app/src/review-context.tsx
+++ b/packages/progressive-review/app/src/review-context.tsx
@@ -159,6 +159,11 @@ interface ReviewContextValue {
   askAgent: (input: CreateReviewCommentInput) => Promise<void>;
   softwareMapFocusRequest: SoftwareMapFocusRequest | null;
   openSoftwareMapElement: (elementPath: string) => void;
+  openTraceSession?: (input: {
+    sessionId: string;
+    trace?: string;
+    eventIndex?: number;
+  }) => void;
   saveComment: (input: CreateReviewCommentInput) => Promise<void>;
   updateComment: (
     threadId: string,
@@ -186,16 +191,23 @@ const ReviewContext = createContext<ReviewContextValue | null>(null);
 export function ReviewProvider({
   documentRoute,
   softwareMapEnabled = false,
+  openTraceSession,
   children,
 }: {
   documentRoute?: string;
   softwareMapEnabled?: boolean;
+  openTraceSession?: (input: {
+    sessionId: string;
+    trace?: string;
+    eventIndex?: number;
+  }) => void;
   children: ReactNode;
 }) {
   return (
     <ReviewCoordinator
       documentRoute={documentRoute}
       softwareMapEnabled={softwareMapEnabled}
+      openTraceSession={openTraceSession}
     >
       {children}
     </ReviewCoordinator>
@@ -205,10 +217,16 @@ export function ReviewProvider({
 function ReviewCoordinator({
   documentRoute,
   softwareMapEnabled,
+  openTraceSession,
   children,
 }: {
   documentRoute?: string;
   softwareMapEnabled: boolean;
+  openTraceSession?: (input: {
+    sessionId: string;
+    trace?: string;
+    eventIndex?: number;
+  }) => void;
   children: ReactNode;
 }) {
   const session = useReviewSession();
@@ -582,6 +600,7 @@ function ReviewCoordinator({
       askAgent,
       softwareMapFocusRequest,
       openSoftwareMapElement,
+      openTraceSession,
       saveComment,
       updateComment,
       deleteComment,
@@ -616,6 +635,7 @@ function ReviewCoordinator({
       lineCommentsForAnchor,
       listVersions,
       openSoftwareMapElement,
+      openTraceSession,
       pendingCommentCount,
       resolvedBaseRef,
       resolvedHeadRef,

--- a/packages/progressive-review/app/src/review-document-error-report.test.ts
+++ b/packages/progressive-review/app/src/review-document-error-report.test.ts
@@ -23,15 +23,15 @@ describe("reviewDocumentErrorReport", () => {
     const zodError = new z.ZodError([
       {
         code: "custom",
-        path: ["messages", 1, "anchor"],
-        message: "Anchor must be used only once within this diagram",
+        path: ["messages", 1, "label"],
+        message: "Label must be unique among parallel A→B messages",
         input: undefined,
       },
     ]);
     const report = reviewDocumentErrorReport(zodError);
     expect(report.name).toBe("ZodError");
     expect(report.message).toContain(
-      "Anchor must be used only once within this diagram",
+      "Label must be unique among parallel A→B messages",
     );
   });
 

--- a/packages/progressive-review/app/src/review-home-view.test.tsx
+++ b/packages/progressive-review/app/src/review-home-view.test.tsx
@@ -372,6 +372,19 @@ describe("setupBannerMessage", () => {
       },
       stale: false,
       shim: { path: "/tmp/review", onPath: false },
+      fff: {
+        serverName: "fff",
+        corpusRoot: "/tmp/trace-search",
+        binary: { path: "/tmp/fff-mcp", installed: false },
+        registrations: [{ target: "codex", present: false, managed: false }],
+      },
+      trace: {
+        enabled: false,
+        configured: false,
+        autoActivateRepositories: false,
+        envPath: "/tmp/trace-env",
+        settingsPath: "/tmp/trace-settings.json",
+      },
       cli: { path: "/tmp/cli.js", version: "0.0.1" },
     };
 

--- a/packages/progressive-review/app/src/review-home-view.tsx
+++ b/packages/progressive-review/app/src/review-home-view.tsx
@@ -310,6 +310,26 @@ export function setupBannerMessage(
       .map((agent) => TARGET_LABELS[agent.target])
       .join(", ")}.`;
   }
+  const traceAgents = status.agents.filter(
+    (agent) =>
+      agent.present &&
+      (agent.target === "claude" ||
+        agent.target === "codex" ||
+        agent.target === "pi"),
+  );
+  const missingFff = traceAgents.filter(
+    (agent) =>
+      !status.fff.registrations.some(
+        (registration) =>
+          registration.target === agent.target && registration.present,
+      ),
+  );
+  if (traceAgents.length > 0 && missingFff.length > 0) {
+    return "FFF trace search needs setup for your coding agents.";
+  }
+  if (!status.trace.enabled) {
+    return "Trace capture needs setup.";
+  }
   return null;
 }
 

--- a/packages/progressive-review/app/src/review-panel-store.ts
+++ b/packages/progressive-review/app/src/review-panel-store.ts
@@ -10,7 +10,7 @@ import type { GuidedTour, ReviewPeekContent } from "./review-components";
 export type DetailPanel =
   | {
       kind: "peek";
-      anchor: AnchorRef;
+      anchor?: AnchorRef;
       content: ReviewPeekContent;
     }
   | {
@@ -38,7 +38,10 @@ export interface ReviewPanelState {
 
 export interface ReviewPanelActions {
   suppressMotion: () => void;
-  openPeek: (anchor: AnchorRef, content: ReviewPeekContent) => void;
+  openPeek: (
+    anchorOrContent: AnchorRef | ReviewPeekContent,
+    content?: ReviewPeekContent,
+  ) => void;
   openTour: (tour: GuidedTour, activeAnchor: string) => void;
   openCommitDiff: (
     commit: ReviewCommitSummary,
@@ -73,8 +76,25 @@ export function createReviewPanelStore() {
     thread: null,
     motion: "live",
     suppressMotion: () => set({ motion: "restored" }),
-    openPeek: (anchor, content) => {
-      set({ detail: { kind: "peek", anchor, content }, motion: "live" });
+    openPeek: (anchorOrContent, content) => {
+      if (content !== undefined) {
+        set({
+          detail: {
+            kind: "peek",
+            anchor: anchorOrContent as AnchorRef,
+            content,
+          },
+          motion: "live",
+        });
+      } else {
+        set({
+          detail: {
+            kind: "peek",
+            content: anchorOrContent as ReviewPeekContent,
+          },
+          motion: "live",
+        });
+      }
     },
     openTour: (tour, activeAnchor) => {
       set((state) => ({

--- a/packages/progressive-review/app/src/review-panel.tsx
+++ b/packages/progressive-review/app/src/review-panel.tsx
@@ -17,6 +17,7 @@ import {
 } from "./review-panel-store";
 
 const ReviewPanelContext = createContext<ReviewPanelStore | null>(null);
+const fallbackReviewPanelStore = createReviewPanelStore();
 
 export function ReviewPanelProvider({
   children,
@@ -43,6 +44,18 @@ export function useReviewPanel<T>(
   selector: (state: ReviewPanelStoreState) => T,
 ): T {
   return useStore(useReviewPanelStore(), selector);
+}
+
+export function useOptionalReviewPanelStore(): ReviewPanelStore | null {
+  return useContext(ReviewPanelContext);
+}
+
+export function useOptionalReviewPanel<T>(
+  selector: (state: ReviewPanelStoreState) => T,
+): T | undefined {
+  const store = useContext(ReviewPanelContext);
+  const selected = useStore(store ?? fallbackReviewPanelStore, selector);
+  return store ? selected : undefined;
 }
 
 export function useReviewPanelStore(): ReviewPanelStore {

--- a/packages/progressive-review/app/src/review-view-route.ts
+++ b/packages/progressive-review/app/src/review-view-route.ts
@@ -1,4 +1,4 @@
-export type ReviewView = "review" | "commits" | "map" | "diff";
+export type ReviewView = "review" | "commits" | "map" | "diff" | "trace";
 
 export function normalizeReviewView(
   view: ReviewView,
@@ -6,7 +6,10 @@ export function normalizeReviewView(
   hasChangeRange = true,
 ): ReviewView {
   if (view === "map" && !softwareMapEnabled) return "review";
-  if (!hasChangeRange && (view === "commits" || view === "diff")) {
+  if (
+    !hasChangeRange &&
+    (view === "commits" || view === "diff" || view === "trace")
+  ) {
     return "review";
   }
   return view;
@@ -16,6 +19,7 @@ export function reviewViewLabel(view: ReviewView): string {
   if (view === "map") return "Map";
   if (view === "diff") return "Diff";
   if (view === "commits") return "Commits";
+  if (view === "trace") return "Trace";
   return "Review";
 }
 

--- a/packages/progressive-review/app/src/sequence-tour.test.ts
+++ b/packages/progressive-review/app/src/sequence-tour.test.ts
@@ -15,7 +15,7 @@ import { createTestReviewDefinitionSession } from "./review-definition-test-util
 import { defineSoftwareModel } from "./software-map/model";
 
 const definitions = createTestReviewDefinitionSession();
-const { defineActors, defineAnchors, defineSoftwareActors } = definitions;
+const { defineActors, defineAnchors } = definitions;
 
 describe("sequence diagram guided tour", () => {
   it("uses the same colours for sequence lines and arrowheads", () => {
@@ -307,35 +307,40 @@ describe("sequence diagram guided tour", () => {
     );
   });
 
-  it("owns duplicate anchor validation within one sequence", () => {
+  it("allows one code anchor to support multiple sequence messages", async () => {
     const anchors = defineAnchors({
       request: {
         title: "Request",
         peek: { file: "src/example.ts", fromLine: 1, toLine: 3 },
       },
     });
-    expectZodIssue(
-      () =>
-        createSequence({
-          label: "Duplicate",
-          messages: [
-            {
-              from: { label: "A" },
-              to: { label: "B" },
-              label: "Send",
-              anchor: anchors.request,
-            },
-            {
-              from: { label: "B" },
-              to: { label: "A" },
-              label: "Reply",
-              anchor: anchors.request,
-            },
-          ],
-        }),
-      ["messages", 1, "anchor"],
-      "Anchor must be used only once within this diagram",
-    );
+    const sequence = createSequence({
+      label: "Reuse",
+      messages: [
+        {
+          from: { label: "A" },
+          to: { label: "B" },
+          label: "Send",
+          anchor: anchors.request,
+        },
+        {
+          from: { label: "B" },
+          to: { label: "A" },
+          label: "Reply",
+          anchor: anchors.request,
+        },
+      ],
+    });
+
+    expect(sequence.messages.map((message) => message.anchor.id)).toEqual([
+      "request",
+      "request--sequence-use-2",
+    ]);
+    expect(sequence.messages[1]?.anchor.peek).toBe(anchors.request.peek);
+    await definitions.ready();
+    expect(
+      createSequenceTourEntry(sequence).stops.map((stop) => stop.anchor.id),
+    ).toEqual(["request", "request--sequence-use-2"]);
   });
 
   it("rejects ambiguous parallel edge label paths", () => {

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -675,45 +675,10 @@
   box-sizing: border-box;
 }
 
-/* Scrollbars. The workbench draws a slider and no track -- a translucent pill
-   floating over the content that brightens on hover and drag -- so the canvas
-   bridges the same scrollbarSlider tokens and paints the track transparent.
-   These are universal rather than class-scoped on purpose: the desktop build
-   wraps this whole sheet in @scope (.review-canvas-root) (see
-   desktop-css-scope.ts), so they cannot reach workbench DOM, and the browser
-   build is the canvas all the way up. Monaco is unaffected either way -- it
-   renders its own slider elements rather than a native overflow scrollbar.
-   Only the -webkit- pseudo-elements are used: Chromium gives the standard
-   scrollbar-width/scrollbar-color properties precedence over them, so setting
-   both would paint the track back in. */
-*::-webkit-scrollbar {
-  width: var(--review-scrollbar-size);
-  height: var(--review-scrollbar-size);
-  background: var(--transparent);
-}
-
-*::-webkit-scrollbar-track,
-*::-webkit-scrollbar-corner {
-  background: var(--transparent);
-}
-
-*::-webkit-scrollbar-thumb {
-  min-height: 28px;
-  border: 2px solid var(--transparent);
-  border-radius: 999px;
-  background-color: var(--review-scrollbar-thumb);
-  /* Inset the pill inside the transparent border rather than shrinking the
-     scrollbar, so the hit target stays the full track width. */
-  background-clip: content-box;
-}
-
-*::-webkit-scrollbar-thumb:hover {
-  background-color: var(--review-scrollbar-thumb-hover);
-}
-
-*::-webkit-scrollbar-thumb:active {
-  background-color: var(--review-scrollbar-thumb-active);
-}
+/* Scrollbars: deliberately unstyled. Any custom ::-webkit-scrollbar rule
+   makes Chromium abandon the platform overlay scrollbars; leaving them
+   native gives auto-hiding bars that appear only while scrolling (per the
+   user's OS setting). Monaco still renders its own slider elements. */
 
 .review-canvas-root {
   margin: 0;
@@ -2341,7 +2306,7 @@ button {
   padding: 24px;
   border: 1px solid var(--rule-soft);
   border-radius: 8px;
-  background: var(--bg-1);
+  background: var(--bg-2);
   font-family: var(--font-mono);
 }
 
@@ -4394,7 +4359,7 @@ button {
   gap: 8px;
   min-height: 34px;
   padding: 7px 11px;
-  border: 1px solid var(--rule-strong);
+  border: 1px solid var(--rule-soft);
   border-radius: 999px;
   background: var(--floating-bar-bg);
   box-shadow: 0 12px 28px var(--shadow-color-strong);
@@ -5367,11 +5332,11 @@ button {
   color: var(--ink-faint);
 }
 
-/* Floating presentation of the same card at narrow widths. Position and width
-   are owned by popoverStyle() in thread-annotations.tsx, which clamps placement
-   against POPOVER_WIDTH — declaring either here would immediately drift. */
+/* Floating presentation of the same card at narrow widths. The portal mounts
+   this direct child of .review-app so the document scroller cannot clip it.
+   Position and width stay with popoverStyle() in thread-annotations.tsx. */
 .thread-popover {
-  z-index: 40;
+  z-index: 60;
 }
 
 .review-floating-draft {
@@ -5605,7 +5570,7 @@ button {
 
 .agent-markdown blockquote {
   padding-left: 10px;
-  border-left: 3px solid var(--rule-strong);
+  border-left: 3px solid var(--rule-soft);
   color: var(--ink-faint);
 }
 
@@ -8936,6 +8901,32 @@ a.review-doc-meta-pr:hover {
   font-family: inherit;
 }
 
+.review-agent-setup-trace {
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.review-agent-setup-trace .review-agent-setup-terminal-info {
+  flex-basis: 100%;
+  flex-wrap: wrap;
+}
+
+.review-agent-setup-trace-fields {
+  display: grid;
+  flex: 1;
+  grid-template-columns: repeat(2, minmax(160px, 1fr));
+  gap: 6px;
+}
+
+.review-agent-setup-trace-fields input {
+  min-width: 0;
+  padding: 5px 8px;
+  border: 1px solid var(--review-home-rule-soft);
+  border-radius: 5px;
+  color: inherit;
+  background: var(--control-bg);
+}
+
 .review-agent-setup button.review-agent-setup-subtle {
   border-color: var(--transparent);
   color: var(--review-home-meta);
@@ -9591,4 +9582,778 @@ a.review-doc-meta-pr:hover {
   color: var(--diff-removed);
   border-bottom-color: var(--diff-removed);
   opacity: 0.85;
+}
+
+/* Agent trace view */
+
+.review-view-region--trace {
+  overflow: auto;
+}
+
+.review-trace-view {
+  min-height: 100%;
+  padding: 36px 24px 96px;
+}
+
+.review-trace-column {
+  width: min(980px, 100%);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.review-trace-kicker {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.review-trace-header {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.review-trace-title {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: 22px;
+  line-height: 28px;
+  font-weight: 500;
+  color: var(--ink);
+}
+
+.review-trace-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-faint);
+}
+
+.review-trace-meta-sep {
+  color: var(--rule-soft);
+}
+
+.review-trace-picker {
+  position: relative;
+  display: inline-block;
+  margin-bottom: 20px;
+}
+
+.review-trace-picker-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: min(680px, 100%);
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 6px;
+  border: 1px solid var(--rule);
+  background: var(--surface);
+  color: var(--ink);
+  font-size: 12.5px;
+  cursor: pointer;
+  box-shadow: 0 1px 2px var(--shadow-color);
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.review-trace-picker-trigger:hover {
+  border-color: var(--rule-soft);
+  background: var(--bg-2);
+}
+
+.review-trace-picker-trigger[aria-expanded="true"] {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-wash);
+}
+
+.review-trace-picker-harness {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.review-trace-picker-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+  color: var(--ink);
+}
+
+.review-trace-picker-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+  margin-left: 2px;
+  flex-shrink: 0;
+  color: var(--ink-faint);
+  transition: transform 0.15s ease;
+}
+
+.review-trace-picker-trigger[aria-expanded="true"]
+  .review-trace-picker-chevron {
+  transform: rotate(180deg);
+}
+
+.review-trace-picker-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 50;
+  min-width: 320px;
+  max-width: min(640px, 90vw);
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  box-shadow: 0 6px 20px var(--shadow-color-strong);
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.review-trace-picker-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: none;
+  background: transparent;
+  color: var(--ink);
+  font-size: 12.5px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+
+.review-trace-picker-item:hover {
+  background: var(--bg-2);
+}
+
+.review-trace-picker-item--active {
+  background: var(--accent-wash);
+  color: var(--accent);
+}
+
+.review-trace-picker-item--active:hover {
+  background: var(--accent-wash);
+}
+
+.review-trace-picker-item--subagent {
+  padding-left: 20px;
+}
+
+.review-trace-picker-item-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  overflow: hidden;
+  min-width: 0;
+  flex: 1;
+}
+
+.review-trace-picker-item-harness {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  flex-shrink: 0;
+  min-width: 52px;
+}
+
+.review-trace-picker-item--active .review-trace-picker-item-harness {
+  color: var(--accent);
+}
+
+.review-trace-picker-item-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 400;
+}
+
+.review-trace-picker-item--active .review-trace-picker-item-title {
+  font-weight: 600;
+}
+
+.review-trace-picker-item-check {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--accent);
+  flex-shrink: 0;
+  margin-left: 6px;
+}
+
+.review-trace-picker-item-badge {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: var(--bg-2);
+  color: var(--ink-faint);
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.review-trace-events {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-top: 28px;
+}
+
+.review-trace-turn {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.review-trace-user {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
+  margin-top: 14px;
+  margin-left: auto;
+  max-width: min(480px, 90%);
+  min-width: 0;
+}
+
+.review-trace-user-bubble {
+  padding: 12px 14px;
+  background: var(--bg-2);
+  border-radius: 12px 12px 4px 12px;
+  font-family: var(--font-serif);
+  font-size: 15px;
+  line-height: 24px;
+  color: var(--ink);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.review-trace-timestamp {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-faint);
+}
+
+.review-trace-thinking {
+  position: relative;
+  padding: 10px 14px;
+  border-left: 2px solid var(--rule-soft);
+  background: var(--bg-2);
+  border-radius: 0 6px 6px 0;
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+
+.review-trace-thinking-label {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 6px;
+}
+
+.review-trace-prose .agent-markdown {
+  font-family: var(--font-serif);
+  font-size: 15px;
+  line-height: 26px;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+
+.review-trace-tool {
+  min-width: 0;
+}
+
+.review-trace-tool summary {
+  list-style: none;
+  cursor: pointer;
+}
+
+.review-trace-tool summary::-webkit-details-marker {
+  display: none;
+}
+
+.review-trace-tool-row {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr) 16px;
+  column-gap: 6px;
+  align-items: center;
+  min-height: 24px;
+}
+
+.review-trace-icon {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: var(--ink-faint);
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.review-trace-tool-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.review-trace-tool-label {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 19px;
+}
+
+.review-trace-tool-verb {
+  color: var(--ink-faint);
+  flex-shrink: 0;
+}
+
+.review-trace-tool-title {
+  color: var(--ink-soft);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.review-trace-tool-title--file {
+  color: var(--accent);
+  /* Ellipsize the FRONT of paths so the filename stays visible. */
+  direction: rtl;
+  text-align: left;
+}
+
+.review-trace-tool-title--file bdi {
+  unicode-bidi: plaintext;
+}
+
+.review-trace-added {
+  color: var(--change-added);
+  flex-shrink: 0;
+}
+
+.review-trace-removed {
+  color: var(--change-removed);
+  flex-shrink: 0;
+}
+
+.review-trace-error-flag {
+  color: var(--change-removed);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.review-trace-tool-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.review-trace-tool-chevron .review-trace-icon {
+  width: 12px;
+  height: 12px;
+  stroke: var(--rule-soft);
+  transform: rotate(-90deg);
+  transition: transform 120ms ease;
+}
+
+.review-trace-tool--expandable[open]
+  .review-trace-tool-chevron
+  .review-trace-icon {
+  transform: rotate(0deg);
+}
+
+.review-trace-figure {
+  margin: 10px 0 0 26px;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.review-trace-figure-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 30px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--rule);
+  background: var(--bg-2);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.review-trace-figure-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 14px 16px;
+  max-height: 420px;
+  overflow: auto;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 20px;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+.review-trace-figure-body--thinking {
+  white-space: normal;
+  font-family: var(--font-serif);
+  font-size: 14px;
+  line-height: 22px;
+  color: var(--ink-soft);
+}
+
+.review-trace-figure-body--thinking .agent-markdown {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  color: inherit;
+}
+
+.review-trace-figure-command {
+  color: var(--ink);
+}
+
+.review-trace-figure-output {
+  color: var(--ink-soft);
+}
+
+.review-trace-worked > summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 6px 0 0;
+  list-style: none;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.review-trace-worked > summary::-webkit-details-marker {
+  display: none;
+}
+
+.review-trace-worked > summary:hover {
+  color: var(--ink-soft);
+}
+
+.review-trace-worked-chevron {
+  display: inline-flex;
+  align-items: center;
+}
+
+.review-trace-worked-chevron .review-trace-icon {
+  width: 11px;
+  height: 11px;
+  stroke: var(--ink-faint);
+  transform: rotate(-90deg);
+  transition: transform 120ms ease;
+}
+
+.review-trace-worked[open] .review-trace-worked-chevron .review-trace-icon {
+  transform: rotate(0deg);
+}
+
+.review-trace-worked-line {
+  flex-grow: 1;
+  height: 1px;
+  background: var(--rule);
+}
+
+.review-trace-worked-body {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-top: 18px;
+}
+
+/* The embedded workbench Chromium does not hide closed details content. */
+.review-trace-worked:not([open]) > .review-trace-worked-body {
+  display: none;
+}
+
+.review-trace-tool--expandable:not([open]) > .review-trace-figure {
+  display: none;
+}
+
+.review-trace-toolgroup:not([open]) > .review-trace-toolgroup-body {
+  display: none;
+}
+
+/* Coalesced tool runs: one summary row per consecutive tool-call run */
+
+.review-trace-toolgroup {
+  min-width: 0;
+}
+
+.review-trace-toolgroup > summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 24px;
+  list-style: none;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--ink-soft);
+}
+
+.review-trace-toolgroup > summary::-webkit-details-marker {
+  display: none;
+}
+
+.review-trace-toolgroup-label {
+  color: var(--ink-soft);
+}
+
+.review-trace-toolgroup-count {
+  color: var(--ink-faint);
+  font-size: 11px;
+}
+
+.review-trace-toolgroup-chevron {
+  display: inline-flex;
+  align-items: center;
+}
+
+.review-trace-toolgroup-chevron .review-trace-icon {
+  width: 12px;
+  height: 12px;
+  stroke: var(--rule-soft);
+  transform: rotate(-90deg);
+  transition: transform 120ms ease;
+}
+
+.review-trace-toolgroup[open]
+  > summary
+  .review-trace-toolgroup-chevron
+  .review-trace-icon {
+  transform: rotate(0deg);
+}
+
+.review-trace-toolgroup-body {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 2px 0 4px 26px;
+}
+
+.review-trace-note {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 19px;
+  color: var(--ink-faint);
+}
+
+.review-trace-note--error {
+  color: var(--change-removed);
+}
+
+.review-trace-empty,
+.review-trace-unconfigured {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 48px;
+  font-family: var(--font-serif);
+  font-size: 15px;
+  line-height: 26px;
+  color: var(--ink);
+}
+
+.review-trace-empty p,
+.review-trace-unconfigured p {
+  margin: 0;
+}
+
+/* Lens / peek scoped trace elements */
+
+.review-trace-events--scoped {
+  margin-top: 22px;
+}
+
+.review-trace-lens-gap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 4px 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  width: 100%;
+}
+
+.review-trace-lens-gap-line {
+  flex-grow: 1;
+  height: 1px;
+  border-top: 1px dashed var(--rule-soft);
+}
+
+.review-trace-lens-gap-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 22px;
+  padding: 0 10px;
+  border: 1px dashed var(--rule-soft);
+  border-radius: 999px;
+  background: var(--surface);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
+.review-trace-lens-gap:hover .review-trace-lens-gap-chip {
+  color: var(--ink-soft);
+  border-color: var(--ink-faint);
+}
+
+.review-trace-lens-elided {
+  display: inline;
+}
+
+.review-trace-lens-kept {
+  font-family: var(--font-serif);
+  font-size: 15px;
+  line-height: 26px;
+  color: var(--ink);
+}
+
+.review-trace-user-bubble--elided .review-trace-lens-kept {
+  line-height: 24px;
+}
+
+.review-trace-lens-chip {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  margin: 0 6px;
+  padding: 0 7px;
+  border: 1px dashed var(--rule-soft);
+  border-radius: 999px;
+  background: var(--surface);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-faint);
+  cursor: pointer;
+  vertical-align: baseline;
+}
+
+.review-trace-lens-chip:hover {
+  color: var(--ink-soft);
+  border-color: var(--ink-faint);
+}
+
+.review-trace-prose--elided {
+  font-family: var(--font-serif);
+  font-size: 15px;
+  line-height: 26px;
+  color: var(--ink);
+}
+
+/* Quote links and marks */
+
+.review-trace-quote,
+.review-trace-quote:visited {
+  color: var(--accent);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.review-trace-quote:hover {
+  text-decoration: underline;
+}
+
+.review-trace-quote[data-review-anchor-open] {
+  background: var(--link-open-wash);
+}
+
+.review-trace-quote--inert {
+  color: var(--ink-faint);
+  text-decoration: none;
+  cursor: default;
+}
+
+.review-trace-quote--inert:hover {
+  text-decoration: none;
+}
+
+.review-trace-quote-mark,
+.review-trace-rfc-mark {
+  background: rgba(255, 230, 0, 0.35);
+  color: inherit;
+  border-radius: 2px;
+  padding: 1px 2px;
+}
+
+.review-trace-peek-open-full {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--rule-soft);
+  background: var(--surface);
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.review-trace-peek-open-full:hover {
+  background: var(--accent-wash);
 }

--- a/packages/progressive-review/app/src/thread-annotations.tsx
+++ b/packages/progressive-review/app/src/thread-annotations.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 
 import type { ThreadTarget } from "../../src/types";
 import {
@@ -25,6 +26,7 @@ import {
   useReview,
 } from "./review-context";
 import { reviewDocumentRange } from "./review-document-text";
+import { useReviewRoots } from "./review-root-context";
 import {
   type ThreadView,
   commentThreadView,
@@ -43,7 +45,7 @@ import {
 } from "./thread-target-state";
 import { captureUiEvent } from "./ui-telemetry";
 
-/** Single source for popover geometry; `.thread-popover` owns nothing but z-index. */
+/** Single source for popover geometry; `.thread-popover` owns only its layer. */
 const POPOVER_WIDTH = 420;
 /** Narrowest margin card worth showing; below this the popover reads better. */
 export const CARD_MIN_WIDTH = 266;
@@ -169,6 +171,7 @@ export function ThreadAnnotations({
 }): ReactElement | null {
   const session = useReviewSession();
   const review = useReview();
+  const reviewRoots = useReviewRoots();
   const commentThreads = review.allCommentThreads();
   const draftTarget = isGlobalCommentDraft(review.draftTarget)
     ? null
@@ -280,7 +283,9 @@ export function ThreadAnnotations({
 
   const closeDraftIfEmpty = () => {
     if (!draftTarget) return;
-    const hasText = draftHasTextRef.current || draftTextareaHasText(rootRef);
+    const hasText =
+      draftHasTextRef.current ||
+      draftTextareaHasText(rootRef, reviewRoots?.appRef.current);
     if (!hasText) review.closeCommentDraft();
   };
 
@@ -680,6 +685,7 @@ export function ThreadAnnotations({
     gutter?.mode === "cards"
       ? annotations.filter((annotation) => annotation.anchorY !== null)
       : [];
+  const popoverHost = reviewRoots?.appRef.current ?? null;
 
   return (
     <div ref={rootRef}>
@@ -732,24 +738,30 @@ export function ThreadAnnotations({
             </span>
           );
         })}
-        {gutter?.mode !== "cards" && draftTarget && (
-          <div
-            className="thread-popover"
-            style={popoverStyle(draftPopoverPlacement(articleRef, draftTarget))}
-          >
-            <ThreadDraftCardWithState
-              quote={draftQuote}
-              variant="popover"
-              intent={draftTarget.intent}
-              initialDraft={draftTextRef.current}
-              onDraftStateChange={updateDraftHasText}
-              onDraftTextChange={updateDraftText}
-              onSubmitComment={(body) => submitDraft(false, body)}
-              onAskAgent={(body) => submitDraft(true, body)}
-              onCancel={() => review.closeCommentDraft()}
-            />
-          </div>
-        )}
+        {gutter?.mode !== "cards" &&
+          draftTarget &&
+          popoverHost &&
+          createPortal(
+            <div
+              className="thread-popover"
+              style={popoverStyle(
+                draftPopoverPlacement(popoverHost, draftTarget),
+              )}
+            >
+              <ThreadDraftCardWithState
+                quote={draftQuote}
+                variant="popover"
+                intent={draftTarget.intent}
+                initialDraft={draftTextRef.current}
+                onDraftStateChange={updateDraftHasText}
+                onDraftTextChange={updateDraftText}
+                onSubmitComment={(body) => submitDraft(false, body)}
+                onAskAgent={(body) => submitDraft(true, body)}
+                onCancel={() => review.closeCommentDraft()}
+              />
+            </div>,
+            popoverHost,
+          )}
       </div>
       {gutter?.mode === "cards" && (marginCards.length > 0 || draftTarget) && (
         <div
@@ -811,17 +823,21 @@ function popoverStyle(placement: { x: number; y: number }): CSSProperties {
     top: placement.y,
     // Width lives here, not in `.thread-popover`, so it cannot drift from the
     // POPOVER_WIDTH the placement clamps are computed against.
-    width: `min(${POPOVER_WIDTH}px, calc(100vw - 32px))`,
+    width: `min(${POPOVER_WIDTH}px, calc(100% - 24px))`,
     pointerEvents: "auto",
   };
 }
 
 function draftTextareaHasText(
   rootRef: RefObject<HTMLDivElement | null>,
+  popoverHost?: HTMLElement | null,
 ): boolean {
-  const textarea = rootRef.current?.querySelector<HTMLTextAreaElement>(
-    ".thread-card--draft textarea",
-  );
+  const selector = ".thread-card--draft textarea";
+  const textarea =
+    rootRef.current?.querySelector<HTMLTextAreaElement>(selector) ??
+    popoverHost?.querySelector<HTMLTextAreaElement>(
+      `.thread-popover ${selector}`,
+    );
   return Boolean(textarea?.value.trim());
 }
 
@@ -853,26 +869,23 @@ function targetStateMapsEqual(
 }
 
 function draftPopoverPlacement(
-  articleRef: RefObject<HTMLElement | null>,
+  popoverHost: HTMLElement,
   draftTarget: CommentDraftTarget,
 ): { x: number; y: number } {
-  const article =
-    articleRef.current ??
-    document.querySelector<HTMLElement>(".review-document");
-  const articleRect = article?.getBoundingClientRect();
+  const hostRect = popoverHost.getBoundingClientRect();
   const viewportX = clamp(
-    draftTarget.placement?.x ?? window.innerWidth / 2,
-    12,
-    Math.max(12, window.innerWidth - POPOVER_WIDTH - 12),
+    draftTarget.placement?.x ?? hostRect.left + hostRect.width / 2,
+    hostRect.left + 12,
+    Math.max(hostRect.left + 12, hostRect.right - POPOVER_WIDTH - 12),
   );
   const viewportY = clamp(
     draftTarget.placement?.y ?? 200,
-    12,
-    window.innerHeight - 200,
+    hostRect.top + 12,
+    Math.max(hostRect.top + 12, hostRect.bottom - 200),
   );
   return {
-    x: viewportX - (articleRect?.left ?? 0),
-    y: viewportY - (articleRect?.top ?? 0),
+    x: viewportX - hostRect.left,
+    y: viewportY - hostRect.top,
   };
 }
 

--- a/packages/progressive-review/app/src/trace-document.test.tsx
+++ b/packages/progressive-review/app/src/trace-document.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+
+import type { ReviewAgentTraceEvent } from "@dev.fast/review-protocol";
+import { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TraceDocument } from "./trace-document";
+
+let root: Root | null = null;
+let container: HTMLDivElement;
+
+describe("TraceDocument", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root?.unmount());
+      root = null;
+    }
+    document.body.replaceChildren();
+  });
+
+  const sampleEvents: ReviewAgentTraceEvent[] = [
+    // Turn 0: events 0..4
+    { kind: "user", text: "First turn question", at: "2025-01-01T00:00:00Z" },
+    {
+      kind: "tool",
+      tool: "edit",
+      verb: "Edited",
+      title: "src/a.ts",
+      input: "edit a",
+      at: "2025-01-01T00:00:05Z",
+    },
+    {
+      kind: "tool",
+      tool: "edit",
+      verb: "Edited",
+      title: "src/b.ts",
+      input: "edit b",
+      at: "2025-01-01T00:00:10Z",
+    },
+    {
+      kind: "tool",
+      tool: "edit",
+      verb: "Edited",
+      title: "src/c.ts",
+      input: "edit c",
+      at: "2025-01-01T00:00:15Z",
+    },
+    {
+      kind: "assistant",
+      thinking: false,
+      markdown: "First turn answer.",
+      at: "2025-01-01T00:00:20Z",
+    },
+
+    // Turn 1: events 5..9 (Target turn)
+    { kind: "user", text: "Second turn question", at: "2025-01-01T00:01:00Z" },
+    {
+      kind: "tool",
+      tool: "bash",
+      verb: "Ran",
+      title: "pnpm build",
+      command: "pnpm build",
+      at: "2025-01-01T00:01:05Z",
+    },
+    {
+      kind: "tool",
+      tool: "bash",
+      verb: "Ran",
+      title: "pnpm test",
+      command: "pnpm test",
+      at: "2025-01-01T00:01:10Z",
+    },
+    {
+      kind: "tool",
+      tool: "bash",
+      verb: "Ran",
+      title: "pnpm lint",
+      command: "pnpm lint",
+      at: "2025-01-01T00:01:15Z",
+    },
+    {
+      kind: "assistant",
+      thinking: false,
+      markdown: "Second turn answer with optimize database queries in it.",
+      at: "2025-01-01T00:01:20Z",
+    },
+  ];
+
+  it("coalesces tool runs in every turn; a group containing the target renders open", async () => {
+    // Target event is event 6 (inside Turn 1)
+    await act(async () => {
+      root?.render(
+        <TraceDocument
+          events={sampleEvents}
+          targetEventIndex={6}
+          highlightQuote="pnpm build"
+        />,
+      );
+    });
+
+    const turns = container.querySelectorAll(".review-trace-turn");
+    expect(turns.length).toBe(2);
+
+    // Turn 0 (non-target turn): 3 edit tools should coalesce into 1 TraceToolGroup
+    const turn0 = turns[0];
+    const turn0ToolGroups = turn0.querySelectorAll(".review-trace-toolgroup");
+    expect(turn0ToolGroups.length).toBe(1);
+    expect(turn0ToolGroups[0].textContent).toContain("Edited 3 files");
+
+    // Turn 1 (contains targetEventIndex 6): tools coalesce too, but the
+    // group holding the target renders expanded so the target stays visible.
+    const turn1 = turns[1];
+    const turn1ToolGroups = turn1.querySelectorAll(".review-trace-toolgroup");
+    expect(turn1ToolGroups.length).toBe(1);
+    expect(turn1ToolGroups[0].hasAttribute("open")).toBe(true);
+    expect(turn1.textContent).toContain("pnpm build");
+    expect(turn1.textContent).toContain("pnpm test");
+    expect(turn1.textContent).toContain("pnpm lint");
+
+    // Target event should have #review-trace-target-event
+    const targetEl = container.querySelector("#review-trace-target-event");
+    expect(targetEl).not.toBeNull();
+    expect(targetEl?.textContent).toContain("pnpm build");
+  });
+
+  it("renders gap chips when picks are provided and expands them on click", async () => {
+    // Picks only include Turn 1 (events 5..9)
+    const picks = [
+      { event: 5, keep: ["Second turn"] },
+      { events: [6, 9] as [number, number] },
+    ];
+
+    await act(async () => {
+      root?.render(
+        <TraceDocument
+          events={sampleEvents}
+          targetEventIndex={5}
+          picks={picks}
+        />,
+      );
+    });
+
+    // Turn 0 is hidden -> gap chip for 5 hidden events
+    const initialGaps = container.querySelectorAll(".review-trace-lens-gap");
+    expect(initialGaps.length).toBe(1);
+    expect(initialGaps[0].textContent).toContain("5 hidden events");
+
+    // Click to expand gap
+    const gapButton = initialGaps[0] as HTMLButtonElement;
+    await act(async () => {
+      gapButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    // Now Turn 0 is revealed!
+    expect(container.textContent).toContain("First turn question");
+    expect(container.textContent).toContain("First turn answer.");
+
+    // Tools coalesce in every turn: Turn 0's revealed run plus the target
+    // turn's run (which renders open because it contains the target).
+    const toolGroups = container.querySelectorAll(".review-trace-toolgroup");
+    expect(toolGroups.length).toBe(2);
+    expect(toolGroups[0].textContent).toContain("Edited 3 files");
+  });
+
+  it("expands elided message text when ellipsis chip is clicked", async () => {
+    const picks = [{ event: 9, keep: ["optimize database queries"] }];
+
+    await act(async () => {
+      root?.render(
+        <TraceDocument
+          events={sampleEvents}
+          targetEventIndex={9}
+          highlightQuote="optimize database queries"
+          picks={picks}
+        />,
+      );
+    });
+
+    // Message is elided with a ⋯ chip
+    const chipButton = container.querySelector(
+      ".review-trace-lens-chip",
+    ) as HTMLButtonElement;
+    expect(chipButton).not.toBeNull();
+    expect(
+      container.querySelector(".review-trace-quote-mark")?.textContent,
+    ).toBe("optimize database queries");
+
+    // Click ⋯ chip
+    await act(async () => {
+      chipButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    // Message is now fully expanded
+    expect(container.textContent).toContain(
+      "Second turn answer with optimize database queries in it.",
+    );
+  });
+
+  it("renders the entire user message and highlights the quote without elision", async () => {
+    // When turn range is included without a keep filter
+    const picks = [{ events: [5, 9] as [number, number] }];
+
+    await act(async () => {
+      root?.render(
+        <TraceDocument
+          events={sampleEvents}
+          targetEventIndex={5}
+          highlightQuote="Second turn"
+          picks={picks}
+        />,
+      );
+    });
+
+    // Full text of the user message is visible without ellipsis chips
+    expect(container.querySelector(".review-trace-lens-chip")).toBeNull();
+    const userBubble = container.querySelector(".review-trace-user-bubble");
+    expect(userBubble?.textContent).toBe("Second turn question");
+    expect(
+      userBubble?.querySelector(".review-trace-quote-mark")?.textContent,
+    ).toBe("Second turn");
+  });
+
+  it("scrolls directly to the highlighted quote mark when available", async () => {
+    const scrollCalls: Element[] = [];
+    Element.prototype.scrollIntoView = vi
+      .fn<typeof Element.prototype.scrollIntoView>()
+      .mockImplementation(function (this: Element) {
+        scrollCalls.push(this);
+      });
+
+    await act(async () => {
+      root?.render(
+        <TraceDocument
+          events={sampleEvents}
+          targetEventIndex={9}
+          highlightQuote="optimize database queries"
+          picks={[{ events: [5, 9] }]}
+        />,
+      );
+    });
+
+    const quoteMark = container.querySelector(".review-trace-quote-mark");
+    expect(quoteMark).not.toBeNull();
+    expect(scrollCalls).toContain(quoteMark);
+  });
+});

--- a/packages/progressive-review/app/src/trace-document.tsx
+++ b/packages/progressive-review/app/src/trace-document.tsx
@@ -1,0 +1,1132 @@
+import type { ReviewAgentTraceEvent } from "@dev.fast/review-protocol";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+
+import { AgentMarkdown } from "./agent-markdown";
+import {
+  HighlightedText,
+  findWhitespaceNormalizedSpan,
+} from "./highlighted-text";
+
+export type TraceTurnEvent = Exclude<
+  ReviewAgentTraceEvent,
+  { kind: "separator" }
+>;
+
+export interface TraceTurnGroup {
+  user: Extract<TraceTurnEvent, { kind: "user" }> | null;
+  work: TraceTurnEvent[];
+  final: TraceTurnEvent[];
+  workedMs: number | null;
+}
+
+const TURN_ACTIVE_GAP_LIMIT_MS = 10 * 60 * 1000;
+
+export interface IndexedTraceTurnEvent {
+  event: TraceTurnEvent;
+  index: number;
+}
+
+export interface IndexedTraceTurnGroup {
+  user: IndexedTraceTurnEvent | null;
+  work: IndexedTraceTurnEvent[];
+  final: IndexedTraceTurnEvent[];
+  workedMs: number | null;
+}
+
+export function buildIndexedTraceTurns(
+  events: ReviewAgentTraceEvent[],
+): IndexedTraceTurnGroup[] {
+  const turns: IndexedTraceTurnGroup[] = [];
+  let current: {
+    user: IndexedTraceTurnEvent | null;
+    items: IndexedTraceTurnEvent[];
+  } | null = null;
+
+  const finish = () => {
+    if (!current) return;
+    let splitIndex = current.items.length;
+    while (
+      splitIndex > 0 &&
+      current.items[splitIndex - 1].event.kind === "assistant" &&
+      !(
+        current.items[splitIndex - 1].event as Extract<
+          TraceTurnEvent,
+          { kind: "assistant" }
+        >
+      ).thinking
+    ) {
+      splitIndex -= 1;
+    }
+    const allItems = current.user
+      ? [current.user.event, ...current.items.map((i) => i.event)]
+      : current.items.map((i) => i.event);
+    turns.push({
+      user: current.user,
+      work: current.items.slice(0, splitIndex),
+      final: current.items.slice(splitIndex),
+      workedMs: activeSpanMs(allItems),
+    });
+    current = null;
+  };
+
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
+    if (event.kind === "separator") continue;
+    if (event.kind === "user") {
+      finish();
+      current = { user: { event, index: i }, items: [] };
+      continue;
+    }
+    current ??= { user: null, items: [] };
+    current.items.push({ event, index: i });
+  }
+  finish();
+  return turns;
+}
+
+export function buildTraceTurns(
+  events: ReviewAgentTraceEvent[],
+): TraceTurnGroup[] {
+  return buildIndexedTraceTurns(events).map((t) => ({
+    user: t.user
+      ? (t.user.event as Extract<TraceTurnEvent, { kind: "user" }>)
+      : null,
+    work: t.work.map((w) => w.event),
+    final: t.final.map((f) => f.event),
+    workedMs: t.workedMs,
+  }));
+}
+
+function activeSpanMs(events: TraceTurnEvent[]): number | null {
+  let total = 0;
+  let previous: number | null = null;
+  let sawTimestamp = false;
+  for (const event of events) {
+    if (!event.at) continue;
+    const at = Date.parse(event.at);
+    if (!Number.isFinite(at)) continue;
+    sawTimestamp = true;
+    if (previous !== null && at > previous) {
+      total += Math.min(at - previous, TURN_ACTIVE_GAP_LIMIT_MS);
+    }
+    previous = at;
+  }
+  return sawTimestamp ? total : null;
+}
+
+export type IndexedTraceToolItem = {
+  event: Extract<ReviewAgentTraceEvent, { kind: "tool" }>;
+  index: number;
+};
+
+export function groupIndexedWorkEvents(
+  work: IndexedTraceTurnEvent[],
+): Array<IndexedTraceTurnEvent | IndexedTraceToolItem[]> {
+  const items: Array<IndexedTraceTurnEvent | IndexedTraceToolItem[]> = [];
+  let run: IndexedTraceToolItem[] = [];
+  const flush = () => {
+    if (run.length === 0) return;
+    if (run.length === 1) items.push(run[0]);
+    else items.push(run);
+    run = [];
+  };
+  for (const item of work) {
+    if (item.event.kind === "tool") {
+      run.push(item as IndexedTraceToolItem);
+      continue;
+    }
+    flush();
+    items.push(item);
+  }
+  flush();
+  return items;
+}
+
+export function toolGroupLabel(
+  events: Array<Extract<ReviewAgentTraceEvent, { kind: "tool" }>>,
+): string {
+  const categories = new Map<string, number>();
+  for (const event of events) {
+    const verb = event.verb;
+    const key =
+      verb === "Edited" || verb === "Wrote" || verb === "Added"
+        ? "edited"
+        : verb === "Deleted"
+          ? "deleted"
+          : verb === "Ran"
+            ? "ran"
+            : verb === "Read"
+              ? "read"
+              : verb === "Ran agent"
+                ? "agents"
+                : verb.startsWith("Searched")
+                  ? "searched"
+                  : "called";
+    categories.set(key, (categories.get(key) ?? 0) + 1);
+  }
+  const phrase = (key: string, count: number): string => {
+    const plural = count !== 1;
+    if (key === "edited") return `edited ${count} ${plural ? "files" : "file"}`;
+    if (key === "deleted")
+      return `deleted ${count} ${plural ? "files" : "file"}`;
+    if (key === "ran") return `ran ${count} ${plural ? "commands" : "command"}`;
+    if (key === "read") return `read ${count} ${plural ? "files" : "file"}`;
+    if (key === "agents") return `ran ${count} ${plural ? "agents" : "agent"}`;
+    if (key === "searched")
+      return `searched ${count} ${plural ? "times" : "time"}`;
+    return `called ${count} ${plural ? "tools" : "tool"}`;
+  };
+  const parts = [...categories.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([key, count]) => phrase(key, count));
+  const label = parts.join(", ");
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+export function TraceToolGroup({
+  items,
+  targetEventIndex,
+  highlightQuote,
+}: {
+  items: IndexedTraceToolItem[];
+  targetEventIndex?: number;
+  highlightQuote?: string;
+}) {
+  const hasTarget =
+    targetEventIndex !== undefined &&
+    items.some((item) => item.index === targetEventIndex);
+  const events = items.map((i) => i.event);
+  return (
+    <details className="review-trace-toolgroup" open={hasTarget}>
+      <summary>
+        <span className="review-trace-tool-icon">
+          {iconSvg(
+            <>
+              <rect
+                x="2"
+                y="3"
+                width="10"
+                height="2.2"
+                rx="1.1"
+                fill="currentColor"
+              />
+              <rect
+                x="2"
+                y="6.9"
+                width="10"
+                height="2.2"
+                rx="1.1"
+                fill="currentColor"
+                opacity="0.6"
+              />
+              <rect
+                x="2"
+                y="10.8"
+                width="10"
+                height="2.2"
+                rx="1.1"
+                fill="currentColor"
+                opacity="0.35"
+              />
+            </>,
+          )}
+        </span>
+        <span className="review-trace-toolgroup-label">
+          {toolGroupLabel(events)}
+        </span>
+        <span className="review-trace-toolgroup-count">
+          {events.length} steps
+        </span>
+        <span className="review-trace-toolgroup-chevron" aria-hidden="true">
+          <ChevronIcon />
+        </span>
+      </summary>
+      <div className="review-trace-toolgroup-body">
+        {items.map((item) => (
+          <div
+            key={item.index}
+            id={
+              item.index === targetEventIndex
+                ? "review-trace-target-event"
+                : undefined
+            }
+            className={
+              item.index === targetEventIndex
+                ? "review-trace-target-turn"
+                : undefined
+            }
+          >
+            <TraceEvent event={item.event} highlightQuote={highlightQuote} />
+          </div>
+        ))}
+      </div>
+    </details>
+  );
+}
+
+export function TraceEvent({
+  event,
+  highlightQuote,
+}: {
+  event: TraceTurnEvent;
+  highlightQuote?: string;
+}) {
+  if (event.kind === "user") {
+    return (
+      <div className="review-trace-user">
+        <div className="review-trace-user-bubble">
+          {highlightQuote ? (
+            <HighlightedText text={event.text} quote={highlightQuote} />
+          ) : (
+            event.text
+          )}
+        </div>
+        {event.at && (
+          <span className="review-trace-timestamp">{timeLabel(event.at)}</span>
+        )}
+      </div>
+    );
+  }
+  if (event.kind === "assistant") {
+    if (event.thinking) {
+      return (
+        <details
+          className="review-trace-tool review-trace-tool--expandable"
+          open={Boolean(highlightQuote)}
+        >
+          <summary>
+            <span className="review-trace-tool-row">
+              <span className="review-trace-tool-icon">
+                {toolIcon("Thinking")}
+              </span>
+              <span className="review-trace-tool-label">
+                <span className="review-trace-tool-verb">Thinking</span>
+              </span>
+              <span className="review-trace-tool-chevron" aria-hidden="true">
+                <ChevronIcon />
+              </span>
+            </span>
+          </summary>
+          <figure className="review-trace-figure">
+            <figcaption className="review-trace-figure-head">
+              <span>Thinking</span>
+            </figcaption>
+            <div className="review-trace-figure-body review-trace-figure-body--thinking">
+              <AgentMarkdown
+                source={event.markdown}
+                highlightQuote={highlightQuote}
+              />
+            </div>
+          </figure>
+        </details>
+      );
+    }
+    return (
+      <div className="review-trace-prose">
+        <AgentMarkdown
+          source={event.markdown}
+          highlightQuote={highlightQuote}
+        />
+      </div>
+    );
+  }
+  return <TraceToolRow event={event} />;
+}
+
+export { HighlightedText } from "./highlighted-text";
+
+export function TraceToolRow({
+  event,
+}: {
+  event: Extract<ReviewAgentTraceEvent, { kind: "tool" }>;
+}) {
+  const expandable = Boolean(event.command || event.input || event.output);
+  const row = (
+    <span className="review-trace-tool-row">
+      <span className="review-trace-tool-icon">{toolIcon(event.verb)}</span>
+      <span className="review-trace-tool-label">
+        <span className="review-trace-tool-verb">{event.verb}</span>
+        <span
+          className={
+            event.filePath
+              ? "review-trace-tool-title review-trace-tool-title--file"
+              : "review-trace-tool-title"
+          }
+        >
+          {event.filePath ? <bdi>{event.title}</bdi> : event.title}
+        </span>
+        {event.additions !== undefined && event.additions > 0 && (
+          <span className="review-trace-added">+{event.additions}</span>
+        )}
+        {event.deletions !== undefined && event.deletions > 0 && (
+          <span className="review-trace-removed">−{event.deletions}</span>
+        )}
+        {event.error && <span className="review-trace-error-flag">failed</span>}
+      </span>
+      {expandable && (
+        <span className="review-trace-tool-chevron" aria-hidden="true">
+          <ChevronIcon />
+        </span>
+      )}
+    </span>
+  );
+  if (!expandable) {
+    return <div className="review-trace-tool">{row}</div>;
+  }
+  return (
+    <details className="review-trace-tool review-trace-tool--expandable">
+      <summary>{row}</summary>
+      <figure className="review-trace-figure">
+        <figcaption className="review-trace-figure-head">
+          <span>{event.command ? "Shell" : event.tool}</span>
+        </figcaption>
+        <pre className="review-trace-figure-body">
+          {event.command && (
+            <code className="review-trace-figure-command">{event.command}</code>
+          )}
+          {!event.command && event.input && (
+            <code className="review-trace-figure-command">{event.input}</code>
+          )}
+          {event.output && (
+            <code className="review-trace-figure-output">{event.output}</code>
+          )}
+        </pre>
+      </figure>
+    </details>
+  );
+}
+
+export function timeLabel(at: string): string {
+  const value = new Date(at);
+  if (Number.isNaN(value.getTime())) return "";
+  return value.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function formatDuration(durationMs: number): string {
+  if (!Number.isFinite(durationMs) || durationMs < 0) return "";
+  const totalSeconds = Math.round(durationMs / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  return rest ? `${hours}h ${rest}m` : `${hours}h`;
+}
+
+function iconSvg(children: ReactNode): ReactNode {
+  return (
+    <svg viewBox="0 0 16 16" className="review-trace-icon" aria-hidden="true">
+      {children}
+    </svg>
+  );
+}
+
+export function toolIcon(verb: string): ReactNode {
+  switch (verb) {
+    case "Thinking":
+      return iconSvg(
+        <path d="M8 2a5 5 0 0 0-3.5 8.5V12a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-1.5A5 5 0 0 0 8 2zM6 15h4" />,
+      );
+    case "Ran":
+      return iconSvg(
+        <>
+          <rect x="1.5" y="2.5" width="13" height="11" rx="2" />
+          <path d="M4.5 6l2 2-2 2M8.5 10.5h3" />
+        </>,
+      );
+    case "Edited":
+    case "Wrote":
+      return iconSvg(
+        <path d="M11.1 2.2a1.6 1.6 0 0 1 2.3 2.3L5 12.9l-3 .7.7-3z" />,
+      );
+    case "Read":
+      return iconSvg(
+        <>
+          <path d="M9.5 1.5h-5a1 1 0 0 0-1 1v11a1 1 0 0 0 1 1h7a1 1 0 0 0 1-1V4.5z" />
+          <path d="M9.5 1.5v3h3" />
+        </>,
+      );
+    case "Searched":
+    case "Searched web":
+    case "Fetched":
+      return iconSvg(
+        <>
+          <circle cx="7" cy="7" r="4.5" />
+          <path d="M10.5 10.5L14 14" />
+        </>,
+      );
+    case "Ran agent":
+      return iconSvg(
+        <path d="M8 1.5l1.8 4.2 4.2 1.8-4.2 1.8L8 13.5 6.2 9.3 2 7.5l4.2-1.8z" />,
+      );
+    default:
+      return iconSvg(
+        <>
+          <path d="M2.5 4.5h11M2.5 8h11M2.5 11.5h7" />
+        </>,
+      );
+  }
+}
+
+export function ChevronIcon() {
+  return iconSvg(<path d="M4 6l4 4 4-4" />);
+}
+
+export interface LensPickEvent {
+  event: number;
+  keep?: string[] | null;
+}
+
+export interface LensPickRange {
+  events: [number, number];
+}
+
+export type LensPick = LensPickEvent | LensPickRange;
+
+export type LensDisplayItem =
+  | { type: "event"; index: number; keep: string[] | null }
+  | { type: "gap"; from: number; count: number };
+
+export function applyLensPicks(
+  eventCount: number,
+  lens: { picks: LensPick[] },
+): Map<number, string[] | null> {
+  const included = new Map<number, string[] | null>();
+  for (const pick of lens.picks) {
+    if ("events" in pick) {
+      const [from, to] = pick.events;
+      for (
+        let index = Math.max(0, from);
+        index <= Math.min(eventCount - 1, to);
+        index += 1
+      ) {
+        included.set(index, null);
+      }
+    } else if (pick.event >= 0 && pick.event < eventCount) {
+      const existing = included.get(pick.event);
+      if (existing === null) continue;
+      included.set(
+        pick.event,
+        pick.keep && pick.keep.length > 0 ? pick.keep : null,
+      );
+    }
+  }
+  return included;
+}
+
+export function buildLensDisplay(
+  eventCount: number,
+  included: Map<number, string[] | null>,
+): LensDisplayItem[] {
+  const items: LensDisplayItem[] = [];
+  let cursor = 0;
+  while (cursor < eventCount) {
+    if (included.has(cursor)) {
+      items.push({
+        type: "event",
+        index: cursor,
+        keep: included.get(cursor) ?? null,
+      });
+      cursor += 1;
+      continue;
+    }
+    let end = cursor;
+    while (end < eventCount && !included.has(end)) end += 1;
+    items.push({ type: "gap", from: cursor, count: end - cursor });
+    cursor = end;
+  }
+  return items;
+}
+
+export interface ElidedSegment {
+  kind: "kept" | "chip";
+  text?: string;
+}
+
+export function elideByKeep(
+  text: string,
+  keep: string[],
+): ElidedSegment[] | null {
+  const segments: ElidedSegment[] = [];
+  let cursor = 0;
+  let matched = 0;
+  for (const snippet of keep) {
+    const span = findWhitespaceNormalizedSpan(text.slice(cursor), snippet);
+    if (!span) continue;
+    matched += 1;
+    const start = cursor + span.start;
+    const end = cursor + span.end;
+    if (start > cursor) segments.push({ kind: "chip" });
+    segments.push({ kind: "kept", text: text.slice(start, end) });
+    cursor = end;
+  }
+  if (matched === 0) return null;
+  if (cursor < text.trimEnd().length) segments.push({ kind: "chip" });
+  return segments;
+}
+
+export function extractEventText(
+  event: ReviewAgentTraceEvent | undefined,
+): string {
+  if (!event) return "";
+  if (event.kind === "user") return event.text;
+  if (event.kind === "assistant") return event.markdown;
+  if (event.kind === "tool") {
+    return [event.title, event.command, event.input, event.output]
+      .filter(Boolean)
+      .join(" ");
+  }
+  if (event.kind === "separator") return event.label;
+  return "";
+}
+
+export function ElidedMessage({
+  event,
+  keep,
+  quote,
+  onExpand,
+}: {
+  event: Extract<ReviewAgentTraceEvent, { kind: "user" | "assistant" }>;
+  keep: string[];
+  quote?: string;
+  onExpand: () => void;
+}) {
+  const text = event.kind === "user" ? event.text : event.markdown;
+  const segments = elideByKeep(text, keep);
+  if (!segments) return <TraceEvent event={event} highlightQuote={quote} />;
+  const body = (
+    <span className="review-trace-lens-elided">
+      {segments.map((segment, index) =>
+        segment.kind === "kept" ? (
+          <span key={index} className="review-trace-lens-kept">
+            <mark className="review-trace-quote-mark">{segment.text}</mark>
+          </span>
+        ) : (
+          <button
+            key={index}
+            type="button"
+            className="review-trace-lens-chip"
+            title="Show the hidden text"
+            onClick={onExpand}
+          >
+            ⋯
+          </button>
+        ),
+      )}
+    </span>
+  );
+  if (event.kind === "user") {
+    return (
+      <div className="review-trace-user">
+        <div className="review-trace-user-bubble review-trace-user-bubble--elided">
+          {body}
+        </div>
+        {event.at && (
+          <span className="review-trace-timestamp">{timeLabel(event.at)}</span>
+        )}
+      </div>
+    );
+  }
+  if (event.thinking) {
+    return (
+      <details className="review-trace-tool review-trace-tool--expandable" open>
+        <summary>
+          <span className="review-trace-tool-row">
+            <span className="review-trace-tool-icon">
+              {toolIcon("Thinking")}
+            </span>
+            <span className="review-trace-tool-label">
+              <span className="review-trace-tool-verb">Thinking</span>
+            </span>
+            <span className="review-trace-tool-chevron" aria-hidden="true">
+              <ChevronIcon />
+            </span>
+          </span>
+        </summary>
+        <figure className="review-trace-figure">
+          <figcaption className="review-trace-figure-head">
+            <span>Thinking</span>
+          </figcaption>
+          <div className="review-trace-figure-body review-trace-figure-body--thinking">
+            <div className="review-trace-prose review-trace-prose--elided">
+              {body}
+            </div>
+          </div>
+        </figure>
+      </details>
+    );
+  }
+  return (
+    <div className="review-trace-prose review-trace-prose--elided">{body}</div>
+  );
+}
+
+export function TraceGapChip({
+  from,
+  count,
+  onExpand,
+}: {
+  from: number;
+  count: number;
+  onExpand: () => void;
+}) {
+  return (
+    <button
+      key={`gap-${from}`}
+      type="button"
+      className="review-trace-lens-gap"
+      onClick={onExpand}
+    >
+      <span className="review-trace-lens-gap-line" />
+      <span className="review-trace-lens-gap-chip">
+        ⋯ {count} hidden {count === 1 ? "event" : "events"}
+      </span>
+      <span className="review-trace-lens-gap-line" />
+    </button>
+  );
+}
+
+export function TraceTurn({
+  turn,
+  effectiveIncluded,
+  expandedEvents,
+  onExpandGap,
+  onExpandEvent,
+  targetEventIndex,
+  highlightQuote,
+  turnCoalesce,
+}: {
+  turn: IndexedTraceTurnGroup;
+  effectiveIncluded: Map<number, string[] | null> | null;
+  expandedEvents: ReadonlySet<number>;
+  onExpandGap: (from: number, count: number) => void;
+  onExpandEvent: (index: number) => void;
+  targetEventIndex?: number;
+  highlightQuote?: string;
+  turnCoalesce: boolean;
+}) {
+  const steps = turn.work.length;
+  const isTargetInWork =
+    targetEventIndex !== undefined &&
+    turn.work.some((w) => w.index === targetEventIndex);
+  const isTargetTurn =
+    targetEventIndex !== undefined &&
+    (turn.user?.index === targetEventIndex ||
+      isTargetInWork ||
+      turn.final.some((f) => f.index === targetEventIndex));
+
+  const workedLabel =
+    turn.workedMs !== null && turn.workedMs >= 1000
+      ? `Worked for ${formatDuration(turn.workedMs)}`
+      : `Worked · ${steps} ${steps === 1 ? "step" : "steps"}`;
+
+  const renderTurnEvent = (item: IndexedTraceTurnEvent) => {
+    const isTarget = item.index === targetEventIndex;
+    const quote = isTarget || isTargetTurn ? highlightQuote : undefined;
+    const keep = effectiveIncluded?.get(item.index);
+    const shouldElide =
+      keep !== undefined &&
+      keep !== null &&
+      keep.length > 0 &&
+      (item.event.kind === "user" || item.event.kind === "assistant") &&
+      !expandedEvents.has(item.index);
+
+    return (
+      <div
+        key={item.index}
+        id={isTarget ? "review-trace-target-event" : undefined}
+        className={isTarget ? "review-trace-target-turn" : undefined}
+      >
+        {shouldElide ? (
+          <ElidedMessage
+            event={
+              item.event as Extract<
+                TraceTurnEvent,
+                { kind: "user" | "assistant" }
+              >
+            }
+            keep={keep}
+            quote={quote}
+            onExpand={() => onExpandEvent(item.index)}
+          />
+        ) : (
+          <TraceEvent event={item.event} highlightQuote={quote} />
+        )}
+      </div>
+    );
+  };
+
+  const renderWorkItems = () => {
+    if (effectiveIncluded === null) {
+      if (turnCoalesce) {
+        return groupIndexedWorkEvents(turn.work).map((item, index) =>
+          Array.isArray(item) ? (
+            <TraceToolGroup
+              key={index}
+              items={item}
+              targetEventIndex={targetEventIndex}
+              highlightQuote={highlightQuote}
+            />
+          ) : (
+            renderTurnEvent(item)
+          ),
+        );
+      }
+      return turn.work.map((item) => renderTurnEvent(item));
+    }
+
+    const elements: ReactNode[] = [];
+    let toolRun: IndexedTraceToolItem[] = [];
+    let gapRun: { from: number; count: number } | null = null;
+
+    const flushToolRun = () => {
+      if (toolRun.length === 0) return;
+      if (turnCoalesce && toolRun.length >= 2) {
+        const items = [...toolRun];
+        elements.push(
+          <TraceToolGroup
+            key={`toolgroup-${items[0].index}`}
+            items={items}
+            targetEventIndex={targetEventIndex}
+            highlightQuote={highlightQuote}
+          />,
+        );
+      } else {
+        for (const item of toolRun) {
+          elements.push(renderTurnEvent(item));
+        }
+      }
+      toolRun = [];
+    };
+
+    const flushGapRun = () => {
+      if (!gapRun) return;
+      const { from, count } = gapRun;
+      elements.push(
+        <TraceGapChip
+          key={`gap-${from}`}
+          from={from}
+          count={count}
+          onExpand={() => onExpandGap(from, count)}
+        />,
+      );
+      gapRun = null;
+    };
+
+    for (const item of turn.work) {
+      const isIncluded = effectiveIncluded.has(item.index);
+      if (!isIncluded) {
+        flushToolRun();
+        if (!gapRun) {
+          gapRun = { from: item.index, count: 1 };
+        } else {
+          gapRun.count += 1;
+        }
+        continue;
+      }
+
+      flushGapRun();
+      if (turnCoalesce && item.event.kind === "tool") {
+        toolRun.push(item as IndexedTraceToolItem);
+      } else {
+        flushToolRun();
+        elements.push(renderTurnEvent(item));
+      }
+    }
+    flushToolRun();
+    flushGapRun();
+
+    return elements;
+  };
+
+  const renderFinalItems = () => {
+    if (effectiveIncluded === null) {
+      return turn.final.map((item) => renderTurnEvent(item));
+    }
+
+    const elements: ReactNode[] = [];
+    let gapRun: { from: number; count: number } | null = null;
+
+    const flushGapRun = () => {
+      if (!gapRun) return;
+      const { from, count } = gapRun;
+      elements.push(
+        <TraceGapChip
+          key={`gap-${from}`}
+          from={from}
+          count={count}
+          onExpand={() => onExpandGap(from, count)}
+        />,
+      );
+      gapRun = null;
+    };
+
+    for (const item of turn.final) {
+      if (!effectiveIncluded.has(item.index)) {
+        if (!gapRun) {
+          gapRun = { from: item.index, count: 1 };
+        } else {
+          gapRun.count += 1;
+        }
+      } else {
+        flushGapRun();
+        elements.push(renderTurnEvent(item));
+      }
+    }
+    flushGapRun();
+    return elements;
+  };
+
+  let userElement: ReactNode = null;
+  if (turn.user) {
+    if (effectiveIncluded === null || effectiveIncluded.has(turn.user.index)) {
+      userElement = renderTurnEvent(turn.user);
+    } else {
+      userElement = (
+        <TraceGapChip
+          key={`gap-${turn.user.index}`}
+          from={turn.user.index}
+          count={1}
+          onExpand={() => onExpandGap(turn.user!.index, 1)}
+        />
+      );
+    }
+  }
+
+  let workElement: ReactNode = null;
+  if (turn.work.length > 0) {
+    const includedWorkCount =
+      effectiveIncluded === null
+        ? turn.work.length
+        : turn.work.filter((w) => effectiveIncluded.has(w.index)).length;
+
+    if (includedWorkCount === 0 && effectiveIncluded !== null) {
+      workElement = (
+        <TraceGapChip
+          key={`gap-${turn.work[0].index}`}
+          from={turn.work[0].index}
+          count={turn.work.length}
+          onExpand={() => onExpandGap(turn.work[0].index, turn.work.length)}
+        />
+      );
+    } else {
+      const openWorked =
+        isTargetInWork || (effectiveIncluded !== null && includedWorkCount > 0);
+      workElement = (
+        <details className="review-trace-worked" open={openWorked}>
+          <summary>
+            <span className="review-trace-worked-label">{workedLabel}</span>
+            <span className="review-trace-worked-chevron" aria-hidden="true">
+              <ChevronIcon />
+            </span>
+            <span className="review-trace-worked-line" />
+          </summary>
+          <div className="review-trace-worked-body">{renderWorkItems()}</div>
+        </details>
+      );
+    }
+  }
+
+  return (
+    <div className="review-trace-turn">
+      {userElement}
+      {workElement}
+      {renderFinalItems()}
+    </div>
+  );
+}
+
+export interface TraceDocumentOptions {
+  picks?: LensPick[] | { picks: LensPick[] } | Map<number, string[] | null>;
+  highlightQuote?: string;
+  targetEventIndex?: number;
+  coalesce?: boolean;
+  className?: string;
+}
+
+export interface TraceDocumentProps extends TraceDocumentOptions {
+  events: ReviewAgentTraceEvent[];
+}
+
+export function TraceDocument({
+  events,
+  picks,
+  highlightQuote,
+  targetEventIndex,
+  coalesce = true,
+  className,
+}: TraceDocumentProps) {
+  useEffect(() => {
+    if (targetEventIndex === undefined) return;
+    const targetTurn = document.getElementById("review-trace-target-event");
+    const quoteMark = targetTurn?.querySelector(".review-trace-quote-mark");
+    const el = quoteMark ?? targetTurn;
+    if (el && typeof el.scrollIntoView === "function") {
+      el.scrollIntoView({ block: "center", behavior: "auto" });
+    }
+  }, [targetEventIndex, events, highlightQuote]);
+
+  const [expandedGaps, setExpandedGaps] = useState<ReadonlySet<number>>(
+    () => new Set(),
+  );
+  const [expandedEvents, setExpandedEvents] = useState<ReadonlySet<number>>(
+    () => new Set(),
+  );
+
+  const baseIncluded = useMemo(() => {
+    if (!picks) return null;
+    if (picks instanceof Map) return picks;
+    if ("picks" in picks) return applyLensPicks(events.length, picks);
+    return applyLensPicks(events.length, { picks });
+  }, [events.length, picks]);
+
+  const effectiveIncluded = useMemo(() => {
+    if (!baseIncluded) return null;
+    const map = new Map(baseIncluded);
+    for (const from of expandedGaps) {
+      let cursor = from;
+      while (cursor < events.length && !baseIncluded.has(cursor)) {
+        map.set(cursor, null);
+        cursor++;
+      }
+    }
+    return map;
+  }, [baseIncluded, expandedGaps, events.length]);
+
+  const handleExpandGap = (from: number, _count: number) => {
+    setExpandedGaps((prev) => new Set(prev).add(from));
+  };
+
+  const handleExpandEvent = (index: number) => {
+    setExpandedEvents((prev) => new Set(prev).add(index));
+  };
+
+  const turns = useMemo(() => buildIndexedTraceTurns(events), [events]);
+
+  const turnElements = useMemo(() => {
+    if (effectiveIncluded === null) {
+      return turns.map((turn, index) => {
+        const isTargetTurn =
+          targetEventIndex !== undefined &&
+          (turn.user?.index === targetEventIndex ||
+            turn.work.some((w) => w.index === targetEventIndex) ||
+            turn.final.some((f) => f.index === targetEventIndex));
+        // Groups containing the target render open (TraceToolGroup), so
+        // even the quoted turn coalesces; quotes in tool text stay visible.
+        const turnCoalesce = coalesce;
+
+        return (
+          <TraceTurn
+            key={index}
+            turn={turn}
+            effectiveIncluded={null}
+            expandedEvents={expandedEvents}
+            onExpandGap={handleExpandGap}
+            onExpandEvent={handleExpandEvent}
+            targetEventIndex={targetEventIndex}
+            highlightQuote={highlightQuote}
+            turnCoalesce={turnCoalesce}
+          />
+        );
+      });
+    }
+
+    const elements: ReactNode[] = [];
+    let hiddenTurns: IndexedTraceTurnGroup[] = [];
+
+    const flushHiddenTurns = () => {
+      if (hiddenTurns.length === 0) return;
+      const firstTurn = hiddenTurns[0];
+      const lastTurn = hiddenTurns[hiddenTurns.length - 1];
+      const from =
+        firstTurn.user?.index ??
+        firstTurn.work[0]?.index ??
+        firstTurn.final[0]?.index;
+      const to =
+        lastTurn.final[lastTurn.final.length - 1]?.index ??
+        lastTurn.work[lastTurn.work.length - 1]?.index ??
+        lastTurn.user?.index;
+      if (from !== undefined && to !== undefined) {
+        const count = to - from + 1;
+        elements.push(
+          <TraceGapChip
+            key={`gap-${from}`}
+            from={from}
+            count={count}
+            onExpand={() => handleExpandGap(from, count)}
+          />,
+        );
+      }
+      hiddenTurns = [];
+    };
+
+    for (let i = 0; i < turns.length; i++) {
+      const turn = turns[i];
+      const isUserIncluded = turn.user
+        ? effectiveIncluded.has(turn.user.index)
+        : false;
+      const includedWorkCount = turn.work.filter((w) =>
+        effectiveIncluded.has(w.index),
+      ).length;
+      const includedFinalCount = turn.final.filter((f) =>
+        effectiveIncluded.has(f.index),
+      ).length;
+      const hasAnyIncluded =
+        isUserIncluded || includedWorkCount > 0 || includedFinalCount > 0;
+
+      if (!hasAnyIncluded) {
+        hiddenTurns.push(turn);
+        continue;
+      }
+
+      flushHiddenTurns();
+
+      const isTargetTurn =
+        targetEventIndex !== undefined &&
+        (turn.user?.index === targetEventIndex ||
+          turn.work.some((w) => w.index === targetEventIndex) ||
+          turn.final.some((f) => f.index === targetEventIndex));
+      // Groups containing the target render open (TraceToolGroup), so
+      // even the quoted turn coalesces; quotes in tool text stay visible.
+      const turnCoalesce = coalesce;
+
+      elements.push(
+        <TraceTurn
+          key={i}
+          turn={turn}
+          effectiveIncluded={effectiveIncluded}
+          expandedEvents={expandedEvents}
+          onExpandGap={handleExpandGap}
+          onExpandEvent={handleExpandEvent}
+          targetEventIndex={targetEventIndex}
+          highlightQuote={highlightQuote}
+          turnCoalesce={turnCoalesce}
+        />,
+      );
+    }
+    flushHiddenTurns();
+    return elements;
+  }, [
+    turns,
+    effectiveIncluded,
+    expandedEvents,
+    targetEventIndex,
+    highlightQuote,
+    coalesce,
+  ]);
+
+  return (
+    <div
+      className={
+        className ? `review-trace-events ${className}` : "review-trace-events"
+      }
+    >
+      {turnElements}
+    </div>
+  );
+}

--- a/packages/progressive-review/app/src/trace-quote.test.tsx
+++ b/packages/progressive-review/app/src/trace-quote.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ReviewPanelProvider, useReviewPanelStore } from "./review-panel";
+import { TraceQuote } from "./trace-quote";
+
+describe("TraceQuote", () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root?.unmount());
+      root = null;
+    }
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("renders inert span when outside ReviewPanelProvider without breaking rules of hooks", () => {
+    const html = renderToStaticMarkup(
+      <TraceQuote sessionId="72b3d130-1234-5678-abcd-0123456789ab">
+        Optimize database queries
+      </TraceQuote>,
+    );
+
+    expect(html).toContain("review-trace-quote--inert");
+    expect(html).toContain("Optimize database queries");
+  });
+
+  it("renders active link when inside ReviewPanelProvider", () => {
+    const html = renderToStaticMarkup(
+      <ReviewPanelProvider>
+        <TraceQuote sessionId="72b3d130-1234-5678-abcd-0123456789ab">
+          Optimize database queries
+        </TraceQuote>
+      </ReviewPanelProvider>,
+    );
+
+    expect(html).toContain('class="review-trace-quote"');
+    expect(html).toContain("Optimize database queries");
+    expect(html).not.toContain("review-trace-quote--inert");
+  });
+
+  it("scrolls to the target quote mark when already open", async () => {
+    const scrollCalls: Element[] = [];
+    Element.prototype.scrollIntoView = vi
+      .fn<typeof Element.prototype.scrollIntoView>()
+      .mockImplementation(function (this: Element) {
+        scrollCalls.push(this);
+      });
+
+    const targetTurn = document.createElement("div");
+    targetTurn.id = "review-trace-target-event";
+    const quoteMark = document.createElement("mark");
+    quoteMark.className = "review-trace-quote-mark";
+    targetTurn.append(quoteMark);
+    document.body.append(targetTurn);
+
+    let storeRef: ReturnType<typeof useReviewPanelStore> | null = null;
+    function TestConsumer() {
+      storeRef = useReviewPanelStore();
+      return (
+        <TraceQuote sessionId="session-1">Optimize database queries</TraceQuote>
+      );
+    }
+
+    await act(async () => {
+      root?.render(
+        <ReviewPanelProvider>
+          <TestConsumer />
+        </ReviewPanelProvider>,
+      );
+    });
+
+    // Manually open the quote so isOpen becomes true
+    act(() => {
+      storeRef?.getState().openPeek({
+        kind: "trace-quote",
+        sessionId: "session-1",
+        quote: "Optimize database queries",
+      });
+    });
+
+    const link = container.querySelector(".review-trace-quote") as HTMLElement;
+    expect(link).not.toBeNull();
+
+    // Click while already open
+    await act(async () => {
+      link.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(scrollCalls).toContain(quoteMark);
+  });
+});

--- a/packages/progressive-review/app/src/trace-quote.tsx
+++ b/packages/progressive-review/app/src/trace-quote.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from "react";
+
+import type { TraceQuoteProps } from "../../src/authoring";
+import { ProsePeekAnchor } from "./review-components";
+import { useOptionalReviewPanel } from "./review-panel";
+import { selectActiveReviewPanel } from "./review-panel-store";
+
+function extractText(node: ReactNode): string {
+  if (node === null || node === undefined || typeof node === "boolean") {
+    return "";
+  }
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(extractText).join("");
+  }
+  if (
+    typeof node === "object" &&
+    "props" in node &&
+    (node as { props?: { children?: ReactNode } }).props
+  ) {
+    return extractText(
+      (node as { props: { children?: ReactNode } }).props.children,
+    );
+  }
+  return "";
+}
+
+export function TraceQuote({
+  sessionId,
+  trace,
+  event,
+  children,
+}: TraceQuoteProps) {
+  const quote = extractText(children);
+  const openPeek = useOptionalReviewPanel((state) => state.openPeek);
+  const isOpen =
+    useOptionalReviewPanel((state) => {
+      const active = selectActiveReviewPanel(state);
+      return (
+        active?.kind === "peek" &&
+        active.content.kind === "trace-quote" &&
+        active.content.sessionId === sessionId &&
+        active.content.quote === quote &&
+        active.content.trace === trace
+      );
+    }) ?? false;
+
+  const href = `#trace-${sessionId}${trace ? `-${trace}` : ""}${event !== undefined ? `-event-${event}` : ""}`;
+
+  return (
+    <ProsePeekAnchor
+      href={href}
+      className="review-trace-quote"
+      isOpen={isOpen}
+      inertFallback={
+        <span className="review-trace-quote review-trace-quote--inert">
+          {children}
+        </span>
+      }
+      onOpen={() => {
+        openPeek?.({
+          kind: "trace-quote",
+          sessionId,
+          trace,
+          event,
+          quote,
+        });
+      }}
+      onAlreadyOpen={() => {
+        const targetTurn = document.getElementById("review-trace-target-event");
+        const quoteMark = targetTurn?.querySelector(".review-trace-quote-mark");
+        const el = quoteMark ?? targetTurn;
+        if (el && typeof el.scrollIntoView === "function") {
+          el.scrollIntoView({ block: "center", behavior: "auto" });
+        }
+      }}
+    >
+      {children}
+    </ProsePeekAnchor>
+  );
+}

--- a/packages/progressive-review/app/src/use-agent-trace.test.tsx
+++ b/packages/progressive-review/app/src/use-agent-trace.test.tsx
@@ -1,0 +1,512 @@
+// @vitest-environment jsdom
+
+import type {
+  ReviewAgentTraceResponse,
+  ReviewCanvasBridge,
+} from "@dev.fast/review-protocol";
+import { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ReviewSessionProvider } from "./host/review-session";
+import { testReviewSession } from "./review-session-test-utils";
+import {
+  type AgentTraceState,
+  type LoadedAgentTrace,
+  clearAgentTraceCache,
+  makeAgentTraceKey,
+  makeAgentTraceUrl,
+  useAgentTrace,
+} from "./use-agent-trace";
+
+const mockTraceData: Extract<ReviewAgentTraceResponse, { ok: true }> = {
+  ok: true,
+  parserVersion: "1.0",
+  session: {
+    sessionId: "session-123",
+    harness: "pi",
+    available: true,
+    source: "r2",
+    commits: [{ sha: "abc1234", subject: "Initial commit" }],
+  },
+  title: "Test Trace Title",
+  subagents: [],
+  startedAt: "2025-01-01T00:00:00Z",
+  endedAt: "2025-01-01T00:01:00Z",
+  activeMs: 60000,
+  userTurns: 1,
+  toolCalls: 2,
+  events: [
+    {
+      kind: "user",
+      text: "Hello agent",
+      at: "2025-01-01T00:00:00Z",
+    },
+  ],
+};
+
+let root: Root | null = null;
+let root2: Root | null = null;
+let container: HTMLDivElement;
+let container2: HTMLDivElement;
+
+describe("useAgentTrace", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    clearAgentTraceCache();
+    container = document.createElement("div");
+    container2 = document.createElement("div");
+    document.body.append(container, container2);
+    root = createRoot(container);
+    root2 = createRoot(container2);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root?.unmount());
+      root = null;
+    }
+    if (root2) {
+      await act(async () => root2?.unmount());
+      root2 = null;
+    }
+    document.body.replaceChildren();
+    clearAgentTraceCache();
+    vi.restoreAllMocks();
+  });
+
+  describe("makeAgentTraceKey & makeAgentTraceUrl", () => {
+    it("builds correct key without trace param", () => {
+      expect(makeAgentTraceKey("session-abc")).toBe("session-abc");
+    });
+
+    it("builds correct key with trace param", () => {
+      expect(makeAgentTraceKey("session-abc", "subagent-1")).toBe(
+        "session-abc:subagent-1",
+      );
+    });
+
+    it("builds URL with query parameter encoding", () => {
+      expect(makeAgentTraceUrl("session-abc")).toBe(
+        "/agent-traces/session-abc",
+      );
+      expect(makeAgentTraceUrl("session-abc", "sub/agent#1")).toBe(
+        "/agent-traces/session-abc?trace=sub%2Fagent%231",
+      );
+    });
+  });
+
+  describe("hook lifecycle and state machine", () => {
+    it("returns idle status when sessionId is missing", () => {
+      let latestState: unknown;
+      function TestComponent() {
+        latestState = useAgentTrace(undefined);
+        return <div>idle</div>;
+      }
+
+      const session = testReviewSession();
+      act(() => {
+        root?.render(
+          <ReviewSessionProvider session={session}>
+            <TestComponent />
+          </ReviewSessionProvider>,
+        );
+      });
+
+      expect(latestState).toEqual({ status: "idle" });
+    });
+
+    it("loads trace successfully and transitions to loaded state", async () => {
+      let latestState: unknown;
+      function TestComponent({ sessionId }: { sessionId: string }) {
+        latestState = useAgentTrace(sessionId);
+        return <div>test</div>;
+      }
+
+      let fetchSignal: AbortSignal | undefined;
+      const requestMock = vi
+        .fn<ReviewCanvasBridge["request"]>()
+        .mockImplementation((_url, init) => {
+          fetchSignal = init?.signal ?? undefined;
+          return Promise.resolve(
+            new Response(JSON.stringify(mockTraceData), { status: 200 }),
+          );
+        });
+
+      const session = testReviewSession({}, { request: requestMock });
+
+      await act(async () => {
+        root?.render(
+          <ReviewSessionProvider session={session}>
+            <TestComponent sessionId="session-123" />
+          </ReviewSessionProvider>,
+        );
+      });
+
+      expect(requestMock).toHaveBeenCalledWith(
+        expect.stringContaining("/agent-traces/session-123"),
+        expect.objectContaining({ signal: expect.any(Object) }),
+      );
+      expect(fetchSignal?.aborted).toBe(false);
+      expect(latestState).toEqual({
+        status: "loaded",
+        trace: mockTraceData,
+      });
+    });
+
+    it("handles fetch errors and transitions to error state", async () => {
+      let latestState: unknown;
+      function TestComponent({ sessionId }: { sessionId: string }) {
+        latestState = useAgentTrace(sessionId);
+        return <div>test</div>;
+      }
+
+      const errorPayload = { ok: false, error: "Trace not found in R2" };
+      const requestMock = vi
+        .fn<ReviewCanvasBridge["request"]>()
+        .mockImplementation(() =>
+          Promise.resolve(
+            new Response(JSON.stringify(errorPayload), { status: 404 }),
+          ),
+        );
+
+      const session = testReviewSession({}, { request: requestMock });
+
+      await act(async () => {
+        root?.render(
+          <ReviewSessionProvider session={session}>
+            <TestComponent sessionId="session-404" />
+          </ReviewSessionProvider>,
+        );
+      });
+
+      expect(latestState).toEqual({
+        status: "error",
+        error: "Trace not found in R2",
+      });
+    });
+
+    it("uses cached response on subsequent mounts without refetching", async () => {
+      let latestState: unknown;
+      function TestComponent({ sessionId }: { sessionId: string }) {
+        latestState = useAgentTrace(sessionId);
+        return <div>{JSON.stringify(latestState)}</div>;
+      }
+
+      const requestMock = vi
+        .fn<ReviewCanvasBridge["request"]>()
+        .mockImplementation(() =>
+          Promise.resolve(
+            new Response(JSON.stringify(mockTraceData), { status: 200 }),
+          ),
+        );
+
+      const session = testReviewSession({}, { request: requestMock });
+
+      // First mount
+      await act(async () => {
+        root?.render(
+          <ReviewSessionProvider session={session}>
+            <TestComponent sessionId="session-123" />
+          </ReviewSessionProvider>,
+        );
+      });
+
+      expect(requestMock).toHaveBeenCalledTimes(1);
+      expect(latestState).toEqual({
+        status: "loaded",
+        trace: mockTraceData,
+      });
+
+      // Unmount first component
+      await act(async () => {
+        root?.unmount();
+        root = createRoot(container);
+      });
+
+      // Second mount with same session ID
+      await act(async () => {
+        root?.render(
+          <ReviewSessionProvider session={session}>
+            <TestComponent sessionId="session-123" />
+          </ReviewSessionProvider>,
+        );
+      });
+
+      expect(requestMock).toHaveBeenCalledTimes(1);
+      expect(latestState).toEqual({
+        status: "loaded",
+        trace: mockTraceData,
+      });
+    });
+
+    it("does not reuse a trace from another Review session", async () => {
+      let latestState: AgentTraceState | undefined;
+      function TestComponent() {
+        latestState = useAgentTrace("session-123");
+        return <div>test</div>;
+      }
+
+      const firstRequest = vi
+        .fn<ReviewCanvasBridge["request"]>()
+        .mockResolvedValue(
+          new Response(JSON.stringify(mockTraceData), { status: 200 }),
+        );
+      const firstSession = testReviewSession({}, { request: firstRequest });
+
+      await act(async () => {
+        root?.render(
+          <ReviewSessionProvider session={firstSession}>
+            <TestComponent />
+          </ReviewSessionProvider>,
+        );
+      });
+      await act(async () => {
+        root?.unmount();
+        root = createRoot(container);
+      });
+
+      const refreshedTrace: LoadedAgentTrace = {
+        ...mockTraceData,
+        events: [...mockTraceData.events, { kind: "user", text: "New prompt" }],
+      };
+      const secondRequest = vi
+        .fn<ReviewCanvasBridge["request"]>()
+        .mockResolvedValue(
+          new Response(JSON.stringify(refreshedTrace), { status: 200 }),
+        );
+      const secondSession = testReviewSession({}, { request: secondRequest });
+
+      await act(async () => {
+        root?.render(
+          <ReviewSessionProvider session={secondSession}>
+            <TestComponent />
+          </ReviewSessionProvider>,
+        );
+      });
+
+      expect(firstRequest).toHaveBeenCalledTimes(1);
+      expect(secondRequest).toHaveBeenCalledTimes(1);
+      expect(latestState).toEqual({
+        status: "loaded",
+        trace: refreshedTrace,
+      });
+    });
+
+    it("refetches after its Review session cache is cleared", async () => {
+      let latestState: AgentTraceState | undefined;
+      function TestComponent() {
+        latestState = useAgentTrace("session-123");
+        return <div>test</div>;
+      }
+
+      const refreshedTrace: LoadedAgentTrace = {
+        ...mockTraceData,
+        events: [...mockTraceData.events, { kind: "user", text: "New prompt" }],
+      };
+      const requestMock = vi
+        .fn<ReviewCanvasBridge["request"]>()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(mockTraceData), { status: 200 }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(refreshedTrace), { status: 200 }),
+        );
+      const session = testReviewSession({}, { request: requestMock });
+
+      await act(async () => {
+        root?.render(
+          <ReviewSessionProvider session={session}>
+            <TestComponent />
+          </ReviewSessionProvider>,
+        );
+      });
+      await act(async () => {
+        root?.unmount();
+        root = createRoot(container);
+      });
+
+      clearAgentTraceCache(session);
+      await act(async () => {
+        root?.render(
+          <ReviewSessionProvider session={session}>
+            <TestComponent />
+          </ReviewSessionProvider>,
+        );
+      });
+
+      expect(requestMock).toHaveBeenCalledTimes(2);
+      expect(latestState).toEqual({
+        status: "loaded",
+        trace: refreshedTrace,
+      });
+    });
+
+    it("deduplicates in-flight requests across concurrent consumers", async () => {
+      let state1: unknown;
+      let state2: unknown;
+      function Consumer1() {
+        state1 = useAgentTrace("shared-session", "subagent-a");
+        return <div>C1</div>;
+      }
+      function Consumer2() {
+        state2 = useAgentTrace("shared-session", "subagent-a");
+        return <div>C2</div>;
+      }
+
+      let resolveFetch!: (res: Response) => void;
+      const fetchPromise = new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      });
+
+      const requestMock = vi
+        .fn<ReviewCanvasBridge["request"]>()
+        .mockImplementation(() => fetchPromise);
+      const session = testReviewSession({}, { request: requestMock });
+
+      // Mount both consumers concurrently
+      act(() => {
+        root?.render(
+          <ReviewSessionProvider session={session}>
+            <Consumer1 />
+          </ReviewSessionProvider>,
+        );
+        root2?.render(
+          <ReviewSessionProvider session={session}>
+            <Consumer2 />
+          </ReviewSessionProvider>,
+        );
+      });
+
+      // Both should be in loading state, and only 1 network fetch triggered
+      expect(requestMock).toHaveBeenCalledTimes(1);
+      expect(state1).toEqual({ status: "loading" });
+      expect(state2).toEqual({ status: "loading" });
+
+      // Resolve the single in-flight fetch
+      await act(async () => {
+        resolveFetch(
+          new Response(JSON.stringify(mockTraceData), { status: 200 }),
+        );
+        await fetchPromise;
+      });
+
+      // Both should be loaded with the same result
+      expect(state1).toEqual({
+        status: "loaded",
+        trace: mockTraceData,
+      });
+      expect(state2).toEqual({
+        status: "loaded",
+        trace: mockTraceData,
+      });
+    });
+
+    it("aborts in-flight request when sole consumer unmounts", async () => {
+      function TestComponent() {
+        useAgentTrace("abort-session");
+        return <div>loading</div>;
+      }
+
+      let capturedSignal: AbortSignal | undefined;
+      const requestMock = vi
+        .fn<ReviewCanvasBridge["request"]>()
+        .mockImplementation((_url, init) => {
+          capturedSignal = init?.signal ?? undefined;
+          return new Promise<Response>(() => {
+            // never resolves
+          });
+        });
+
+      const session = testReviewSession({}, { request: requestMock });
+
+      act(() => {
+        root?.render(
+          <ReviewSessionProvider session={session}>
+            <TestComponent />
+          </ReviewSessionProvider>,
+        );
+      });
+
+      expect(capturedSignal).toBeDefined();
+      expect(capturedSignal?.aborted).toBe(false);
+
+      // Unmount the component
+      act(() => {
+        root?.unmount();
+        root = null;
+      });
+
+      expect(capturedSignal?.aborted).toBe(true);
+    });
+
+    it("does not abort shared in-flight fetch if another consumer is still mounted", async () => {
+      let state2: unknown;
+      function Consumer1() {
+        useAgentTrace("shared-abort-session");
+        return <div>C1</div>;
+      }
+      function Consumer2() {
+        state2 = useAgentTrace("shared-abort-session");
+        return <div>C2</div>;
+      }
+
+      let capturedSignal: AbortSignal | undefined;
+      let resolveFetch!: (res: Response) => void;
+      const fetchPromise = new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      });
+
+      const requestMock = vi
+        .fn<ReviewCanvasBridge["request"]>()
+        .mockImplementation((_url, init) => {
+          capturedSignal = init?.signal ?? undefined;
+          return fetchPromise;
+        });
+
+      const session = testReviewSession({}, { request: requestMock });
+
+      act(() => {
+        root?.render(
+          <ReviewSessionProvider session={session}>
+            <Consumer1 />
+          </ReviewSessionProvider>,
+        );
+        root2?.render(
+          <ReviewSessionProvider session={session}>
+            <Consumer2 />
+          </ReviewSessionProvider>,
+        );
+      });
+
+      expect(capturedSignal?.aborted).toBe(false);
+
+      // Unmount Consumer 1
+      act(() => {
+        root?.unmount();
+        root = null;
+      });
+
+      // Signal must NOT be aborted because Consumer 2 is still mounted
+      expect(capturedSignal?.aborted).toBe(false);
+
+      // Complete fetch
+      await act(async () => {
+        resolveFetch(
+          new Response(JSON.stringify(mockTraceData), { status: 200 }),
+        );
+        await fetchPromise;
+      });
+
+      // Consumer 2 receives the result
+      expect(state2).toEqual({
+        status: "loaded",
+        trace: mockTraceData,
+      });
+    });
+  });
+});

--- a/packages/progressive-review/app/src/use-agent-trace.ts
+++ b/packages/progressive-review/app/src/use-agent-trace.ts
@@ -1,0 +1,203 @@
+import {
+  type ReviewAgentTraceResponse,
+  parseReviewAgentTraceResponse,
+} from "@dev.fast/review-protocol";
+import { useEffect, useState } from "react";
+
+import { type ReviewSession, useReviewSession } from "./host/review-session";
+
+export type LoadedAgentTrace = Extract<ReviewAgentTraceResponse, { ok: true }>;
+
+export type AgentTraceState =
+  | { status: "idle"; trace?: undefined; error?: undefined }
+  | { status: "loading"; trace?: undefined; error?: undefined }
+  | { status: "error"; error: string; trace?: undefined }
+  | { status: "loaded"; trace: LoadedAgentTrace; error?: undefined };
+
+export function makeAgentTraceKey(
+  sessionId: string,
+  trace?: string | null,
+): string {
+  return trace ? `${sessionId}:${trace}` : sessionId;
+}
+
+export const makeTraceKey = makeAgentTraceKey;
+
+export function makeAgentTraceUrl(
+  sessionId: string,
+  trace?: string | null,
+): `/${string}` {
+  const query = trace ? `?trace=${encodeURIComponent(trace)}` : "";
+  return `/agent-traces/${encodeURIComponent(sessionId)}${query}`;
+}
+
+interface InFlightRequest {
+  controller: AbortController;
+  subscribers: Set<(state: AgentTraceState) => void>;
+}
+
+let traceCaches = new WeakMap<ReviewSession, Map<string, LoadedAgentTrace>>();
+let inFlightRequestCaches = new WeakMap<
+  ReviewSession,
+  Map<string, InFlightRequest>
+>();
+
+function traceCacheFor(session: ReviewSession): Map<string, LoadedAgentTrace> {
+  let cache = traceCaches.get(session);
+  if (!cache) {
+    cache = new Map();
+    traceCaches.set(session, cache);
+  }
+  return cache;
+}
+
+function inFlightRequestsFor(
+  session: ReviewSession,
+): Map<string, InFlightRequest> {
+  let requests = inFlightRequestCaches.get(session);
+  if (!requests) {
+    requests = new Map();
+    inFlightRequestCaches.set(session, requests);
+  }
+  return requests;
+}
+
+export function getAgentTraceCache(
+  session: ReviewSession,
+  key: string,
+): LoadedAgentTrace | undefined {
+  return traceCaches.get(session)?.get(key);
+}
+
+export function clearAgentTraceCache(session?: ReviewSession): void {
+  if (!session) {
+    traceCaches = new WeakMap();
+    inFlightRequestCaches = new WeakMap();
+    return;
+  }
+  traceCaches.delete(session);
+  const requests = inFlightRequestCaches.get(session);
+  for (const request of requests?.values() ?? []) {
+    request.controller.abort();
+  }
+  inFlightRequestCaches.delete(session);
+}
+
+/**
+ * Shared data hook to load and cache agent traces.
+ * Manages request URL construction, loading/error/loaded state transitions,
+ * abort-on-unmount, session-scoped response caching, and in-flight request
+ * deduplication.
+ */
+export function useAgentTrace(
+  sessionId?: string | null,
+  trace?: string | null,
+): AgentTraceState {
+  const session = useReviewSession();
+  const key = sessionId ? makeAgentTraceKey(sessionId, trace) : null;
+  const traceCache = traceCacheFor(session);
+  const inFlightRequests = inFlightRequestsFor(session);
+
+  const [state, setState] = useState<{
+    key: string | null;
+    traceState: AgentTraceState;
+  }>(() => {
+    if (!key) return { key: null, traceState: { status: "idle" } };
+    const cached = traceCache.get(key);
+    if (cached) {
+      return { key, traceState: { status: "loaded", trace: cached } };
+    }
+    return { key, traceState: { status: "loading" } };
+  });
+
+  let activeState = state.traceState;
+  if (state.key !== key) {
+    const cached = key ? traceCache.get(key) : undefined;
+    const nextState: AgentTraceState = !key
+      ? { status: "idle" }
+      : cached
+        ? { status: "loaded", trace: cached }
+        : { status: "loading" };
+    setState({ key, traceState: nextState });
+    activeState = nextState;
+  }
+
+  useEffect(() => {
+    if (!key || !sessionId) return;
+
+    let cancelled = false;
+
+    const handleUpdate = (nextState: AgentTraceState) => {
+      if (cancelled) return;
+      setState((prev) =>
+        prev.key === key ? { key, traceState: nextState } : prev,
+      );
+    };
+
+    // The cache may have been filled by another consumer between this
+    // component's render (which saw a miss) and this effect. Deliver the
+    // cached value through the same update path instead of skipping out,
+    // or that render's "loading" state would never resolve.
+    const cachedNow = traceCache.get(key);
+    if (cachedNow) {
+      handleUpdate({ status: "loaded", trace: cachedNow });
+      return;
+    }
+
+    let inFlight = inFlightRequests.get(key);
+    if (!inFlight) {
+      const controller = new AbortController();
+      const subscribers = new Set<(nextState: AgentTraceState) => void>([
+        handleUpdate,
+      ]);
+
+      const url = makeAgentTraceUrl(sessionId, trace);
+
+      session
+        .fetch(url, { signal: controller.signal })
+        .then(async (response) => {
+          const json = await response.json();
+          const result = parseReviewAgentTraceResponse(json);
+          if (!response.ok || !result.ok) {
+            throw new Error(result.ok ? "Unable to load trace." : result.error);
+          }
+          traceCache.set(key, result);
+          const currentSubscribers = Array.from(subscribers);
+          for (const sub of currentSubscribers) {
+            sub({ status: "loaded", trace: result });
+          }
+        })
+        .catch((error: unknown) => {
+          if (controller.signal.aborted) return;
+          const message =
+            error instanceof Error ? error.message : String(error);
+          const currentSubscribers = Array.from(subscribers);
+          for (const sub of currentSubscribers) {
+            sub({ status: "error", error: message });
+          }
+        })
+        .finally(() => {
+          inFlightRequests.delete(key);
+        });
+
+      inFlight = { controller, subscribers };
+      inFlightRequests.set(key, inFlight);
+    } else {
+      inFlight.subscribers.add(handleUpdate);
+    }
+
+    return () => {
+      cancelled = true;
+      const entry = inFlightRequests.get(key);
+      if (entry) {
+        entry.subscribers.delete(handleUpdate);
+        if (entry.subscribers.size === 0) {
+          entry.controller.abort();
+          inFlightRequests.delete(key);
+        }
+      }
+    };
+  }, [inFlightRequests, key, session, sessionId, trace, traceCache]);
+
+  return activeState;
+}

--- a/packages/progressive-review/app/src/use-review-tab-telemetry.test.tsx
+++ b/packages/progressive-review/app/src/use-review-tab-telemetry.test.tsx
@@ -30,4 +30,5 @@ it("reports the in-tab Diff view under the original files tab name", () => {
   expect(reviewTelemetryTab("diff")).toBe("files");
   expect(reviewTelemetryTab("review")).toBe("review");
   expect(reviewTelemetryTab("map")).toBe("map");
+  expect(reviewTelemetryTab("trace")).toBe("trace");
 });

--- a/packages/progressive-review/app/src/welcome-page.tsx
+++ b/packages/progressive-review/app/src/welcome-page.tsx
@@ -42,7 +42,7 @@ export function WelcomePage({
   >(undefined);
   const status = cardStatus ?? install?.status;
   const installed = status
-    ? status.agents.some((agent) => agent.installed)
+    ? onboardingSetupComplete(status)
     : (onboarding?.installed ?? false);
   const tourChecked = onboarding?.tutorialChecked ?? 0;
   const tourTotal = onboarding?.tutorialTotal ?? 0;
@@ -172,6 +172,24 @@ export function WelcomePage({
         </div>
       </div>
     </main>
+  );
+}
+
+function onboardingSetupComplete(status: ReviewCliInstallStatus): boolean {
+  const installedAgents = status.agents.filter((agent) => agent.installed);
+  if (installedAgents.length === 0) return false;
+  const fffAgents = installedAgents.filter(
+    (agent) => agent.target === "claude" || agent.target === "codex",
+  );
+  return (
+    status.trace.enabled &&
+    (fffAgents.length === 0 ||
+      fffAgents.every((agent) =>
+        status.fff.registrations.some(
+          (registration) =>
+            registration.target === agent.target && registration.present,
+        ),
+      ))
   );
 }
 

--- a/packages/progressive-review/onboarding.md
+++ b/packages/progressive-review/onboarding.md
@@ -6,8 +6,9 @@ are edited with normal file tools. Read and mutate comment threads only through
 `review threads`. The `.build/` directory is disposable publish output.
 
 1. Run `review app launch --json`.
-2. Run `review info --json` in the source checkout. If it finds no Review, run
-   `review scaffold --json`.
+2. Run `review info --json` in the source checkout. It lists active Reviews
+   bound to that worktree and reports `matchesCheckout` for each one. If no
+   Review matches the requested change, run `review scaffold --json`.
 3. Read the JSONL event for the UUID directory, source binding, sync state,
    and unresolved threads.
 4. Edit `review.mdx` and `data.ts` in that directory. Keep the H1 and write
@@ -30,9 +31,10 @@ are edited with normal file tools. Read and mutate comment threads only through
 resolve <threadId>` only after its exact target is addressed. Question
    records remain `running`, `answered`, or `error`.
 
-`review info` is read-only discovery. It lists all Reviews for the current
-worktree, or all worktrees in the repository with `review info --all`; no
-match produces an empty `reviews` list. A new Review is `draft`; publishing
+`review info` is read-only discovery. It lists active Reviews bound to the
+current worktree, or all worktrees in the repository with `review info --all`.
+The `matchesCheckout` field reports whether the checkout equals or descends
+from each Review change. A new Review is `draft`; publishing
 sets it to `awaiting-review`. The
 reviewer submits **Approve** (`accepted`) or **Request changes**
 (`awaiting-agent-updates`), with or without comments. Dismissal sets

--- a/packages/progressive-review/package.json
+++ b/packages/progressive-review/package.json
@@ -52,7 +52,7 @@
     "build": "tsdown",
     "build:tutorial-assets": "tsx scripts/build-tutorial-assets.ts",
     "check:tutorial": "tsx scripts/check-tutorial.ts",
-    "build:workspace-deps": "node ../../scripts/run-workspace-build.mjs pnpm --filter @dev.fast/local-vcs --filter @dev.fast/review-protocol build",
+    "build:workspace-deps": "node ../../scripts/run-workspace-build.mjs pnpm --filter @dev.fast/local-vcs --filter @dev.fast/review-protocol --filter @dev-fast/trace-shared build",
     "pretypecheck": "pnpm run build:workspace-deps",
     "pretest": "pnpm run build:workspace-deps",
     "preapp:desktop:build": "pnpm run build:workspace-deps",
@@ -103,6 +103,7 @@
     "zustand": "4.5.7"
   },
   "devDependencies": {
+    "@dev-fast/trace-shared": "workspace:*",
     "@dev.fast/review-protocol": "workspace:*",
     "@types/estree": "1.0.8",
     "@types/hast": "3.0.4",

--- a/packages/progressive-review/skills/dev-review-map/SKILL.md
+++ b/packages/progressive-review/skills/dev-review-map/SKILL.md
@@ -1,13 +1,51 @@
 ---
 name: dev-review-map
 description: Author and save the pinned base and head software maps for a Review.
-argument-hint: [--pr <number-or-url>] [--base <ref> [--head <ref>]]
 ---
 
-Generate or refresh the dev.fast code map for this repository. Per-commit maps are git notes under `refs/notes/dev-fast/*` — the only durable map state, shareable with `review map push` / `review map fetch` and never checked into any branch. The editable file is a commit-addressed scratch buffer under `$GIT_COMMON_DIR/dev-fast/scratch/<commit>/`: `review map open <rev>` hydrates it and prints a provenance line that is your work order, and `review map check <rev> --review <uuid>` validates it strictly, records the map worker, and flushes it to `<rev>`'s note on success.
+# Review software-map worker
 
-Act as the dedicated map worker. Do not edit `review.mdx` or `data.ts`. Do not publish the Review document or software map. Follow the Map Agent Prompt section of [../dev-review/SKILL.md](../dev-review/SKILL.md): one loop applied twice, base first — `open <base>` → follow its work order → `check <base> --review <uuid>` → `open <head>` → apply the diff's structural changes → `check <head> --review <uuid>` → `push` when origin is writable. Use the user-supplied `--pr` / `--base` / `--head` refs, defaulting to the working-tree diff (jj `@-..@`, git merge-base(default, HEAD)..HEAD).
+Author and save two commit-addressed software maps. Work on the base first. Then update that structure for the head diff.
 
-The old `review map init` / `review map update` / `review map scaffold` / `review map snapshot` / `review map refresh` commands were removed; `open` + your own authoring + `check`'s flush-on-green replaces them all.
+Do not edit `review.mdx` or `data.ts`. Do not run `review publish` or `review map publish`.
 
-Done when `review map check <rev> --review <uuid>` passes for both revisions. Surface generation errors and the smallest next action instead of retrying blindly.
+## Storage contract
+
+Git notes under `refs/notes/dev-fast/*` are the only durable map state. Never commit a map to the source branch.
+
+`review map open <rev>` hydrates this scratch file:
+
+```text
+$GIT_COMMON_DIR/dev-fast/scratch/<commit>/software-map.ts
+```
+
+The command prints a provenance line and a work order. Read both before you edit the adjacent model declaration.
+
+`review map check <rev> --review <uuid>` validates the scratch file. A successful check saves the file to that commit's git note.
+
+## Workflow
+
+1. Use the exact base and head commits from the dispatch prompt.
+2. Run `review map open <base>`.
+3. Read the work order and inspect the repository at the base commit.
+4. Model the important people, systems, containers, components, and code elements.
+5. Use stable dot-path identities. Do not model incidental implementation detail.
+6. Run `review map check <base> --review <uuid>`. Correct errors until it passes.
+7. Run `review map open <head>` only after the base check passes.
+8. Inspect the base-to-head diff. Apply only its structural changes.
+9. Run `review map check <head> --review <uuid>`. Correct errors until it passes.
+10. Run `review map push` when the notes remote is writable. Use `--remote <name>` when `origin` is read-only.
+
+If head provenance names the wrong seed, check the base again. Then reopen the head with `--force`.
+
+Resolve validation errors. Report unrelated existing warnings without expanding the task scope. Do not retry an environmental failure without new evidence.
+
+A push failure does not invalidate successful local checks. Report the push failure so the main agent can continue local map publication.
+
+To keep a non-origin choice, run `git config devFast.notesRemote <name>`. Review uses that remote for map push, map fetch, and the installed notes refspec.
+
+When a user invokes this skill directly, use supplied base and head refs. If the user supplies none, use an active Review's pins. Otherwise, use the working-tree diff: jj `@-..@`, or the Git merge base to `HEAD`.
+
+## Completion criteria
+
+Return only after both `review map check` commands pass. Report the base and head commits, both check results, the push result, and remaining warnings. If an environmental condition blocks a check, return the blocking evidence and the smallest next action.

--- a/packages/progressive-review/skills/dev-review/SKILL.md
+++ b/packages/progressive-review/skills/dev-review/SKILL.md
@@ -1,35 +1,65 @@
 ---
 name: dev-review
-description: Author, validate, and publish a progressive Review document.
+description: Author and publish a progressive Review for a branch, jj change, or pull request. Use when a user asks to explain or review a code change in Review Desktop.
 ---
 
 # dev.fast Review
 
-The `review` app and CLI let a user engage with complex AI-generated changes through two independent artifacts:
+Author a short Review document while a dedicated sub-agent authors the software map. Publish each artifact through its own command.
 
-- an MDX Review document with exact source ranges and document-owned diagrams
-- a C4-inspired software map
+The Review has two independent artifacts:
 
-At a high level: discover or scaffold the Review, dispatch a software-map worker, author and publish the document, publish the map when the worker finishes, then iterate on reviewer feedback. Document publication never waits for the map.
+- `review.mdx` explains the change with exact source ranges and focused visuals.
+- The software map describes the repository structure at the base and head commits.
 
-A `review.mdx` file is associated with (in order of specificity) a repo, a git worktree/jj workspace, and an AI agent session.
+Document publication must not wait for map authoring.
 
-## DEV-REVIEW.md
+## Before authoring
 
-If `DEV-REVIEW.md` exists at the repo root, read it before any other review work and follow its instructions. It holds the user's review rules and domain language. Respect the rules in that document.
+Read `DEV-REVIEW.md` at the source repository root when it exists. Follow its review rules and domain language.
 
-## Parallel software-map worker
+Read [Document authoring](references/document-authoring.md) for writing rules and document structure.
 
-After scaffold resolves the Review UUID and pinned commits, delegate software-map authoring to one sub-agent. The main agent must not author the map.
+Read [Component API](references/component-api.md) before you write `data.ts`. It defines every component's props and every helper's input shape.
 
-Give the worker the source worktree, Review UUID, Review directory, `baseCommit`, and `sourceCommit`. Tell it to use `$dev-review-map`, edit only map scratch files, and return only after both `review map check` commands pass.
+Read [Trace quoting](references/trace-quoting.md) when `review trace list --review <uuid> --json` reports an available session.
 
-The main agent owns `review.mdx`, `data.ts`, document publication, the final `review map publish`, and reviewer feedback. It continues document work while the map worker runs. This separation avoids file overlap and prevents map work from delaying the first document publication.
+Read [Lifecycle and storage](references/lifecycle-and-storage.md) when you must select or update the binding. It also defines publication, state, migration, and thread behavior.
 
-Use this worker prompt with resolved values:
+Read [Prepared worktrees](references/prepared-worktrees.md) only when pinned worktree dependencies or language-server navigation do not work.
+
+## In-app Ask replies
+
+When the prompt starts with `dev-review-thread-id: <id>`, answer that Review thread. Run `review threads get <id>` from the source worktree. Treat its target and complete message list as the canonical context. Read the Review document or repository files only when the question requires them.
+
+Do not modify files. Do not publish, resolve, or reply through the CLI. Review Desktop stores your returned text in the same thread. Return only the answer to the user message that follows the header.
+
+## Workflow
+
+### 1. Resolve the Review
+
+Run `review app launch --json` to start Review Desktop. Then run `review info --json` in the source worktree. It lists active Reviews bound to that worktree and reports `matchesCheckout` for each one. Use an existing Review when it matches the requested change. If none matches, run `review scaffold --json` to create one. When the user asks for a fresh Review, pass `--new`; the explicit request overrides reuse.
+
+Pass resolved commit ids to `--base` and `--head`. Parent suffixes like `<rev>^` do not resolve in a jj workspace; resolve the parent first with `jj log -r '<rev>-'`.
+
+Read the scaffold JSON event and `<review-dir>/review.json`. Together they carry these values; record them:
+
+- Review UUID and directory
+- source worktree
+- `baseCommit` and `sourceCommit` (the scaffold event prints them under `pins`)
+- both pinned checkout paths (the scaffold event prints them under `checkouts`)
+- source binding and status
+
+`inSync: false` in `review info` means only that the source worktree does not sit on the pinned commit. That alone requires no action. Use `review scaffold --update --review <uuid>` only when the bound branch or pull request gained commits past the pin. Re-read each file whose anchored range changed after the update.
+
+### 2. Dispatch the map worker
+
+Use the current harness sub-agent facility. Dispatch one worker after Review resolution provides the UUID and pinned commits. The worker must follow the dev-review-map skill.
+
+Give the worker this prompt with resolved values. Prepend any environment setup the worker needs to run the `review` CLI (for example, a PATH prefix). When the harness has no dev-review-map skill registered, or you are not sure the worker can resolve it, give the worker the path to the skill file instead:
 
 ```text
-Use $dev-review-map in <source-worktree>.
+Use the dev-review-map skill in <source-worktree>.
 
 Review UUID: <uuid>
 Review directory: <review-dir>
@@ -42,692 +72,89 @@ Do not publish the Review document or software map.
 Return only after both `review map check <rev> --review <uuid>` commands pass.
 ```
 
-After the worker succeeds, the main agent runs `review map publish --review <uuid> --json`. If the Review became terminal, report the valid unpublished-map state and do not retry.
+The worker owns only map scratch files and git notes. The main agent owns `review.mdx`, `data.ts`, both publish commands, and reviewer feedback.
 
-If no sub-agent facility exists, publish the document and report that the map remains unpublished. Do not silently move map authoring into the main agent.
+Continue document work while the worker runs. Do not author the map in the main-agent context.
 
-## In-app Ask replies
+If no sub-agent facility exists, publish the document. Report that the map is not published. Do not silently author it in the main-agent context.
 
-When the prompt starts with `dev-review-thread-id: <id>`, answer that Review
-thread. Run `review threads get <id>` from the source worktree. Treat its
-target and complete message list as the canonical context. Read the Review
-document or repository files only when the question requires them.
+### 3. Author the document
 
-Do not modify files. Do not publish, resolve, or reply through the CLI. Review
-Desktop stores your returned text in the same thread. Return only the answer
-to the user message that follows the header.
+Read [Document authoring](references/document-authoring.md) before you edit `review.mdx` or `data.ts`.
 
-## Writing a great review
+Run `review trace list --review <uuid> --json`. When it reports an available session, run `review trace pull --review <uuid> --json`. Then read [Trace quoting](references/trace-quoting.md) and complete its intent pass before authoring. Use FFF for candidate discovery.
 
-The H1 is the review's display title in Review Desktop tabs and Home. Write a short, specific title for the change (for example, "Publish pipeline: single mount"), not a generic one. Publishing syncs the title. Use progressive disclosure: short prose first, then details that earn their cost. Typical useful sections are interface change, lifecycle/data flow, state/storage, and testing evidence. Write in ASD-STE100 Simplified Technical English (STE).
+Use the smallest document that explains the important change. Default to `AnchorLink` for source evidence. Use `CodePeek` only when readers must see the code inline to understand the main claim.
 
-Assume raw prose will confuse the reader. Spend substantial reasoning effort deciding what to omit, rather than what to include; deep analysis followed by a small amount of clear output text is the correct tradeoff. Start brief and add resolution only where it earns the reader's attention; the reader's time and attention are incredibly expensive and thus every word you put out taxes and pains them. Your job is to not waste that time. A useful trick is to write in ASD-STE100 Simplified Technical English (STE). Think about the style of RFCs from great tech leaders like Russ Cox, Dave Cheney, and the early React RFCs.
+Read every referenced range from the correct pinned checkout before you add it. Use the `checkouts` paths from the scaffold event: the head checkout for a head range, the base checkout for a base range.
 
-- Remember that the reader can ONLY see the 'user' prompts _before_ coding started and the document you write to explain what changed. This means jargon in the middle - references to specific parts of code, especially any and all abstractions, changes, and code referenced _during_ the editing process - is confusing and not helpful. More words do not help. Progressive disclosure of complexity is key.
+### 4. Publish the document
 
-1. In order to help a human understand a diff, there are likely <5 sections they would want to see in the markdown. This is a heuristic, not a hard requirement; use your best judgement and ask the user if you're unsure.
-2. Here are some high-level sections which might be helpful (but are not limited to): dataflow/lifecycle, state model, architecture boundary, storage, risks.
+Run:
 
-- risks, in particular, are tricky to get right. Models tend to state obvious ones ('untested' x LOC) which are easy to catch, and miss important ones (customer X uses this workflow and we're not accounting for it). Risk assessment is fundamentally a question of user impact; you should ask for more context here instead of guessing before deciding on risks.
-- These are three sections which are almost always relevant (esp. for larger changes):
-  - **Interface change** — show any changed contract as its caller sees it (signature, RPC/HTTP/JSON shape, CLI flag, config, or event), with a short code example and a link to a real consumer.
-  - **Testing** — connect the main claims to linked test evidence and say what remains unpinned.
-  - **Decision Log** — split into two components:
-    1. Collect and dedupe the invariants the user expressed to you in the prompt _in their own words_. Later decisions can semantically overwrite earlier ones.
-    2. Decisions that you made during implementation. State them in plain language (ASD-STE100 Simplified Technical English).
-
-## SDK Reference (data.ts file)
-
-The `data.ts` file is the data layer of the review documents.
-
-- The review runtime provides a typed SDK for source ranges and document-owned diagrams. It is available under the `virtual:progressive-review-authoring` module.
-- Anchor props take `defineAnchors` references, never strings. Do not use
-  casts, `any`, `<Participant>`, or `<Message>`.
-- Do not import run-time values from local files. Put TypeScript-only support
-  code in `data.ts`.
-
-These are the supported runtime exports and their canonical input schemas:
-
-```ts
-export const defineActors = session.defineActors;
-export const defineAnchors = session.defineAnchors;
-export const defineStores = session.defineStores;
-
-export const actorInputSchema = z.strictObject({
-  label: nonEmptyStringSchema,
-  softwareMapPath: optionalNonEmptyStringSchema,
-});
-export type ActorInput = z.infer<typeof actorInputSchema>;
-
-export const actorInputMapSchema = z.record(
-  nonEmptyStringSchema,
-  actorInputSchema,
-);
-export type ActorInputMap = z.infer<typeof actorInputMapSchema>;
-
-const codePeekCommonShape = {
-  theme: z.enum(["system", "light", "dark"]).optional(),
-  graph: z.enum(["head", "base"]).optional(),
-  children: noChildrenSchema,
-};
-
-export const codePeekRangeInputSchema = z
-  .strictObject({
-    file: nonEmptyStringSchema,
-    fromLine: z.int().positive(),
-    toLine: z.int().positive(),
-    ...codePeekCommonShape,
-  })
-  .refine((value) => value.toLine >= value.fromLine, {
-    path: ["toLine"],
-    message: "Must be greater than or equal to fromLine",
-  });
-
-export const codePeekPropsSchema = codePeekRangeInputSchema;
-
-export const anchorInputSchema = z.strictObject({
-  title: nonEmptyStringSchema,
-  peek: codePeekPropsSchema.optional(),
-  detail: optionalNonEmptyStringSchema,
-  softwareMapPath: optionalNonEmptyStringSchema,
-});
-
-export const anchorInputMapSchema = z.record(
-  nonEmptyStringSchema,
-  z.union([nonEmptyStringSchema, anchorInputSchema]),
-);
-export type AnchorInputMap = z.infer<typeof anchorInputMapSchema>;
-
-const softwareDataStoreForeignKeyRefSchema = z.union([
-  nonEmptyStringSchema,
-  z.strictObject({
-    table: nonEmptyStringSchema,
-    field: nonEmptyStringSchema,
-    label: optionalNonEmptyStringSchema,
-    cardinality: z.enum(["one-to-one", "many-to-one"]).optional(),
-    onDelete: optionalNonEmptyStringSchema,
-    onUpdate: optionalNonEmptyStringSchema,
-  }),
-]);
-const softwareDataStoreFieldSchema: z.ZodType<SoftwareDataStoreFieldSchema> =
-  z.lazy(() =>
-    z.record(
-      nonEmptyStringSchema,
-      z.union([
-        z.strictObject({
-          type: nonEmptyStringSchema,
-          example: z.unknown().optional(),
-          pk: z.boolean().optional(),
-          fk: softwareDataStoreForeignKeyRefSchema.optional(),
-          schema: softwareDataStoreFieldSchema.optional(),
-        }),
-        softwareDataStoreFieldSchema,
-      ]),
-    ),
-  );
-
-export const softwareDataStoreCollectionInputSchema = z.strictObject({
-  label: optionalNonEmptyStringSchema,
-  key: optionalNonEmptyStringSchema,
-  schema: softwareDataStoreFieldSchema,
-});
-const softwareDataStoreCollectionMapSchema = z.record(
-  nonEmptyStringSchema,
-  softwareDataStoreCollectionInputSchema,
-);
-export const storeKindSchema = z.enum(["relational", "document"]);
-export const storeInputSchema = z.strictObject({
-  kind: storeKindSchema,
-  label: nonEmptyStringSchema,
-  dataStoreKind: softwareDataStoreKindSchema.optional(),
-  softwareMapPath: optionalNonEmptyStringSchema,
-  tables: softwareDataStoreCollectionMapSchema.optional(),
-  documents: softwareDataStoreCollectionMapSchema.optional(),
-});
-
-export const storeInputMapSchema = z.record(
-  nonEmptyStringSchema,
-  storeInputSchema,
-);
-export type StoreInputMap = z.infer<typeof storeInputMapSchema>;
+```sh
+review publish --review <uuid> --json
 ```
 
-Use the smallest source range that proves the claim. Do not use a broad region.
-Read the range from the correct pinned worktree before you add the anchor.
+Read each NDJSON error event. Correct all document errors and publish again. A missing software map is not a document error.
 
-## MDX Component Reference (review.mdx file)
+A successful document publish updates `presentedDocumentRevision`. It preserves `presentedSoftwareMapRevision` and sets the status to `awaiting-review`.
 
-The `review.mdx` file is the presentation layer of the review documents.
+Show the published document immediately:
 
-`SequenceDiagram` is more useful than prose for temporal behavior and
-`DatabaseLens` for persisted-state changes. Visuals are cheaper to understand than prose.
-
-Default to `AnchorLink` for source evidence. Use `CodePeek` only when readers
-must see the code inline to understand the main claim.
-
-- MDX uses JavaScript grammar.
-- Write diagram inputs in `data.ts` instead; component schemas validate them.
-- Every sequence message needs anchored peek or inline-code evidence.
-- You're not limited the components below, although they are included by default. You are free to write any valid MDX that you would like to include to communicate the software system to the user, including arbitrary React + MDX.
-
-These are the canonical prop schemas. `DbRead` and `DbWrite` both use
-`dbOperationPropsSchema`.
-
-```ts
-const sequenceMessageBaseShape = {
-  from: sequenceActorInputSchema,
-  to: sequenceActorInputSchema,
-  label: nonEmptyStringSchema,
-};
-export const sequenceMessageInputSchema = z.union([
-  z.strictObject({
-    ...sequenceMessageBaseShape,
-    anchor: peekableAnchorRefSchema,
-    code: sequenceMessageCodeInputSchema.optional(),
-  }),
-  z.strictObject({
-    ...sequenceMessageBaseShape,
-    anchor: anchorRefSchema.optional(),
-    code: sequenceMessageCodeInputSchema,
-  }),
-]);
-
-export const sequenceDiagramPropsSchema = z.strictObject({
-  label: nonEmptyStringSchema,
-  messages: z.array(sequenceMessageInputSchema).min(1),
-  children: noChildrenSchema,
-});
-
-export const reviewCodePeekPropsSchema = z.strictObject({
-  anchor: peekableAnchorRefSchema,
-  children: noChildrenSchema,
-});
-
-export const anchorLinkPropsSchema = z.strictObject({
-  anchor: peekableAnchorRefSchema,
-  children: reactNodeSchema,
-});
-
-export const reviewSectionPropsSchema = z.strictObject({
-  title: nonEmptyStringSchema,
-  defaultCollapsed: z.boolean().optional(),
-  children: reactNodeSchema,
-});
-
-export const dbUseCasePropsSchema = z.strictObject({
-  id: nonEmptyStringSchema,
-  label: nonEmptyStringSchema,
-  summary: optionalNonEmptyStringSchema,
-  children: reactNodeSchema,
-});
-
-export const dbOperationPropsSchema = z.strictObject({
-  from: z.union([actorRefSchema, targetRefSchema]),
-  to: z.union([actorRefSchema, targetRefSchema]),
-  label: nonEmptyStringSchema,
-  anchor: peekableAnchorRefSchema,
-  children: noChildrenSchema,
-});
-
-export const databaseLensPropsSchema = z.strictObject({
-  title: optionalNonEmptyStringSchema,
-  stores: z.record(
-    nonEmptyStringSchema,
-    z.custom<StoreRef>(
-      (value) =>
-        Boolean(value) &&
-        typeof value === "object" &&
-        (value as { __kind?: unknown }).__kind === "db-store-ref" &&
-        typeof (value as { id?: unknown }).id === "string" &&
-        typeof (value as { label?: unknown }).label === "string",
-      "Must be a store reference returned by defineStores",
-    ),
-  ),
-  height: z.number().positive().optional(),
-  children: reactNodeSchema,
-});
+```sh
+review app pick --review <uuid> --json
 ```
 
-### CallStackDiff (call-flow evidence)
+### 5. Publish the map
 
-`CallStackDiff` renders two authored call stacks as one git-diff-styled
-stack. Removed frames print `-`, added frames print `+`, shared frames are
-context. Every frame is a live link: a click opens that anchor's peek.
+Join the map worker after document publication. If the Review became terminal, report the valid unpublished-map state and do not retry.
 
-```ts
-export const callStackDiffPropsSchema = z
-  .strictObject({
-    title: optionalNonEmptyStringSchema,
-    base: z.array(z.union([peekableAnchorRefSchema, callsAssertionSchema])),
-    head: z.array(z.union([peekableAnchorRefSchema, callsAssertionSchema])),
-    children: noChildrenSchema,
-  })
-  .superRefine(/* side rules below */);
+A worker that finishes early changes nothing. Publish the map only after the document publish. A failed or skipped `review map push` to origin does not gate publication. Only the two checks gate publication.
+
+If both checks passed, run:
+
+```sh
+review map publish --review <uuid> --json
 ```
 
-Rules:
+This command updates only `presentedSoftwareMapRevision`. It preserves the document pointer and Review status.
 
-1. List order is the stack. Each frame calls the one below it.
-2. Define one anchor per frame. Point its peek at the call site or the
-   function head.
-3. The diff is positional over anchor identity. A shared frame is one head
-   anchor listed in both `base` and `head`; it renders as context and opens
-   the new code.
-4. A frame only in `base` is a removed call. Its anchor must set
-   `graph: "base"` so the `-` row opens the old code. The schema rejects a
-   head-graph anchor that appears only in `base`, and any base-graph anchor
-   in `head`.
-5. Use `calls(parent, child, reason?)` in place of a frame when the hop is
-   hard to follow by eye (queues, callbacks, RPC). It renders the child
-   frame with a dashed `≈` marker; hover shows parent, child, and reason.
-6. One component holds one linear stack. Use two components for two flows.
-7. A `-` row is a claim of removal and a `+` row a claim of addition.
-   Publish checks each against the pinned diff: a `-` frame must anchor a
-   range with deleted lines, and a `+` frame a range with added lines.
-   Anchor the removed or added call site. Do not list a frame on one side
-   for contrast — publish rejects it.
+If the worker fails, keep the valid document publication. Report the map failure and the smallest next action.
 
-```mdx
-<CallStackDiff
-  title="Warm allocation"
-  base={[anchors.reconcile, anchors.auth, anchors.enqueueWork]}
-  head={[
-    anchors.reconcile,
-    anchors.enqueueWork,
-    calls(anchors.enqueueWork, anchors.processItem, "dispatched via the workqueue"),
-  ]}
-/>
+### 6. Handle feedback
+
+Wait for a status that requires agent action. Use the command for the current harness:
+
+```sh
+review wait --requires-agent --review <uuid>
+review wait --requires-agent --codex --review <uuid>
 ```
 
-The stacks are authored claims, like prose — nothing verifies the edges.
-Publish still resolves every anchor against its pinned worktree, so a
-frame that points at code that does not exist fails the publish.
+Use only one wait command.
 
-### Example document
+- For `awaiting-agent-updates`, read the threads with `review threads list`. Address every open thread. Mark each addressed thread with `review threads resolve <threadId> --review <uuid>`. A document re-publish requires zero open comment threads. Update moved pins with `review scaffold --update` when required. If pins move, dispatch a new map worker with the new pins. Publish the document without waiting for the new map. Then publish the new map after both checks pass.
+- For `review-dismissed` or `review-deleted`, stop the loop.
+- While the status is `awaiting-review`, the reviewer owns the next action.
 
-`${DEV_REVIEW_HOME}/reviews/${uuid}/data.ts`
-
-```ts
-import {
-  defineActors,
-  defineAnchors,
-} from "virtual:progressive-review-authoring";
-
-export const actors = defineActors({
-  agent: { label: "Agent" },
-  desktop: { label: "Desktop" },
-});
-
-export const anchors = defineAnchors({
-  resolveThing: {
-    title: "Resolver",
-    peek: { file: "src/resolve.ts", fromLine: 12, toLine: 28 },
-  },
-  publish: {
-    title: "Publish",
-    peek: { file: "src/publish.ts", fromLine: 40, toLine: 66 },
-  },
-});
-
-export const messages = [
-  {
-    from: actors.agent,
-    to: actors.desktop,
-    label: "Publish candidate",
-    anchor: anchors.publish,
-  },
-];
-```
-
-`${DEV_REVIEW_HOME}/reviews/${uuid}/review.mdx`
-
-```mdx
-import { anchors, messages } from "./data.ts";
-
-<CodePeek anchor={anchors.resolveThing} />
-
-See <AnchorLink anchor={anchors.publish}>the publish implementation</AnchorLink>
-for supporting evidence.
-
-<SequenceDiagram label="Publish" messages={messages} />
-```
-
-## Disk layout
-
-A review has one canonical UUID directory under
-`${DEV_REVIEW_HOME:-~/.dev}/reviews/<uuid>/`. The directory contains
-the source document, the review state, and the history of the document.
-
-```text
-${DEV_REVIEW_HOME:-~/.dev}/reviews/
-└── <uuid>/
-    ├── review.mdx
-    ├── data.ts
-    ├── review.json
-    ├── review.db              # Comment threads and drafts (SQLite).
-    ├── package.json
-    ├── review-test.mjs
-    ├── .gitignore
-    ├── .bundle/
-    │   ├── document/          # Current document candidate.
-    │   └── software-map/      # Current map candidate, when present.
-    ├── .build/
-    │   └── <revision>/        # An exact, temporary artifact copy.
-    └── .git/
-```
-
-- Agent-Owned Files: agents are allowed to modify the following files:
-  - `review.mdx` is the main Review document. Edit this file.
-  - `data.ts` contains optional TypeScript support code. Use this file only for
-    TypeScript support code.
-- Review Infrastructure: the following files are read-only infra files. Do not directly edit any of them except (incidentally) through 'review' CLI commands:
-  - `review.json` contains the UUID, the source worktree, the pinned commits, the
-    status, `presentedDocumentRevision`, and `presentedSoftwareMapRevision`.
-  - `review.db` contains durable comment threads and comment drafts
-    (SQLite). Read and mutate it only through `review threads` — never open or
-    edit the storage directly.
-  - `.bundle/document/` contains the current document candidate.
-    `.bundle/software-map/` contains the current map candidate, when present.
-    Review owns both directories.
-  - `.build/<revision>/` contains a materialized document or map revision.
-    Do not edit this directory. Review can make the directory again.
-  - `package.json` and `review-test.mjs` supply the Review test interface. Review
-    owns these files.
-  - `.git/` contains the private Review document history. It is a normal Git
-    repository, but Review owns its commits and refs. Do not use it as the source
-    repository or mutate it directly.
-  - `.gitignore` keeps `.build/` and the thread database out of the Review
-    history.
-
-`review migrate apply` converts supported Reviews to schema 3 and the split
-bundle layout. The migration drops old question data. Private history can
-retain older combined revisions. Active pointers and materialized artifacts
-use the current layout. Do not edit migration records directly.
-
-## Lifecycle
-
-The reviewer only sees sealed revisions. `review publish` presents the
-document. `review map publish` presents the software map independently.
-
-The checkout's position never matters. Scaffold pins the head from the
-review's binding (a branch, bookmark, change id, or PR). It materializes and
-prepares dedicated worktrees for the pinned head and base. Sessions read those
-worktrees, not the user's working tree. To review a GitHub PR,
-scaffold with `--pr <number-or-url>` — and bind to the PR even when its
-branch is checked out locally. A PR-bound review re-pins from GitHub on
-`--update` and takes its base from the PR; a branch-bound review follows only
-the local bookmark. When the bound change gains commits, run
-`review scaffold --update` to re-pin (it is an upsert: with no existing
-review it creates one). Publish never moves pins — it warns when they are
-behind the bound change. During `--update`, scaffold reports each anchor whose
-source file changed between the old and new pins. Re-read each reported file
-in the new pinned worktree. Then adjust the range in `data.ts` if necessary.
-A bare scaffold requires a named checkout (a branch,
-bookmark, or change id); a detached HEAD needs `--head <ref>`.
-
-1. Run `review app launch --json`. This command works outside a repository and
-   does not need a terminal.
-2. Run `review info --json` in the source worktree. If it reports no Review for
-   the worktree, run `review scaffold --json` to create a new review document
-   (under a new UUID path).
-3. Read the JSONL output. Use its directory, unit of change, sync state, and
-   open-thread count. The document is `<dir>/review.mdx`; the pinned commits
-   live in `<dir>/review.json`.
-4. Dispatch the dedicated software-map worker with the UUID, directory, and
-   pinned commits. Do not wait for it before you author the document.
-5. Edit `data.ts` and `review.mdx`. Before you add a code range, read its exact
-   lines from `.git/dev-fast/worktrees/<commit-prefix>`. Use `sourceCommit` for
-   a head range and `baseCommit` for a base range.
-6. Run `review publish --json` in the source worktree. Always pass `--json`.
-   Every `review` command accepts it.
-   With `--json`, stdout carries only JSON events, one per line, and human
-   progress goes to stderr. Failures also print a JSON error event on stdout.
-7. If `review publish --json` fails, read the JSON error events. Every
-   diagnostic is a hard error. A path outside the pinned worktree or a line
-   range outside its file blocks publish.
-   Correct the Review files and run the command again.
-8. If `review publish` succeeds, Review records a new
-   `presentedDocumentRevision`. It preserves `presentedSoftwareMapRevision`.
-   A missing software map does not block document publication.
-9. Join the map worker. If the Review is active, run
-   `review map publish --review <uuid> --json`. This command preserves the
-   document pointer and status. If the Review became terminal, report the
-   valid document-only result and do not retry.
-10. Run `review app pick --review <uuid> --json` to show the active Review.
-11. Run one command that waits for a status that requires agent action:
-   - `review wait --requires-agent --review <uuid>` with a backgrounded bash tool (harnesses like claude code)
-   - `review wait --requires-agent --codex --review <uuid>` (the openai codex harness)
-   - Depending on the state of the review:
-     - `awaiting-agent-updates`: Read the threads, correct the Review, run `review scaffold --update` if the commits moved, and publish again.
-     - `accepted`, `rejected`, and `review-deleted` end the loop, then end the turn.
-
-```mermaid
-sequenceDiagram
-    participant Agent
-    participant MapWorker as Map worker
-    participant CLI as Review CLI
-    participant Store as UUID Review directory
-    participant Desktop
-    participant Reviewer
-
-    Agent->>CLI: review app launch --json
-    CLI->>Desktop: start or activate the released app
-    Agent->>CLI: review info or review scaffold
-    CLI->>Store: discover or create the UUID binding
-    Agent->>MapWorker: UUID and pinned commits
-    Agent->>Store: edit data.ts and review.mdx
-    Agent->>CLI: review publish --json --review <uuid>
-    CLI->>Store: seal the document revision
-    CLI->>Desktop: present document revision
-    Desktop->>Store: set presentedDocumentRevision and awaiting-review
-    MapWorker->>CLI: save checked base and head notes
-    MapWorker-->>Agent: map checks pass
-    Agent->>CLI: review map publish --json --review <uuid>
-    CLI->>Store: seal the software-map revision
-    CLI->>Desktop: present software-map revision
-    Desktop->>Store: set presentedSoftwareMapRevision; preserve status
-    Desktop-->>Reviewer: show document with optional map
-    Agent->>CLI: review app pick --review <uuid> --json
-    Agent->>CLI: review wait --requires-agent --review <uuid>
-    Reviewer->>Desktop: comment, ask, submit, or dismiss
-    Desktop->>Store: persist thread and status changes
-    CLI-->>Agent: wait resolves with the new status
-```
-
-Do not run `npm test` directly. `review publish` gives the required private test
-command to `review-test.mjs`.
+Read and change threads only through `review threads`. Do not edit `review.db`.
 
 ## Architecture reviews
 
-Most Reviews explain a change. A Review can also explain a codebase as it
-stands — the reader asks for an "architecture review", or for the data flows,
-access patterns, and code paths of a repo. There is no diff to walk, so:
+A Review can explain a codebase as it stands:
 
-1. Pin the same commit as base and head: `review scaffold --base <ref> --head
-   <ref>` with one ref (`@` in jj, `HEAD` in git). An empty diff is expected
-   and valid; the bundled tutorial Review is built this way.
-2. Choose sections that describe the system, not a change. Data flow and
-   lifecycle, the state and storage model, the boundaries between modules, and
-   the paths a request or command takes are the useful ones. The
-   interface-change, testing-evidence, and decision-log sections assume a diff
-   — omit them.
-3. Carry the weight in code peeks and diagrams rather than prose. A sequence
-   diagram of the main path and peeks at the functions it names teach more
-   than a written tour of the same code.
-4. Scope it. A whole repo does not fit one document; name the subsystem in the
-   H1 and say in the first paragraph what the review leaves out.
+1. Pin the same commit as base and head: `review scaffold --base <ref> --head <ref>` with one ref (`@` in jj, `HEAD` in git).
+2. Choose sections that describe the system (data flows, state, storage, and module boundaries). Omit diff-specific sections (interface changes, test claims, decision logs).
+3. Use diagrams and code peeks instead of raw prose. Scope the review to one subsystem.
 
-Everything else — the map worker, publish, the wait loop — is unchanged.
+All other steps (map worker, publish, wait loop) remain identical.
 
-A Review binds to one unit of change: a git branch, a jj bookmark, or a jj
-change id. Choose it deliberately with `review scaffold --head <name>` — a
-bookmark for a document about a whole stack, a change id for a single-change
-review. The base needs the same deliberateness: a bare scaffold defaults it
-to the trunk fork point, which is correct only for work branched from trunk.
-For a review in the middle of a stack, pass `--base <the branch directly
-below>`; for a single-change review, pass the change's parent (`--base @-` in
-jj, `--base <head>~1` in git). A wrong base is visible immediately as an
-oversized diff, and `review scaffold --update --base <ref>` corrects it
-without re-scaffolding. A bare `review scaffold` defaults to the bookmark on the checked-out
-change (or its change id when unnamed); the scaffold output echoes the chosen
-`change` so a wrong default is visible immediately. The binding is movable:
-`review rebind <change> --review <uuid>` points the review at a different
-bookmark, branch, or change id and re-pins from it immediately.
+## Completion criteria
 
-Use `review scaffold` when you need a new, separate Review for the same worktree.
-`review info` is read-only discovery: it lists all Reviews for the current
-worktree, or all worktrees in the repository with `--all`. Read each
-`status` to determine who acts next. Then, run `review publish --review <uuid>`.
+Complete the authoring turn only when all applicable conditions are true:
 
-A newly scaffolded Review is `draft`. Desktop Home does not show a draft. Every
-successful document publish sets status to `awaiting-review`. A map publish
-does not change the status. The reviewer acts through three controls, each
-valid only from `awaiting-review`. "Ask now" adds a draft comment and starts
-an agent without a status change. "Request changes" submits the feedback and
-sets `awaiting-agent-updates`. **Approve** sets `accepted`. **Dismiss** closes
-the Review without changing its handoff status. Approve and Request changes
-work with or without comments.
-
-`accepted` and `rejected` are terminal: you cannot publish either Review
-again. Desktop Home keeps every published Review visible through these
-states. Use `review scaffold` if the work must continue.
-
-```mermaid
-stateDiagram-v2
-    [*] --> draft: review scaffold
-    draft --> awaiting_review: document publish
-    awaiting_agent_updates --> awaiting_review: document publish
-    awaiting_review --> awaiting_agent_updates: Request changes
-    awaiting_review --> accepted: Approve
-    awaiting_review --> rejected: Reject
-    accepted --> [*]
-    rejected --> [*]
-
-    awaiting_review: awaiting-review
-    awaiting_agent_updates: awaiting-agent-updates
-```
-
-`review wait --requires-agent` resolves on any status except `awaiting-review`
-(`draft`, `awaiting-agent-updates`, `accepted`, `rejected`) or when the review
-directory disappears — that last case is a distinct `review-deleted` event,
-not a status.
-
-`review publish` validates the document before it contacts Review Desktop. It
-checks compilation and each source range against the pinned worktree. A map is
-not part of this gate. A failed validation does not replace the last good
-document revision. After promotion, the desktop mounts the document and
-reports mount errors through the CLI.
-
-A document re-publish requires zero open comment threads. Before each
-re-publish, run `review threads list`. Address every open thread. Mark each
-addressed thread with `review threads resolve <threadId> --review <uuid>`.
-Run `review threads list` again. Do not re-publish until no comment thread has
-`status: "open"`. The first document publication does not use this gate.
-
-`review map publish` validates the saved base and head maps for the commits in
-the presented document. It does not compile or publish the document. An
-identical map publish reuses the existing map revision.
-
-## Prepared worktrees (devfast.prepare)
-
-Scaffold materializes one worktree per pinned commit (head and base) and runs
-the repo's prepare commands in each. Prepared trees give editor language
-servers working go-to-definition. The commands live in the repo's git
-config as the multi-valued key `devfast.prepare` — unversioned, per clone, set
-by the human or agent on the machine, never by the reviewed commits.
-
-To configure `devfast.prepare`:
-
-1. Inspect the repo's toolchain and match its lockfile exactly:
-   `pnpm-lock.yaml` → `pnpm install --frozen-lockfile`; `package-lock.json` →
-   `npm ci`; `yarn.lock` → `yarn install --immutable`; `uv.lock` → `uv sync`;
-   `go.mod` → `go mod download`; `Cargo.lock` → `cargo fetch`.
-2. `git config devfast.prepare '<install command>'` sets the first command.
-   `git config --add devfast.prepare '<next command>'` appends more; commands
-   run in file order.
-3. Installing is often not enough. If workspace packages export from build
-   output (`"exports"` pointing at `dist/`), imports of those packages stay
-   unresolved until they are built — add a build step, scoped to library
-   packages, for example `git config --add devfast.prepare
-'pnpm -r --filter "./packages/**" run build'`. Exclude application targets;
-   they are slow and unneeded.
-4. Verify: after the next scaffold, the worktree under
-   `.git/dev-fast/worktrees/<commit>` should resolve a workspace import
-   (spot-check one `node_modules` symlink and the target's built artifacts).
-
-Prepare failure is soft: scaffold warns and keeps the unprepared tree. The
-warning includes the tail of the command output plus the full log
-path (`<worktree>.prepare-log`). A `.prepared` marker beside each worktree
-records the command-list hash; changing the config re-prepares automatically.
-Config changes re-run prepare on the next `scaffold` or `scaffold --update`.
-
-## Thread stores
-
-Read and mutate thread state only through the CLI, run in the source worktree:
-
-- `review threads list [--review <uuid>]` prints `{ review, comments }` as JSON.
-- `review threads get <threadId> [--review <uuid>]` prints one submitted or
-  draft comment thread as JSON. Without `--review`, it searches all Reviews in
-  the source worktree.
-- `review threads resolve <threadId> [--review <uuid>]` marks a comment thread
-  resolved.
-- `review threads reply <threadId> --body <text> [--review <uuid>]` appends a
-  reply message to a comment thread.
-
-`comments` is a map keyed by its own `threadId`:
-
-```ts
-type CommentThread = {
-  threadId: string;
-  target: ThreadTarget;
-  status: "open" | "resolved";
-  messages: Array<{
-    id: string;
-    by: string;
-    at: string;
-    body: string;
-    role?: "reviewer" | "agent";
-    format?: "plain" | "markdown";
-  }>;
-};
-type Comments = Record<string, CommentThread>;
-```
-
-Do not invent, rewrite, or merge opaque targets. Resolve only the exact thread
-after its document/code change is present. A re-publish fails while any comment
-thread remains open.
-
-## Migrations of Legacy Review State
-
-Run `review migrate apply` to move legacy Review data. Do not use it for the
-normal authoring workflow. The command converts supported Reviews to schema 3.
-It also splits a valid combined revision into independent document and map
-pointers. It drops legacy question state. It drops stored UUID Reviews whose
-`data.ts` still defines removed `symbol` or `declarationId` peeks. It preserves
-range-only Reviews. Use `--force` only to restart interrupted development state.
-
-## Source and software-map rules
-
-`review.json` is the source of truth for the commits and branches that a
-software map represents.
-Its `sourceBranch` is the bound unit of change and `sourceCommit`/`baseCommit`
-are the pinned commits. `review publish` presents the pinned commits as
-stored; when they are behind the bound change it warns to run
-`review scaffold --update` first.
-
-### Map Agent Prompt
-
-> Non-interactively author the software map for this repository. Maps are
-> per-commit git notes under `refs/notes/dev-fast/*`; never commit them to the
-> source branch. Read the adjacent model declaration before editing. Model a C4
-> structure with stable dot-path identities: people, systems, containers,
-> components, and only important code elements. Resolve validation errors and
-> report unrelated pre-existing warnings without expanding scope.
->
-> Use the pinned commits from `review.json`. Run `review map open <base>`.
-> Follow its provenance and work order. Run `review map check <base> --review <uuid>`. Then run
-> `review map open <head>`. Apply only the target diff. Run
-> `review map check <head> --review <uuid>`. Run `review map push` when origin is writable.
-> Base must pass before head so head seeds from the pinned base map. If head
-> provenance names another seed, check base and reopen head with `--force`.
-> Do not edit `review.mdx` or `data.ts`. Do not publish either artifact.
+- Review Desktop shows the published document.
+- The map is published, or you reported why it is not published.
+- All document diagnostics are resolved.
+- Both map checks passed before map publication.
+- The Review is waiting on the reviewer, the reader dismissed it, or the Review was deleted.

--- a/packages/progressive-review/skills/dev-review/references/component-api.md
+++ b/packages/progressive-review/skills/dev-review/references/component-api.md
@@ -1,0 +1,189 @@
+# Component API
+
+Props for every built-in MDX component and every `data.ts` helper. All schemas are strict: an unknown prop fails validation. `children: none` means the component rejects children.
+
+Import helper functions only in `data.ts`. In `review.mdx`, import authored values from `./data.ts`. Use the built-in MDX components without importing them.
+
+## data.ts helpers
+
+Import from `virtual:progressive-review-authoring`.
+
+### defineActors
+
+```ts
+export const actors = defineActors({
+  agent: { label: "Agent" },                              // label: string (required)
+  server: { label: "Server", softwareMapPath: "system.server" }, // softwareMapPath?: string
+});
+```
+
+### defineAnchors
+
+Each value is a string title, or:
+
+```ts
+export const anchors = defineAnchors({
+  spawn: {
+    title: "PTY spawn site",             // required
+    detail: "Cold-path fallback branch", // optional
+    softwareMapPath: "system.server",    // optional
+    peek: {                              // optional; required for CodePeek/SequenceDiagram/CallStackDiff/DbRead/DbWrite use
+      file: "src/auth.ts",               // path inside the pinned worktree
+      fromLine: 214,                     // positive int
+      toLine: 223,                       // >= fromLine
+      graph: "head",                     // "head" (default) | "base"
+      theme: "system",                   // "system" | "light" | "dark", optional
+    },
+  },
+});
+```
+
+An anchor without `peek` can label things but cannot open code. `AnchorLink` and every diagram frame require an anchor **with** `peek`.
+
+### defineStores
+
+```ts
+export const stores = defineStores({
+  reviewDb: {
+    kind: "relational",                  // "relational" | "document"
+    label: "review.db",
+    tables: {                            // or `documents` for kind "document"
+      threads: {
+        label: "threads",                // optional
+        key: "id",                       // optional
+        schema: {
+          id: { type: "text", pk: true },
+          body: { type: "text" },
+        },
+      },
+    },
+  },
+});
+```
+
+### calls(parent, child, reason?)
+
+For `CallStackDiff` frames where the hop is hard to follow (queues, callbacks, RPC). `parent` and `child` are peekable anchors; `reason` is an optional string shown on hover.
+
+## Components
+
+### AnchorLink
+
+Link prose to an anchored source range, opened in side peek.
+
+```mdx
+<AnchorLink anchor={anchors.spawn}>the spawn site</AnchorLink>
+```
+
+Props: `anchor` (peekable anchor, required). Children: the link text (required).
+
+### CodePeek
+
+Show one anchored range inline in the document.
+
+```mdx
+<CodePeek anchor={anchors.spawn} />
+```
+
+Props: `anchor` (peekable anchor, required). Children: none.
+
+### ReviewSection
+
+Collapse optional detail. `##` headings wrap into sections automatically; use the explicit component only to start collapsed.
+
+```mdx
+<ReviewSection title="Edge cases" defaultCollapsed>…</ReviewSection>
+```
+
+Props: `title` (required), `defaultCollapsed?` (boolean). Children: content.
+
+### SequenceDiagram
+
+```mdx
+<SequenceDiagram label="Open a trace quote" messages={messages} />
+```
+
+Props: `label` (required), `messages` (non-empty array, required). Children: none.
+
+Each message:
+
+```ts
+{
+  from: actors.agent,            // actor ref, or inline { label: "CLI" }
+  to: actors.server,
+  label: "startLogin(cols, rows)",
+  anchor: anchors.spawn,         // peekable anchor — required unless `code` is set
+  code: "spawnPty(dims)",        // string or { language?, text } — required unless `anchor` peek is set
+}
+```
+
+Every message needs source evidence: a peekable `anchor`, or an inline `code` value.
+
+### CallStackDiff
+
+Two authored call stacks rendered as one git-diff-styled stack.
+
+```mdx
+<CallStackDiff
+  title="Warm allocation"
+  base={[anchors.reconcile, anchors.auth, anchors.enqueueWork]}
+  head={[
+    anchors.reconcile,
+    anchors.enqueueWork,
+    calls(anchors.enqueueWork, anchors.processItem, "dispatched via the workqueue"),
+  ]}
+/>
+```
+
+Props: `title?`, `base` and `head` (arrays of peekable anchors or `calls(...)` entries). Children: none.
+
+Rules:
+
+1. List order is the stack. Each frame calls the one below it.
+2. Define one anchor per frame. Point its peek at the call site or the function head.
+3. The diff is positional over anchor identity. A shared frame is one head anchor listed in both `base` and `head`; it renders as context and opens the new code.
+4. A frame only in `base` is a removed call. Its anchor must set `graph: "base"`. The schema rejects a head-graph anchor that appears only in `base`, and any base-graph anchor in `head`.
+5. Use `calls(parent, child, reason?)` in place of a frame when the hop is hard to follow by eye. It renders the child frame with a dashed `≈` marker.
+6. One component holds one linear stack. Use two components for two flows.
+7. A `-` row claims removal and a `+` row claims addition. Publish checks each against the pinned diff: a `-` frame must anchor a range with deleted lines, and a `+` frame a range with added lines. Do not list a frame on one side only for contrast — publish rejects it.
+
+### DatabaseLens, DbUseCase, DbRead, DbWrite
+
+Persisted-state structure and operations. Add this model only when a storage diagram materially helps the reader.
+
+```mdx
+<DatabaseLens title="Thread storage" stores={{ reviewDb: stores.reviewDb }}>
+  <DbUseCase id="resolve" label="Resolve a thread">
+    <DbRead from={stores.reviewDb.tables.threads} to={actors.agent}
+      label="load open threads" anchor={anchors.loadThreads} />
+    <DbWrite from={actors.agent} to={stores.reviewDb.tables.threads}
+      label="mark resolved" anchor={anchors.markResolved} />
+  </DbUseCase>
+</DatabaseLens>
+```
+
+- `DatabaseLens` props: `title?`, `stores` (record of `defineStores` refs, required), `height?`. Children: use cases.
+- `DbUseCase` props: `id`, `label` (both required), `summary?`. Children: operations.
+- `DbRead` props: `from` (store collection ref), `to` (actor ref), `label`, `anchor` (peekable). Children: none.
+- `DbWrite` props: `from` (actor ref), `to` (store collection ref), `label`, `anchor` (peekable). Children: none.
+
+Direction is part of the schema: a read flows store → actor, a write flows actor → store. A swapped pair fails validation.
+
+Use a collection reference for an operation on the full collection. Use `.fields.<name>` for a specific field:
+
+```mdx
+<DbRead from={stores.reviewDb.tables.threads.fields.body} to={actors.agent}
+  label="load thread body" anchor={anchors.loadThreads} />
+```
+
+### TraceQuote
+
+Quote one agent-session event; the quote opens the trace at that moment.
+
+```mdx
+<TraceQuote sessionId="0a50cd8a-…" event={46}>Keep the fallback at 120x30.</TraceQuote>
+```
+
+Props: `sessionId` (required), `event?` (non-negative int hint), `trace?` (subagent trace name). Children: the quoted text.
+
+Publish verifies the children against the session transcript. Read [Trace quoting](trace-quoting.md) for the workflow and quote rules.

--- a/packages/progressive-review/skills/dev-review/references/document-authoring.md
+++ b/packages/progressive-review/skills/dev-review/references/document-authoring.md
@@ -1,236 +1,101 @@
 # Document authoring
 
-## Writing a great review
+## Reader contract
+
+The reader sees the original user request and the Review document. The reader does not see agent reasoning or the implementation session.
 
 The H1 is the review's display title in Review Desktop tabs and Home. Write a short, specific title for the change (for example, "Publish pipeline: single mount"), not a generic one. Publishing syncs the title. Use progressive disclosure: short prose first, then details that earn their cost. Typical useful sections are interface change, lifecycle/data flow, state/storage, and testing evidence. Write in ASD-STE100 Simplified Technical English (STE).
 
-Assume raw prose will confuse the reader. Spend substantial reasoning effort deciding what to omit, rather than what to include; deep analysis followed by a small amount of clear output text is the correct tradeoff. Start brief and add resolution only where it earns the reader's attention; the reader's time and attention are incredibly expensive and thus every word you put out taxes and pains them. Your job is to not waste that time. A useful trick is to write in ASD-STE100 Simplified Technical English (STE). Think about the style of RFCs from great tech leaders like Russ Cox, Dave Cheney, and the early React RFCs.
+Assume raw prose will confuse the reader. Spend substantial reasoning effort deciding what to omit, rather than what to include; deep analysis followed by a small amount of clear output text is the correct tradeoff. Start brief and add resolution only where it earns the reader's attention; the reader's time and attention are incredibly expensive and thus every word you put out taxes and pains them. Your job is to not waste that time. Think about the style of RFCs from great tech leaders like Russ Cox, Dave Cheney, and the early React RFCs.
 
-- Remember that the reader can ONLY see the 'user' prompts _before_ coding started and the document you write to explain what changed. This means jargon in the middle - references to specific parts of code, especially any and all abstractions, changes, and code referenced _during_ the editing process - is confusing and not helpful. More words do not help. Progressive disclosure of complexity is key.
+Remember that the reader can ONLY see the 'user' prompts _before_ coding started and the document you write to explain what changed. This means jargon in the middle - references to specific parts of code, especially any and all abstractions, changes, and code referenced _during_ the editing process - is confusing and not helpful. More words do not help. Progressive disclosure of complexity is key.
 
-1. In order to help a human understand a diff, there are likely <5 sections they would want to see in the markdown. This is a heuristic, not a hard requirement; use your best judgement and ask the user if you're unsure.
-2. Here are some high-level sections which might be helpful (but are not limited to): dataflow/lifecycle, state model, architecture boundary, storage, risks.
+Open the document with a landing section. The landing section merges the problem statement and the summary in one paragraph of two to four sentences:
 
-- risks, in particular, are tricky to get right. Models tend to state obvious ones ('untested' x LOC) which are easy to catch, and miss important ones (customer X uses this workflow and we're not accounting for it). Risk assessment is fundamentally a question of user impact; you should ask for more context here instead of guessing before deciding on risks.
-- These are three sections which are almost always relevant (esp. for larger changes):
-  - **Interface change** — show any changed contract as its caller sees it (signature, RPC/HTTP/JSON shape, CLI flag, config, or event), with a short code example and a link to a real consumer.
-  - **Testing** — connect the main claims to linked test evidence and say what remains unpinned.
-  - **Decision Log** — split into two components:
-    1. Collect and dedupe the invariants the user expressed to you in the prompt _in their own words_. Later decisions can semantically overwrite earlier ones.
-    2. Decisions that you made during implementation. State them in plain language (ASD-STE100 Simplified Technical English).
+- State the context, then the gap, then the change, in that order. For a bugfix, the gap is what was wrong before. For a new feature, the gap is what was missing and why it matters.
+- Answer why completely. Answer what briefly. The detail belongs in the later sections.
+- Define each domain term at its first mention.
 
-## SDK Reference (data.ts file)
+Add implementation detail only when it helps the reader check an important claim.
 
-The `data.ts` file is the data layer of the review documents.
+After the landing section, use fewer than five further sections when practical. Choose the sections that fit this change. Good section choices are:
 
-- The review runtime provides a typed SDK for source ranges and document-owned diagrams. It is available under the `virtual:progressive-review-authoring` module.
-- Anchor props take `defineAnchors` references, never strings. Do not use
-  casts, `any`, `<Participant>`, or `<Message>`.
-- Do not import run-time values from local files. Put TypeScript-only support
-  code in `data.ts`.
+- requirements
+- design
+- interface change
+- lifecycle or data flow
+- state or storage
+- testing evidence
+- decision log
 
-These are the supported runtime exports and their canonical input schemas:
+In the decision log, preserve important user requirements in the user's language. Add only implementation decisions that affect the result.
 
-```ts
-export const defineActors = session.defineActors;
-export const defineAnchors = session.defineAnchors;
-export const defineStores = session.defineStores;
+When the change has synced agent sessions, build the landing, requirements, design, and decision-log sections from trace quotes. Read [Trace quoting](trace-quoting.md) for the workflow and rules. Without sessions, the same structure holds in authored prose.
 
-export const actorInputSchema = z.strictObject({
-  label: nonEmptyStringSchema,
-  softwareMapPath: optionalNonEmptyStringSchema,
-});
-export type ActorInput = z.infer<typeof actorInputSchema>;
+Do not invent user-impact risks. Ask the user when risk depends on product usage that you do not know.
 
-export const actorInputMapSchema = z.record(
-  nonEmptyStringSchema,
-  actorInputSchema,
-);
-export type ActorInputMap = z.infer<typeof actorInputMapSchema>;
+## File ownership
 
-const codePeekCommonShape = {
-  theme: z.enum(["system", "light", "dark"]).optional(),
-  graph: z.enum(["head", "base"]).optional(),
-  children: noChildrenSchema,
-};
+Agents can edit only these Review files:
 
-export const codePeekRangeInputSchema = z
-  .strictObject({
-    file: nonEmptyStringSchema,
-    fromLine: z.int().positive(),
-    toLine: z.int().positive(),
-    ...codePeekCommonShape,
-  })
-  .refine((value) => value.toLine >= value.fromLine, {
-    path: ["toLine"],
-    message: "Must be greater than or equal to fromLine",
-  });
+- `review.mdx` is the presentation layer.
+- `data.ts` contains typed document inputs.
 
-export const codePeekPropsSchema = codePeekRangeInputSchema;
+Do not edit `review.json`, `review.db`, `.bundle/`, `.build/`, or the private Review `.git/` directory.
 
-export const anchorInputSchema = z.strictObject({
-  title: nonEmptyStringSchema,
-  peek: codePeekPropsSchema.optional(),
-  detail: optionalNonEmptyStringSchema,
-  softwareMapPath: optionalNonEmptyStringSchema,
-});
+Do not import runtime values from source repository files. Put document data in `data.ts`.
 
-export const anchorInputMapSchema = z.record(
-  nonEmptyStringSchema,
-  z.union([nonEmptyStringSchema, anchorInputSchema]),
-);
-export type AnchorInputMap = z.infer<typeof anchorInputMapSchema>;
+## Source ranges
 
-const softwareDataStoreForeignKeyRefSchema = z.union([
-  nonEmptyStringSchema,
-  z.strictObject({
-    table: nonEmptyStringSchema,
-    field: nonEmptyStringSchema,
-    label: optionalNonEmptyStringSchema,
-    cardinality: z.enum(["one-to-one", "many-to-one"]).optional(),
-    onDelete: optionalNonEmptyStringSchema,
-    onUpdate: optionalNonEmptyStringSchema,
-  }),
-]);
-const softwareDataStoreFieldSchema: z.ZodType<SoftwareDataStoreFieldSchema> =
-  z.lazy(() =>
-    z.record(
-      nonEmptyStringSchema,
-      z.union([
-        z.strictObject({
-          type: nonEmptyStringSchema,
-          example: z.unknown().optional(),
-          pk: z.boolean().optional(),
-          fk: softwareDataStoreForeignKeyRefSchema.optional(),
-          schema: softwareDataStoreFieldSchema.optional(),
-        }),
-        softwareDataStoreFieldSchema,
-      ]),
-    ),
-  );
+Scaffold creates one pinned checkout per pinned commit and prints both paths in its JSON event, under `checkouts.head` and `checkouts.base`. Read the paths from that output. Do not derive them from the repository layout. When you have no scaffold output, the layout is `<git-common-dir>/dev-fast/reviews/<review-uuid>/{head,base}/<full-commit>/`; resolve the common dir with `git rev-parse --git-common-dir` in the source worktree.
 
-export const softwareDataStoreCollectionInputSchema = z.strictObject({
-  label: optionalNonEmptyStringSchema,
-  key: optionalNonEmptyStringSchema,
-  schema: softwareDataStoreFieldSchema,
-});
-const softwareDataStoreCollectionMapSchema = z.record(
-  nonEmptyStringSchema,
-  softwareDataStoreCollectionInputSchema,
-);
-export const storeKindSchema = z.enum(["relational", "document"]);
-export const storeInputSchema = z.strictObject({
-  kind: storeKindSchema,
-  label: nonEmptyStringSchema,
-  dataStoreKind: softwareDataStoreKindSchema.optional(),
-  softwareMapPath: optionalNonEmptyStringSchema,
-  tables: softwareDataStoreCollectionMapSchema.optional(),
-  documents: softwareDataStoreCollectionMapSchema.optional(),
-});
+Read each range from the correct pinned checkout before you add it:
 
-export const storeInputMapSchema = z.record(
-  nonEmptyStringSchema,
-  storeInputSchema,
-);
-export type StoreInputMap = z.infer<typeof storeInputMapSchema>;
-```
+- Use the head checkout (`sourceCommit`) for a head range.
+- Use the base checkout (`baseCommit`) for a base range.
 
-Use the smallest source range that proves the claim. Do not use a broad region.
-Read the range from the correct pinned worktree before you add the anchor.
+Use the smallest range that proves the claim. Default to `AnchorLink` for source evidence. Use `CodePeek` only when readers must see the code inline to understand the main claim. A path outside the pinned checkout or an invalid line range blocks document publication.
 
-## MDX Component Reference (review.mdx file)
+## Authoring API (data.ts)
 
-The `review.mdx` file is the presentation layer of the review documents.
-
-`SequenceDiagram` is more useful than prose for temporal behavior and
-`DatabaseLens` for persisted-state changes. Visuals are cheaper to understand than prose.
-
-- MDX uses JavaScript grammar.
-- Write diagram inputs in `data.ts` instead; component schemas validate them.
-- Every sequence message needs anchored peek or inline-code evidence.
-- You're not limited the components below, although they are included by default. You are free to write any valid MDX that you would like to include to communicate the software system to the user, including arbitrary React + MDX.
-
-These are the canonical prop schemas. `DbRead` and `DbWrite` both use
-`dbOperationPropsSchema`.
+Import typed helpers from `virtual:progressive-review-authoring` in `data.ts`:
 
 ```ts
-const sequenceMessageBaseShape = {
-  from: sequenceActorInputSchema,
-  to: sequenceActorInputSchema,
-  label: nonEmptyStringSchema,
-};
-export const sequenceMessageInputSchema = z.union([
-  z.strictObject({
-    ...sequenceMessageBaseShape,
-    anchor: peekableAnchorRefSchema,
-    code: sequenceMessageCodeInputSchema.optional(),
-  }),
-  z.strictObject({
-    ...sequenceMessageBaseShape,
-    anchor: anchorRefSchema.optional(),
-    code: sequenceMessageCodeInputSchema,
-  }),
-]);
-
-export const sequenceDiagramPropsSchema = z.strictObject({
-  label: nonEmptyStringSchema,
-  messages: z.array(sequenceMessageInputSchema).min(1),
-  children: noChildrenSchema,
-});
-
-export const reviewCodePeekPropsSchema = z.strictObject({
-  anchor: peekableAnchorRefSchema,
-  children: noChildrenSchema,
-});
-
-export const anchorLinkPropsSchema = z.strictObject({
-  anchor: peekableAnchorRefSchema,
-  children: reactNodeSchema,
-});
-
-export const reviewSectionPropsSchema = z.strictObject({
-  title: nonEmptyStringSchema,
-  defaultCollapsed: z.boolean().optional(),
-  children: reactNodeSchema,
-});
-
-export const dbUseCasePropsSchema = z.strictObject({
-  id: nonEmptyStringSchema,
-  label: nonEmptyStringSchema,
-  summary: optionalNonEmptyStringSchema,
-  children: reactNodeSchema,
-});
-
-export const dbOperationPropsSchema = z.strictObject({
-  from: z.union([actorRefSchema, targetRefSchema]),
-  to: z.union([actorRefSchema, targetRefSchema]),
-  label: nonEmptyStringSchema,
-  anchor: peekableAnchorRefSchema,
-  children: noChildrenSchema,
-});
-
-export const databaseLensPropsSchema = z.strictObject({
-  title: optionalNonEmptyStringSchema,
-  stores: z.record(
-    nonEmptyStringSchema,
-    z.custom<StoreRef>(
-      (value) =>
-        Boolean(value) &&
-        typeof value === "object" &&
-        (value as { __kind?: unknown }).__kind === "db-store-ref" &&
-        typeof (value as { id?: unknown }).id === "string" &&
-        typeof (value as { label?: unknown }).label === "string",
-      "Must be a store reference returned by defineStores",
-    ),
-  ),
-  height: z.number().positive().optional(),
-  children: reactNodeSchema,
-});
+import {
+  defineActors,
+  defineAnchors,
+  defineStores,
+} from "virtual:progressive-review-authoring";
 ```
 
-### Example document
+Read [Component API](component-api.md) for every helper's input shape and every component's props, with one example each.
 
-`${DEV_REVIEW_HOME}/reviews/${uuid}/data.ts`
+Do not use casts, `any`, `<Participant>`, or `<Message>`. Pass typed references from these helpers to the MDX components.
+
+## Public MDX components (review.mdx)
+
+Review supplies these built-in components to MDX. Do not import them. Import only authored values from `./data.ts`.
+
+Use these built-in components:
+
+| Component         | Use                                                    |
+| ----------------- | ------------------------------------------------------ |
+| `CodePeek`        | Show one anchor with an exact source range inline.     |
+| `AnchorLink`      | Link prose to an anchored source range in side peek.   |
+| `SequenceDiagram` | Show important temporal behavior.                      |
+| `CallStackDiff`   | Show call-flow differences between base and head.      |
+| `DatabaseLens`    | Show persisted-state structure and operations.         |
+| `DbUseCase`       | Group related database operations.                     |
+| `DbRead`          | Show a read between typed actor or store references.   |
+| `DbWrite`         | Show a write between typed actor or store references.  |
+| `ReviewSection`   | Collapse optional detail.                              |
+| `TraceQuote`      | Quote and link directly to an agent execution session. |
+
+Write diagram inputs in `data.ts`. Component validation is strict. Read [Component API](component-api.md) for each component's props, rules, and a minimal example. Read [Trace quoting](trace-quoting.md) for the `TraceQuote` workflow, rules, and per-section density.
+
+## Small example
+
+`data.ts`:
 
 ```ts
 import {
@@ -244,12 +109,8 @@ export const actors = defineActors({
 });
 
 export const anchors = defineAnchors({
-  resolveThing: {
-    title: "Resolver",
-    peek: { file: "src/resolve.ts", fromLine: 12, toLine: 28 },
-  },
   publish: {
-    title: "Publish",
+    title: "Publish document",
     peek: { file: "src/publish.ts", fromLine: 40, toLine: 66 },
   },
 });
@@ -258,18 +119,26 @@ export const messages = [
   {
     from: actors.agent,
     to: actors.desktop,
-    label: "Publish candidate",
+    label: "Publish document",
     anchor: anchors.publish,
   },
 ];
 ```
 
-`${DEV_REVIEW_HOME}/reviews/${uuid}/review.mdx`
+`review.mdx`:
 
 ```mdx
 import { anchors, messages } from "./data.ts";
 
-<CodePeek anchor={anchors.resolveThing} />
+# Document publication
+
+The CLI seals one document revision.
+
+See <AnchorLink anchor={anchors.publish}>the publish implementation</AnchorLink> for evidence.
 
 <SequenceDiagram label="Publish" messages={messages} />
 ```
+
+## Publication checks
+
+Run `review publish --review <uuid> --json`. Do not run `npm test` against the private Review directory. The publish command supplies the correct private test command and returns document diagnostics as NDJSON events.

--- a/packages/progressive-review/skills/dev-review/references/lifecycle-and-storage.md
+++ b/packages/progressive-review/skills/dev-review/references/lifecycle-and-storage.md
@@ -9,8 +9,7 @@ A Review binds to one unit of change:
 - a jj change ID
 - a GitHub pull request
 
-Use a bookmark for a document about a stack. Use a change ID for one jj
-change. Use `review scaffold --pr <number-or-url>` for a pull request.
+Use a bookmark for a document about a stack. Use a change ID for one jj change. Use `review scaffold --pr <number-or-url>` for a pull request.
 
 Choose the base deliberately:
 
@@ -20,22 +19,17 @@ Choose the base deliberately:
 
 Use `--base @-` for one jj change. Use `--base <head>~1` for one Git commit.
 
-A bare scaffold needs a named checkout. Use `--head <ref>` for a detached Git
-HEAD. Scaffold output shows the selected change and pins.
+A bare scaffold needs a named checkout. Use `--head <ref>` for a detached Git HEAD. Scaffold output shows the selected change and pins.
 
-`review scaffold --update` re-pins an existing Review from its binding. It
-creates a Review when none exists. A pull-request binding updates from GitHub.
-A branch binding follows only its local branch or bookmark.
+`review scaffold --update` re-pins an existing Review from its binding. It creates a Review when none exists. A pull-request binding updates from GitHub. A branch binding follows only its local branch or bookmark.
 
-`review rebind <change> --review <uuid>` changes the binding and immediately
-re-pins the Review.
+`review rebind <change> --review <uuid>` changes the binding and immediately re-pins the Review.
 
 Publication never moves pins. It warns when pins are behind the binding.
 
 ## Artifact publication
 
-The reviewer sees sealed artifact revisions. The two publish commands have
-independent validation and presentation pointers.
+The reviewer sees sealed artifact revisions. The two publish commands have independent validation and presentation pointers.
 
 `review publish`:
 
@@ -56,28 +50,23 @@ independent validation and presentation pointers.
 - preserves `presentedDocumentRevision` and the Review status
 - reuses the existing map revision when its bytes are identical
 
-The document can render without a map. Map absence never blocks document
-publication. Agent workflows must use the two explicit publish commands.
+The document can render without a map. Map absence never blocks document publication. Agent workflows must use the two explicit publish commands.
 
-A failed publish keeps the last good pointer. `accepted` and `rejected` block
-both publish commands.
+A failed publish keeps the last good pointer.
 
 ## Review states
 
 | Status                   | Owner and next action                                        |
 | ------------------------ | ------------------------------------------------------------ |
 | `draft`                  | Agent authors and publishes the document.                    |
-| `awaiting-review`        | Reviewer asks, requests changes, approves, or rejects.       |
+| `awaiting-review`        | Reviewer reads, asks questions, or submits comments.         |
 | `awaiting-agent-updates` | Agent reads threads, corrects the document, and republishes. |
-| `accepted`               | Terminal. Start another Review if work must continue.        |
-| `rejected`               | Terminal. Start another Review if work must continue.        |
 
-An "Ask now" question does not change the status. "Request changes" sets
-`awaiting-agent-updates`. Approve sets `accepted`. Reject sets `rejected`.
+An "Ask now" question does not change the status. "Submit review" with pending comments sets `awaiting-agent-updates`.
 
-`review wait --requires-agent` resolves on every status except
-`awaiting-review`. It also resolves with `review-deleted` when the Review
-directory disappears.
+Dismissal is separate from Review status. It removes the Review from the active list and stops the waiting agent. The reader can restore it from Home until retention deletes it. Closing the tab does not dismiss the Review. A new document publication clears dismissal and returns the Review to the active list.
+
+After publication, `review wait --requires-agent` resolves for `awaiting-agent-updates`, `review-dismissed`, or `review-deleted`.
 
 ## UUID directory
 
@@ -99,19 +88,13 @@ ${DEV_REVIEW_HOME:-~/.dev}/reviews/<uuid>/
 └── .git/
 ```
 
-`review.json` is schema 3 state. It contains the source worktree, binding,
-pinned commits, status, `presentedDocumentRevision`, and
-`presentedSoftwareMapRevision`.
+`review.json` is schema 3 state. It contains the source worktree, binding, pinned commits, status, `presentedDocumentRevision`, and `presentedSoftwareMapRevision`.
 
-`review.db` contains durable comment and question threads. Use only
-`review threads` to read or change it.
+`review.db` contains durable comment and question threads. Use only `review threads` to read or change it.
 
-`.bundle/document/` contains the current document candidate.
-`.bundle/software-map/` contains the current map candidate when one exists.
-The private Review Git repository seals these candidates as revisions.
+`.bundle/document/` contains the current document candidate. `.bundle/software-map/` contains the current map candidate when one exists. The private Review Git repository seals these candidates as revisions.
 
-`.build/<revision>/` contains a temporary materialization of one sealed
-revision. Review can create it again.
+`.build/<revision>/` contains a temporary materialization of one sealed revision. Review can create it again.
 
 Do not edit Review infrastructure files or directories directly.
 
@@ -125,18 +108,14 @@ review threads reply <threadId> --body <text> --review <uuid>
 review threads resolve <threadId> --review <uuid>
 ```
 
-Do not invent, rewrite, or merge opaque thread targets. Resolve a thread only
-after its requested document or code change is present.
+Do not invent, rewrite, or merge opaque thread targets. Resolve a thread only after its requested document or code change is present.
+
+A document re-publish requires zero open comment threads. Before each re-publish, run `review threads list`. Address every open thread. Mark each addressed thread with `review threads resolve <threadId> --review <uuid>`. Run `review threads list` again. Do not re-publish until no comment thread has `status: "open"`. The first document publication does not use this gate.
 
 ## Migration
 
-Run `review migrate apply` only for legacy Review state. It converts supported
-Reviews to schema 3 and the split bundle layout.
+Run `review migrate apply` only for legacy Review state. It converts supported Reviews to schema 3 and the split bundle layout.
 
-A migrated valid combined revision gets independent document and map
-pointers. The private history can retain old combined revisions. Active
-pointers and materialized artifacts use the current layout.
+A migrated valid combined revision gets independent document and map pointers. The private history can retain old combined revisions. Active pointers and materialized artifacts use the current layout.
 
-Migration drops stored Reviews whose `data.ts` uses removed `symbol` or
-`declarationId` peeks. It preserves range-only Reviews. Use `--force` only to
-restart interrupted development migration state.
+Migration drops stored Reviews whose `data.ts` uses removed `symbol` or `declarationId` peeks. It preserves range-only Reviews. Use `--force` only to restart interrupted development migration state.

--- a/packages/progressive-review/skills/dev-review/references/prepared-worktrees.md
+++ b/packages/progressive-review/skills/dev-review/references/prepared-worktrees.md
@@ -1,10 +1,8 @@
 # Prepared worktrees
 
-Scaffold materializes one worktree for each pinned base and head commit. It
-runs each configured `devfast.prepare` command in both worktrees.
+Scaffold materializes one worktree for each pinned base and head commit. It runs each configured `devfast.prepare` command in both worktrees.
 
-Prepared worktrees let language servers resolve repository dependencies. The
-configuration is local to one clone. Do not commit it.
+Prepared worktrees let language servers resolve repository dependencies. The configuration is local to one clone. Do not commit it.
 
 ## Configure preparation
 
@@ -29,9 +27,7 @@ Append another command:
 git config --add devfast.prepare '<next command>'
 ```
 
-Commands run in file order. Add a focused library build when workspace exports
-point to generated output. Do not build application targets without a clear
-need.
+Commands run in file order. Add a focused library build when workspace exports point to generated output. Do not build application targets without a clear need.
 
 For example:
 
@@ -39,9 +35,6 @@ For example:
 git config --add devfast.prepare 'pnpm -r --filter "./packages/**" run build'
 ```
 
-After the next scaffold, check one dependency link and its generated output in
-`.git/dev-fast/worktrees/<commit>/`.
+After the next scaffold, check one dependency link and its generated output in the pinned checkout (the `checkouts` paths in the scaffold event).
 
-Prepare failure is soft. Scaffold keeps the worktree and prints the log path.
-A `.prepared` marker stores the command-list hash. A configuration change runs
-preparation again during the next scaffold or update.
+Prepare failure is soft. Scaffold keeps the worktree and prints the log path. A `.prepared` marker stores the command-list hash. A configuration change runs preparation again during the next scaffold or update.

--- a/packages/progressive-review/skills/dev-review/references/trace-quoting.md
+++ b/packages/progressive-review/skills/dev-review/references/trace-quoting.md
@@ -1,0 +1,128 @@
+# Trace quoting
+
+A Review can quote the agent sessions that produced the change. The reader then learns the intent from the user's own words, and each quote opens the trace at that moment.
+
+Read this reference when the pinned change has at least one available session. Skip it when `review trace list` reports none.
+
+## Find the sessions
+
+Run in the source worktree:
+
+```sh
+review trace list --review <uuid> --json
+review trace pull --review <uuid> --json
+```
+
+The command resolves sessions from `Agent-Session` commit trailers in the pinned range. Each entry reports its id, availability, commits, and trace names.
+
+Quote only sessions with `"available": true`. An unsynced session has no transcript in R2, and publish rejects quotes from it. Report unsynced sessions. Do not guess their content.
+
+## Complete the intent pass
+
+Survey each available main trace before you author the document:
+
+```sh
+review trace show <session-id>
+```
+
+The output shows the complete ordered event index. Read the whole index. It provides the narrative shape that isolated search hits cannot provide.
+
+During this pass, identify the user's requirements, corrections, accepted decisions, reversals, emphasis, and unresolved questions. Check these findings against the pinned diff.
+
+Survey a listed subagent trace when the main trace delegates relevant design or implementation work:
+
+```sh
+review trace show <session-id> --trace <name>
+```
+
+Do not filter the first pass to user events. Agent actions and tool use explain how the conversation changed the implementation. Use `--kind user` only as a second view.
+
+The intent pass is complete when every available main trace has been surveyed and each relevant subagent trace has been surveyed.
+
+The pull command writes one normalized JSONL file per trace under:
+
+```text
+~/.dev/trace-search/<owner>/<repo>/<session>/main.jsonl
+~/.dev/trace-search/<owner>/<repo>/<session>/<subagent>.jsonl
+```
+
+Its JSON output returns each absolute file path in `paths`. Use these paths directly. Do not derive them from the corpus layout.
+
+The first line contains trace metadata. Each later line contains one event with its index, kind, exact projected text, and structured event.
+
+If the pull command reports missing trace configuration, ask the user to use Review Agent Setup. Do not change setup autonomously.
+
+## Find supporting events
+
+After the intent pass, use FFF to search the files returned in `paths` for each important requirement or decision.
+
+Ignore a match on physical line 1 because it is trace metadata. Each later physical line contains one event. For a match on line `<L>`, the event index is `<L> - 2`. Use the record's `index` when the excerpt shows it. Otherwise, derive the index from the physical line number.
+
+Prefer user event records for requirements and corrections. Use assistant event records only when the assistant stated a decision that the user accepted. Confirm the kind with `review trace show --event` when the FFF excerpt omits it.
+
+FFF results locate candidates. Never copy quote text from a search result.
+
+## Read exact quote text
+
+Print one event in full before you quote it:
+
+```sh
+review trace show <session-id> --trace <trace> --event <n> --json
+```
+
+Pass the session and trace from the result path. Pass the event index from the matching record. Use `main` for `main.jsonl`. The `text` field uses the same projection that publish validates. Copy quote text only from this field.
+
+Use `trace_quote_props` from the response without reconstructing it. Every `TraceQuote` must use those props and an exact substring of `text`.
+
+## Quote rules
+
+- Write quotes inline in paragraphs with `TraceQuote`. Do not use separate quote blocks.
+- Quote the user's words by default. Quote the agent's words only for a decision the agent stated and the user accepted. The diff is the test of acceptance: an agent decision the shipped diff confirms, and the user did not reverse, counts as accepted.
+- Each quote must be an exact substring of one event's text. Publish checks every quote against the transcript and rejects text it cannot find. Whitespace is compared collapsed; all other characters must match.
+- Keep edits outside the quotes. Put `[brackets]`, ellipsis, and connecting grammar in the plain text between two quotes. An edited quote fails the substring check.
+- MDX parses the quote children. A `{` starts an expression, so wrap a code fragment such as `{ cols: 120 }` in backticks inside the quote; the backticks survive as code formatting and the checked text still matches. Backtick characters in the transcript itself do not round-trip; choose a quote span that avoids them, or put that fragment in glue text.
+- Prefer clause-length quotes of 8 to 30 words.
+- Glue text connects quotes. It must not add claims the trace does not contain. Do not paraphrase where a quote exists.
+- Apply the returned `trace_quote_props` to each quote. Publish reports the correct event when a hint is stale or ambiguous.
+
+## Quote density by section
+
+- Landing section: build it almost entirely from quotes — the gap and the change especially. The two-to-four-sentence cap holds; short quotes beat long ones here.
+- Requirements: at least one quote per bullet.
+- Design: a quote states each decision. An `AnchorLink` shows the decision in code.
+- Implementation: authored prose with `AnchorLink` evidence. Quotes are optional.
+- Decision log: the full replay. Quote the turns in trace order. Include decisions the user later reversed, each with the quote that reversed it. Quote both decisions that the user made, as well as decisions that the agent made.
+
+## Decisions that changed
+
+Outside the decision log, quote only decisions that the pinned diff confirms. When a later event reversed a decision, the earlier quote does not describe the change. Reversed decisions belong only in the decision log.
+
+## Example texture
+
+A landing paragraph reads like this:
+
+```mdx
+<TraceQuote sessionId="019fdb00-f032-79d2-9ee8-0b8fe0e86a9e" event={62}>
+  I actually don't think you pretty much ever should have to do an image build.
+</TraceQuote>
+In practice,
+<TraceQuote sessionId="019fdb00-f032-79d2-9ee8-0b8fe0e86a9e" event={62}>
+  the container image itself should be almost constantly static and it has been
+  for the last four or five days.
+</TraceQuote>
+Existing startup latencies are excessive:
+<TraceQuote sessionId="019fdb00-f032-79d2-9ee8-0b8fe0e86a9e" event={129}>
+  i want like 5 seconds in the happy path
+</TraceQuote>
+.
+```
+
+A requirements bullet reads like this:
+
+```mdx
+- Deterministic pool identity: <TraceQuote sessionId="019fe07f-9e9d-79a3-966b-51ef899c03f7" event={183}>pool_id = (blueprint, sidecar, source_infra_hash). when any of these change, consider the pool_id have changed</TraceQuote>.
+```
+
+Keep the user's typos and casing. The quote is evidence, not copy.
+
+The quote pass is complete when every quote comes from `show.text`, uses its returned props, and describes code in the pinned diff.

--- a/packages/progressive-review/skills/trace-archaeology/SKILL.md
+++ b/packages/progressive-review/skills/trace-archaeology/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: trace-archaeology
+description: Find the agent sessions behind existing code and search past traces. Use when asked "why does this code exist", "what was the agent thinking here", "who/what wrote this", "has an agent solved X before", or when debugging agent-produced code where the original reasoning would help.
+---
+
+# Trace archaeology
+
+Agent-written commits record `Agent-Session: <id>` trailers. Use the `review trace` CLI to resolve and pull those sessions. Use FFF to find candidate events. Use `review trace show` for exact evidence.
+
+## Configuration
+
+Setup is human-owned. If a command reports missing trace configuration, ask the user to use Review Agent Setup. Then stop.
+
+FFF setup is human-owned. If FFF is unavailable, report the setup gap. Do not replace or reconfigure it.
+
+Local commit trailers and blame resolution work without trace storage access.
+
+## Explain code provenance
+
+When asked why code exists, who wrote it, or what decisions produced it:
+
+1. Identify the commits behind the target lines:
+
+   ```sh
+   review trace blame <file> -L <start,end> --json
+   ```
+
+   This command identifies the last commit that touched each line. Add `--history` only when the current provenance does not explain the decision:
+
+   ```sh
+   review trace blame <file> -L <start,end> --history --json
+   ```
+
+2. Pull each relevant session into the local corpus:
+
+   ```sh
+   review trace pull --session <session-id> --json
+   ```
+
+   Read the absolute normalized file paths from the response's `paths` array. Do not derive them from the corpus layout.
+
+3. Use FFF to search the normalized files returned in `paths`.
+
+   Treat each result only as a candidate locator. Each trace file has this shape:
+
+   ```text
+   <owner>/<repo>/<session>/main.jsonl
+   <owner>/<repo>/<session>/<subagent>.jsonl
+   ```
+
+   Ignore physical line 1 because it is trace metadata. For a match on line `<L>`, use event index `<L> - 2`. Use the record's `index` when the excerpt shows it.
+
+4. Inspect each relevant event:
+
+   ```sh
+   review trace show <session-id> --trace <trace> --event <event> --json
+   ```
+
+   Pass the trace name from the result, including `main`. Search results are not final evidence.
+
+5. Check the current code before you explain the result. The trace can describe a decision that the author later reversed.
+
+This flow is complete when you inspected the relevant events and checked every historical claim against the current code.
+
+## Research a topic
+
+When asked if an agent has previously solved a problem or handled a topic:
+
+1. Pull the current repository traces:
+
+   ```sh
+   review trace pull --json
+   ```
+
+   Add `--main-only` only when subagent work is not relevant.
+   Read the absolute normalized file paths from the response's `paths` array.
+
+2. Use FFF to search the normalized files returned in `paths`. Read the session and trace from the result path. Ignore physical line 1. For a match on line `<L>`, use event index `<L> - 2`.
+
+3. Inspect the relevant events:
+
+   ```sh
+   review trace show <session-id> --trace <trace> --event <event> --json
+   ```
+
+When the investigation starts from one commit, list its sessions first:
+
+```sh
+review trace list --commit <rev> --json
+review trace pull --commit <rev> --json
+```
+
+Use `review trace show <session-id>` when the full session timeline helps explain the result.
+
+This flow is complete when you inspected the source events and checked the result against current code.
+
+## Evidence Rules
+
+- Treat traces as historical evidence, not current specifications.
+- Prefer `--json` when you parse command output.
+- Cite session, trace, and event locators for event evidence.
+- Cite commit IDs and source lines for current code evidence.
+- Report missing or uncertain provenance. Never invent an explanation.

--- a/packages/progressive-review/src/agent-fff.ts
+++ b/packages/progressive-review/src/agent-fff.ts
@@ -1,0 +1,283 @@
+import { execFile } from "node:child_process";
+import { mkdir, readFile, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import type {
+  ReviewFffInstallTarget,
+  ReviewFffManagedRegistration,
+} from "@dev.fast/review-protocol";
+
+export const FFF_SERVER_NAME = "fff";
+export const FFF_INSTALL_URL = "https://dmtrkovalenko.dev/install-fff-mcp.sh";
+export const FFF_TARGETS: ReviewFffInstallTarget[] = ["claude", "codex", "pi"];
+export const PI_FFF_PACKAGE = "npm:@ff-labs/pi-fff";
+
+const execFileAsync = promisify(execFile);
+
+export function fffBinaryPath(homeDir = os.homedir()): string {
+  return path.join(homeDir, ".local", "bin", "fff-mcp");
+}
+
+export function fffCorpusRoot(homeDir = os.homedir()): string {
+  return path.join(homeDir, ".dev", "trace-search");
+}
+
+export function isFffTarget(target: string): target is ReviewFffInstallTarget {
+  return target === "claude" || target === "codex" || target === "pi";
+}
+
+export async function installFffForTargets(input: {
+  targets: ReviewFffInstallTarget[];
+  homeDir: string;
+  env: NodeJS.ProcessEnv;
+  write: (text: string) => void;
+}): Promise<{ ok: boolean; created: ReviewFffManagedRegistration[] }> {
+  const binaryPath = fffBinaryPath(input.homeDir);
+  const corpusRoot = fffCorpusRoot(input.homeDir);
+  await mkdir(corpusRoot, { recursive: true });
+
+  const missingTargets: ReviewFffInstallTarget[] = [];
+  for (const target of input.targets) {
+    const current = await readFffRegistration(target, input.homeDir, input.env);
+    if (current.present) {
+      input.write(`[ok] existing ${fffTargetLabel(target)} left unchanged\n`);
+    } else {
+      missingTargets.push(target);
+    }
+  }
+  if (missingTargets.length === 0) {
+    return { ok: true, created: [] };
+  }
+
+  const needsMcpBinary = missingTargets.some((target) => target !== "pi");
+  if (needsMcpBinary && !(await isFile(binaryPath))) {
+    input.write("Installing FFF MCP…\n");
+    const installer = await runCommand(
+      "/bin/bash",
+      ["-c", `set -o pipefail; curl -fL ${FFF_INSTALL_URL} | bash`],
+      input.homeDir,
+      input.env,
+    );
+    input.write(installer.output);
+    if (!installer.ok || !(await isFile(binaryPath))) {
+      input.write(`FFF MCP was not installed at ${binaryPath}.\n`);
+      return { ok: false, created: [] };
+    }
+  } else if (needsMcpBinary) {
+    input.write(`[ok] FFF MCP binary found at ${binaryPath}\n`);
+  }
+
+  const created: ReviewFffManagedRegistration[] = [];
+  for (const target of missingTargets) {
+    const registration = fffRegistration(target, binaryPath, corpusRoot);
+    const result = await runCommand(
+      registration.command,
+      registration.args,
+      input.homeDir,
+      input.env,
+    );
+    input.write(result.output);
+    if (!result.ok) return { ok: false, created };
+    created.push(registration);
+    input.write(`[ok] installed ${fffTargetLabel(target)}\n`);
+  }
+  return { ok: true, created };
+}
+
+export async function readFffRegistration(
+  target: ReviewFffInstallTarget,
+  homeDir: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{ present: boolean; output: string }> {
+  if (target === "pi") {
+    const present = await isPiFffInstalled(homeDir, env);
+    return { present, output: present ? PI_FFF_PACKAGE : "" };
+  }
+  const result = await runCommand(
+    target,
+    target === "codex"
+      ? ["mcp", "get", FFF_SERVER_NAME, "--json"]
+      : ["mcp", "get", FFF_SERVER_NAME],
+    homeDir,
+    env,
+  );
+  return { present: result.ok, output: result.output };
+}
+
+export function fffRegistration(
+  target: ReviewFffInstallTarget,
+  binaryPath: string,
+  corpusRoot: string,
+): ReviewFffManagedRegistration {
+  if (target === "pi") {
+    return {
+      target,
+      command: "pi",
+      args: ["install", PI_FFF_PACKAGE],
+    };
+  }
+  return target === "claude"
+    ? {
+        target,
+        command: "claude",
+        args: [
+          "mcp",
+          "add",
+          "-s",
+          "user",
+          FFF_SERVER_NAME,
+          "--",
+          binaryPath,
+          corpusRoot,
+        ],
+      }
+    : {
+        target,
+        command: "codex",
+        args: ["mcp", "add", FFF_SERVER_NAME, "--", binaryPath, corpusRoot],
+      };
+}
+
+export function fffRegistrationMatches(
+  output: string,
+  registration: ReviewFffManagedRegistration,
+): boolean {
+  if (registration.target === "pi") {
+    return output.trim() === PI_FFF_PACKAGE;
+  }
+  const binaryPath = registration.args.at(-2);
+  const corpusRoot = registration.args.at(-1);
+  if (!binaryPath || !corpusRoot) return false;
+
+  if (registration.target === "codex") {
+    try {
+      const config = findStdioConfig(JSON.parse(output));
+      return (
+        config?.command === binaryPath &&
+        config.args.length === 1 &&
+        config.args[0] === corpusRoot
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  const lines = output.split("\n").map((line) => line.trim());
+  const command = readLabeledValue(lines, "Command");
+  const args =
+    readLabeledValue(lines, "Args") ?? readLabeledValue(lines, "Arguments");
+  return command === binaryPath && args === corpusRoot;
+}
+
+export async function removeFffRegistration(
+  target: ReviewFffInstallTarget,
+  homeDir: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{ ok: boolean; output: string }> {
+  const command =
+    target === "pi"
+      ? { command: "pi", args: ["remove", PI_FFF_PACKAGE] }
+      : target === "claude"
+        ? {
+            command: "claude",
+            args: ["mcp", "remove", "-s", "user", FFF_SERVER_NAME],
+          }
+        : {
+            command: "codex",
+            args: ["mcp", "remove", FFF_SERVER_NAME],
+          };
+  return runCommand(command.command, command.args, homeDir, env);
+}
+
+async function isPiFffInstalled(
+  homeDir: string,
+  env: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  const configured = env.PI_CODING_AGENT_DIR;
+  const agentDir = configured
+    ? path.resolve(homeDir, configured)
+    : path.join(homeDir, ".pi", "agent");
+  try {
+    const settings = JSON.parse(
+      await readFile(path.join(agentDir, "settings.json"), "utf8"),
+    ) as { packages?: unknown };
+    return (
+      Array.isArray(settings.packages) &&
+      settings.packages.includes(PI_FFF_PACKAGE)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function fffTargetLabel(target: ReviewFffInstallTarget): string {
+  return target === "pi"
+    ? `Pi extension ${PI_FFF_PACKAGE}`
+    : `${target} fff MCP`;
+}
+
+function findStdioConfig(
+  value: unknown,
+): { command: string; args: string[] } | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.command === "string" &&
+    Array.isArray(record.args) &&
+    record.args.every((arg) => typeof arg === "string")
+  ) {
+    return { command: record.command, args: record.args as string[] };
+  }
+  for (const child of Object.values(record)) {
+    const found = findStdioConfig(child);
+    if (found) return found;
+  }
+  return null;
+}
+
+function readLabeledValue(lines: string[], label: string): string | null {
+  const prefix = `${label}:`;
+  const line = lines.find((candidate) => candidate.startsWith(prefix));
+  if (!line) return null;
+  return line
+    .slice(prefix.length)
+    .trim()
+    .replace(/^['"]|['"]$/g, "");
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  homeDir: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{ ok: boolean; output: string }> {
+  try {
+    const result = await execFileAsync(command, args, {
+      cwd: homeDir,
+      env: { ...env, HOME: homeDir },
+      maxBuffer: 8 * 1024 * 1024,
+      timeout: 120_000,
+    });
+    return { ok: true, output: `${result.stdout}${result.stderr}` };
+  } catch (error) {
+    const failure = error as {
+      stdout?: string;
+      stderr?: string;
+      message?: string;
+    };
+    return {
+      ok: false,
+      output: `${failure.stdout ?? ""}${failure.stderr ?? failure.message ?? ""}`,
+    };
+  }
+}
+
+async function isFile(target: string): Promise<boolean> {
+  try {
+    return (await stat(target)).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/packages/progressive-review/src/agent-trace-hooks.test.ts
+++ b/packages/progressive-review/src/agent-trace-hooks.test.ts
@@ -1,0 +1,124 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  installClaudeTraceHook,
+  installCodexTraceHook,
+  installPiTraceExtension,
+  removeAgentTraceHook,
+} from "./agent-trace-hooks";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  while (tempRoots.length > 0) {
+    const dir = tempRoots.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function makeTempHome(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "agent-trace-hooks-test-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+describe("agent-trace-hooks", () => {
+  it("installs Claude Code trace hooks in ~/.claude/settings.json idempotently", async () => {
+    const homeDir = await makeTempHome();
+
+    const first = await installClaudeTraceHook(homeDir);
+    expect(first.modified).toBe(true);
+    expect(existsSync(first.path)).toBe(true);
+
+    const content = JSON.parse(await readFile(first.path, "utf8"));
+    expect(content.hooks.SessionStart[0].hooks[0].command).toBe(
+      "review trace hook SessionStart",
+    );
+    expect(content.hooks.SessionEnd[0].hooks[0].command).toBe(
+      "review trace hook SessionEnd",
+    );
+
+    const second = await installClaudeTraceHook(homeDir);
+    expect(second.modified).toBe(false);
+
+    // Verify existing custom settings are preserved
+    await writeFile(
+      first.path,
+      JSON.stringify(
+        { customKey: "customValue", hooks: content.hooks },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    const third = await installClaudeTraceHook(homeDir);
+    expect(third.modified).toBe(false);
+    const preserved = JSON.parse(await readFile(first.path, "utf8"));
+    expect(preserved.customKey).toBe("customValue");
+  });
+
+  it("installs Codex trace hooks in ~/.codex/config.toml idempotently", async () => {
+    const homeDir = await makeTempHome();
+
+    const first = await installCodexTraceHook(homeDir);
+    expect(first.modified).toBe(true);
+    expect(existsSync(first.path)).toBe(true);
+
+    const content = await readFile(first.path, "utf8");
+    expect(content).toContain("[[hooks.SessionStart]]");
+    expect(content).toContain("review trace hook SessionStart");
+    expect(content).toContain("[[hooks.SessionEnd]]");
+    expect(content).toContain("review trace hook SessionEnd");
+
+    const second = await installCodexTraceHook(homeDir);
+    expect(second.modified).toBe(false);
+  });
+
+  it("installs Pi trace extension in ~/.pi/agent/extensions/review-trace.ts idempotently", async () => {
+    const homeDir = await makeTempHome();
+
+    const first = await installPiTraceExtension(homeDir);
+    expect(first.modified).toBe(true);
+    expect(existsSync(first.path)).toBe(true);
+
+    const content = await readFile(first.path, "utf8");
+    expect(content).toContain("session_start");
+    expect(content).toContain("session_shutdown");
+    expect(content).toContain("review");
+
+    const second = await installPiTraceExtension(homeDir);
+    expect(second.modified).toBe(false);
+  });
+
+  it("removes owned hooks and preserves unrelated agent configuration", async () => {
+    const homeDir = await makeTempHome();
+    const claude = await installClaudeTraceHook(homeDir);
+    const codex = await installCodexTraceHook(homeDir);
+    const pi = await installPiTraceExtension(homeDir);
+    const claudeConfig = JSON.parse(await readFile(claude.path, "utf8"));
+    claudeConfig.customKey = "keep";
+    await writeFile(claude.path, JSON.stringify(claudeConfig, null, 2));
+    await writeFile(
+      codex.path,
+      `model = "gpt-5"\n${await readFile(codex.path, "utf8")}`,
+    );
+
+    expect(await removeAgentTraceHook("claude", homeDir)).toBe(true);
+    expect(await removeAgentTraceHook("codex", homeDir)).toBe(true);
+    expect(await removeAgentTraceHook("pi", homeDir)).toBe(true);
+
+    expect(await readFile(claude.path, "utf8")).toContain(
+      '"customKey": "keep"',
+    );
+    expect(await readFile(claude.path, "utf8")).not.toContain(
+      "review trace hook",
+    );
+    expect(await readFile(codex.path, "utf8")).toBe('model = "gpt-5"\n');
+    expect(existsSync(pi.path)).toBe(false);
+  });
+});

--- a/packages/progressive-review/src/agent-trace-hooks.ts
+++ b/packages/progressive-review/src/agent-trace-hooks.ts
@@ -1,0 +1,298 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export interface AgentTraceHookInstallResult {
+  agent: "claude" | "codex" | "pi";
+  path: string;
+  modified: boolean;
+}
+
+const PI_EXTENSION_MARKER = "Managed by Review Desktop trace setup";
+
+function piExtensionSource(reviewCommand: string): string {
+  return `// ${PI_EXTENSION_MARKER}
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { spawn } from "node:child_process";
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    const sessionId = ctx.sessionManager.getSessionId();
+    if (!sessionId) return;
+    runTraceHook("SessionStart", sessionId, ctx.cwd);
+  });
+
+  pi.on("session_shutdown", async (_event, ctx) => {
+    const sessionId = ctx.sessionManager.getSessionId();
+    if (!sessionId) return;
+    runTraceHook("SessionEnd", sessionId, ctx.cwd);
+  });
+}
+
+function runTraceHook(eventName: string, sessionId: string, cwd: string) {
+  const payload = JSON.stringify({
+    hook_event_name: eventName,
+    session_id: sessionId,
+  });
+
+  const proc = spawn(${JSON.stringify(reviewCommand)}, ["trace", "hook", eventName], {
+    cwd,
+    stdio: ["pipe", "ignore", "ignore"],
+  });
+
+  proc.stdin.end(payload);
+}
+`;
+}
+
+const CODEX_HOOK_TOML = `
+# review-trace-hooks:start
+[[hooks.SessionStart]]
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "review trace hook SessionStart"
+statusMessage = "Recording agent session id for trace stamping"
+
+[[hooks.SessionEnd]]
+[[hooks.SessionEnd.hooks]]
+type = "command"
+command = "review trace hook SessionEnd"
+# review-trace-hooks:end
+`;
+
+/**
+ * Idempotently configures Claude Code session lifecycle hooks in ~/.claude/settings.json.
+ */
+export async function installClaudeTraceHook(
+  homeDir = os.homedir(),
+  reviewCommand = "review",
+): Promise<AgentTraceHookInstallResult> {
+  const settingsDir = path.join(homeDir, ".claude");
+  const settingsPath = path.join(settingsDir, "settings.json");
+
+  let parsed: Record<string, unknown> = {};
+  if (existsSync(settingsPath)) {
+    try {
+      const content = await readFile(settingsPath, "utf8");
+      parsed = JSON.parse(content);
+    } catch {
+      parsed = {};
+    }
+  }
+
+  const hooks = (parsed.hooks as Record<string, unknown>) ?? {};
+  let modified = false;
+
+  const hookCommand = (eventName: "SessionStart" | "SessionEnd") => ({
+    type: "command",
+    command: `${shellCommand(reviewCommand)} trace hook ${eventName}`,
+  });
+
+  for (const eventName of ["SessionStart", "SessionEnd"] as const) {
+    const existingGroup = (hooks[eventName] as unknown[]) ?? [];
+    const hasHook = existingGroup.some((entry) => {
+      if (typeof entry !== "object" || !entry) return false;
+      const subHooks = (entry as { hooks?: Array<{ command?: string }> }).hooks;
+      if (Array.isArray(subHooks)) {
+        return subHooks.some((h) => isReviewTraceHookCommand(h.command));
+      }
+      return false;
+    });
+
+    if (!hasHook) {
+      existingGroup.push({
+        hooks: [hookCommand(eventName)],
+      });
+      hooks[eventName] = existingGroup;
+      modified = true;
+    }
+  }
+
+  if (modified || !existsSync(settingsPath)) {
+    parsed.hooks = hooks;
+    await mkdir(settingsDir, { recursive: true });
+    await writeFile(
+      settingsPath,
+      `${JSON.stringify(parsed, null, 2)}\n`,
+      "utf8",
+    );
+  }
+
+  return { agent: "claude", path: settingsPath, modified };
+}
+
+/**
+ * Idempotently configures Codex session lifecycle hooks in ~/.codex/config.toml.
+ */
+export async function installCodexTraceHook(
+  homeDir = os.homedir(),
+  reviewCommand = "review",
+): Promise<AgentTraceHookInstallResult> {
+  const codexDir = path.join(homeDir, ".codex");
+  const configPath = path.join(codexDir, "config.toml");
+
+  let existing = "";
+  if (existsSync(configPath)) {
+    existing = await readFile(configPath, "utf8");
+  }
+
+  if (existing.includes(" trace hook SessionStart")) {
+    return { agent: "codex", path: configPath, modified: false };
+  }
+
+  const codexHookToml = CODEX_HOOK_TOML.replaceAll(
+    "review trace hook",
+    `${shellCommand(reviewCommand)} trace hook`,
+  );
+  await mkdir(codexDir, { recursive: true });
+  await writeFile(
+    configPath,
+    existing
+      ? `${existing.trimEnd()}\n${codexHookToml}`
+      : codexHookToml.trimStart(),
+    "utf8",
+  );
+
+  return { agent: "codex", path: configPath, modified: true };
+}
+
+/**
+ * Idempotently writes the Pi session lifecycle extension into ~/.pi/agent/extensions/review-trace.ts.
+ */
+export async function installPiTraceExtension(
+  homeDir = os.homedir(),
+  reviewCommand = "review",
+): Promise<AgentTraceHookInstallResult> {
+  const extensionsDir = path.join(homeDir, ".pi", "agent", "extensions");
+  const extensionPath = path.join(extensionsDir, "review-trace.ts");
+
+  let existing = "";
+  if (existsSync(extensionPath)) {
+    existing = await readFile(extensionPath, "utf8");
+  }
+
+  const source = piExtensionSource(reviewCommand);
+  if (existing.trim() === source.trim()) {
+    return { agent: "pi", path: extensionPath, modified: false };
+  }
+
+  await mkdir(extensionsDir, { recursive: true });
+  await writeFile(extensionPath, source, "utf8");
+
+  return { agent: "pi", path: extensionPath, modified: true };
+}
+
+/** Removes only lifecycle hooks that Review owns for one agent. */
+export async function removeAgentTraceHook(
+  agent: "claude" | "codex" | "pi",
+  homeDir = os.homedir(),
+): Promise<boolean> {
+  if (agent === "claude") {
+    const settingsPath = path.join(homeDir, ".claude", "settings.json");
+    if (!existsSync(settingsPath)) return false;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(await readFile(settingsPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      return false;
+    }
+    const hooks = parsed.hooks as Record<string, unknown> | undefined;
+    if (!hooks) return false;
+    let changed = false;
+    for (const eventName of ["SessionStart", "SessionEnd"] as const) {
+      const groups = Array.isArray(hooks[eventName]) ? hooks[eventName] : [];
+      const keptGroups = groups.flatMap((group) => {
+        if (!group || typeof group !== "object") return [group];
+        const record = group as Record<string, unknown>;
+        if (!Array.isArray(record.hooks)) return [group];
+        const keptHooks = record.hooks.filter((hook) => {
+          const command =
+            hook && typeof hook === "object"
+              ? (hook as { command?: unknown }).command
+              : undefined;
+          const owned = isReviewTraceHookCommand(command);
+          if (owned) changed = true;
+          return !owned;
+        });
+        return keptHooks.length > 0 ? [{ ...record, hooks: keptHooks }] : [];
+      });
+      if (keptGroups.length > 0) hooks[eventName] = keptGroups;
+      else delete hooks[eventName];
+    }
+    if (!changed) return false;
+    parsed.hooks = hooks;
+    await writeFile(
+      settingsPath,
+      `${JSON.stringify(parsed, null, 2)}\n`,
+      "utf8",
+    );
+    return true;
+  }
+
+  if (agent === "codex") {
+    const configPath = path.join(homeDir, ".codex", "config.toml");
+    if (!existsSync(configPath)) return false;
+    const existing = await readFile(configPath, "utf8");
+    const marked =
+      /# review-trace-hooks:start\n[\s\S]*?# review-trace-hooks:end\n?/;
+    const defaultHookText = CODEX_HOOK_TOML.trim();
+    const legacyHookText = CODEX_HOOK_TOML.replace(
+      /# review-trace-hooks:(?:start|end)\n/g,
+      "",
+    ).trim();
+    if (
+      !marked.test(existing) &&
+      !existing.includes(defaultHookText) &&
+      !existing.includes(legacyHookText)
+    ) {
+      return false;
+    }
+    const next = existing
+      .replace(marked, "")
+      .replace(defaultHookText, "")
+      .replace(legacyHookText, "")
+      .replace(/\n{3,}/g, "\n\n");
+    await writeFile(
+      configPath,
+      next.trim() ? `${next.trimEnd()}\n` : "",
+      "utf8",
+    );
+    return true;
+  }
+
+  const extensionPath = path.join(
+    homeDir,
+    ".pi",
+    "agent",
+    "extensions",
+    "review-trace.ts",
+  );
+  if (!existsSync(extensionPath)) return false;
+  const existing = await readFile(extensionPath, "utf8");
+  const installedSources = [
+    piExtensionSource("review"),
+    piExtensionSource(path.join(homeDir, ".local", "bin", "review")),
+  ];
+  if (!installedSources.some((source) => source.trim() === existing.trim())) {
+    return false;
+  }
+  await rm(extensionPath, { force: true });
+  return true;
+}
+
+function shellCommand(command: string): string {
+  return command === "review"
+    ? command
+    : `'${command.replaceAll("'", `'"'"'`)}'`;
+}
+
+function isReviewTraceHookCommand(command: unknown): boolean {
+  if (typeof command !== "string") return false;
+  const match = /^(.*) trace hook (SessionStart|SessionEnd)$/.exec(command);
+  if (!match) return false;
+  return match[1] === "review" || match[1].endsWith("/review'");
+}

--- a/packages/progressive-review/src/agent-trace-parser.test.ts
+++ b/packages/progressive-review/src/agent-trace-parser.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AGENT_TRACE_PARSER_VERSION,
+  parseAgentTraceJsonl,
+  sniffAgentTraceHarness,
+} from "./agent-trace-parser";
+
+describe("agent-trace-parser", () => {
+  it("exports the parser version", () => {
+    expect(AGENT_TRACE_PARSER_VERSION).toBe("1");
+  });
+
+  describe("sniffAgentTraceHarness", () => {
+    it("sniffs codex harness from session_meta", () => {
+      const chunk = JSON.stringify({
+        type: "session_meta",
+        payload: { id: "123" },
+      });
+      expect(sniffAgentTraceHarness(chunk)).toBe("codex");
+    });
+
+    it("sniffs pi harness from session", () => {
+      const chunk = JSON.stringify({ type: "session", id: "123" });
+      expect(sniffAgentTraceHarness(chunk)).toBe("pi");
+    });
+
+    it("sniffs claude-code harness from first claude record", () => {
+      const chunk = JSON.stringify({ type: "ai-title", aiTitle: "Fix bug" });
+      expect(sniffAgentTraceHarness(chunk)).toBe("claude-code");
+    });
+  });
+
+  describe("Claude Code transcripts", () => {
+    it("parses user turns, thinking blocks, assistant prose, and tool calls", () => {
+      const jsonl = [
+        JSON.stringify({ type: "ai-title", aiTitle: "Fix memory leak" }),
+        JSON.stringify({
+          type: "user",
+          timestamp: "2026-08-16T12:00:00Z",
+          message: {
+            content: [{ type: "text", text: "Please investigate the leak." }],
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          timestamp: "2026-08-16T12:01:00Z",
+          message: {
+            content: [
+              { type: "thinking", thinking: "I need to check allocations." },
+              {
+                type: "tool_use",
+                id: "tool-1",
+                name: "Bash",
+                input: { command: "rg 'leak' src/" },
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "user",
+          timestamp: "2026-08-16T12:01:10Z",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tool-1",
+                content: [{ type: "text", text: "src/leak.ts:10" }],
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          timestamp: "2026-08-16T12:02:00Z",
+          message: {
+            content: [
+              { type: "text", text: "I found the leak in `src/leak.ts`." },
+            ],
+          },
+        }),
+      ].join("\n");
+
+      const result = parseAgentTraceJsonl(jsonl);
+      expect(result.harness).toBe("claude-code");
+      expect(result.title).toBe("Fix memory leak");
+      expect(result.userTurns).toBe(1);
+      expect(result.toolCalls).toBe(1);
+      expect(result.events).toHaveLength(4);
+
+      expect(result.events[0]).toEqual({
+        kind: "user",
+        text: "Please investigate the leak.",
+        at: "2026-08-16T12:00:00Z",
+      });
+      expect(result.events[1]).toEqual({
+        kind: "assistant",
+        markdown: "I need to check allocations.",
+        thinking: true,
+        at: "2026-08-16T12:01:00Z",
+      });
+      expect(result.events[2]).toEqual({
+        kind: "tool",
+        tool: "Bash",
+        verb: "Ran",
+        title: "rg 'leak' src/",
+        command: "rg 'leak' src/",
+        output: "src/leak.ts:10",
+        at: "2026-08-16T12:01:00Z",
+      });
+      expect(result.events[3]).toEqual({
+        kind: "assistant",
+        markdown: "I found the leak in `src/leak.ts`.",
+        at: "2026-08-16T12:02:00Z",
+      });
+    });
+
+    it("filters out sidechain records for main trace unless isSubagent is true", () => {
+      const jsonl = [
+        JSON.stringify({
+          type: "user",
+          timestamp: "2026-08-16T12:00:00Z",
+          message: { content: [{ type: "text", text: "Main turn" }] },
+        }),
+        JSON.stringify({
+          type: "user",
+          isSidechain: true,
+          timestamp: "2026-08-16T12:00:30Z",
+          message: { content: [{ type: "text", text: "Subagent turn" }] },
+        }),
+      ].join("\n");
+
+      const mainResult = parseAgentTraceJsonl(jsonl);
+      expect(mainResult.events).toHaveLength(1);
+      expect(mainResult.events[0].kind).toBe("user");
+      expect((mainResult.events[0] as any).text).toBe("Main turn");
+
+      const subResult = parseAgentTraceJsonl(jsonl, { isSubagent: true });
+      expect(subResult.events).toHaveLength(2);
+    });
+  });
+
+  describe("Codex transcripts", () => {
+    it("parses event_msg user_message, agent_message, and patch_apply_end", () => {
+      const jsonl = [
+        JSON.stringify({
+          type: "session_meta",
+          payload: { cwd: "/repo", timestamp: "2026-08-16T10:00:00Z" },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          timestamp: "2026-08-16T10:00:05Z",
+          payload: {
+            type: "user_message",
+            message: "Refactor database queries",
+          },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          timestamp: "2026-08-16T10:01:00Z",
+          payload: {
+            type: "patch_apply_end",
+            changes: {
+              "/repo/src/db.ts": {
+                type: "edit",
+                unified_diff:
+                  "--- a/src/db.ts\n+++ b/src/db.ts\n@@ -1,2 +1,2 @@\n-old\n+new",
+              },
+            },
+            stdout: "Success",
+          },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          timestamp: "2026-08-16T10:02:00Z",
+          payload: {
+            type: "agent_message",
+            message: "Refactoring complete.",
+          },
+        }),
+      ].join("\n");
+
+      const result = parseAgentTraceJsonl(jsonl);
+      expect(result.harness).toBe("codex");
+      expect(result.userTurns).toBe(1);
+      expect(result.toolCalls).toBe(1);
+      expect(result.events).toHaveLength(3);
+      expect(result.events[0]).toEqual({
+        kind: "user",
+        text: "Refactor database queries",
+        at: "2026-08-16T10:00:05Z",
+      });
+      expect(result.events[1]).toMatchObject({
+        kind: "tool",
+        tool: "apply_patch",
+        verb: "Edited",
+        filePath: "src/db.ts",
+        additions: 1,
+        deletions: 1,
+      });
+      expect(result.events[2]).toEqual({
+        kind: "assistant",
+        markdown: "Refactoring complete.",
+        at: "2026-08-16T10:02:00Z",
+      });
+    });
+  });
+
+  describe("Pi transcripts", () => {
+    it("parses session, user turns, assistant with thinking, and tools", () => {
+      const jsonl = [
+        JSON.stringify({
+          type: "session",
+          id: "pi-session-1",
+          cwd: "/repo",
+          timestamp: "2026-08-16T14:00:00Z",
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-08-16T14:00:05Z",
+          message: {
+            role: "user",
+            content: "Add unit tests",
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-08-16T14:01:00Z",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "I will read existing tests." },
+              {
+                type: "toolCall",
+                id: "call-1",
+                name: "read",
+                arguments: { path: "src/db.test.ts" },
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-08-16T14:01:05Z",
+          message: {
+            role: "toolResult",
+            toolCallId: "call-1",
+            content: "describe('db', () => {})",
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-08-16T14:02:00Z",
+          message: {
+            role: "assistant",
+            content: "Added tests for db module.",
+          },
+        }),
+      ].join("\n");
+
+      const result = parseAgentTraceJsonl(jsonl);
+      expect(result.harness).toBe("pi");
+      expect(result.userTurns).toBe(1);
+      expect(result.toolCalls).toBe(1);
+      expect(result.events).toHaveLength(4);
+
+      expect(result.events[0]).toEqual({
+        kind: "user",
+        text: "Add unit tests",
+        at: "2026-08-16T14:00:05Z",
+      });
+      expect(result.events[1]).toEqual({
+        kind: "assistant",
+        markdown: "I will read existing tests.",
+        thinking: true,
+        at: "2026-08-16T14:01:00Z",
+      });
+      expect(result.events[2]).toMatchObject({
+        kind: "tool",
+        tool: "read",
+        verb: "Read",
+        title: "src/db.test.ts",
+        filePath: "src/db.test.ts",
+        output: "describe('db', () => {})",
+        at: "2026-08-16T14:01:00Z",
+      });
+      expect(result.events[3]).toEqual({
+        kind: "assistant",
+        markdown: "Added tests for db module.",
+        at: "2026-08-16T14:02:00Z",
+      });
+    });
+  });
+});

--- a/packages/progressive-review/src/agent-trace-parser.ts
+++ b/packages/progressive-review/src/agent-trace-parser.ts
@@ -1,0 +1,1183 @@
+import path from "node:path";
+
+import type {
+  ReviewAgentTraceEvent,
+  ReviewAgentTraceSession,
+} from "@dev.fast/review-protocol";
+
+export const AGENT_TRACE_PARSER_VERSION = "1";
+
+export type AgentTraceHarness = ReviewAgentTraceSession["harness"];
+export type AgentTraceEvent = ReviewAgentTraceEvent;
+export type AgentTraceUserEvent = Extract<AgentTraceEvent, { kind: "user" }>;
+export type AgentTraceAssistantEvent = Extract<
+  AgentTraceEvent,
+  { kind: "assistant" }
+>;
+export type AgentTraceToolEvent = Extract<AgentTraceEvent, { kind: "tool" }>;
+export type AgentTraceSeparatorEvent = Extract<
+  AgentTraceEvent,
+  { kind: "separator" }
+>;
+
+// The one text projection of an event. TraceQuote validation matches quotes
+// against this text, so any surface that shows event text for quote picking
+// must use the same projection.
+export function extractTraceEventText(event: AgentTraceEvent): string {
+  if (event.kind === "user") return event.text;
+  if (event.kind === "assistant") return event.markdown;
+  if (event.kind === "tool") {
+    return [event.title, event.command, event.input, event.output]
+      .filter(Boolean)
+      .join(" ");
+  }
+  if (event.kind === "separator") return event.label;
+  return "";
+}
+
+export interface AgentTraceParseResult {
+  harness: AgentTraceHarness;
+  title: string | null;
+  events: AgentTraceEvent[];
+  startedAt: string | null;
+  endedAt: string | null;
+  /** Active work time: idle gaps longer than ten minutes are excluded. */
+  activeMs: number | null;
+  userTurns: number;
+  toolCalls: number;
+}
+
+const ACTIVE_GAP_LIMIT_MS = 10 * 60 * 1000;
+
+function computeActiveMs(events: AgentTraceEvent[]): number | null {
+  let total = 0;
+  let previous: number | null = null;
+  let sawTimestamp = false;
+  for (const event of events) {
+    const at = timestampOf(event);
+    if (at === null) continue;
+    sawTimestamp = true;
+    if (previous !== null && at > previous) {
+      total += Math.min(at - previous, ACTIVE_GAP_LIMIT_MS);
+    }
+    previous = at;
+  }
+  return sawTimestamp ? total : null;
+}
+
+const OUTPUT_LIMIT = 20_000;
+const INPUT_LIMIT = 4_000;
+const TITLE_LIMIT = 160;
+
+export function sniffAgentTraceHarness(
+  jsonlFirstChunk: string,
+): AgentTraceHarness {
+  for (const line of jsonlFirstChunk.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const record = JSON.parse(trimmed) as { type?: unknown };
+      if (record.type === "session_meta") return "codex";
+      if (record.type === "session") return "pi";
+      return "claude-code";
+    } catch {
+      continue;
+    }
+  }
+  return "unknown";
+}
+
+export function parseAgentTraceJsonl(
+  jsonl: string,
+  options?: { isSubagent?: boolean },
+): AgentTraceParseResult {
+  const records: unknown[] = [];
+  for (const line of jsonl.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      records.push(JSON.parse(trimmed));
+    } catch {
+      // Partial trailing writes are expected in live transcripts.
+    }
+  }
+  const first = records[0] as { type?: unknown } | undefined;
+  const parsed =
+    first?.type === "session_meta"
+      ? parseCodexRecords(records)
+      : first?.type === "session"
+        ? parsePiRecords(records)
+        : parseClaudeRecords(records, options);
+  parsed.activeMs = computeActiveMs(parsed.events);
+  return parsed;
+}
+
+function truncate(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  const half = Math.floor(limit / 2);
+  return `${text.slice(0, half)}\n… (+${text.length - limit} characters omitted) …\n${text.slice(-half)}`;
+}
+
+function compactLine(text: string, limit = TITLE_LIMIT): string {
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= limit) return collapsed;
+  return `${collapsed.slice(0, limit - 1)}…`;
+}
+
+/** File titles keep their tail: the filename matters more than the prefix. */
+function compactFileLine(text: string, limit = TITLE_LIMIT): string {
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= limit) return collapsed;
+  return `…${collapsed.slice(-(limit - 1))}`;
+}
+
+function relativizePath(filePath: string, cwd: string | null): string {
+  if (!cwd) return filePath;
+  const relative = path.relative(cwd, filePath);
+  if (!relative || relative.startsWith("..")) return filePath;
+  return relative;
+}
+
+function timestampOf(event: AgentTraceEvent | undefined): number | null {
+  if (!event || event.kind === "separator" || !event.at) return null;
+  const value = Date.parse(event.at);
+  return Number.isFinite(value) ? value : null;
+}
+
+// --- Claude Code transcripts ----------------------------------------------
+
+interface ClaudeContentBlock {
+  type?: string;
+  text?: string;
+  thinking?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  content?: unknown;
+  is_error?: boolean;
+}
+
+interface ClaudeRecord {
+  type?: string;
+  isSidechain?: boolean;
+  isMeta?: boolean;
+  timestamp?: string;
+  cwd?: string;
+  aiTitle?: string;
+  customTitle?: string;
+  message?: { role?: string; content?: unknown };
+  toolUseResult?: {
+    filePath?: string;
+    structuredPatch?: Array<{ lines?: string[] }>;
+  };
+}
+
+function claudeContentBlocks(content: unknown): ClaudeContentBlock[] {
+  if (typeof content === "string") return [{ type: "text", text: content }];
+  if (Array.isArray(content)) return content as ClaudeContentBlock[];
+  return [];
+}
+
+const CLAUDE_NOISE_PATTERNS = [
+  /^\[SYSTEM NOTIFICATION/,
+  /^\[Request interrupted/,
+  /^This session is being continued/,
+  /^<task-notification>/,
+  /^<local-command-stdout>/,
+];
+
+function cleanClaudeUserText(text: string): string | null {
+  let cleaned = text;
+  cleaned = cleaned.replace(
+    /<system-reminder>[\s\S]*?<\/system-reminder>/g,
+    "",
+  );
+  cleaned = cleaned.replace(
+    /<local-command-caveat>[\s\S]*?<\/local-command-caveat>/g,
+    "",
+  );
+  const commandName = /<command-name>([\s\S]*?)<\/command-name>/.exec(
+    cleaned,
+  )?.[1];
+  if (commandName) {
+    const args =
+      /<command-args>([\s\S]*?)<\/command-args>/.exec(cleaned)?.[1] ?? "";
+    const slash = commandName.trim().startsWith("/") ? "" : "/";
+    return `${slash}${commandName.trim()} ${args.trim()}`.trim();
+  }
+  cleaned = cleaned.trim();
+  if (!cleaned) return null;
+  for (const pattern of CLAUDE_NOISE_PATTERNS) {
+    if (pattern.test(cleaned)) return null;
+  }
+  return cleaned;
+}
+
+function claudeResultText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const block of content as ClaudeContentBlock[]) {
+    if (block?.type === "text" && typeof block.text === "string") {
+      parts.push(block.text);
+    } else if (block?.type === "image") {
+      parts.push("[image]");
+    }
+  }
+  return parts.join("\n");
+}
+
+function patchCounts(
+  patch: Array<{ lines?: string[] }> | undefined,
+): { additions: number; deletions: number } | null {
+  if (!patch) return null;
+  let additions = 0;
+  let deletions = 0;
+  for (const hunk of patch) {
+    for (const line of hunk.lines ?? []) {
+      if (line.startsWith("+")) additions += 1;
+      else if (line.startsWith("-")) deletions += 1;
+    }
+  }
+  return { additions, deletions };
+}
+
+function claudeToolEvent(
+  block: ClaudeContentBlock,
+  at: string | undefined,
+  cwd: string | null,
+): AgentTraceToolEvent {
+  const name = block.name ?? "tool";
+  const input = (block.input ?? {}) as Record<string, unknown>;
+  const event: AgentTraceToolEvent = {
+    kind: "tool",
+    tool: name,
+    verb: "Called",
+    title: name,
+    at,
+  };
+  const inputText = (key: string): string | null =>
+    typeof input[key] === "string" ? (input[key] as string) : null;
+  const filePath =
+    inputText("file_path") ?? inputText("path") ?? inputText("notebook_path");
+  switch (name) {
+    case "Bash": {
+      const command = inputText("command") ?? "";
+      event.verb = "Ran";
+      event.title = compactLine(command);
+      event.command = truncate(command, INPUT_LIMIT);
+      break;
+    }
+    case "Edit":
+    case "MultiEdit":
+    case "NotebookEdit":
+      event.verb = "Edited";
+      event.title = filePath ? relativizePath(filePath, cwd) : name;
+      if (filePath) event.filePath = relativizePath(filePath, cwd);
+      break;
+    case "Write":
+      event.verb = "Wrote";
+      event.title = filePath ? relativizePath(filePath, cwd) : name;
+      if (filePath) event.filePath = relativizePath(filePath, cwd);
+      break;
+    case "Read":
+      event.verb = "Read";
+      event.title = filePath ? relativizePath(filePath, cwd) : name;
+      if (filePath) event.filePath = relativizePath(filePath, cwd);
+      break;
+    case "Grep":
+    case "Glob": {
+      const pattern = inputText("pattern") ?? "";
+      event.verb = "Searched";
+      event.title = compactLine(
+        inputText("path")
+          ? `${pattern} in ${relativizePath(inputText("path") ?? "", cwd)}`
+          : pattern,
+      );
+      break;
+    }
+    case "Task":
+    case "Agent": {
+      event.verb = "Ran agent";
+      event.title = compactLine(
+        inputText("description") ?? inputText("prompt") ?? "subagent",
+      );
+      break;
+    }
+    case "WebFetch":
+      event.verb = "Fetched";
+      event.title = compactLine(inputText("url") ?? "");
+      break;
+    case "WebSearch":
+      event.verb = "Searched web";
+      event.title = compactLine(inputText("query") ?? "");
+      break;
+    case "TodoWrite":
+      event.verb = "Updated";
+      event.title = "task list";
+      break;
+    case "Skill":
+      event.verb = "Loaded skill";
+      event.title = compactLine(inputText("skill") ?? "");
+      break;
+    default: {
+      if (name.startsWith("mcp__")) {
+        event.verb = "Called";
+        event.title = name.replace(/^mcp__/, "").replace(/__/g, " · ");
+      }
+      break;
+    }
+  }
+  if (!event.command) {
+    const pretty = JSON.stringify(input, null, 2);
+    if (pretty && pretty !== "{}") event.input = truncate(pretty, INPUT_LIMIT);
+  }
+  return event;
+}
+
+function parseClaudeRecords(
+  records: unknown[],
+  options?: { isSubagent?: boolean },
+): AgentTraceParseResult {
+  const events: AgentTraceEvent[] = [];
+  const pendingTools = new Map<string, AgentTraceToolEvent>();
+  let title: string | null = null;
+  let startedAt: string | null = null;
+  let endedAt: string | null = null;
+  let cwd: string | null = null;
+  let userTurns = 0;
+  let toolCalls = 0;
+
+  for (const raw of records) {
+    const record = raw as ClaudeRecord;
+    if (record.type === "ai-title" && typeof record.aiTitle === "string") {
+      title ??= record.aiTitle;
+      continue;
+    }
+    if (
+      record.type === "custom-title" &&
+      typeof record.customTitle === "string"
+    ) {
+      title = record.customTitle;
+      continue;
+    }
+    if (record.type !== "user" && record.type !== "assistant") continue;
+    if (!options?.isSubagent && record.isSidechain) continue;
+    cwd ??= record.cwd ?? null;
+    const at = record.timestamp;
+    if (at) {
+      startedAt ??= at;
+      endedAt = at;
+    }
+    const blocks = claudeContentBlocks(record.message?.content);
+    if (record.type === "user") {
+      let sawToolResult = false;
+      for (const block of blocks) {
+        if (block?.type !== "tool_result") continue;
+        sawToolResult = true;
+        const pending = block.tool_use_id
+          ? pendingTools.get(block.tool_use_id)
+          : undefined;
+        if (!pending) continue;
+        const resultText = claudeResultText(block.content).trim();
+        if (resultText) pending.output = truncate(resultText, OUTPUT_LIMIT);
+        if (block.is_error) pending.error = true;
+        const counts = patchCounts(record.toolUseResult?.structuredPatch);
+        if (counts) {
+          pending.additions = counts.additions;
+          pending.deletions = counts.deletions;
+        }
+        if (record.toolUseResult?.filePath && !pending.filePath) {
+          pending.filePath = relativizePath(record.toolUseResult.filePath, cwd);
+        }
+        if (block.tool_use_id) pendingTools.delete(block.tool_use_id);
+      }
+      if (sawToolResult || record.isMeta) continue;
+      const text = blocks
+        .filter(
+          (block) => block?.type === "text" && typeof block.text === "string",
+        )
+        .map((block) => block.text as string)
+        .join("\n");
+      const cleaned = cleanClaudeUserText(text);
+      if (!cleaned) continue;
+      userTurns += 1;
+      events.push({ kind: "user", text: cleaned, at });
+      continue;
+    }
+    for (const block of blocks) {
+      if (block?.type === "thinking" && typeof block.thinking === "string") {
+        const trimmed = block.thinking.trim();
+        if (trimmed) {
+          events.push({
+            kind: "assistant",
+            markdown: trimmed,
+            thinking: true,
+            at,
+          });
+        }
+      } else if (block?.type === "text" && typeof block.text === "string") {
+        const trimmed = block.text.trim();
+        if (trimmed) events.push({ kind: "assistant", markdown: trimmed, at });
+      } else if (block?.type === "tool_use") {
+        const event = claudeToolEvent(block, at, cwd);
+        toolCalls += 1;
+        events.push(event);
+        if (block.id) pendingTools.set(block.id, event);
+      }
+    }
+  }
+
+  return {
+    harness: "claude-code",
+    title,
+    events,
+    startedAt,
+    endedAt,
+    activeMs: null,
+    userTurns,
+    toolCalls,
+  };
+}
+
+// --- Codex rollouts --------------------------------------------------------
+
+interface CodexPayload {
+  type?: string;
+  role?: string;
+  content?: Array<{ type?: string; text?: string }>;
+  name?: string;
+  arguments?: unknown;
+  input?: unknown;
+  call_id?: string;
+  output?: unknown;
+  action?: { query?: string };
+  cwd?: string;
+  timestamp?: string;
+  message?: string;
+  query?: string;
+  stdout?: string;
+  success?: boolean;
+  changes?: Record<
+    string,
+    { type?: string; unified_diff?: string; content?: string }
+  >;
+  invocation?: {
+    server?: string;
+    tool?: string;
+    arguments?: unknown;
+  };
+  result?: unknown;
+  command?: unknown;
+  aggregated_output?: string;
+  exit_code?: number;
+}
+
+interface CodexRecord {
+  type?: string;
+  timestamp?: string;
+  payload?: CodexPayload;
+}
+
+const CODEX_USER_NOISE_PREFIXES = [
+  "<recommended_plugins",
+  "<permissions",
+  "<environment_context",
+  "<environments_instructions",
+  "<user_instructions",
+  "<user_shell_command",
+  "<turn_aborted",
+  "<subagent_notification",
+  "<codex_internal_context",
+  "<goal_context",
+  "<codex_delegation",
+  "<external_",
+  "<skills_instructions",
+  "<skill>",
+  "<apps_instructions",
+  "<plugins_instructions",
+  "<tools>",
+  "<collaboration_mode",
+  "<multi_agent_mode",
+  "<multi_agent_role",
+  "<realtime_conversation",
+  "<context_window",
+  "<turn_context",
+  "<model_switch",
+  "<personality_spec",
+  "<token_budget",
+  "<rollout_budget",
+  "<git_attribution",
+  "<ENVIRONMENT",
+  "# AGENTS",
+];
+
+function codexText(payload: CodexPayload): string {
+  return (payload.content ?? [])
+    .filter(
+      (block) =>
+        (block?.type === "input_text" || block?.type === "output_text") &&
+        typeof block.text === "string",
+    )
+    .map((block) => block.text as string)
+    .join("\n")
+    .trim();
+}
+
+function codexPatchSummary(
+  patch: string,
+  cwd: string | null,
+): {
+  filePath?: string;
+  additions: number;
+  deletions: number;
+  files: string[];
+} {
+  const files: string[] = [];
+  let additions = 0;
+  let deletions = 0;
+  for (const line of patch.split("\n")) {
+    const header = /^\*\*\* (?:Add|Update|Delete) File: (.+)$/.exec(line);
+    if (header) {
+      files.push(relativizePath(header[1].trim(), cwd));
+      continue;
+    }
+    if (line.startsWith("***")) continue;
+    if (line.startsWith("+")) additions += 1;
+    else if (line.startsWith("-")) deletions += 1;
+  }
+  return { filePath: files[0], additions, deletions, files };
+}
+
+const CODE_MODE_FILE_PATTERN =
+  /\*\*\* (?:Add|Update|Delete) File: ([^\n\\"`]+)/g;
+
+function unifiedDiffCounts(diff: string): {
+  additions: number;
+  deletions: number;
+} {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+") && !line.startsWith("+++")) additions += 1;
+    else if (line.startsWith("-") && !line.startsWith("---")) deletions += 1;
+  }
+  return { additions, deletions };
+}
+
+function codexValueText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function codexPatchEvent(
+  payload: CodexPayload,
+  at: string | undefined,
+  cwd: string | null,
+): AgentTraceToolEvent | null {
+  const changes = payload.changes ?? {};
+  const paths = Object.keys(changes);
+  if (paths.length === 0) return null;
+  let additions = 0;
+  let deletions = 0;
+  const relativePaths = paths.map((filePath) => relativizePath(filePath, cwd));
+  for (const filePath of paths) {
+    const change = changes[filePath] ?? {};
+    if (change.type === "add" && typeof change.content === "string") {
+      additions += change.content.split("\n").length;
+    } else if (change.type === "delete" && typeof change.content === "string") {
+      deletions += change.content.split("\n").length;
+    } else if (typeof change.unified_diff === "string") {
+      const counts = unifiedDiffCounts(change.unified_diff);
+      additions += counts.additions;
+      deletions += counts.deletions;
+    }
+  }
+  const single = paths.length === 1 ? changes[paths[0]] : null;
+  const verb =
+    single?.type === "add"
+      ? "Added"
+      : single?.type === "delete"
+        ? "Deleted"
+        : "Edited";
+  const event: AgentTraceToolEvent = {
+    kind: "tool",
+    tool: "apply_patch",
+    verb,
+    title: compactFileLine(relativePaths.join(", ")),
+    filePath: relativePaths[0],
+    additions,
+    deletions,
+    at,
+  };
+  const diffs = paths
+    .map((filePath) => changes[filePath]?.unified_diff)
+    .filter((diff): diff is string => typeof diff === "string");
+  if (diffs.length > 0) event.input = truncate(diffs.join("\n"), INPUT_LIMIT);
+  if (payload.stdout) event.output = truncate(payload.stdout, OUTPUT_LIMIT);
+  if (payload.success === false) event.error = true;
+  return event;
+}
+
+function codexMcpEvent(
+  payload: CodexPayload,
+  at: string | undefined,
+): AgentTraceToolEvent {
+  const invocation = payload.invocation ?? {};
+  const server =
+    typeof invocation.server === "string" ? invocation.server : "mcp";
+  const tool = typeof invocation.tool === "string" ? invocation.tool : "tool";
+  const argumentsValue = invocation.arguments as
+    | { title?: unknown }
+    | undefined;
+  const title =
+    argumentsValue && typeof argumentsValue.title === "string"
+      ? `${server} · ${tool} — ${argumentsValue.title}`
+      : `${server} · ${tool}`;
+  const event: AgentTraceToolEvent = {
+    kind: "tool",
+    tool: `${server}.${tool}`,
+    verb: "Called",
+    title: compactLine(title),
+    at,
+  };
+  const input = codexValueText(invocation.arguments);
+  if (input && input !== "{}") event.input = truncate(input, INPUT_LIMIT);
+  const result = payload.result as
+    | {
+        Ok?: {
+          content?: Array<{ type?: string; text?: string }>;
+          isError?: boolean;
+        };
+        Err?: unknown;
+      }
+    | undefined;
+  if (result?.Ok?.content) {
+    const text = result.Ok.content
+      .filter(
+        (block) => block?.type === "text" && typeof block.text === "string",
+      )
+      .map((block) => block.text as string)
+      .join("\n")
+      .trim();
+    if (text) event.output = truncate(text, OUTPUT_LIMIT);
+    if (result.Ok.isError) event.error = true;
+  } else if (result && "Err" in result) {
+    event.error = true;
+    event.output = truncate(codexValueText(result.Err), OUTPUT_LIMIT);
+  }
+  return event;
+}
+
+function codexCodeModeEvent(
+  event: AgentTraceToolEvent,
+  source: string,
+  cwd: string | null,
+  skipPatches: boolean,
+): AgentTraceToolEvent | null {
+  const cmdMatch = /"cmd"\s*:\s*"((?:[^"\\]|\\.)*)"/.exec(source);
+  if (cmdMatch) {
+    let command = cmdMatch[1];
+    try {
+      command = JSON.parse(`"${cmdMatch[1]}"`) as string;
+    } catch {
+      // Keep the escaped form.
+    }
+    event.verb = "Ran";
+    event.title = compactLine(command);
+    event.command = truncate(command, INPUT_LIMIT);
+    return event;
+  }
+  const files: string[] = [];
+  for (const match of source.matchAll(CODE_MODE_FILE_PATTERN)) {
+    const file = relativizePath(match[1].trim(), cwd);
+    if (!files.includes(file)) files.push(file);
+  }
+  if (files.length > 0) {
+    if (skipPatches) return null;
+    event.verb = "Edited";
+    event.title = compactFileLine(files.join(", "));
+    event.filePath = files[0];
+    event.input = truncate(source, INPUT_LIMIT);
+    return event;
+  }
+  const inner = /tools\.(\w+)\(/.exec(source);
+  if (inner) {
+    if (inner[1] === "wait") return null;
+    if (inner[1].startsWith("mcp__")) return null;
+    event.verb = "Called";
+    event.title = inner[1].replace(/^mcp__/, "").replace(/__/g, " · ");
+    event.input = truncate(source, INPUT_LIMIT);
+    return event;
+  }
+  return null;
+}
+
+function codexToolEvent(
+  payload: CodexPayload,
+  at: string | undefined,
+  cwd: string | null,
+  flags: { hasPatchEvents: boolean; hasMcpEvents: boolean },
+): AgentTraceToolEvent | null {
+  const name = payload.name ?? "tool";
+  if (name === "wait") return null;
+  const event: AgentTraceToolEvent = {
+    kind: "tool",
+    tool: name,
+    verb: "Called",
+    title: name,
+    at,
+  };
+  if (
+    name === "exec" ||
+    name === "exec_command" ||
+    name === "shell" ||
+    name === "local_shell"
+  ) {
+    const source = codexValueText(payload.arguments ?? payload.input);
+    if (source.includes("tools.")) {
+      return codexCodeModeEvent(event, source, cwd, flags.hasPatchEvents);
+    }
+    let command = source;
+    try {
+      const parsed = JSON.parse(source || "{}") as {
+        cmd?: string;
+        command?: string[] | string;
+      };
+      command =
+        typeof parsed.cmd === "string"
+          ? parsed.cmd
+          : Array.isArray(parsed.command)
+            ? parsed.command.join(" ")
+            : typeof parsed.command === "string"
+              ? parsed.command
+              : command;
+    } catch {
+      // Keep the raw arguments string.
+    }
+    event.verb = "Ran";
+    event.title = compactLine(command);
+    event.command = truncate(command, INPUT_LIMIT);
+    return event;
+  }
+  if (name === "apply_patch") {
+    if (flags.hasPatchEvents) return null;
+    const patchInput = codexValueText(payload.input);
+    const summary = codexPatchSummary(patchInput, cwd);
+    event.verb = "Edited";
+    event.title = compactFileLine(summary.files.join(", ") || "files");
+    event.filePath = summary.filePath;
+    event.additions = summary.additions;
+    event.deletions = summary.deletions;
+    event.input = truncate(patchInput, INPUT_LIMIT);
+    return event;
+  }
+  const inputSource = codexValueText(payload.arguments ?? payload.input);
+  if (inputSource) event.input = truncate(inputSource, INPUT_LIMIT);
+  return event;
+}
+
+function codexOutputText(output: unknown): string {
+  if (typeof output === "string") {
+    try {
+      const parsed = JSON.parse(output) as { output?: unknown };
+      if (typeof parsed.output === "string") return parsed.output;
+    } catch {
+      // Raw output string.
+    }
+    return output;
+  }
+  if (output && typeof output === "object") {
+    const inner = (output as { output?: unknown }).output;
+    if (typeof inner === "string") return inner;
+    return codexValueText(output);
+  }
+  return "";
+}
+
+function parseCodexRecords(records: unknown[]): AgentTraceParseResult {
+  const events: AgentTraceEvent[] = [];
+  const pendingTools = new Map<string, AgentTraceToolEvent>();
+  let startedAt: string | null = null;
+  let endedAt: string | null = null;
+  let cwd: string | null = null;
+  let userTurns = 0;
+  let toolCalls = 0;
+  let firstUserText: string | null = null;
+
+  let hasMessageEvents = false;
+  let hasPatchEvents = false;
+  let hasMcpEvents = false;
+  for (const raw of records) {
+    const record = raw as CodexRecord;
+    if (record.type !== "event_msg") continue;
+    const eventType = record.payload?.type;
+    if (eventType === "user_message" || eventType === "agent_message") {
+      hasMessageEvents = true;
+    } else if (eventType === "patch_apply_end") {
+      hasPatchEvents = true;
+    } else if (eventType === "mcp_tool_call_end") {
+      hasMcpEvents = true;
+    }
+  }
+  const flags = { hasPatchEvents, hasMcpEvents };
+
+  for (const raw of records) {
+    const record = raw as CodexRecord;
+    const payload = record.payload;
+    if (record.type === "session_meta") {
+      cwd = payload?.cwd ?? null;
+      startedAt ??= payload?.timestamp ?? record.timestamp ?? null;
+      continue;
+    }
+    const at = record.timestamp;
+    if (record.type === "event_msg" && payload) {
+      if (at) {
+        startedAt ??= at;
+        endedAt = at;
+      }
+      switch (payload.type) {
+        case "user_message": {
+          const text = (payload.message ?? "").trim();
+          if (!text) break;
+          const lowered = text.trimStart().toLowerCase();
+          if (
+            CODEX_USER_NOISE_PREFIXES.some((prefix) =>
+              lowered.startsWith(prefix.toLowerCase()),
+            )
+          ) {
+            break;
+          }
+          userTurns += 1;
+          firstUserText ??= text;
+          events.push({ kind: "user", text, at });
+          break;
+        }
+        case "agent_message": {
+          const text = (payload.message ?? "").trim();
+          if (text) events.push({ kind: "assistant", markdown: text, at });
+          break;
+        }
+        case "patch_apply_end": {
+          const event = codexPatchEvent(payload, at, cwd);
+          if (event) {
+            toolCalls += 1;
+            events.push(event);
+          }
+          break;
+        }
+        case "mcp_tool_call_end": {
+          toolCalls += 1;
+          events.push(codexMcpEvent(payload, at));
+          break;
+        }
+        case "web_search_end": {
+          toolCalls += 1;
+          events.push({
+            kind: "tool",
+            tool: "web_search",
+            verb: "Searched web",
+            title: compactLine(payload.query ?? ""),
+            at,
+          });
+          break;
+        }
+        case "exec_command_end": {
+          const command = Array.isArray(payload.command)
+            ? (payload.command as string[]).join(" ")
+            : codexValueText(payload.command);
+          if (!command) break;
+          toolCalls += 1;
+          const event: AgentTraceToolEvent = {
+            kind: "tool",
+            tool: "exec",
+            verb: "Ran",
+            title: compactLine(command),
+            command: truncate(command, INPUT_LIMIT),
+            at,
+          };
+          if (payload.aggregated_output) {
+            event.output = truncate(payload.aggregated_output, OUTPUT_LIMIT);
+          }
+          if (
+            typeof payload.exit_code === "number" &&
+            payload.exit_code !== 0
+          ) {
+            event.error = true;
+          }
+          events.push(event);
+          break;
+        }
+        default:
+          break;
+      }
+      continue;
+    }
+    if (record.type !== "response_item" || !payload) continue;
+    if (at) {
+      startedAt ??= at;
+      endedAt = at;
+    }
+    switch (payload.type) {
+      case "message": {
+        if (hasMessageEvents) break;
+        const text = codexText(payload);
+        if (!text) break;
+        if (payload.role === "user") {
+          const lowered = text.trimStart().toLowerCase();
+          if (
+            CODEX_USER_NOISE_PREFIXES.some((prefix) =>
+              lowered.startsWith(prefix.toLowerCase()),
+            )
+          ) {
+            break;
+          }
+          userTurns += 1;
+          events.push({ kind: "user", text, at });
+        } else if (payload.role === "assistant") {
+          events.push({ kind: "assistant", markdown: text, at });
+        }
+        break;
+      }
+      case "function_call":
+      case "custom_tool_call": {
+        const event = codexToolEvent(payload, at, cwd, flags);
+        if (!event) break;
+        toolCalls += 1;
+        events.push(event);
+        if (payload.call_id) pendingTools.set(payload.call_id, event);
+        break;
+      }
+      case "function_call_output":
+      case "custom_tool_call_output": {
+        const pending = payload.call_id
+          ? pendingTools.get(payload.call_id)
+          : undefined;
+        if (!pending) break;
+        const text = codexOutputText(payload.output).trim();
+        if (text && !pending.output) {
+          pending.output = truncate(text, OUTPUT_LIMIT);
+        }
+        if (payload.call_id) pendingTools.delete(payload.call_id);
+        break;
+      }
+      case "web_search_call": {
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return {
+    harness: "codex",
+    title: firstUserText ? compactLine(firstUserText) : null,
+    events,
+    startedAt,
+    endedAt,
+    activeMs: null,
+    userTurns,
+    toolCalls,
+  };
+}
+
+// --- Pi sessions -----------------------------------------------------------
+
+interface PiContentBlock {
+  type?: string;
+  text?: string;
+  thinking?: string;
+  id?: string;
+  name?: string;
+  arguments?: Record<string, unknown>;
+}
+
+interface PiRecord {
+  type?: string;
+  timestamp?: string;
+  cwd?: string;
+  message?: {
+    role?: string;
+    toolCallId?: string;
+    content?: PiContentBlock[] | string;
+  };
+}
+
+function piText(content: PiContentBlock[] | string | undefined): string {
+  if (typeof content === "string") return content;
+  return (content ?? [])
+    .filter((block) => block?.type === "text" && typeof block.text === "string")
+    .map((block) => block.text as string)
+    .join("\n")
+    .trim();
+}
+
+function piToolEvent(
+  block: PiContentBlock,
+  at: string | undefined,
+  cwd: string | null,
+): AgentTraceToolEvent {
+  const name = block.name ?? "tool";
+  const args = block.arguments ?? {};
+  const argText = (key: string): string | null =>
+    typeof args[key] === "string" ? (args[key] as string) : null;
+  const event: AgentTraceToolEvent = {
+    kind: "tool",
+    tool: name,
+    verb: "Called",
+    title: name,
+    at,
+  };
+  const pathValue = argText("path");
+  switch (name) {
+    case "bash": {
+      const command = argText("command") ?? "";
+      event.verb = "Ran";
+      event.title = compactLine(command);
+      event.command = truncate(command, INPUT_LIMIT);
+      break;
+    }
+    case "read":
+      event.verb = "Read";
+      event.title = pathValue
+        ? compactFileLine(relativizePath(pathValue, cwd))
+        : name;
+      if (pathValue) event.filePath = relativizePath(pathValue, cwd);
+      break;
+    case "edit":
+      event.verb = "Edited";
+      event.title = pathValue
+        ? compactFileLine(relativizePath(pathValue, cwd))
+        : name;
+      if (pathValue) event.filePath = relativizePath(pathValue, cwd);
+      break;
+    case "write":
+      event.verb = "Wrote";
+      event.title = pathValue
+        ? compactFileLine(relativizePath(pathValue, cwd))
+        : name;
+      if (pathValue) event.filePath = relativizePath(pathValue, cwd);
+      if (typeof args.content === "string") {
+        event.additions = (args.content as string).split("\n").length;
+      }
+      break;
+    case "subagent":
+      event.verb = "Ran agent";
+      event.title = compactLine(codexValueText(args.action));
+      break;
+    case "web_search":
+      event.verb = "Searched web";
+      event.title = compactLine(argText("query") ?? "");
+      break;
+    default:
+      break;
+  }
+  if (!event.command) {
+    const pretty = codexValueText(args);
+    if (pretty && pretty !== "{}") event.input = truncate(pretty, INPUT_LIMIT);
+  }
+  return event;
+}
+
+function parsePiRecords(records: unknown[]): AgentTraceParseResult {
+  const events: AgentTraceEvent[] = [];
+  const pendingTools = new Map<string, AgentTraceToolEvent>();
+  let startedAt: string | null = null;
+  let endedAt: string | null = null;
+  let cwd: string | null = null;
+  let userTurns = 0;
+  let toolCalls = 0;
+  let firstUserText: string | null = null;
+
+  for (const raw of records) {
+    const record = raw as PiRecord;
+    if (record.type === "session") {
+      cwd = record.cwd ?? null;
+      startedAt ??= record.timestamp ?? null;
+      continue;
+    }
+    if (record.type !== "message" || !record.message) continue;
+    const at = record.timestamp;
+    if (at) {
+      startedAt ??= at;
+      endedAt = at;
+    }
+    const message = record.message;
+    if (message.role === "user") {
+      const text = piText(message.content);
+      if (!text) continue;
+      const lowered = text.trimStart().toLowerCase();
+      if (
+        CODEX_USER_NOISE_PREFIXES.some((prefix) =>
+          lowered.startsWith(prefix.toLowerCase()),
+        )
+      ) {
+        continue;
+      }
+      userTurns += 1;
+      firstUserText ??= text;
+      events.push({ kind: "user", text, at });
+      continue;
+    }
+    if (message.role === "assistant") {
+      if (typeof message.content === "string") {
+        const trimmed = message.content.trim();
+        if (trimmed) events.push({ kind: "assistant", markdown: trimmed, at });
+        continue;
+      }
+      for (const block of Array.isArray(message.content)
+        ? message.content
+        : []) {
+        if (block?.type === "thinking" && typeof block.thinking === "string") {
+          const trimmed = block.thinking.trim();
+          if (trimmed) {
+            events.push({
+              kind: "assistant",
+              markdown: trimmed,
+              thinking: true,
+              at,
+            });
+          }
+        } else if (block?.type === "text" && typeof block.text === "string") {
+          const trimmed = block.text.trim();
+          if (trimmed)
+            events.push({ kind: "assistant", markdown: trimmed, at });
+        } else if (block?.type === "toolCall") {
+          if (block.name === "subagent_wait") continue;
+          const event = piToolEvent(block, at, cwd);
+          toolCalls += 1;
+          events.push(event);
+          if (block.id) pendingTools.set(block.id, event);
+        }
+      }
+      continue;
+    }
+    if (message.role === "toolResult") {
+      const pending = message.toolCallId
+        ? pendingTools.get(message.toolCallId)
+        : undefined;
+      if (!pending) continue;
+      const text = piText(message.content);
+      if (text && !pending.output)
+        pending.output = truncate(text, OUTPUT_LIMIT);
+      if (message.toolCallId) pendingTools.delete(message.toolCallId);
+    }
+  }
+
+  return {
+    harness: "pi",
+    title: firstUserText ? compactLine(firstUserText) : null,
+    events,
+    startedAt,
+    endedAt,
+    activeMs: null,
+    userTurns,
+    toolCalls,
+  };
+}

--- a/packages/progressive-review/src/authoring.ts
+++ b/packages/progressive-review/src/authoring.ts
@@ -246,7 +246,7 @@ export type StoreKind = z.infer<typeof storeKindSchema>;
 export const collectionKindSchema = z.enum(["tables", "documents"]);
 export type CollectionKind = z.infer<typeof collectionKindSchema>;
 
-export const targetRefSchema = z.strictObject({
+const targetRefShape = {
   __kind: z.literal("db-target-ref"),
   storeId: nonEmptyStringSchema,
   storeKind: storeKindSchema,
@@ -258,8 +258,32 @@ export const targetRefSchema = z.strictObject({
   collectionLabel: nonEmptyStringSchema,
   collectionKey: optionalNonEmptyStringSchema,
   path: z.array(nonEmptyStringSchema),
-});
-export type TargetRef = z.infer<typeof targetRefSchema>;
+};
+export interface TargetRef {
+  __kind: "db-target-ref";
+  storeId: string;
+  storeKind: StoreKind;
+  storeLabel: string;
+  storeDataStoreKind?: SoftwareDataStoreKind;
+  storeSoftwareMapPath?: string;
+  collectionKind: CollectionKind;
+  collectionId: string;
+  collectionLabel: string;
+  collectionKey?: string;
+  path: string[];
+  fields?: Record<string, TargetRef>;
+}
+
+const fieldTargetRefSchema: z.ZodType<TargetRef> = z.lazy(() =>
+  z.strictObject({
+    ...targetRefShape,
+    fields: z.record(nonEmptyStringSchema, fieldTargetRefSchema).optional(),
+  }),
+);
+
+export const targetRefSchema: z.ZodType<TargetRef> = z.lazy(() =>
+  z.union([collectionRefSchema, fieldTargetRefSchema]),
+);
 
 const dbOperationCommonShape = {
   label: nonEmptyStringSchema,
@@ -338,6 +362,14 @@ export const tutorialKeymapPickerPropsSchema = z.strictObject({
 export type TutorialKeymapPickerProps = z.infer<
   typeof tutorialKeymapPickerPropsSchema
 >;
+
+export const traceQuotePropsSchema = z.strictObject({
+  sessionId: nonEmptyStringSchema,
+  trace: optionalNonEmptyStringSchema,
+  event: z.number().int().nonnegative().optional(),
+  children: reactNodeSchema.optional(),
+});
+export type TraceQuoteProps = z.infer<typeof traceQuotePropsSchema>;
 
 export const callsAssertionSchema = z.strictObject({
   __kind: z.literal("call-assertion"),
@@ -448,6 +480,7 @@ export interface ReviewAuthoringComponentRegistry {
   DbWrite: ComponentType<DbWriteProps>;
   ReviewSection: ComponentType<ReviewSectionProps>;
   SequenceDiagram: ComponentType<SequenceDiagramProps>;
+  TraceQuote: ComponentType<TraceQuoteProps>;
   TutorialKeymapPicker: ComponentType<TutorialKeymapPickerProps>;
 }
 
@@ -466,6 +499,7 @@ export const reviewAuthoringPropsSchemas = {
   DbWrite: dbWritePropsSchema,
   ReviewSection: reviewSectionPropsSchema,
   SequenceDiagram: sequenceDiagramPropsSchema,
+  TraceQuote: traceQuotePropsSchema,
   TutorialKeymapPicker: tutorialKeymapPickerPropsSchema,
 } satisfies Record<keyof ReviewAuthoringComponentRegistry, z.ZodType>;
 
@@ -496,6 +530,11 @@ const softwareDataStoreFieldSchema: z.ZodType<SoftwareDataStoreFieldSchema> =
       ]),
     ),
   );
+const collectionRefSchema: z.ZodType<CollectionRef> = z.strictObject({
+  ...targetRefShape,
+  schema: softwareDataStoreFieldSchema,
+  fields: z.record(nonEmptyStringSchema, fieldTargetRefSchema),
+});
 export const softwareDataStoreCollectionInputSchema = z.strictObject({
   label: optionalNonEmptyStringSchema,
   key: optionalNonEmptyStringSchema,
@@ -528,33 +567,41 @@ export interface StoreRef {
   label: string;
   dataStoreKind?: SoftwareDataStoreKind;
   softwareMapPath?: string;
-  tables?: Record<string, DynamicCollectionRef>;
-  documents?: Record<string, DynamicCollectionRef>;
+  tables?: Record<string, CollectionRef>;
+  documents?: Record<string, CollectionRef>;
 }
 
 export interface CollectionRef extends TargetRef {
-  __collectionId: string;
-  __collectionLabel: string;
-  __collectionKey?: string;
   schema: SoftwareDataStoreFieldSchema;
+  fields: Record<string, TargetRef>;
 }
-
-type DynamicCollectionRef = CollectionRef & Record<string, unknown>;
 
 export type CollectionRefs<T> =
   T extends Record<string, SoftwareDataStoreCollectionInput>
     ? {
-        [K in keyof T]: Omit<CollectionRef, keyof FieldRefs<T[K]["schema"]>> &
-          FieldRefs<T[K]["schema"]>;
+        [K in keyof T]: Omit<CollectionRef, "fields"> & {
+          fields: FieldRefs<T[K]["schema"]>;
+        };
       }
     : never;
 
 type FieldRefs<T> = T extends SoftwareDataStoreFieldLeaf
   ? T extends { schema: infer Schema extends Record<string, unknown> }
-    ? FieldRefs<Schema>
-    : unknown
+    ? { fields: FieldRefs<Schema> }
+    : TargetRef
   : T extends Record<string, unknown>
-    ? { [K in keyof T]: TargetRef & FieldRefs<T[K]> }
+    ? {
+        [K in keyof T]: TargetRef &
+          (T[K] extends SoftwareDataStoreFieldLeaf
+            ? T[K] extends {
+                schema: infer Schema extends Record<string, unknown>;
+              }
+              ? { fields: FieldRefs<Schema> }
+              : unknown
+            : T[K] extends Record<string, unknown>
+              ? { fields: FieldRefs<T[K]> }
+              : unknown);
+      }
     : unknown;
 
 export type StoreRefFor<T extends StoreInput> = Omit<
@@ -913,15 +960,12 @@ function defineCollections(
   store: StoreInput,
   collectionKind: CollectionKind,
   collections: Record<string, SoftwareDataStoreCollectionInput>,
-): Record<string, DynamicCollectionRef> {
+): Record<string, CollectionRef> {
   return Object.fromEntries(
     Object.entries(collections).map(([collectionId, collection]) => {
       const collectionLabel = collection.label ?? collectionId;
       const base: CollectionRef = {
         __kind: "db-target-ref",
-        __collectionId: collectionId,
-        __collectionLabel: collectionLabel,
-        __collectionKey: collection.key,
         storeId,
         storeKind: store.kind,
         storeLabel: store.label,
@@ -933,8 +977,9 @@ function defineCollections(
         collectionKey: collection.key,
         path: [],
         schema: collection.schema,
+        fields: {} as Record<string, TargetRef>,
       };
-      Object.assign(base, defineFieldTargets(base, collection.schema, []));
+      base.fields = defineFieldTargets(base, collection.schema, []);
       return [collectionId, Object.freeze(base)];
     }),
   );
@@ -961,13 +1006,9 @@ function defineFieldTargets(
         collectionKey: collection.collectionKey,
         path,
       };
-      if (isNestedSchema(value)) {
-        Object.assign(target, defineFieldTargets(collection, value, path));
-      } else if (value.schema) {
-        Object.assign(
-          target,
-          defineFieldTargets(collection, value.schema, path),
-        );
+      const nestedSchema = isNestedSchema(value) ? value : value.schema;
+      if (nestedSchema) {
+        target.fields = defineFieldTargets(collection, nestedSchema, path);
       }
       return [field, Object.freeze(target)];
     }),
@@ -977,7 +1018,7 @@ function defineFieldTargets(
 function isNestedSchema(
   value: SoftwareDataStoreFieldSchema[string],
 ): value is SoftwareDataStoreFieldSchema {
-  return !("type" in value);
+  return typeof (value as { type?: unknown }).type !== "string";
 }
 
 function softwareElementForPath(

--- a/packages/progressive-review/src/cli-runner.ts
+++ b/packages/progressive-review/src/cli-runner.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
+import { devfastPrepareCommands } from "@dev.fast/local-vcs";
 import { Argument, Command, CommanderError, Option } from "commander";
 
 import { humanStream, jsonRequestedInArgv } from "./cli-output";
@@ -34,6 +35,7 @@ import {
 import { runReviewInfo } from "./review-info";
 import { runReviewInternalTest } from "./review-internal-test";
 import { emitReviewEvent, serializeReviewError } from "./review-logger";
+import { prepareReviewPinnedCheckout } from "./review-prepare";
 import { runReviewPublish } from "./review-publish";
 import { runReviewRebind } from "./review-rebind";
 import {
@@ -49,6 +51,19 @@ import {
   runReviewThreadsReply,
   runReviewThreadsResolve,
 } from "./threads-cli";
+import {
+  runReviewTraceBlame,
+  runReviewTraceDisable,
+  runReviewTraceEnable,
+  runReviewTraceGitHook,
+  runReviewTraceHook,
+  runReviewTraceList,
+  runReviewTracePull,
+  runReviewTraceRepair,
+  runReviewTraceShow,
+  runReviewTraceStatus,
+  runReviewTraceSync,
+} from "./trace-cli";
 
 interface ProgressiveReviewCliRuntime {
   runReviewAppLaunch: typeof runReviewAppLaunch;
@@ -74,8 +89,20 @@ interface ProgressiveReviewCliRuntime {
   runInstall: typeof runInstall;
   runReviewMigration: typeof runReviewMigration;
   runSoftwareMapCli: typeof runSoftwareMapCli;
+  runReviewTraceStatus: typeof runReviewTraceStatus;
+  runReviewTraceEnable: typeof runReviewTraceEnable;
+  runReviewTraceDisable: typeof runReviewTraceDisable;
+  runReviewTraceRepair: typeof runReviewTraceRepair;
+  runReviewTraceList: typeof runReviewTraceList;
+  runReviewTraceShow: typeof runReviewTraceShow;
+  runReviewTracePull: typeof runReviewTracePull;
+  runReviewTraceBlame: typeof runReviewTraceBlame;
+  runReviewTraceHook: typeof runReviewTraceHook;
+  runReviewTraceGitHook: typeof runReviewTraceGitHook;
+  runReviewTraceSync: typeof runReviewTraceSync;
   listReviews: typeof listReviews;
   sealReviewCandidate: typeof sealReviewCandidate;
+  prepareReviewPinnedCheckout: typeof prepareReviewPinnedCheckout;
 }
 
 export interface ProgressiveReviewCliInput {
@@ -92,6 +119,7 @@ export interface ProgressiveReviewCliInput {
 
 interface ReviewInfoOptions {
   all?: boolean;
+  review?: string;
 }
 
 interface ReviewScaffoldOptions {
@@ -307,7 +335,10 @@ export async function runProgressiveReviewCli(
   configureJsonOutput(
     program
       .command("publish")
-      .description("Publish the Review document")
+      .alias("present")
+      .description(
+        "Present the Review document in the local Review Desktop app",
+      )
       .option("--review <uuid>", "review UUID"),
     "plain",
   ).action(async (options: { review?: string; json?: boolean }) => {
@@ -401,14 +432,38 @@ export async function runProgressiveReviewCli(
   });
 
   configureJsonOutput(
+    program
+      .command("prepare-worktree <checkout-path>", { hidden: true })
+      .description("Internal background worktree prepare runner")
+      .requiredOption("--commit <commit>")
+      .action(async (checkoutPath: string, options: { commit: string }) => {
+        const resolvedPath = path.resolve(checkoutPath);
+        const commands = await devfastPrepareCommands(resolvedPath).catch(
+          () => [] as string[],
+        );
+        const result = await runtime.prepareReviewPinnedCheckout({
+          checkoutPath: resolvedPath,
+          commit: options.commit,
+          commands,
+        });
+        state.exitCode = result.prepared ? 0 : 1;
+      }),
+    "plain",
+  );
+
+  configureJsonOutput(
     program.command("info").description("Print Review information"),
     "plain",
   )
     .option("--all", "list active reviews for every worktree in this repo")
+    .addOption(
+      new Option("--review <uuid>", "select a Review").conflicts("all"),
+    )
     .action(async (options: ReviewInfoOptions) => {
       const event = await runtime.runReviewInfo({
         cwd,
         all: options.all,
+        reviewUuid: options.review,
       });
       input.stdout.write(`${JSON.stringify(event)}\n`);
       state.exitCode = 0;
@@ -467,20 +522,52 @@ export async function runProgressiveReviewCli(
           "claude-code",
           "codex",
           "cursor",
+          "pi",
           "all",
         ]),
       )
+      .option("--trace-endpoint <url>", "R2 endpoint URL")
+      .option("--trace-bucket <name>", "R2 bucket name")
+      .option("--trace-key <id>", "R2 access key ID")
+      .option("--trace-secret <key>", "R2 secret access key")
+      .option("--without-traces", "Do not configure trace capture")
       .addHelpText("after", progressiveReviewInstallHelp()),
     "plain",
   );
-  install.action(async (targets: string[], options: { json?: boolean }) => {
-    state.exitCode = await runtime.runInstall({
-      targets: installTargets(targets),
-      json: options.json,
-      stdout: input.stdout,
-      stderr: input.stderr,
-    });
-  });
+  install.action(
+    async (
+      targets: string[],
+      options: {
+        json?: boolean;
+        traces?: boolean;
+        traceEndpoint?: string;
+        traceBucket?: string;
+        traceKey?: string;
+        traceSecret?: string;
+      },
+    ) => {
+      state.exitCode = await runtime.runInstall({
+        targets: installTargets(targets),
+        env,
+        fff: true,
+        ...(options.traces === false
+          ? {}
+          : {
+              trace: {
+                credentials: {
+                  endpoint: options.traceEndpoint,
+                  bucket: options.traceBucket,
+                  key: options.traceKey,
+                  secret: options.traceSecret,
+                },
+              },
+            }),
+        json: options.json,
+        stdout: input.stdout,
+        stderr: input.stderr,
+      });
+    },
+  );
 
   const migrate = configureOutput(
     program.command("migrate").description("Migrate legacy Review data"),
@@ -603,6 +690,252 @@ export async function runProgressiveReviewCli(
       );
     }
     state.exitCode = 0;
+  });
+
+  // The trace surface: inspect storage, manage one repository, or read events.
+  const trace = configureOutput(
+    program.command("trace").description("Manage agent traces"),
+    "plain",
+  );
+  configureOutput(
+    trace
+      .command("status")
+      .description("Verify R2 trace storage configuration and connectivity"),
+    "plain",
+  ).action(async () => {
+    state.exitCode = await runtime.runReviewTraceStatus({
+      cwd,
+      stdout: input.stdout,
+      stderr: input.stderr,
+    });
+  });
+
+  configureOutput(
+    trace
+      .command("enable [path]")
+      .description("Enable trace hooks for one Git repository"),
+    "plain",
+  ).action(async (repoPath?: string) => {
+    state.exitCode = await runtime.runReviewTraceEnable({
+      cwd: repoPath ? path.resolve(cwd, repoPath) : cwd,
+      stdout: input.stdout,
+      stderr: input.stderr,
+    });
+  });
+
+  configureOutput(
+    trace
+      .command("disable [path]")
+      .description("Disable Review trace hooks for one Git repository"),
+    "plain",
+  ).action(async (repoPath?: string) => {
+    state.exitCode = await runtime.runReviewTraceDisable({
+      cwd: repoPath ? path.resolve(cwd, repoPath) : cwd,
+      stdout: input.stdout,
+    });
+  });
+
+  configureOutput(
+    trace
+      .command("repair [path]")
+      .description("Repair Review trace hooks for one Git repository"),
+    "plain",
+  ).action(async (repoPath?: string) => {
+    state.exitCode = await runtime.runReviewTraceRepair({
+      cwd: repoPath ? path.resolve(cwd, repoPath) : cwd,
+      stdout: input.stdout,
+      stderr: input.stderr,
+    });
+  });
+
+  configureJsonOutput(
+    trace
+      .command("list")
+      .description("List agent sessions for a Review or commit")
+      .option("--review <uuid>", "review UUID")
+      .option("--commit <sha>", "commit or revision"),
+    "plain",
+  ).action(
+    async (options: { review?: string; commit?: string; json?: boolean }) => {
+      if (options.review && options.commit) {
+        throw new Error("Use either --review or --commit, not both.");
+      }
+      state.exitCode = await runtime.runReviewTraceList({
+        cwd,
+        reviewUuid: options.review,
+        commitSha: options.commit,
+        json: options.json,
+        stdout: input.stdout,
+      });
+    },
+  );
+
+  configureJsonOutput(
+    trace
+      .command("show <session-id>")
+      .description("Survey a trace or show an exact event")
+      .option("--trace <name>", "trace name; omit for the main trace")
+      .option(
+        "--event <index>",
+        "print the complete text of one event",
+        (value: string) => Number.parseInt(value, 10),
+      )
+      .option("--kind <kind>", "only list user|assistant|tool|separator rows"),
+    "plain",
+  ).action(
+    async (
+      sessionId: string,
+      options: {
+        trace?: string;
+        event?: number;
+        kind?: string;
+        json?: boolean;
+      },
+    ) => {
+      state.exitCode = await runtime.runReviewTraceShow({
+        cwd,
+        sessionId,
+        trace: options.trace,
+        eventIndex: options.event,
+        kind: options.kind,
+        json: options.json,
+        stdout: input.stdout,
+        stderr: input.stderr,
+      });
+    },
+  );
+
+  configureJsonOutput(
+    trace
+      .command("pull")
+      .description("Pull traces into the local FFF search corpus")
+      .option("--repo <owner/repo>", "repository for the corpus path")
+      .option("--review <uuid>", "pull sessions for one Review")
+      .option("--commit <sha>", "pull sessions for one commit or revision")
+      .option("--session <id>", "pull one session")
+      .option("--main-only", "exclude subagent traces"),
+    "plain",
+  ).action(
+    async (options: {
+      repo?: string;
+      review?: string;
+      commit?: string;
+      session?: string;
+      mainOnly?: boolean;
+      json?: boolean;
+    }) => {
+      const selectors = [
+        options.review,
+        options.commit,
+        options.session,
+      ].filter(Boolean);
+      if (selectors.length > 1) {
+        throw new Error("Use only one of --review, --commit, or --session.");
+      }
+      state.exitCode = await runtime.runReviewTracePull({
+        cwd,
+        repo: options.repo,
+        reviewUuid: options.review,
+        commitSha: options.commit,
+        session: options.session,
+        mainOnly: options.mainOnly,
+        json: options.json,
+        stdout: input.stdout,
+        stderr: input.stderr,
+      });
+    },
+  );
+
+  configureJsonOutput(
+    trace
+      .command("blame <file>")
+      .description("Blame lines in a file to agent sessions")
+      .option("-L, --lines <range>", "start,end line range")
+      .option(
+        "--history",
+        "use git log -L to include every commit that shaped the lines",
+      ),
+    "plain",
+  ).action(
+    async (
+      file: string,
+      options: {
+        lines?: string;
+        history?: boolean;
+        json?: boolean;
+      },
+    ) => {
+      state.exitCode = await runtime.runReviewTraceBlame({
+        cwd,
+        file,
+        lines: options.lines,
+        history: options.history,
+        json: options.json,
+        stdout: input.stdout,
+        stderr: input.stderr,
+      });
+    },
+  );
+
+  configureJsonOutput(
+    trace
+      .command("sync <session-id>")
+      .description("Upload a local session trace and its metadata")
+      .option("--repo <repo>", "GitHub owner/repo"),
+    "plain",
+  ).action(
+    async (
+      sessionId: string,
+      options: {
+        repo?: string;
+        json?: boolean;
+      },
+    ) => {
+      state.exitCode = await runtime.runReviewTraceSync({
+        cwd,
+        sessionId,
+        repo: options.repo,
+        json: options.json,
+        stdout: input.stdout,
+      });
+    },
+  );
+
+  configureOutput(
+    trace
+      .command("hook <event>", { hidden: true })
+      .description("Handle agent session lifecycle hooks")
+      .option("--session <id>", "Agent session ID"),
+    "plain",
+  ).action(
+    async (
+      event: string,
+      options: {
+        session?: string;
+      },
+    ) => {
+      state.exitCode = await runtime.runReviewTraceHook({
+        cwd,
+        event,
+        sessionId: options.session,
+        stdin: input.stdin as NodeJS.ReadStream | undefined,
+      });
+    },
+  );
+
+  configureOutput(
+    trace
+      .command("git-hook <hook> [args...]", { hidden: true })
+      .description("Run a package-owned Git trace hook"),
+    "plain",
+  ).action(async (hook: string, args: string[]) => {
+    state.exitCode = await runtime.runReviewTraceGitHook({
+      cwd,
+      hook,
+      args,
+      stdin: input.stdin,
+      stderr: input.stderr,
+    });
   });
 
   // The map surface is owned by map-cli.ts: git-notes storage with
@@ -807,8 +1140,20 @@ function progressiveReviewCliRuntime(
     runInstall,
     runReviewMigration,
     runSoftwareMapCli,
+    runReviewTraceStatus,
+    runReviewTraceEnable,
+    runReviewTraceDisable,
+    runReviewTraceRepair,
+    runReviewTraceList,
+    runReviewTraceShow,
+    runReviewTracePull,
+    runReviewTraceBlame,
+    runReviewTraceHook,
+    runReviewTraceGitHook,
+    runReviewTraceSync,
     listReviews,
     sealReviewCandidate,
+    prepareReviewPinnedCheckout,
     ...overrides,
   };
 }
@@ -817,7 +1162,7 @@ function progressiveReviewTopLevelHelp(): string {
   return [
     "",
     "Use `review info` to discover Review documents for this checkout, or `review scaffold` to create one.",
-    "Edit the returned review.mdx and data.ts files, then use `review publish`. It validates in the CLI before contacting Review Desktop.",
+    "Edit the returned review.mdx and data.ts files, then use `review present` (alias of `review publish`). It validates in the CLI before contacting Review Desktop.",
     "The CLI validates before publishing; Review Desktop promotes the revision before mounting it.",
     "Use `review app launch` to start Review Desktop. Use `review app pick --review <uuid>` after publication.",
     "",
@@ -862,12 +1207,15 @@ function progressiveReviewInstallHelp(): string {
     "  claude   Claude Code (~/.claude/skills)",
     "  codex    Codex (~/.agents/skills)",
     "  cursor   Cursor (~/.cursor/skills)",
+    "  pi       Pi (~/.agents/skills and npm:@ff-labs/pi-fff)",
     "  all      Every supported agent (default)",
     "",
     "Examples:",
     "  review install codex",
     "  review install claude cursor",
     "  review install all",
+    "  review install codex --trace-endpoint <url> --trace-bucket <name> --trace-key <id> --trace-secret <key>",
+    "  review install codex --without-traces",
   ].join("\n");
 }
 
@@ -876,7 +1224,7 @@ function progressiveReviewMapHelp(): string {
     "",
     "Notes under refs/notes/dev-fast/* are the only durable map state: one map per commit, never checked into any branch.",
     "The editable file is a scratch buffer — a commit-addressed working copy of one commit's note, hydrated from a note and disposable at any time.",
-    "Use review map open <rev> to hydrate <rev>'s scratch, review map check [<rev>] [--review <uuid>] to validate and save it to <rev>'s note, review map publish to present the pinned maps, review map prune to drop stale notes and swept scratches, and review map push / fetch to share map notes via origin.",
+    "Use review map open <rev> to hydrate <rev>'s scratch, review map check [<rev>] [--review <uuid>] to validate and save it to <rev>'s note, review map publish to present the pinned maps, review map prune to drop stale notes and swept scratches, and review map push / fetch to share map notes through the selected notes remote.",
     "Run review map help for the full subcommand reference.",
   ].join("\n");
 }
@@ -936,7 +1284,8 @@ function normalizeMapTelemetrySubcommand(
   | "help"
   | "unknown" {
   const args = inputArgs[0] === "--" ? inputArgs.slice(1) : inputArgs;
-  const command = args[0] ?? "check";
+  const rawCommand = args[0] ?? "check";
+  const command = rawCommand === "present" ? "publish" : rawCommand;
   if (isMapHelpCommand(command)) {
     return "help";
   }

--- a/packages/progressive-review/src/cli.test.ts
+++ b/packages/progressive-review/src/cli.test.ts
@@ -3,6 +3,7 @@ import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 
 import { runProgressiveReviewCli } from "./cli-runner";
+import { runInstall as runInstallActual } from "./install";
 import { runReviewMigration as runReviewMigrationActual } from "./migrate";
 import type { ProgressiveReviewTelemetry } from "./progressive-review-telemetry";
 import { runReviewApp as runReviewAppActual } from "./review-app";
@@ -22,6 +23,60 @@ import {
 } from "./threads-cli";
 
 describe("Review CLI", () => {
+  it("routes trace configuration through the shared installer", async () => {
+    const runInstall = vi.fn<typeof runInstallActual>(async () => 0);
+
+    await expect(
+      runProgressiveReviewCli({
+        argv: [
+          "install",
+          "codex",
+          "--trace-endpoint",
+          "mock://endpoint",
+          "--trace-bucket",
+          "mock-bucket",
+          "--trace-key",
+          "mock-key",
+          "--trace-secret",
+          "mock-value",
+        ],
+        stdout: outputStream(),
+        stderr: outputStream(),
+        runtime: { runInstall },
+      }),
+    ).resolves.toBe(0);
+
+    expect(runInstall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targets: ["codex"],
+        fff: true,
+        trace: {
+          credentials: {
+            endpoint: "mock://endpoint",
+            bucket: "mock-bucket",
+            key: "mock-key",
+            secret: "mock-value",
+          },
+        },
+      }),
+    );
+  });
+
+  it("does not expose the removed trace setup command", async () => {
+    const stderr = outputStream();
+    let output = "";
+    stderr.on("data", (chunk) => (output += String(chunk)));
+
+    await expect(
+      runProgressiveReviewCli({
+        argv: ["trace", "setup"],
+        stdout: outputStream(),
+        stderr,
+      }),
+    ).resolves.toBe(1);
+    expect(output).toContain("unknown command 'setup'");
+  });
+
   it("prints the package version", async () => {
     const stdout = outputStream();
     let output = "";
@@ -102,7 +157,7 @@ describe("Review CLI", () => {
       runtime: { runReviewAppPick: runReviewApp },
     });
     await runProgressiveReviewCli({
-      argv: ["info", "--all"],
+      argv: ["info", "--review", "review-uuid"],
       stdout: outputStream(),
       stderr: outputStream(),
       runtime: { runReviewInfo },
@@ -124,7 +179,7 @@ describe("Review CLI", () => {
       expect.objectContaining({ reviewUuid: "review-uuid" }),
     );
     expect(runReviewInfo).toHaveBeenCalledWith(
-      expect.objectContaining({ all: true }),
+      expect.objectContaining({ reviewUuid: "review-uuid" }),
     );
     expect(runReviewPublish).toHaveBeenCalledWith(
       expect.objectContaining({ reviewUuid: "review-uuid" }),
@@ -510,6 +565,33 @@ describe("Review CLI", () => {
     expect(sealReviewCandidate).toHaveBeenCalledWith(
       review.dir,
       "Review turn checkpoint",
+    );
+  });
+
+  it("handles the internal prepare-worktree command", async () => {
+    const prepareReviewPinnedCheckout = vi.fn<
+      () => Promise<{ prepared: true }>
+    >(async () => ({ prepared: true }));
+
+    await expect(
+      runProgressiveReviewCli({
+        argv: [
+          "prepare-worktree",
+          "/tmp/test-checkout",
+          "--commit",
+          "0123456789abcdef0123456789abcdef01234567",
+        ],
+        stdout: outputStream(),
+        stderr: outputStream(),
+        runtime: { prepareReviewPinnedCheckout },
+      }),
+    ).resolves.toBe(0);
+
+    expect(prepareReviewPinnedCheckout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        checkoutPath: expect.stringContaining("test-checkout"),
+        commit: "0123456789abcdef0123456789abcdef01234567",
+      }),
     );
   });
 });

--- a/packages/progressive-review/src/cli.ts
+++ b/packages/progressive-review/src/cli.ts
@@ -34,6 +34,7 @@ if (delegatedExitCode !== null) {
   process.exitCode = await span("runProgressiveReviewCli", () =>
     runProgressiveReviewCli({
       argv: process.argv.slice(2),
+      stdin: process.stdin,
       stdout: process.stdout,
       stderr: process.stderr,
     }),
@@ -56,7 +57,13 @@ function maybeDelegateToDesktopCli(argv: string[]): number | null {
   // stop-hook runs on every agent stop and must not pay a discovery read plus
   // a second node spawn; internal-test must exercise this entry, not the
   // app's.
-  if (argv[0] === "stop-hook" || argv[0] === "internal-test") return null;
+  if (
+    argv[0] === "stop-hook" ||
+    argv[0] === "internal-test" ||
+    argv[0] === "wait-codex" ||
+    argv[0] === "prepare-worktree"
+  )
+    return null;
   const ownPath = fileURLToPath(import.meta.url);
   if (!/[\\/]dist[\\/]cli\.js$/.test(ownPath)) return null;
   const devHome = env.DEV_REVIEW_HOME?.trim()

--- a/packages/progressive-review/src/compiler/review-document-compiler.test.ts
+++ b/packages/progressive-review/src/compiler/review-document-compiler.test.ts
@@ -10,9 +10,54 @@ import {
   reviewDocumentRevision,
 } from "./review-document-compiler";
 
-const fixturePath = path.join(process.cwd(), "reviews", "typed.mdx");
-
 describe("compileReviewDocument", () => {
+  it("explains that built-in MDX components must not be imported", async () => {
+    const rootPath = await mkdtemp(
+      path.join(os.tmpdir(), "review-document-component-import-"),
+    );
+    const filePath = path.join(rootPath, "review.mdx");
+    const source = [
+      'import { CodePeek, DatabaseLens } from "virtual:progressive-review-authoring";',
+      "",
+      "# Review",
+      "",
+      "<CodePeek anchor={anchors.example} />",
+    ].join("\n");
+
+    try {
+      await writeFile(filePath, source);
+      const result = await compileReviewDocument({
+        filePath,
+        reviewRootPath: rootPath,
+        source,
+      });
+
+      expect(result.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "MDX_COMPONENT_IMPORT",
+            message: expect.stringContaining(
+              "Remove it from this import and use <CodePeek> directly",
+            ),
+          }),
+          expect.objectContaining({
+            code: "MDX_COMPONENT_IMPORT",
+            message: expect.stringContaining(
+              "Remove it from this import and use <DatabaseLens> directly",
+            ),
+          }),
+        ]),
+      );
+      expect(result.diagnostics).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: "Cannot find name 'CodePeek'." }),
+        ]),
+      );
+    } finally {
+      await rm(rootPath, { recursive: true, force: true });
+    }
+  });
+
   it("reports and formats related component and anchor diagnostics from one document", async () => {
     const rootPath = await mkdtemp(
       path.join(os.tmpdir(), "review-document-diagnostic-"),

--- a/packages/progressive-review/src/compiler/review-document-compiler.ts
+++ b/packages/progressive-review/src/compiler/review-document-compiler.ts
@@ -291,16 +291,24 @@ async function compileReviewDocumentUncached(
   }
   const mdxCode = String(file);
   const runtimeMap = file.map as RawSourceMap | undefined;
+  const syntaxDiagnostics = unsupportedTypescriptDiagnostics(
+    input,
+    authoredTypescript,
+  );
+  if (
+    syntaxDiagnostics.some(
+      (diagnostic) => diagnostic.code === "MDX_COMPONENT_IMPORT",
+    )
+  ) {
+    return { diagnostics: syntaxDiagnostics, reviewDocument };
+  }
   const typescriptDiagnostics = await span(
     "review document: type-check",
     () =>
       checkAuthoredTypescript(input, authoredTypescript, mdxCode, runtimeMap),
     input.filePath,
   );
-  const diagnostics = [
-    ...unsupportedTypescriptDiagnostics(input, authoredTypescript),
-    ...typescriptDiagnostics,
-  ];
+  const diagnostics = [...syntaxDiagnostics, ...typescriptDiagnostics];
   if (diagnostics.some((diagnostic) => diagnostic.severity === "error")) {
     return { diagnostics, reviewDocument };
   }

--- a/packages/progressive-review/src/compiler/review-document-syntax-validator.ts
+++ b/packages/progressive-review/src/compiler/review-document-syntax-validator.ts
@@ -1,5 +1,6 @@
 import ts from "typescript";
 
+import { reviewAuthoringPropsSchemas } from "../authoring";
 import type {
   ReviewDocumentDiagnostic,
   ReviewDocumentInput,
@@ -28,6 +29,25 @@ export function unsupportedTypescriptDiagnostics(
       ts.ScriptKind.TS,
     );
     const visit = (node: ts.Node): void => {
+      if (ts.isImportDeclaration(node)) {
+        for (const imported of importedMdxComponents(node, sourceFile)) {
+          const position = sourceFile.getLineAndCharacterOfPosition(
+            imported.start,
+          );
+          diagnostics.push({
+            source: "typescript",
+            severity: "error",
+            code: "MDX_COMPONENT_IMPORT",
+            message: `\`${imported.name}\` is a built-in Review MDX component. Remove it from this import and use <${imported.name}> directly.`,
+            filePath: input.filePath,
+            line: region.sourceStartLine + position.line,
+            column:
+              position.character +
+              1 +
+              (position.line === 0 ? region.sourceStartColumn - 1 : 0),
+          });
+        }
+      }
       const unsupported = unsupportedTypescriptNode(node, sourceFile);
       if (unsupported) {
         const position = sourceFile.getLineAndCharacterOfPosition(
@@ -52,6 +72,26 @@ export function unsupportedTypescriptDiagnostics(
     visit(sourceFile);
   }
   return diagnostics;
+}
+
+function importedMdxComponents(
+  node: ts.ImportDeclaration,
+  sourceFile: ts.SourceFile,
+): Array<{ name: string; start: number }> {
+  if (
+    !ts.isStringLiteral(node.moduleSpecifier) ||
+    node.moduleSpecifier.text !== "virtual:progressive-review-authoring"
+  ) {
+    return [];
+  }
+  const bindings = node.importClause?.namedBindings;
+  if (!bindings || !ts.isNamedImports(bindings)) return [];
+  return bindings.elements.flatMap((element) => {
+    const name = element.propertyName?.text ?? element.name.text;
+    return Object.hasOwn(reviewAuthoringPropsSchemas, name)
+      ? [{ name, start: element.getStart(sourceFile) }]
+      : [];
+  });
 }
 
 function unsupportedTypescriptNode(

--- a/packages/progressive-review/src/install.test.ts
+++ b/packages/progressive-review/src/install.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -33,7 +34,7 @@ async function writeSkill(
 
 async function makePackageRoot(): Promise<string> {
   const packageRoot = await makeTempDir();
-  for (const name of ["dev-review", "dev-review-map"]) {
+  for (const name of ["dev-review", "dev-review-map", "trace-archaeology"]) {
     await writeSkill(packageRoot, name);
   }
   return packageRoot;
@@ -65,7 +66,7 @@ describe("runInstall", () => {
     });
 
     expect(code).toBe(0);
-    for (const name of ["dev-review", "dev-review-map"]) {
+    for (const name of ["dev-review", "dev-review-map", "trace-archaeology"]) {
       expect(
         await readFile(
           path.join(homeDir, ".claude", "skills", name, "SKILL.md"),
@@ -85,6 +86,12 @@ describe("runInstall", () => {
         ),
       ).toContain(`# ${name}`);
     }
+    // Verify trace hooks are installed
+    expect(existsSync(path.join(homeDir, ".claude", "settings.json"))).toBe(
+      true,
+    );
+    expect(existsSync(path.join(homeDir, ".codex", "config.toml"))).toBe(true);
+
     // Legacy prompt/command locations should stay empty.
     await expect(
       readFile(
@@ -155,7 +162,7 @@ describe("runInstall", () => {
         "utf8",
       ),
     ).rejects.toThrow(/ENOENT/);
-    for (const name of ["dev-review", "dev-review-map"]) {
+    for (const name of ["dev-review", "dev-review-map", "trace-archaeology"]) {
       expect(
         await readFile(
           path.join(homeDir, ".agents", "skills", name, "SKILL.md"),
@@ -245,7 +252,7 @@ describe("runInstall", () => {
     });
 
     expect(code).toBe(0);
-    for (const name of ["dev-review", "dev-review-map"]) {
+    for (const name of ["dev-review", "dev-review-map", "trace-archaeology"]) {
       expect(
         await readFile(
           path.join(homeDir, ".cursor", "skills", name, "SKILL.md"),
@@ -266,6 +273,35 @@ describe("runInstall", () => {
       ),
     ).rejects.toThrow(/ENOENT/);
     expect(streams.out.join("")).toContain("In Cursor, invoke the skills");
+  });
+
+  it("installs only Pi when requested", async () => {
+    const packageRoot = await makePackageRoot();
+    const homeDir = await makeTempDir();
+    const streams = silentStreams();
+
+    const code = await runInstall({
+      targets: ["pi"],
+      homeDir,
+      packageRoot,
+      stdout: streams.stdout,
+      stderr: streams.stderr,
+    });
+
+    expect(code).toBe(0);
+    for (const name of ["dev-review", "dev-review-map", "trace-archaeology"]) {
+      expect(
+        await readFile(
+          path.join(homeDir, ".agents", "skills", name, "SKILL.md"),
+          "utf8",
+        ),
+      ).toContain(`# ${name}`);
+    }
+    expect(
+      existsSync(
+        path.join(homeDir, ".pi", "agent", "extensions", "review-trace.ts"),
+      ),
+    ).toBe(true);
   });
 
   it("fails clearly when the bundled skill is missing", async () => {

--- a/packages/progressive-review/src/install.ts
+++ b/packages/progressive-review/src/install.ts
@@ -13,11 +13,25 @@ import { fileURLToPath } from "node:url";
 
 import { ensureNotesConfig, gitCommonDir } from "@dev.fast/local-vcs";
 
+import { installFffForTargets, isFffTarget } from "./agent-fff";
+import {
+  installClaudeTraceHook,
+  installCodexTraceHook,
+  installPiTraceExtension,
+} from "./agent-trace-hooks";
 import { emitJsonEvent, failWithJsonError, humanStream } from "./cli-output";
+import {
+  type TraceCredentialsInput,
+  configureTraceMachine,
+} from "./trace-machine-setup";
 
-export type InstallTarget = "claude" | "codex" | "cursor";
+export type InstallTarget = "claude" | "codex" | "cursor" | "pi";
 
-const REQUIRED_SKILL_NAMES = ["dev-review", "dev-review-map"] as const;
+const REQUIRED_SKILL_NAMES = [
+  "dev-review",
+  "dev-review-map",
+  "trace-archaeology",
+] as const;
 const STALE_SKILL_NAMES = [
   "review",
   "review-map",
@@ -29,9 +43,10 @@ export const ALL_INSTALL_TARGETS: InstallTarget[] = [
   "claude",
   "codex",
   "cursor",
+  "pi",
 ];
 
-type InstalledItem = { kind: "skill"; dest: string };
+type InstalledItem = { kind: "skill" | "extension"; dest: string };
 
 export function defaultPackageRoot(): string {
   return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -42,13 +57,22 @@ export async function runInstall(input: {
   cwd?: string;
   homeDir?: string;
   packageRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  fff?: boolean;
+  reviewCommand?: string;
+  trace?: {
+    credentials?: TraceCredentialsInput;
+    verify?: boolean;
+  };
   json?: boolean;
   stdout: NodeJS.WriteStream;
   stderr: NodeJS.WriteStream;
 }): Promise<number> {
   const homeDir = input.homeDir ?? os.homedir();
   const packageRoot = input.packageRoot ?? defaultPackageRoot();
+  const env = input.env ?? process.env;
   const human = humanStream(input);
+  let traceEnabled = false;
 
   const skillsDir = path.join(packageRoot, "skills");
   const skillDirs = await listSkillDirs(skillsDir);
@@ -64,6 +88,31 @@ export async function runInstall(input: {
     );
   }
 
+  // Check machine trace configuration before any per-agent mutation. A
+  // headless install with missing credentials must fail without a partial
+  // skills or FFF install.
+  if (input.trace) {
+    try {
+      const status = await configureTraceMachine({
+        homeDir,
+        env,
+        credentials: input.trace.credentials,
+        verify: input.trace.verify,
+      });
+      traceEnabled = status.enabled;
+      human.write(`[ok] trace capture -> ${status.envPath}\n`);
+      if (status.error) {
+        human.write(`Trace storage check failed: ${status.error}\n`);
+      }
+    } catch (cause) {
+      return failWithJsonError(
+        input,
+        "install",
+        cause instanceof Error ? cause.message : String(cause),
+      );
+    }
+  }
+
   const installed: InstalledItem[] = [];
   for (const target of input.targets) {
     const destRoot = skillsDestRoot(homeDir, target);
@@ -73,14 +122,43 @@ export async function runInstall(input: {
       await installDirectory(skillDir.src, skillDest);
       installed.push({ kind: "skill", dest: skillDest });
     }
+    if (target === "claude") {
+      await installClaudeTraceHook(homeDir, input.reviewCommand);
+    } else if (target === "codex") {
+      await installCodexTraceHook(homeDir, input.reviewCommand);
+    } else if (target === "pi") {
+      await installPiTraceExtension(homeDir, input.reviewCommand);
+    }
+  }
+
+  if (input.fff) {
+    const result = await installFffForTargets({
+      targets: input.targets.filter(isFffTarget),
+      homeDir,
+      env,
+      write: (text) => human.write(text),
+    });
+    if (!result.ok) {
+      return failWithJsonError(
+        input,
+        "install",
+        "Could not install the selected FFF integrations.",
+      );
+    }
+    installed.push(
+      ...result.created.map((registration) => ({
+        kind: "extension" as const,
+        dest: `${registration.target}:fff`,
+      })),
+    );
   }
 
   for (const item of installed) {
     human.write(`[ok] ${item.kind} -> ${item.dest}\n`);
   }
   // Best-effort per-repo git-notes setup: notes.rewriteRef so git-native
-  // rebases/amends carry map notes, and the origin fetch refspec so ordinary
-  // fetches receive teammates' notes. Never fails the install.
+  // rebases/amends carry map notes, and the selected remote's fetch refspec so
+  // ordinary fetches receive teammates' notes. Never fails the install.
   let gitNotesConfigured = false;
   if (input.cwd) {
     try {
@@ -95,22 +173,25 @@ export async function runInstall(input: {
     }
   }
   const installedSkills = skillDirs.map((skill) => skill.name).join(", ");
-  human.write(
-    `\nInstalled Review skills for ${formatTargets(input.targets)}: ${installedSkills}.\n` +
-      (input.targets.includes("codex")
-        ? "In Codex, invoke via /skills or the installed dev-review skill.\n"
-        : "") +
-      (input.targets.includes("cursor")
-        ? "In Cursor, invoke the skills from the / menu (for example /dev-review).\n"
-        : "") +
-      "Restart the agent (or open a new session) to pick up the changes.\n",
-  );
+  if (input.targets.length > 0) {
+    human.write(
+      `\nInstalled Review skills for ${formatTargets(input.targets)}: ${installedSkills}.\n` +
+        (input.targets.includes("codex")
+          ? "In Codex, invoke via /skills or the installed dev-review skill.\n"
+          : "") +
+        (input.targets.includes("cursor")
+          ? "In Cursor, invoke the skills from the / menu (for example /dev-review).\n"
+          : "") +
+        "Restart the agent (or open a new session) to pick up the changes.\n",
+    );
+  }
   emitJsonEvent(input, {
     event: "installed",
     targets: input.targets,
     skills: skillDirs.map((skill) => skill.name),
     items: installed,
     gitNotesConfigured,
+    traceEnabled,
   });
   return 0;
 }
@@ -144,6 +225,7 @@ export async function detectInstalledTargets(
 function skillsDestRoot(homeDir: string, target: InstallTarget): string {
   if (target === "claude") return path.join(homeDir, ".claude", "skills");
   if (target === "cursor") return path.join(homeDir, ".cursor", "skills");
+  if (target === "pi") return path.join(homeDir, ".agents", "skills");
   return path.join(homeDir, ".agents", "skills");
 }
 

--- a/packages/progressive-review/src/map-cli.test.ts
+++ b/packages/progressive-review/src/map-cli.test.ts
@@ -97,6 +97,21 @@ describe("parseSoftwareMapCliArgs", () => {
     });
   });
 
+  it("parses an explicit notes remote for push and fetch", () => {
+    expect(parseSoftwareMapCliArgs(["push", "--remote", "fork"])).toMatchObject(
+      {
+        ok: true,
+        command: "push",
+        remote: "fork",
+      },
+    );
+    expect(parseSoftwareMapCliArgs(["fetch", "--remote=fork"])).toMatchObject({
+      ok: true,
+      command: "fetch",
+      remote: "fork",
+    });
+  });
+
   it("hard-errors on unknown flags instead of silently ignoring them", () => {
     expect(parseSoftwareMapCliArgs(["open", "HEAD", "--froce"])).toEqual({
       ok: false,
@@ -129,6 +144,13 @@ describe("parseSoftwareMapCliArgs", () => {
     expect(parseSoftwareMapCliArgs(["check", `--${option}=`])).toEqual({
       ok: false,
       error: `Expected a value after --${option}.`,
+    });
+  });
+
+  it("reports a missing --remote value", () => {
+    expect(parseSoftwareMapCliArgs(["push", "--remote"])).toEqual({
+      ok: false,
+      error: "Expected a value after --remote.",
     });
   });
 
@@ -183,7 +205,7 @@ describe("removed commands point at their replacements", () => {
       expect(exitCode).toBe(1);
       expect(stderr.join("")).toContain(`review map ${command} was removed`);
       expect(stderr.join("")).toContain("review map open");
-      expect(stderr.join("")).toContain("dev-review skill's Map Agent Prompt");
+      expect(stderr.join("")).toContain("dev-review-map skill");
     },
   );
 });
@@ -1180,6 +1202,43 @@ describe("review map prune", () => {
 });
 
 describe("review map push / fetch", () => {
+  it("pushes notes through an explicit writable remote", async () => {
+    if (!commandExists("git")) return;
+    const rootPath = await gitFixture("review-map-push-remote-");
+    const bareDir = await mkdtemp(path.join(os.tmpdir(), "review-map-fork-"));
+    try {
+      execGit(bareDir, ["init", "--bare"]);
+      execGit(rootPath, ["remote", "add", "fork", bareDir]);
+      const commit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
+      await writeNote({
+        rootPath,
+        ref: SOFTWARE_MAP_NOTES_REF,
+        commit,
+        content: authoredMapSource("Fork map"),
+      });
+      const stdout: string[] = [];
+
+      const exitCode = await runSoftwareMapCli({
+        args: ["push", "--remote", "fork", "--json"],
+        cwd: rootPath,
+        stdout: writable(stdout),
+        stderr: writable([]),
+      });
+
+      expect(exitCode).toBe(0);
+      expect(JSON.parse(stdout.join(""))).toMatchObject({
+        event: "map-push",
+        remote: "fork",
+      });
+      expect(
+        execGitOutput(bareDir, ["show-ref", SOFTWARE_MAP_NOTES_REF]),
+      ).toContain(SOFTWARE_MAP_NOTES_REF);
+    } finally {
+      await rm(rootPath, { recursive: true, force: true });
+      await rm(bareDir, { recursive: true, force: true });
+    }
+  });
+
   it("shares notes through a bare origin", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-push-");

--- a/packages/progressive-review/src/map-cli.ts
+++ b/packages/progressive-review/src/map-cli.ts
@@ -6,6 +6,7 @@ import {
   fetchNotes,
   git,
   gitCommonDirSync,
+  notesRemote,
   pruneNotes,
   pushNotes,
   readNote,
@@ -141,17 +142,25 @@ export async function runSoftwareMapCli(
       "map",
       `review map ${command} was removed: it spawned a nested coding agent. ` +
         "Run `review map open <rev>` to hydrate the scratch, author it " +
-        "following the dev-review skill's Map Agent Prompt, and validate/" +
+        "with the dev-review-map skill, and validate/" +
         "flush with `review map check <rev>`.",
     );
   }
 
   if (command === "push") {
-    return pushSoftwareMapNotes({ ...output, rootPath: input.cwd });
+    return pushSoftwareMapNotes({
+      ...output,
+      rootPath: input.cwd,
+      remote: parsed.remote,
+    });
   }
 
   if (command === "fetch") {
-    return fetchSoftwareMapNotes({ ...output, rootPath: input.cwd });
+    return fetchSoftwareMapNotes({
+      ...output,
+      rootPath: input.cwd,
+      remote: parsed.remote,
+    });
   }
 
   const exitCode = failWithJsonError(
@@ -169,8 +178,8 @@ function softwareMapCliHelp() {
     "       review map check [<rev>] [--review <uuid>]",
     "       review map publish [--review <uuid>]",
     "       review map prune",
-    "       review map push",
-    "       review map fetch",
+    "       review map push [--remote <name>]",
+    "       review map fetch [--remote <name>]",
     "",
     "Manage the git-notes-backed software map.",
     "Every verb accepts --json: stdout then carries one JSON event and the human report moves to stderr.",
@@ -180,7 +189,7 @@ function softwareMapCliHelp() {
     "Use review map check [<rev>] [--review <uuid>] to validate the scratch strictly; on success it SAVES the scratch to <rev>'s note. Without <rev> it targets the selected review's head commit.",
     "Use review map publish to publish the saved base and head maps to Review Desktop.",
     "Use review map prune to drop notes on commits that are gone or unreachable (jj working copies are kept), then sweep fully-flushed scratch buffers (dirty or note-less scratches are kept).",
-    "Use review map push / fetch to share map notes with teammates via origin.",
+    "Use review map push / fetch to share map notes with teammates. The remote defaults to devFast.notesRemote, then origin.",
     "",
   ].join("\n");
 }
@@ -199,6 +208,7 @@ type ParsedSoftwareMapCliArgs =
       diffRefs: SoftwareMapDiffRefOptions;
       pullRequest?: string;
       review?: string;
+      remote?: string;
       json: boolean;
     }
   | { ok: false; error: string };
@@ -207,7 +217,9 @@ export function parseSoftwareMapCliArgs(
   inputArgs: readonly string[],
 ): ParsedSoftwareMapCliArgs {
   const args = inputArgs[0] === "--" ? inputArgs.slice(1) : [...inputArgs];
-  const command = args[0] ?? "check";
+  const rawCommand = args[0] ?? "check";
+  // `present` is an alias of `publish`.
+  const command = rawCommand === "present" ? "publish" : rawCommand;
   if (command === "--help" || command === "-h" || command === "help") {
     return {
       ok: true,
@@ -245,6 +257,7 @@ export function parseSoftwareMapCliArgs(
     head?: string;
     pr?: string;
     review?: string;
+    remote?: string;
     json?: boolean;
   }>();
   const missingRemovedOption = (
@@ -259,6 +272,9 @@ export function parseSoftwareMapCliArgs(
       ok: false,
       error: `Expected a value after --${missingRemovedOption[0]}.`,
     };
+  }
+  if (options.remote !== undefined && !options.remote.trim()) {
+    return { ok: false, error: "Expected a value after --remote." };
   }
 
   if (
@@ -278,6 +294,7 @@ export function parseSoftwareMapCliArgs(
     force: options.force ?? false,
     diffRefs: {},
     review: options.review,
+    remote: options.remote?.trim(),
     json: options.json ?? false,
   };
 }
@@ -314,7 +331,9 @@ function softwareMapCommandModel(commandName: string): Command {
     commandName === "push" ||
     commandName === "fetch"
   ) {
-    return command;
+    return commandName === "push" || commandName === "fetch"
+      ? command.addOption(new Option("--remote <name>"))
+      : command;
   }
   return command.addArgument(new Argument("[args...]"));
 }
@@ -323,6 +342,9 @@ function softwareMapCommanderError(
   error: CommanderError,
   command: string,
 ): string {
+  if (/option '--remote <name>' argument missing/.test(error.message)) {
+    return "Expected a value after --remote.";
+  }
   const missingRemovedOption = error.message.match(
     /option '(--(?:base|head|pr))(?: <[^>]+>)?' argument missing/,
   )?.[1];
@@ -716,48 +738,52 @@ async function scratchIsFullyFlushed(input: {
 }
 
 async function pushSoftwareMapNotes(
-  input: CliJsonOutput & { rootPath: string },
+  input: CliJsonOutput & { rootPath: string; remote?: string },
 ) {
   const human = humanStream(input);
+  const remote = await notesRemote(input.rootPath, input.remote);
   const result = await pushNotes({
     rootPath: input.rootPath,
+    remote,
     refs: [SOFTWARE_MAP_NOTES_REF],
   });
   if (!result.ok) {
     return failWithJsonError(
       input,
       "map-push",
-      `software map push failed: ${result.error ?? "unknown error"}`,
+      `software map push failed for ${remote}: ${result.error ?? "unknown error"}. If another remote is writable, retry with --remote <name>.`,
     );
   }
   human.write(
     result.pushed.length === 0
       ? "no software-map notes to push.\n"
-      : `pushed ${result.pushed.join(", ")} to origin. Teammates receive them on their next fetch (review install configures the refspec).\n`,
+      : `pushed ${result.pushed.join(", ")} to ${remote}. Teammates receive them on their next fetch (review install configures the refspec).\n`,
   );
-  emitJsonEvent(input, { event: "map-push", pushed: result.pushed });
+  emitJsonEvent(input, { event: "map-push", remote, pushed: result.pushed });
   return 0;
 }
 
 async function fetchSoftwareMapNotes(
-  input: CliJsonOutput & { rootPath: string },
+  input: CliJsonOutput & { rootPath: string; remote?: string },
 ) {
   const human = humanStream(input);
-  const result = await fetchNotes({ rootPath: input.rootPath });
+  const remote = await notesRemote(input.rootPath, input.remote);
+  const result = await fetchNotes({ rootPath: input.rootPath, remote });
   if (!result.ok) {
     return failWithJsonError(
       input,
       "map-fetch",
-      `software map fetch failed: ${result.error ?? "unknown error"}`,
+      `software map fetch failed for ${remote}: ${result.error ?? "unknown error"}`,
     );
   }
   human.write(
     result.skipped
       ? "software-map note fetch skipped (devFast.fetchNotes=false).\n"
-      : "fetched software-map notes from origin into refs/notes/dev-fast/remote/*.\n",
+      : `fetched software-map notes from ${remote} into refs/notes/dev-fast/remote/*.\n`,
   );
   emitJsonEvent(input, {
     event: "map-fetch",
+    remote,
     skipped: result.skipped ?? false,
   });
   return 0;

--- a/packages/progressive-review/src/migrate.ts
+++ b/packages/progressive-review/src/migrate.ts
@@ -43,7 +43,11 @@ const LEGACY_SKILL_NAMES = [
   "progressive-review",
   "pr-review",
 ] as const;
-const CURRENT_SKILL_NAMES = ["dev-review", "dev-review-map"] as const;
+const CURRENT_SKILL_NAMES = [
+  "dev-review",
+  "dev-review-map",
+  "trace-archaeology",
+] as const;
 const execFilePromise = promisify(execFile);
 
 export type ReviewPackageManager = "npm" | "pnpm" | "yarn" | "bun";

--- a/packages/progressive-review/src/progressive-review-telemetry.test.ts
+++ b/packages/progressive-review/src/progressive-review-telemetry.test.ts
@@ -1,4 +1,4 @@
-import { readFile, rm } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -11,6 +11,10 @@ import {
   type ProgressiveReviewTelemetryCaptureClient,
   REVIEW_APP_VERSION_ENV,
 } from "./progressive-review-telemetry";
+import {
+  type ProgressiveReviewTelemetryInstallConfig,
+  normalizeTelemetryInstallConfig,
+} from "./telemetry-config";
 
 describe("ProgressiveReviewTelemetry", () => {
   const cleanupPaths: string[] = [];
@@ -70,6 +74,120 @@ describe("ProgressiveReviewTelemetry", () => {
       version: await progressiveReviewPackageVersion(),
       internal: true,
     });
+  });
+
+  it.each([
+    ["absent", {}, false],
+    ["false", { internal: false }, false],
+    ["true", { internal: true }, true],
+    ["invalid", { internal: "true" }, false],
+  ])("normalizes the %s stored internal marker", (_name, marker, expected) => {
+    const config = normalizeTelemetryInstallConfig(
+      {
+        installationId: "existing-install",
+        ...marker,
+      } as Partial<ProgressiveReviewTelemetryInstallConfig>,
+      () => new Date("2026-01-02T03:04:05.000Z"),
+    );
+
+    expect(config?.internal).toBe(expected);
+  });
+
+  it("migrates an existing configuration without changing its installation id", async () => {
+    const { configPath, rootPath, telemetry } = createTelemetry();
+    cleanupPaths.push(rootPath);
+    await writeStoredConfig(configPath, {
+      installationId: "existing-install",
+      createdAt: "2025-01-02T03:04:05.000Z",
+      installationCreatedSent: true,
+      enabled: true,
+    });
+
+    await expect(telemetry.getInstallationId()).resolves.toBe(
+      "existing-install",
+    );
+    await expect(readStoredConfig(configPath)).resolves.toMatchObject({
+      installationId: "existing-install",
+      internal: false,
+    });
+  });
+
+  it("migrates a legacy installation id with a false internal marker", async () => {
+    const { configPath, legacyConfigPath, rootPath, telemetry } =
+      createTelemetry();
+    cleanupPaths.push(rootPath);
+    await writeStoredConfig(legacyConfigPath, { installId: "legacy-install" });
+
+    await expect(telemetry.getInstallationId()).resolves.toBe("legacy-install");
+    await expect(readStoredConfig(configPath)).resolves.toMatchObject({
+      installationId: "legacy-install",
+      internal: false,
+    });
+  });
+
+  it("preserves the stored internal marker when the telemetry setting changes", async () => {
+    const { configPath, rootPath, telemetry } = createTelemetry();
+    cleanupPaths.push(rootPath);
+    await writeStoredConfig(configPath, storedConfig({ internal: true }));
+
+    await telemetry.setEnabled(false);
+    await expect(readStoredConfig(configPath)).resolves.toMatchObject({
+      installationId: "stored-install",
+      enabled: false,
+      internal: true,
+    });
+
+    await telemetry.setEnabled(true);
+    await expect(readStoredConfig(configPath)).resolves.toMatchObject({
+      installationId: "stored-install",
+      enabled: true,
+      internal: true,
+    });
+  });
+
+  it("lets an environment zero override a true stored marker", async () => {
+    const { configPath, events, rootPath, telemetry } = createTelemetry({
+      env: { PROGRESSIVE_REVIEW_TELEMETRY_INTERNAL: "0" },
+    });
+    cleanupPaths.push(rootPath);
+    await writeStoredConfig(configPath, storedConfig({ internal: true }));
+
+    await telemetry.captureCommandSucceeded({ command: "info", exitCode: 0 });
+
+    expect(events[0].properties).toMatchObject({ internal: false });
+  });
+
+  it("lets an environment one override a false stored marker", async () => {
+    const { configPath, events, rootPath, telemetry } = createTelemetry({
+      env: { PROGRESSIVE_REVIEW_TELEMETRY_INTERNAL: "1" },
+    });
+    cleanupPaths.push(rootPath);
+    await writeStoredConfig(configPath, storedConfig({ internal: false }));
+
+    await telemetry.captureCommandSucceeded({ command: "info", exitCode: 0 });
+
+    expect(events[0].properties).toMatchObject({ internal: true });
+  });
+
+  it("marks installation, command, server, and UI events from a stored marker", async () => {
+    const { configPath, events, rootPath, telemetry } = createTelemetry();
+    cleanupPaths.push(rootPath);
+    await writeStoredConfig(configPath, storedConfig({ internal: true }));
+
+    await telemetry.captureInstallationCreated();
+    await telemetry.captureCommandSucceeded({ command: "info", exitCode: 0 });
+    await telemetry.captureReviewReaped({ retentionDays: 30 });
+    await telemetry.captureUiEvent("review_app_opened", {});
+
+    expect(events.map((event) => event.event)).toEqual([
+      "review_installation_created",
+      "review_command_succeeded",
+      "review_review_reaped",
+      "review_app_opened",
+    ]);
+    for (const event of events) {
+      expect(event.properties).toMatchObject({ internal: true });
+    }
   });
 
   it("adds a valid Desktop version without changing the package version", async () => {
@@ -203,6 +321,7 @@ describe("ProgressiveReviewTelemetry", () => {
 function createTelemetry(input?: { env?: NodeJS.ProcessEnv }): {
   configPath: string;
   events: PostHogCaptureInput[];
+  legacyConfigPath: string;
   rootPath: string;
   telemetry: ProgressiveReviewTelemetry;
 } {
@@ -213,6 +332,7 @@ function createTelemetry(input?: { env?: NodeJS.ProcessEnv }): {
       .slice(2)}`,
   );
   const configPath = path.join(rootPath, "telemetry.json");
+  const legacyConfigPath = path.join(rootPath, "legacy.json");
   const events: PostHogCaptureInput[] = [];
   const captureClient: ProgressiveReviewTelemetryCaptureClient = {
     enabled: true,
@@ -224,10 +344,41 @@ function createTelemetry(input?: { env?: NodeJS.ProcessEnv }): {
     captureClient,
     env: input?.env ?? {},
     installConfigPath: configPath,
+    legacyInstallConfigPath: legacyConfigPath,
     idFactory: () => "install-123",
     now: () => new Date("2026-01-02T03:04:05.000Z"),
   });
-  return { configPath, events, rootPath, telemetry };
+  return { configPath, events, legacyConfigPath, rootPath, telemetry };
+}
+
+function storedConfig(
+  input: Partial<ProgressiveReviewTelemetryInstallConfig> = {},
+): ProgressiveReviewTelemetryInstallConfig {
+  return {
+    installationId: "stored-install",
+    createdAt: "2025-01-02T03:04:05.000Z",
+    installationCreatedSent: false,
+    enabled: true,
+    internal: false,
+    ...input,
+  };
+}
+
+async function writeStoredConfig(
+  configPath: string,
+  config: unknown,
+): Promise<void> {
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+}
+
+async function readStoredConfig(
+  configPath: string,
+): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(configPath, "utf8")) as Record<
+    string,
+    unknown
+  >;
 }
 
 async function progressiveReviewPackageVersion(): Promise<string> {

--- a/packages/progressive-review/src/progressive-review-telemetry.ts
+++ b/packages/progressive-review/src/progressive-review-telemetry.ts
@@ -6,8 +6,8 @@ import { valid as validSemver } from "semver";
 
 import { writeFileAtomic } from "./atomic-write";
 import { resolveAuthoringSessionRef } from "./authoring-session";
-import { findProgressiveReviewPackageRoot } from "./package-paths";
 import { EMBEDDED_PROGRESSIVE_REVIEW_POSTHOG_KEY } from "./embedded-posthog-key";
+import { findProgressiveReviewPackageRoot } from "./package-paths";
 import {
   PROGRESSIVE_REVIEW_POSTHOG_HOST_ENV,
   PROGRESSIVE_REVIEW_POSTHOG_KEY_ENV,
@@ -75,6 +75,7 @@ export type ProgressiveReviewTelemetryErrorCategory =
 export type ProgressiveReviewSourceKind =
   | "pull_request"
   | "git_branch"
+  | "git_commit"
   | "jj_bookmark"
   | "jj_change";
 export type ProgressiveReviewSessionAgent = "codex" | "claude" | "pi" | "other";
@@ -84,7 +85,12 @@ export type ProgressiveReviewSessionOutcome =
   // Replaced "rejected": the reader dismisses a review instead of rejecting it.
   | "dismissed";
 
-export type ReviewTelemetryTab = "review" | "commits" | "map" | "files";
+export type ReviewTelemetryTab =
+  | "review"
+  | "commits"
+  | "map"
+  | "files"
+  | "trace";
 export type ReviewTabTelemetryReason =
   | "tab_change"
   | "visibility_hidden"
@@ -231,7 +237,7 @@ export class ProgressiveReviewTelemetry {
       await this.captureClient.capture({
         event: "review_installation_created",
         distinctId: config.installationId,
-        properties: await this.commonProperties(),
+        properties: await this.commonProperties(config),
       });
       // A printed event is not a sent event. Persisting the flag here would
       // suppress the real installation event on this machine forever.
@@ -326,7 +332,7 @@ export class ProgressiveReviewTelemetry {
         event,
         distinctId: config.installationId,
         properties: {
-          ...(await this.commonProperties()),
+          ...(await this.commonProperties(config)),
           ...properties,
         },
       });
@@ -418,7 +424,16 @@ export class ProgressiveReviewTelemetry {
         await readFile(this.installConfigPath, "utf8"),
       ) as Partial<ProgressiveReviewTelemetryInstallConfig>;
       const config = normalizeTelemetryInstallConfig(parsed, this.now);
-      if (config) return config;
+      if (config) {
+        if (parsed.internal !== config.internal) {
+          try {
+            this.writeInstallConfig(config);
+          } catch {
+            // Keep the existing identity when a best-effort migration fails.
+          }
+        }
+        return config;
+      }
     } catch {
       // Missing or invalid config gets replaced below.
     }
@@ -474,7 +489,9 @@ export class ProgressiveReviewTelemetry {
     }
   }
 
-  private async commonProperties(): Promise<PostHogCaptureProperties> {
+  private async commonProperties(
+    config: Pick<ProgressiveReviewTelemetryInstallConfig, "internal">,
+  ): Promise<PostHogCaptureProperties> {
     const appVersion = reviewAppVersion(this.env);
     return {
       product: "review-cli",
@@ -485,7 +502,7 @@ export class ProgressiveReviewTelemetry {
       platform: process.platform,
       arch: process.arch,
       ci: Boolean(this.env.CI),
-      internal: isInternalTelemetry(this.env),
+      internal: isInternalTelemetry(this.env, config),
     };
   }
 

--- a/packages/progressive-review/src/review-agent-traces.test.ts
+++ b/packages/progressive-review/src/review-agent-traces.test.ts
@@ -1,0 +1,708 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearTraceEnvCache,
+  describeTraceSession,
+  findLocalTrace,
+  isTraceR2Configured,
+  listReviewTraceSessions,
+  loadReviewAgentTrace,
+  lookupReviewTraceBlame,
+  lookupReviewTraceCommit,
+  lookupReviewTraceSession,
+  syncReviewTrace,
+} from "./review-agent-traces";
+
+describe("review-agent-traces", () => {
+  let tempDir: string;
+  let mockR2Dir: string;
+  let searchDir: string;
+  let localClaudeDir: string;
+  let localCodexDir: string;
+  let localPiDir: string;
+
+  beforeEach(() => {
+    tempDir = path.join(
+      tmpdir(),
+      `trace-test-${process.pid}-${Math.random().toString(36).slice(2)}`,
+    );
+    mockR2Dir = path.join(tempDir, "mock-r2");
+    searchDir = path.join(tempDir, "trace-search");
+    localClaudeDir = path.join(tempDir, "local-claude");
+    localCodexDir = path.join(tempDir, "local-codex");
+    localPiDir = path.join(tempDir, "local-pi");
+
+    mkdirSync(mockR2Dir, { recursive: true });
+    mkdirSync(searchDir, { recursive: true });
+    mkdirSync(localClaudeDir, { recursive: true });
+    mkdirSync(localCodexDir, { recursive: true });
+    mkdirSync(localPiDir, { recursive: true });
+
+    process.env.TRACE_R2_MODE = "mock";
+    process.env.TRACE_R2_MOCK_DIR = mockR2Dir;
+    process.env.REVIEW_TEST_TRACE_SEARCH_DIR = searchDir;
+    process.env.TRACE_LOCAL_TRACE_ROOT = localClaudeDir;
+    process.env.TRACE_CODEX_SESSIONS_ROOT = localCodexDir;
+    process.env.TRACE_PI_SESSIONS_ROOT = localPiDir;
+    clearTraceEnvCache();
+  });
+
+  afterEach(() => {
+    delete process.env.TRACE_R2_MODE;
+    delete process.env.TRACE_R2_MOCK_DIR;
+    delete process.env.REVIEW_TEST_TRACE_SEARCH_DIR;
+    delete process.env.TRACE_LOCAL_TRACE_ROOT;
+    delete process.env.TRACE_CODEX_SESSIONS_ROOT;
+    delete process.env.TRACE_PI_SESSIONS_ROOT;
+    clearTraceEnvCache();
+    vi.restoreAllMocks();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("reports configured when in mock mode", () => {
+    expect(isTraceR2Configured()).toBe(true);
+  });
+
+  it("describes a session as available when stored in mock R2", async () => {
+    const sessionId = "72b3d130-2e72-41b6-8686-527a93d16647";
+    const sessionDir = path.join(mockR2Dir, "by-session", sessionId);
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(
+      path.join(sessionDir, "trace.jsonl"),
+      JSON.stringify({
+        type: "session",
+        id: sessionId,
+        cwd: "/repo",
+        timestamp: "2026-08-16T12:00:00Z",
+      }) + "\n",
+    );
+
+    const desc = await describeTraceSession({
+      sessionId,
+      commits: [
+        { sha: "1111111111111111111111111111111111111111", subject: "feat" },
+      ],
+    });
+
+    expect(desc.sessionId).toBe(sessionId);
+    expect(desc.available).toBe(true);
+    expect(desc.source).toBe("r2");
+    expect(desc.notSynced).toBe(false);
+  });
+
+  it("marks session as notSynced when missing from R2", async () => {
+    const sessionId = "88888888-2e72-41b6-8686-527a93d16647";
+    const desc = await describeTraceSession({
+      sessionId,
+      commits: [
+        { sha: "1111111111111111111111111111111111111111", subject: "feat" },
+      ],
+    });
+
+    expect(desc.sessionId).toBe(sessionId);
+    expect(desc.available).toBe(false);
+    expect(desc.source).toBe(null);
+    expect(desc.notSynced).toBe(true);
+  });
+
+  it("materializes main and subagent traces from R2", async () => {
+    const sessionId = "72b3d130-2e72-41b6-8686-527a93d16647";
+    const sessionDir = path.join(mockR2Dir, "by-session", sessionId);
+    const subagentsDir = path.join(sessionDir, "subagents");
+    mkdirSync(subagentsDir, { recursive: true });
+
+    writeFileSync(
+      path.join(sessionDir, "trace.jsonl"),
+      [
+        JSON.stringify({
+          type: "session",
+          id: sessionId,
+          cwd: "/repo",
+          timestamp: "2026-08-16T12:00:00Z",
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-08-16T12:00:05Z",
+          message: { role: "user", content: "Main task" },
+        }),
+      ].join("\n"),
+    );
+
+    writeFileSync(
+      path.join(subagentsDir, "pi-run-0-sub1.jsonl"),
+      [
+        JSON.stringify({
+          type: "session",
+          id: "sub-1",
+          cwd: "/repo",
+          timestamp: "2026-08-16T12:01:00Z",
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-08-16T12:01:05Z",
+          message: { role: "user", content: "Subagent task" },
+        }),
+      ].join("\n"),
+    );
+
+    // Load main trace
+    const mainLoaded = await loadReviewAgentTrace({
+      sessionId,
+      repo: "acme/widgets",
+    });
+    expect(mainLoaded).not.toBeNull();
+    expect(mainLoaded?.trace.userTurns).toBe(1);
+    expect(mainLoaded?.subagents).toContain("pi-run-0-sub1");
+    expect(mainLoaded?.traceName).toBeNull();
+
+    // Load subagent trace
+    const subLoaded = await loadReviewAgentTrace({
+      sessionId,
+      trace: "pi-run-0-sub1",
+      repo: "acme/widgets",
+    });
+    expect(subLoaded).not.toBeNull();
+    expect(subLoaded?.trace.userTurns).toBe(1);
+    expect(subLoaded?.traceName).toBe("pi-run-0-sub1");
+    expect(subLoaded?.trace.events[0]).toMatchObject({
+      kind: "user",
+      text: "Subagent task",
+    });
+  });
+
+  it("looks up commit from R2 index when trailers are absent", async () => {
+    const sha = "a1b2c3d4e5f60718293a4b5c6d7e8f9a0b1c2d3e";
+    const sessionId = "12345678-aaaa-bbbb-cccc-000000000001";
+    const commitDir = path.join(mockR2Dir, "by-commit");
+    mkdirSync(commitDir, { recursive: true });
+    writeFileSync(
+      path.join(commitDir, `${sha}.json`),
+      JSON.stringify({
+        commit: sha,
+        sessions: [sessionId],
+        repo: "acme/widgets",
+        pr: 42,
+        branch: "feature-branch",
+        indexed_by: "ci",
+        ts: "2026-08-16T12:00:00Z",
+      }),
+    );
+
+    const result = await lookupReviewTraceCommit({
+      cwd: tempDir,
+      sha,
+    });
+
+    expect(result.commit).toBe(sha);
+    expect(result.sessions).toEqual([sessionId]);
+    expect(result.pr).toBe(42);
+    expect(result.branch).toBe("feature-branch");
+    expect(result.source).toBe("index");
+  });
+
+  it("looks up session metadata from R2", async () => {
+    const sessionId = "12345678-aaaa-bbbb-cccc-000000000002";
+    const sha1 = "1111111111111111111111111111111111111111";
+    const sha2 = "2222222222222222222222222222222222222222";
+    const sessionDir = path.join(mockR2Dir, "by-session", sessionId);
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(
+      path.join(sessionDir, "meta.json"),
+      JSON.stringify({
+        session: sessionId,
+        repo: "acme/widgets",
+        branch: "main",
+        pr: 10,
+        commits: [sha1, sha2],
+        author: "alice@example.com",
+        ts: "2026-08-16T12:00:00Z",
+      }),
+    );
+
+    const result = await lookupReviewTraceSession({ sessionId });
+    expect(result.session).toBe(sessionId);
+    expect(result.meta).toMatchObject({
+      session: sessionId,
+      repo: "acme/widgets",
+      branch: "main",
+      pr: 10,
+      commits: [sha1, sha2],
+      author: "alice@example.com",
+    });
+  });
+
+  it("discovers local traces across Claude, Codex, and Pi layouts and syncs to R2 with truthful status", async () => {
+    // 1. Claude trace
+    const claudeId = "11111111-aaaa-bbbb-cccc-000000000001";
+    const claudeProjectDir = path.join(localClaudeDir, "-Users-dev-project");
+    mkdirSync(claudeProjectDir, { recursive: true });
+    writeFileSync(
+      path.join(claudeProjectDir, `${claudeId}.jsonl`),
+      JSON.stringify({ type: "session", id: claudeId }) + "\n",
+    );
+    const claudeSubDir = path.join(claudeProjectDir, claudeId, "subagents");
+    mkdirSync(claudeSubDir, { recursive: true });
+    writeFileSync(
+      path.join(claudeSubDir, "agent-sub1.jsonl"),
+      JSON.stringify({ type: "session", id: "sub1" }) + "\n",
+    );
+
+    const claudeDiscovery = await findLocalTrace(claudeId);
+    expect(claudeDiscovery).not.toBeNull();
+    expect(claudeDiscovery?.tracePath).toBe(
+      path.join(claudeProjectDir, `${claudeId}.jsonl`),
+    );
+    expect(claudeDiscovery?.subagentPaths).toHaveLength(1);
+
+    // Initial sync uploads blobs
+    const claudeSync = await syncReviewTrace({
+      sessionId: claudeId,
+      cwd: tempDir,
+      repo: "acme/widgets",
+    });
+    expect(claudeSync.session).toBe(claudeId);
+    expect(claudeSync.repo).toBe("acme/widgets");
+    expect(claudeSync.uploads).toEqual([
+      {
+        blob: "trace.jsonl",
+        bytes_stored: expect.any(Number),
+        status: "uploaded",
+      },
+      {
+        blob: "subagents/agent-sub1.jsonl",
+        bytes_stored: expect.any(Number),
+        status: "uploaded",
+      },
+    ]);
+    expect(
+      existsSync(path.join(mockR2Dir, "by-session", claudeId, "trace.jsonl")),
+    ).toBe(true);
+
+    // Second sync with unchanged files reports unchanged status
+    const secondSync = await syncReviewTrace({
+      sessionId: claudeId,
+      cwd: tempDir,
+      repo: "acme/widgets",
+    });
+    expect(secondSync.uploads).toEqual([
+      {
+        blob: "trace.jsonl",
+        bytes_stored: expect.any(Number),
+        status: "unchanged",
+      },
+      {
+        blob: "subagents/agent-sub1.jsonl",
+        bytes_stored: expect.any(Number),
+        status: "unchanged",
+      },
+    ]);
+
+    // 2. Codex rollout trace
+    const codexId = "22222222-aaaa-bbbb-cccc-000000000002";
+    const codexDateDir = path.join(localCodexDir, "2026", "08", "16");
+    mkdirSync(codexDateDir, { recursive: true });
+    writeFileSync(
+      path.join(codexDateDir, `rollout-2026-08-16T12-00-00-${codexId}.jsonl`),
+      JSON.stringify({ type: "session", id: codexId }) + "\n",
+    );
+
+    const codexDiscovery = await findLocalTrace(codexId);
+    expect(codexDiscovery).not.toBeNull();
+    expect(codexDiscovery?.tracePath).toContain(codexId);
+
+    // 3. Pi trace with child run
+    const piId = "33333333-aaaa-bbbb-cccc-000000000003";
+    const piProjectDir = path.join(localPiDir, "project-slug");
+    mkdirSync(piProjectDir, { recursive: true });
+    const piTracePath = path.join(
+      piProjectDir,
+      `2026-08-16T12-00-00_${piId}.jsonl`,
+    );
+    writeFileSync(
+      piTracePath,
+      JSON.stringify({ type: "session", id: piId }) + "\n",
+    );
+    const piChildRunDir = path.join(
+      piProjectDir,
+      `2026-08-16T12-00-00_${piId}`,
+      "childagent123456",
+      "run-0",
+    );
+    mkdirSync(piChildRunDir, { recursive: true });
+    writeFileSync(
+      path.join(piChildRunDir, "session.jsonl"),
+      JSON.stringify({ type: "session", id: "child1" }) + "\n",
+    );
+
+    const piDiscovery = await findLocalTrace(piId);
+    expect(piDiscovery).not.toBeNull();
+    expect(piDiscovery?.subagentPaths).toEqual([
+      {
+        name: "pi-run-0-childage.jsonl",
+        path: path.join(piChildRunDir, "session.jsonl"),
+      },
+    ]);
+  });
+
+  it("fails loudly when R2 data upload fails", async () => {
+    const sessionId = "44444444-aaaa-bbbb-cccc-000000000004";
+    writeFileSync(
+      path.join(localClaudeDir, `${sessionId}.jsonl`),
+      JSON.stringify({ type: "session", id: sessionId }) + "\n",
+    );
+
+    const blockPath = path.join(mockR2Dir, "by-session", sessionId);
+    mkdirSync(path.dirname(blockPath), { recursive: true });
+    writeFileSync(blockPath, "blocker");
+
+    await expect(
+      syncReviewTrace({
+        sessionId,
+        cwd: tempDir,
+        repo: "acme/widgets",
+      }),
+    ).rejects.toThrow("Failed to upload");
+  });
+
+  it("fails loudly when session metadata upload fails", async () => {
+    const sessionId = "55555555-aaaa-bbbb-cccc-000000000005";
+    writeFileSync(
+      path.join(localClaudeDir, `${sessionId}.jsonl`),
+      JSON.stringify({ type: "session", id: sessionId }) + "\n",
+    );
+
+    // Block meta.json write by creating meta.json as a directory with read-only permissions
+    const sessionDir = path.join(mockR2Dir, "by-session", sessionId);
+    mkdirSync(sessionDir, { recursive: true });
+    const blockMetaPath = path.join(sessionDir, "meta.json");
+    mkdirSync(blockMetaPath, { recursive: true });
+
+    await expect(
+      syncReviewTrace({
+        sessionId,
+        cwd: tempDir,
+        repo: "acme/widgets",
+      }),
+    ).rejects.toThrow("Failed to update session metadata");
+  });
+
+  describe("lookupReviewTraceCommit cheapest-first ladder", () => {
+    it("resolves local Agent-Session trailers with highest priority", async () => {
+      const gitDir = path.join(tempDir, "repo-trailer");
+      mkdirSync(gitDir, { recursive: true });
+      execFileSync("git", ["init", "--quiet"], { cwd: gitDir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: gitDir });
+      execFileSync("git", ["config", "user.email", "test@test.com"], {
+        cwd: gitDir,
+      });
+
+      writeFileSync(path.join(gitDir, "a.txt"), "hello");
+      execFileSync("git", ["add", "a.txt"], { cwd: gitDir });
+      execFileSync(
+        "git",
+        [
+          "commit",
+          "-m",
+          "Initial commit\n\nAgent-Session: 11111111-aaaa-bbbb-cccc-000000000001",
+        ],
+        { cwd: gitDir },
+      );
+
+      const sha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: gitDir,
+        encoding: "utf8",
+      }).trim();
+
+      // Write mock R2 entry that would differ (to ensure trailer wins first)
+      const r2Entry = {
+        commit: sha,
+        sessions: ["99999999-aaaa-bbbb-cccc-000000000099"],
+        repo: "acme/widgets",
+        pr: null,
+        branch: "main",
+        indexed_by: "ci",
+        ts: new Date().toISOString(),
+      };
+      const byCommitDir = path.join(mockR2Dir, "by-commit");
+      mkdirSync(byCommitDir, { recursive: true });
+      writeFileSync(
+        path.join(byCommitDir, `${sha}.json`),
+        JSON.stringify(r2Entry),
+      );
+
+      const result = await lookupReviewTraceCommit({ cwd: gitDir, sha });
+      expect(result.source).toBe("trailer");
+      expect(result.sessions).toEqual(["11111111-aaaa-bbbb-cccc-000000000001"]);
+    });
+
+    it("resolves direct R2 index when local trailers are absent", async () => {
+      const gitDir = path.join(tempDir, "repo-index");
+      mkdirSync(gitDir, { recursive: true });
+      execFileSync("git", ["init", "--quiet"], { cwd: gitDir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: gitDir });
+      execFileSync("git", ["config", "user.email", "test@test.com"], {
+        cwd: gitDir,
+      });
+
+      writeFileSync(path.join(gitDir, "a.txt"), "hello");
+      execFileSync("git", ["add", "a.txt"], { cwd: gitDir });
+      execFileSync("git", ["commit", "-m", "Plain commit without trailer"], {
+        cwd: gitDir,
+      });
+
+      const sha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: gitDir,
+        encoding: "utf8",
+      }).trim();
+
+      const r2Entry = {
+        commit: sha,
+        sessions: [
+          "22222222-aaaa-bbbb-cccc-000000000002",
+          "22222222-aaaa-bbbb-cccc-000000000002",
+        ],
+        repo: "acme/widgets",
+        pr: 101,
+        branch: "feature-branch",
+        indexed_by: "hook",
+        ts: new Date().toISOString(),
+      };
+      const byCommitDir = path.join(mockR2Dir, "by-commit");
+      mkdirSync(byCommitDir, { recursive: true });
+      writeFileSync(
+        path.join(byCommitDir, `${sha}.json`),
+        JSON.stringify(r2Entry),
+      );
+
+      // Session meta enrichment
+      const sessionDir = path.join(
+        mockR2Dir,
+        "by-session",
+        "22222222-aaaa-bbbb-cccc-000000000002",
+      );
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        path.join(sessionDir, "meta.json"),
+        JSON.stringify({
+          session: "22222222-aaaa-bbbb-cccc-000000000002",
+          repo: "acme/widgets",
+          branch: "feature-branch",
+          pr: 101,
+          author: "dev@acme.test",
+          commits: [sha],
+          ts: new Date().toISOString(),
+        }),
+      );
+
+      const result = await lookupReviewTraceCommit({ cwd: gitDir, sha });
+      expect(result.source).toBe("index");
+      expect(result.sessions).toEqual(["22222222-aaaa-bbbb-cccc-000000000002"]);
+      expect(result.pr).toBe(101);
+      expect(
+        result.session_meta?.["22222222-aaaa-bbbb-cccc-000000000002"],
+      ).toEqual({
+        repo: "acme/widgets",
+        branch: "feature-branch",
+        pr: 101,
+        author: "dev@acme.test",
+      });
+    });
+
+    it("scans PR branch commits from fake origin when trailer and index are empty", async () => {
+      const originBare = path.join(tempDir, "remote.git");
+      const clientRepo = path.join(tempDir, "client-repo");
+
+      execFileSync("git", ["init", "--bare", "--quiet", originBare]);
+      execFileSync("git", ["clone", "--quiet", originBare, clientRepo]);
+      execFileSync("git", ["config", "user.name", "Test"], {
+        cwd: clientRepo,
+      });
+      execFileSync("git", ["config", "user.email", "test@test.com"], {
+        cwd: clientRepo,
+      });
+
+      // Initial commit on main
+      writeFileSync(path.join(clientRepo, "f.txt"), "base");
+      execFileSync("git", ["add", "f.txt"], { cwd: clientRepo });
+      execFileSync("git", ["commit", "-m", "Base commit"], {
+        cwd: clientRepo,
+      });
+      execFileSync("git", ["push", "--quiet", "origin", "HEAD:main"], {
+        cwd: clientRepo,
+      });
+
+      // Branch commit with trailer
+      execFileSync("git", ["checkout", "-b", "feature"], { cwd: clientRepo });
+      writeFileSync(path.join(clientRepo, "f.txt"), "branch change");
+      execFileSync("git", ["add", "f.txt"], { cwd: clientRepo });
+      execFileSync(
+        "git",
+        [
+          "commit",
+          "-m",
+          "Feature work\n\nAgent-Session: 33333333-aaaa-bbbb-cccc-000000000003",
+        ],
+        { cwd: clientRepo },
+      );
+      execFileSync(
+        "git",
+        ["push", "--quiet", "origin", "HEAD:refs/pull/42/head"],
+        { cwd: clientRepo },
+      );
+
+      // Return to main and make a squash merge commit with subject ending in (#42)
+      execFileSync("git", ["checkout", "main"], { cwd: clientRepo });
+      writeFileSync(path.join(clientRepo, "f.txt"), "squashed branch change");
+      execFileSync("git", ["add", "f.txt"], { cwd: clientRepo });
+      execFileSync("git", ["commit", "-m", "Merge pull request (#42)"], {
+        cwd: clientRepo,
+      });
+
+      const squashSha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: clientRepo,
+        encoding: "utf8",
+      }).trim();
+
+      const result = await lookupReviewTraceCommit({
+        cwd: clientRepo,
+        sha: squashSha,
+      });
+      expect(result.source).toBe("pr-scan");
+      expect(result.pr).toBe(42);
+      expect(result.sessions).toEqual(["33333333-aaaa-bbbb-cccc-000000000003"]);
+    });
+
+    it("works offline locally when R2 is not configured", async () => {
+      delete process.env.TRACE_R2_MODE;
+      delete process.env.TRACE_R2_BUCKET;
+      clearTraceEnvCache();
+
+      const gitDir = path.join(tempDir, "offline-repo");
+      mkdirSync(gitDir, { recursive: true });
+      execFileSync("git", ["init", "--quiet"], { cwd: gitDir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: gitDir });
+      execFileSync("git", ["config", "user.email", "test@test.com"], {
+        cwd: gitDir,
+      });
+
+      writeFileSync(path.join(gitDir, "a.txt"), "offline");
+      execFileSync("git", ["add", "a.txt"], { cwd: gitDir });
+      execFileSync(
+        "git",
+        [
+          "commit",
+          "-m",
+          "Offline commit\n\nAgent-Session: 44444444-aaaa-bbbb-cccc-000000000004",
+        ],
+        { cwd: gitDir },
+      );
+
+      const sha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: gitDir,
+        encoding: "utf8",
+      }).trim();
+
+      const result = await lookupReviewTraceCommit({ cwd: gitDir, sha });
+      expect(result.source).toBe("trailer");
+      expect(result.sessions).toEqual(["44444444-aaaa-bbbb-cccc-000000000004"]);
+    });
+  });
+
+  describe("lookupReviewTraceBlame", () => {
+    it("blames lines and resolves unique commits in default mode and history mode", async () => {
+      const gitDir = path.join(tempDir, "repo-blame");
+      mkdirSync(gitDir, { recursive: true });
+      execFileSync("git", ["init", "--quiet"], { cwd: gitDir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: gitDir });
+      execFileSync("git", ["config", "user.email", "test@test.com"], {
+        cwd: gitDir,
+      });
+
+      writeFileSync(path.join(gitDir, "code.ts"), "line 1\nline 2\nline 3\n");
+      execFileSync("git", ["add", "code.ts"], { cwd: gitDir });
+      execFileSync(
+        "git",
+        [
+          "commit",
+          "-m",
+          "Commit 1\n\nAgent-Session: 11111111-0000-0000-0000-000000000001",
+        ],
+        { cwd: gitDir },
+      );
+
+      writeFileSync(
+        path.join(gitDir, "code.ts"),
+        "line 1\nline 2 modified\nline 3\n",
+      );
+      execFileSync("git", ["add", "code.ts"], { cwd: gitDir });
+      execFileSync(
+        "git",
+        [
+          "commit",
+          "-m",
+          "Commit 2\n\nAgent-Session: 22222222-0000-0000-0000-000000000002",
+        ],
+        { cwd: gitDir },
+      );
+
+      // Default blame for line 2
+      const blame = await lookupReviewTraceBlame({
+        cwd: gitDir,
+        file: "code.ts",
+        lines: "2,2",
+      });
+      expect(blame.file).toBe("code.ts");
+      expect(blame.range).toBe("2,2");
+      expect(blame.resolutions).toHaveLength(1);
+      expect(blame.resolutions[0].sessions).toEqual([
+        "22222222-0000-0000-0000-000000000002",
+      ]);
+
+      // History blame for line 2 includes commit 2 and commit 1
+      const historyBlame = await lookupReviewTraceBlame({
+        cwd: gitDir,
+        file: "code.ts",
+        lines: "2,2",
+        history: true,
+      });
+      expect(historyBlame.history).toBe(true);
+      expect(historyBlame.resolutions).toHaveLength(2);
+    });
+  });
+
+  describe("lookupReviewTraceSession", () => {
+    it("reports metadata, raw trace availability, and subagent names", async () => {
+      const sessionId = "99999999-aaaa-bbbb-cccc-000000000009";
+      const sessionDir = path.join(mockR2Dir, "by-session", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+
+      writeFileSync(
+        path.join(sessionDir, "meta.json"),
+        JSON.stringify({
+          session: sessionId,
+          repo: "acme/widgets",
+          branch: "main",
+          pr: null,
+          commits: ["1".repeat(40)],
+          author: "dev@acme.test",
+          ts: new Date().toISOString(),
+        }),
+      );
+      writeFileSync(path.join(sessionDir, "trace.jsonl"), "{}\n");
+      const subDir = path.join(sessionDir, "subagents");
+      mkdirSync(subDir, { recursive: true });
+      writeFileSync(path.join(subDir, "agent-planner.jsonl"), "{}\n");
+
+      const sessionLookup = await lookupReviewTraceSession({ sessionId });
+      expect(sessionLookup.session).toBe(sessionId);
+      expect(sessionLookup.meta?.repo).toBe("acme/widgets");
+      expect(sessionLookup.has_raw_trace).toBe(true);
+      expect(sessionLookup.subagents).toContain("agent-planner");
+    });
+  });
+});

--- a/packages/progressive-review/src/review-agent-traces.ts
+++ b/packages/progressive-review/src/review-agent-traces.ts
@@ -1,0 +1,1916 @@
+import { execFile } from "node:child_process";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import {
+  type ByCommitEntry,
+  type SessionMeta,
+  byCommitSchema,
+  commitShaSchema,
+  sessionIdSchema,
+  sessionMetaSchema,
+} from "@dev-fast/trace-shared";
+import { git, resolveRepoContext } from "@dev.fast/local-vcs";
+import type { ReviewAgentTraceSession } from "@dev.fast/review-protocol";
+
+import {
+  AGENT_TRACE_PARSER_VERSION,
+  type AgentTraceEvent,
+  type AgentTraceHarness,
+  type AgentTraceParseResult,
+  extractTraceEventText,
+  parseAgentTraceJsonl,
+  sniffAgentTraceHarness,
+} from "./agent-trace-parser";
+
+/**
+ * Resolves the agent sessions behind a review's change range, loads their
+ * transcripts, syncs local agent traces directly to R2, and materializes a
+ * local corpus for FFF search.
+ */
+
+const RECORD_SEPARATOR = "\u001e";
+const FIELD_SEPARATOR = "\u001f";
+const R2_COMMIT_LOOKUP_LIMIT = 30;
+const REMOTE_HEAD_TTL_MS = 15_000;
+
+export interface ReviewTraceCommitRef {
+  sha: string;
+  subject: string;
+}
+
+export interface ReviewTraceSessionRef {
+  sessionId: string;
+  commits: ReviewTraceCommitRef[];
+}
+
+export type ReviewTraceSessionDescriptor = ReviewAgentTraceSession;
+
+export interface LoadedReviewAgentTrace {
+  parserVersion: string;
+  descriptor: ReviewTraceSessionDescriptor;
+  trace: AgentTraceParseResult;
+  subagents: string[];
+  traceName: string | null;
+}
+
+export type ReviewTraceLookupSource = "trailer" | "index" | "pr-scan" | "none";
+
+export interface ReviewTraceCommitLookupResult {
+  commit: string;
+  sessions: string[];
+  pr: number | null;
+  branch: string | null;
+  source: ReviewTraceLookupSource;
+  session_meta?: Record<
+    string,
+    {
+      repo?: string | null;
+      branch?: string | null;
+      pr?: number | null;
+      author?: string | null;
+    }
+  >;
+}
+
+export interface ReviewTraceSessionLookupResult {
+  session: string;
+  meta: SessionMeta | null;
+  has_raw_trace: boolean;
+  subagents: string[];
+}
+
+export interface ReviewTraceBlameLookupResult {
+  file: string;
+  range: string | null;
+  history: boolean;
+  resolutions: ReviewTraceCommitLookupResult[];
+}
+
+export interface ReviewTraceSyncUpload {
+  blob: string;
+  bytes_stored: number;
+  status: "uploaded" | "unchanged";
+}
+
+export interface ReviewTraceSyncResult {
+  session: string;
+  repo: string;
+  uploads: ReviewTraceSyncUpload[];
+}
+
+export interface ReviewTraceDoctorResult {
+  ok: boolean;
+  envPath: string;
+  config?: { endpoint: string; bucket: string; accessKeyId: string };
+  reachable: boolean;
+  error?: string;
+}
+
+const lastCheckedTimes = new Map<string, number>();
+
+export function isTraceR2Configured(): boolean {
+  if (process.env.TRACE_R2_MODE === "mock") return true;
+  const config = traceR2Config();
+  return config !== null;
+}
+
+export async function listReviewTraceSessions(input: {
+  rootPath: string;
+  baseCommit: string;
+  headCommit: string;
+}): Promise<ReviewTraceSessionDescriptor[]> {
+  const sessions = new Map<string, ReviewTraceSessionRef>();
+  const commits = await commitsWithTrailers(input);
+  for (const commit of commits) {
+    for (const sessionId of commit.sessions) {
+      const existing = sessions.get(sessionId);
+      if (existing) {
+        existing.commits.push({ sha: commit.sha, subject: commit.subject });
+      } else {
+        sessions.set(sessionId, {
+          sessionId,
+          commits: [{ sha: commit.sha, subject: commit.subject }],
+        });
+      }
+    }
+  }
+  if (sessions.size === 0 && commits.length <= R2_COMMIT_LOOKUP_LIMIT) {
+    await addSessionsFromR2Index(commits, sessions);
+  }
+
+  const descriptors: ReviewTraceSessionDescriptor[] = [];
+  for (const ref of sessions.values()) {
+    const desc = await describeTraceSession(ref);
+    descriptors.push(desc);
+  }
+  return descriptors;
+}
+
+export function sniffTraceHarnessFromFile(filePath: string): AgentTraceHarness {
+  try {
+    const fd = openSync(filePath, "r");
+    try {
+      const buffer = Buffer.alloc(4096);
+      const bytesRead = readSync(fd, buffer, 0, 4096, 0);
+      const chunk = buffer.toString("utf8", 0, bytesRead);
+      return sniffAgentTraceHarness(chunk);
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return "unknown";
+  }
+}
+
+export async function describeTraceSession(
+  ref: ReviewTraceSessionRef,
+): Promise<ReviewTraceSessionDescriptor> {
+  const configured = isTraceR2Configured();
+  const mainKey = `by-session/${ref.sessionId}/trace.jsonl`;
+  const local = findNormalizedTraceFile(ref.sessionId, "main");
+  const normalized = local ? readNormalizedTrace(local) : null;
+  const remoteSize = configured ? await r2HeadObjectSize(mainKey) : null;
+  const available =
+    normalized !== null || (remoteSize !== null && remoteSize > 0);
+  const harness = normalized?.metadata.harness ?? "unknown";
+
+  const subagents = await listSessionSubagents(ref.sessionId);
+
+  return {
+    sessionId: ref.sessionId,
+    harness,
+    available,
+    source: available ? "r2" : null,
+    notSynced: !available,
+    subagents,
+    commits: ref.commits,
+  };
+}
+
+export async function loadReviewAgentTrace(input: {
+  sessionId: string;
+  trace?: string;
+  commits?: ReviewTraceCommitRef[];
+  cwd?: string;
+  repo?: string | { owner: string; repo: string };
+  refresh?: boolean;
+}): Promise<LoadedReviewAgentTrace | null> {
+  const { sessionId, trace } = input;
+  if (!sessionIdSchema.safeParse(sessionId).success) return null;
+  const traceName = trace ?? "main";
+  const traceKey =
+    traceName === "main"
+      ? `by-session/${sessionId}/trace.jsonl`
+      : `by-session/${sessionId}/subagents/${normalizeSubagentFileName(traceName)}`;
+
+  let normalizedPath = input.repo
+    ? normalizedTracePath(normalizeRepo(input.repo), sessionId, traceName)
+    : findNormalizedTraceFile(sessionId, traceName);
+  let normalized = normalizedPath ? readNormalizedTrace(normalizedPath) : null;
+  const now = Date.now();
+  const lastChecked = lastCheckedTimes.get(traceKey) ?? 0;
+  const canUseWithoutCheck =
+    normalized && !input.refresh && now - lastChecked < REMOTE_HEAD_TTL_MS;
+
+  if (!canUseWithoutCheck) {
+    const remoteSize = await r2HeadObjectSize(traceKey);
+    lastCheckedTimes.set(traceKey, now);
+    const mustMaterialize =
+      remoteSize !== null &&
+      (!normalized || remoteSize > normalized.metadata.source.bytes);
+    if (mustMaterialize) {
+      let repo = input.repo ? normalizeRepo(input.repo) : null;
+      if (!repo && input.cwd) {
+        repo = await inferRepoFromGit(input.cwd).catch(() => null);
+      }
+      if (!repo) {
+        const meta = await r2GetJson<SessionMeta>(
+          `by-session/${sessionId}/meta.json`,
+        );
+        if (meta?.repo) {
+          try {
+            repo = parseRepo(meta.repo);
+          } catch {
+            repo = null;
+          }
+        }
+      }
+      if (!repo) {
+        return normalized
+          ? loadedNormalizedTrace(normalized, input.commits)
+          : null;
+      }
+      normalizedPath = normalizedTracePath(repo, sessionId, traceName);
+      normalized = await materializeNormalizedTrace({
+        sessionId,
+        traceName,
+        traceKey,
+        normalizedPath,
+        repo,
+      });
+    }
+  }
+
+  if (!normalized) return null;
+  return loadedNormalizedTrace(normalized, input.commits);
+}
+
+function loadedNormalizedTrace(
+  normalized: NormalizedTrace,
+  commits: ReviewTraceCommitRef[] | undefined,
+): LoadedReviewAgentTrace {
+  const metadata = normalized.metadata;
+
+  const descriptor: ReviewTraceSessionDescriptor = {
+    sessionId: metadata.session,
+    harness: metadata.harness,
+    available: true,
+    source: "r2",
+    subagents: metadata.subagents,
+    commits: commits ?? [],
+  };
+
+  return {
+    parserVersion: metadata.parserVersion,
+    descriptor,
+    trace: {
+      harness: metadata.harness,
+      title: metadata.title,
+      events: normalized.events.map((record) => record.event),
+      startedAt: metadata.startedAt,
+      endedAt: metadata.endedAt,
+      activeMs: metadata.activeMs,
+      userTurns: metadata.userTurns,
+      toolCalls: metadata.toolCalls,
+    },
+    subagents: metadata.subagents,
+    traceName: metadata.trace === "main" ? null : metadata.trace,
+  };
+}
+
+interface NormalizedTraceMetadata {
+  type: "metadata";
+  version: 1;
+  parserVersion: string;
+  repository: string;
+  session: string;
+  trace: string;
+  harness: AgentTraceHarness;
+  title: string | null;
+  startedAt: string | null;
+  endedAt: string | null;
+  activeMs: number | null;
+  userTurns: number;
+  toolCalls: number;
+  subagents: string[];
+  source: { r2Key: string; bytes: number; checkedAt: string };
+}
+
+interface NormalizedTraceEventRecord {
+  type: "event";
+  index: number;
+  kind: AgentTraceEvent["kind"];
+  text: string;
+  event: AgentTraceEvent;
+}
+
+interface NormalizedTrace {
+  metadata: NormalizedTraceMetadata;
+  events: NormalizedTraceEventRecord[];
+}
+
+async function materializeNormalizedTrace(input: {
+  sessionId: string;
+  traceName: string;
+  traceKey: string;
+  normalizedPath: string;
+  repo: { owner: string; repo: string };
+}): Promise<NormalizedTrace | null> {
+  const rawTempPath = path.join(
+    tmpdir(),
+    `review-trace-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.jsonl`,
+  );
+  try {
+    if (!(await r2GetObject(input.traceKey, rawTempPath))) return null;
+    const parsed = parseAgentTraceJsonl(readFileSync(rawTempPath, "utf8"), {
+      isSubagent: input.traceName !== "main",
+    });
+    const subagents = await listSessionSubagents(input.sessionId);
+    const normalized: NormalizedTrace = {
+      metadata: {
+        type: "metadata",
+        version: 1,
+        parserVersion: AGENT_TRACE_PARSER_VERSION,
+        repository: `${input.repo.owner}/${input.repo.repo}`,
+        session: input.sessionId,
+        trace: input.traceName,
+        harness: parsed.harness,
+        title: parsed.title,
+        startedAt: parsed.startedAt,
+        endedAt: parsed.endedAt,
+        activeMs: parsed.activeMs,
+        userTurns: parsed.userTurns,
+        toolCalls: parsed.toolCalls,
+        subagents,
+        source: {
+          r2Key: input.traceKey,
+          bytes: statSync(rawTempPath).size,
+          checkedAt: new Date().toISOString(),
+        },
+      },
+      events: parsed.events.map((event, index) => ({
+        type: "event",
+        index,
+        kind: event.kind,
+        text: extractTraceEventText(event),
+        event,
+      })),
+    };
+    writeNormalizedTraceAtomic(input.normalizedPath, normalized);
+    return normalized;
+  } finally {
+    rmSync(rawTempPath, { force: true });
+  }
+}
+
+function writeNormalizedTraceAtomic(
+  targetPath: string,
+  trace: NormalizedTrace,
+): void {
+  mkdirSync(path.dirname(targetPath), { recursive: true });
+  const tempPath = `${targetPath}.tmp-${process.pid}-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2)}`;
+  const content = [trace.metadata, ...trace.events]
+    .map((record) => JSON.stringify(record))
+    .join("\n");
+  try {
+    writeFileSync(tempPath, `${content}\n`, "utf8");
+    renameSync(tempPath, targetPath);
+  } finally {
+    rmSync(tempPath, { force: true });
+  }
+}
+
+function readNormalizedTrace(filePath: string): NormalizedTrace | null {
+  try {
+    const records = readFileSync(filePath, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as unknown);
+    const metadata = records[0] as NormalizedTraceMetadata | undefined;
+    if (
+      !metadata ||
+      metadata.type !== "metadata" ||
+      metadata.version !== 1 ||
+      metadata.parserVersion !== AGENT_TRACE_PARSER_VERSION ||
+      typeof metadata.source?.bytes !== "number"
+    ) {
+      return null;
+    }
+    const events = records.slice(1) as NormalizedTraceEventRecord[];
+    if (
+      events.some(
+        (record, index) =>
+          record.type !== "event" ||
+          record.index !== index ||
+          record.kind !== record.event?.kind ||
+          record.text !== extractTraceEventText(record.event),
+      )
+    ) {
+      return null;
+    }
+    return { metadata, events };
+  } catch {
+    return null;
+  }
+}
+
+export interface ReviewTracePullSession {
+  id: string;
+  traces?: string[];
+}
+
+export interface ReviewTracePullSessionResult {
+  session: string;
+  traces: number;
+  events: number;
+  files: number;
+}
+
+export interface ReviewTracePullResult {
+  corpusRoot: string;
+  repository: string;
+  sessions: ReviewTracePullSessionResult[];
+  unavailableSessions: string[];
+  events: number;
+  files: number;
+  paths: string[];
+}
+
+export function traceSearchCorpusDir(): string {
+  const dir =
+    process.env.REVIEW_TEST_TRACE_SEARCH_DIR ??
+    path.join(homedir(), ".dev", "trace-search");
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+export async function pullReviewTraceCorpus(input: {
+  repo: { owner: string; repo: string };
+  sessions: ReviewTracePullSession[];
+  mainOnly?: boolean;
+}): Promise<ReviewTracePullResult> {
+  const repository = `${input.repo.owner}/${input.repo.repo}`;
+  const corpusRoot = traceSearchCorpusDir();
+
+  const sessions: ReviewTracePullSessionResult[] = [];
+  const unavailableSessions: string[] = [];
+  const paths: string[] = [];
+  for (const sessionRef of input.sessions) {
+    const main = await loadReviewAgentTrace({
+      sessionId: sessionRef.id,
+      repo: input.repo,
+      refresh: true,
+    });
+    if (!main) {
+      unavailableSessions.push(sessionRef.id);
+      continue;
+    }
+    paths.push(normalizedTracePath(input.repo, sessionRef.id, "main"));
+    let traceCount = 1;
+    let eventCount = main.trace.events.length;
+    if (!input.mainOnly) {
+      for (const traceName of sessionRef.traces ?? main.subagents) {
+        const subagent = await loadReviewAgentTrace({
+          sessionId: sessionRef.id,
+          trace: traceName,
+          repo: input.repo,
+          refresh: true,
+        });
+        if (subagent) {
+          paths.push(normalizedTracePath(input.repo, sessionRef.id, traceName));
+          traceCount += 1;
+          eventCount += subagent.trace.events.length;
+        }
+      }
+    }
+
+    sessions.push({
+      session: sessionRef.id,
+      traces: traceCount,
+      events: eventCount,
+      files: traceCount,
+    });
+  }
+
+  return {
+    corpusRoot,
+    repository,
+    sessions,
+    unavailableSessions,
+    events: sessions.reduce((total, session) => total + session.events, 0),
+    files: sessions.reduce((total, session) => total + session.files, 0),
+    paths,
+  };
+}
+
+function normalizeRepo(repo: string | { owner: string; repo: string }): {
+  owner: string;
+  repo: string;
+} {
+  return typeof repo === "string" ? parseRepo(repo) : repo;
+}
+
+function normalizedTracePath(
+  repo: { owner: string; repo: string },
+  sessionId: string,
+  traceName: string,
+): string {
+  return path.join(
+    traceSearchCorpusDir(),
+    corpusPathSegment(repo.owner, "owner"),
+    corpusPathSegment(repo.repo, "repository"),
+    corpusPathSegment(sessionId, "session"),
+    `${corpusPathSegment(traceName.replace(/\.jsonl$/, ""), "trace")}.jsonl`,
+  );
+}
+
+function findNormalizedTraceFile(
+  sessionId: string,
+  traceName: string,
+): string | null {
+  const fileName = `${corpusPathSegment(traceName.replace(/\.jsonl$/, ""), "trace")}.jsonl`;
+  for (const sessionDir of findNormalizedSessionDirs(sessionId)) {
+    const candidate = path.join(sessionDir, fileName);
+    if (isFile(candidate)) return candidate;
+  }
+  return null;
+}
+
+function findNormalizedSessionDirs(sessionId: string): string[] {
+  const root = traceSearchCorpusDir();
+  const session = corpusPathSegment(sessionId, "session");
+  const results: string[] = [];
+  try {
+    for (const owner of readdirSync(root, { withFileTypes: true })) {
+      if (!owner.isDirectory()) continue;
+      const ownerDir = path.join(root, owner.name);
+      for (const repo of readdirSync(ownerDir, { withFileTypes: true })) {
+        if (!repo.isDirectory()) continue;
+        const candidate = path.join(ownerDir, repo.name, session);
+        if (isDirectory(candidate)) results.push(candidate);
+      }
+    }
+  } catch {
+    return [];
+  }
+  return results.sort();
+}
+
+function corpusPathSegment(value: string, label: string): string {
+  if (!/^[A-Za-z0-9._-]+$/.test(value)) {
+    throw new Error(`Invalid ${label} path segment: ${value}`);
+  }
+  return value;
+}
+
+function normalizeSubagentFileName(name: string): string {
+  const base = path.basename(name);
+  return base.endsWith(".jsonl") ? base : `${base}.jsonl`;
+}
+
+async function runGit(
+  cwd: string,
+  args: string[],
+): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      "git",
+      ["-C", cwd, ...args],
+      {
+        maxBuffer: 64 * 1024 * 1024,
+      },
+    );
+    return { ok: true, stdout, stderr };
+  } catch (error) {
+    const err = error as { stdout?: string; stderr?: string };
+    return {
+      ok: false,
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? String(error),
+    };
+  }
+}
+
+export const r2ListSubagents = listSessionSubagents;
+
+// --- Lookup Commit & Session -----------------------------------------------
+
+export async function lookupReviewTraceCommit(input: {
+  cwd: string;
+  sha: string;
+}): Promise<ReviewTraceCommitLookupResult> {
+  const commit = await resolveCommitSha(input.cwd, input.sha);
+  const trailerSessions = await readTrailerSessions(input.cwd, commit);
+  const pr = await readSubjectPullNumber(input.cwd, commit);
+
+  // Step 1: local trailers
+  if (trailerSessions.length > 0) {
+    const sessionMeta = await enrichSessionMeta(trailerSessions);
+    return {
+      commit,
+      sessions: trailerSessions,
+      pr,
+      branch: null,
+      source: "trailer",
+      ...(sessionMeta ? { session_meta: sessionMeta } : {}),
+    };
+  }
+
+  // Step 2: direct R2 by-commit index
+  let r2Entry: ByCommitEntry | null = null;
+  if (isTraceR2Configured() && commitShaSchema.safeParse(commit).success) {
+    try {
+      const raw = await r2GetJson<unknown>(`by-commit/${commit}.json`);
+      const parsed = byCommitSchema.safeParse(raw);
+      if (parsed.success && parsed.data.sessions.length > 0) {
+        r2Entry = parsed.data;
+      }
+    } catch {
+      // R2 read error; proceed to next steps
+    }
+  }
+
+  if (r2Entry && r2Entry.sessions.length > 0) {
+    const sessions = deduplicateStrings(r2Entry.sessions);
+    const sessionMeta = await enrichSessionMeta(sessions);
+    return {
+      commit,
+      sessions,
+      pr: r2Entry.pr ?? pr,
+      branch: r2Entry.branch ?? null,
+      source: "index",
+      ...(sessionMeta ? { session_meta: sessionMeta } : {}),
+    };
+  }
+
+  // Step 3: PR scan if commit subject ends in PR number
+  if (pr !== null) {
+    const fetchRes = await runGit(input.cwd, [
+      "fetch",
+      "--quiet",
+      "origin",
+      `refs/pull/${pr}/head`,
+    ]);
+    if (fetchRes.ok) {
+      let revListRes = await runGit(input.cwd, [
+        "rev-list",
+        "FETCH_HEAD",
+        "--not",
+        `${commit}^`,
+      ]);
+      if (!revListRes.ok) {
+        revListRes = await runGit(input.cwd, [
+          "rev-list",
+          "FETCH_HEAD",
+          "--not",
+          `${commit}~1`,
+        ]);
+      }
+      if (!revListRes.ok) {
+        revListRes = await runGit(input.cwd, ["rev-list", "FETCH_HEAD"]);
+      }
+      if (revListRes.ok) {
+        const branchShas = revListRes.stdout
+          .trim()
+          .split(/\s+/)
+          .filter(Boolean);
+        const prSessions: string[] = [];
+        for (const branchSha of branchShas) {
+          const sessionsOnSha = await readTrailerSessions(input.cwd, branchSha);
+          for (const s of sessionsOnSha) {
+            if (!prSessions.includes(s)) {
+              prSessions.push(s);
+            }
+          }
+        }
+        if (prSessions.length > 0) {
+          const sessionMeta = await enrichSessionMeta(prSessions);
+          return {
+            commit,
+            sessions: prSessions,
+            pr,
+            branch: null,
+            source: "pr-scan",
+            ...(sessionMeta ? { session_meta: sessionMeta } : {}),
+          };
+        }
+      }
+    }
+  }
+
+  return {
+    commit,
+    sessions: [],
+    pr,
+    branch: null,
+    source: "none",
+  };
+}
+
+function deduplicateStrings(items: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of items) {
+    if (!seen.has(item)) {
+      seen.add(item);
+      out.push(item);
+    }
+  }
+  return out;
+}
+
+async function enrichSessionMeta(sessions: string[]): Promise<
+  | Record<
+      string,
+      {
+        repo?: string | null;
+        branch?: string | null;
+        pr?: number | null;
+        author?: string | null;
+      }
+    >
+  | undefined
+> {
+  if (!isTraceR2Configured() || sessions.length === 0) return undefined;
+  const detail: Record<
+    string,
+    {
+      repo?: string | null;
+      branch?: string | null;
+      pr?: number | null;
+      author?: string | null;
+    }
+  > = {};
+  for (const session of sessions) {
+    try {
+      const raw = await r2GetJson<unknown>(`by-session/${session}/meta.json`);
+      const parsed = sessionMetaSchema.safeParse(raw);
+      if (parsed.success) {
+        detail[session] = {
+          repo: parsed.data.repo,
+          branch: parsed.data.branch,
+          pr: parsed.data.pr,
+          author: parsed.data.author,
+        };
+      }
+    } catch {
+      // Ignore individual session metadata fetch errors
+    }
+  }
+  return Object.keys(detail).length > 0 ? detail : undefined;
+}
+
+export async function lookupReviewTraceSession(input: {
+  sessionId: string;
+}): Promise<ReviewTraceSessionLookupResult> {
+  const parseResult = sessionIdSchema.safeParse(input.sessionId);
+  if (!parseResult.success) {
+    throw new Error(
+      "Session id must be 8-128 characters of letters, digits, dots, dashes, or underscores.",
+    );
+  }
+  const sessionId = parseResult.data;
+
+  let meta: SessionMeta | null = null;
+  if (isTraceR2Configured()) {
+    try {
+      const raw = await r2GetJson<unknown>(`by-session/${sessionId}/meta.json`);
+      if (raw) {
+        const parsed = sessionMetaSchema.safeParse(raw);
+        if (parsed.success) {
+          meta = parsed.data;
+        }
+      }
+    } catch {
+      // Ignore error fetching metadata
+    }
+  }
+
+  let hasRawTrace = false;
+  if (isTraceR2Configured()) {
+    const size = await r2HeadObjectSize(`by-session/${sessionId}/trace.jsonl`);
+    if (size !== null) {
+      hasRawTrace = true;
+    }
+  }
+  if (!hasRawTrace) {
+    const local = await findLocalTrace(sessionId);
+    if (local && existsSync(local.tracePath)) {
+      hasRawTrace = true;
+    }
+  }
+
+  const subagentSet = new Set<string>();
+  if (isTraceR2Configured()) {
+    const r2Subs = await r2ListSubagents(sessionId);
+    for (const s of r2Subs) {
+      subagentSet.add(s);
+    }
+  }
+  const local = await findLocalTrace(sessionId);
+  if (local) {
+    for (const s of local.subagentPaths) {
+      subagentSet.add(s.name.replace(/\.jsonl(\.gz)?$/, ""));
+    }
+  }
+
+  return {
+    session: sessionId,
+    meta,
+    has_raw_trace: hasRawTrace,
+    subagents: [...subagentSet],
+  };
+}
+
+export async function lookupReviewTraceBlame(input: {
+  cwd: string;
+  file: string;
+  lines?: string;
+  history?: boolean;
+}): Promise<ReviewTraceBlameLookupResult> {
+  if (!input.file) {
+    throw new Error("File path is required.");
+  }
+  if (input.lines) {
+    const match = /^(\d+)(?:,(\d+))?$/.exec(input.lines.trim());
+    if (!match) {
+      throw new Error(
+        `Invalid line range "${input.lines}". Expected start,end or single line number.`,
+      );
+    }
+    const start = parseInt(match[1], 10);
+    const end = match[2] ? parseInt(match[2], 10) : start;
+    if (start <= 0 || end < start) {
+      throw new Error(
+        `Invalid line range "${input.lines}". Start must be >= 1 and end >= start.`,
+      );
+    }
+  }
+
+  let shas: string[] = [];
+  if (input.history) {
+    const spec = input.lines
+      ? `${input.lines}:${input.file}`
+      : `1,$:${input.file}`;
+    const res = await runGit(input.cwd, [
+      "log",
+      "-L",
+      spec,
+      "--format=%H",
+      "-s",
+    ]);
+    if (!res.ok) {
+      throw new Error(
+        res.stderr.trim() || `git log -L failed for ${input.file}`,
+      );
+    }
+    shas = deduplicateStrings(res.stdout.trim().split(/\s+/).filter(Boolean));
+  } else {
+    const args = ["blame", "--line-porcelain"];
+    if (input.lines) {
+      args.push("-L", input.lines);
+    }
+    args.push("--", input.file);
+    const res = await runGit(input.cwd, args);
+    if (!res.ok) {
+      throw new Error(
+        res.stderr.trim() || `git blame failed for ${input.file}`,
+      );
+    }
+    const collected: string[] = [];
+    for (const line of res.stdout.split("\n")) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length >= 3 && /^[0-9a-f]{40,64}$/i.test(parts[0])) {
+        if (!collected.includes(parts[0])) {
+          collected.push(parts[0]);
+        }
+      }
+    }
+    shas = collected;
+  }
+
+  const resolutions: ReviewTraceCommitLookupResult[] = [];
+  for (const sha of shas) {
+    resolutions.push(await lookupReviewTraceCommit({ cwd: input.cwd, sha }));
+  }
+
+  return {
+    file: input.file,
+    range: input.lines ?? null,
+    history: Boolean(input.history),
+    resolutions,
+  };
+}
+
+// --- Local Trace Discovery & Sync ------------------------------------------
+
+export interface LocalTraceDiscovery {
+  tracePath: string;
+  subagentPaths: Array<{ name: string; path: string }>;
+}
+
+export async function findLocalTrace(
+  sessionId: string,
+): Promise<LocalTraceDiscovery | null> {
+  if (!sessionIdSchema.safeParse(sessionId).success) return null;
+
+  const claudeRoot =
+    traceEnvValue("TRACE_LOCAL_TRACE_ROOT") ||
+    path.join(homedir(), ".claude", "projects");
+  const codexRoot =
+    traceEnvValue("TRACE_CODEX_SESSIONS_ROOT") ||
+    path.join(homedir(), ".codex", "sessions");
+  const piRoot =
+    traceEnvValue("TRACE_PI_SESSIONS_ROOT") ||
+    path.join(homedir(), ".pi", "agent", "sessions");
+
+  let tracePath =
+    findClaudeTrace(claudeRoot, sessionId) ||
+    findCodexTrace(codexRoot, sessionId) ||
+    findPiTrace(piRoot, sessionId);
+
+  if (!tracePath) {
+    if (
+      existsSync(claudeRoot) &&
+      isFile(path.join(claudeRoot, `${sessionId}.jsonl`))
+    ) {
+      tracePath = path.join(claudeRoot, `${sessionId}.jsonl`);
+    }
+  }
+
+  if (!tracePath) return null;
+
+  const subagentPaths = findSubagentBlobs(tracePath);
+  return { tracePath, subagentPaths };
+}
+
+function findClaudeTrace(root: string, sessionId: string): string | null {
+  const fileName = `${sessionId}.jsonl`;
+  if (!existsSync(root)) return null;
+  const direct = path.join(root, fileName);
+  if (isFile(direct)) return direct;
+  try {
+    const entries = readdirSync(root, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const candidate = path.join(root, entry.name, fileName);
+        if (isFile(candidate)) return candidate;
+      }
+    }
+  } catch {
+    // Ignore read errors
+  }
+  return null;
+}
+
+function findCodexTrace(root: string, sessionId: string): string | null {
+  if (!existsSync(root)) return null;
+  const suffix = `-${sessionId}.jsonl`;
+  const allFiles = listFilesRecursive(root);
+  for (const entry of allFiles.sort()) {
+    const name = path.basename(entry);
+    if (name.startsWith("rollout-") && name.endsWith(suffix)) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+function findPiTrace(root: string, sessionId: string): string | null {
+  if (!existsSync(root)) return null;
+  try {
+    const entries = readdirSync(root, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const subDir = path.join(root, entry.name);
+        for (const file of readdirSync(subDir)) {
+          if (
+            file.endsWith(`_${sessionId}.jsonl`) ||
+            file === `${sessionId}.jsonl`
+          ) {
+            const candidate = path.join(subDir, file);
+            if (isFile(candidate)) return candidate;
+          }
+        }
+      } else if (entry.isFile()) {
+        if (
+          entry.name.endsWith(`_${sessionId}.jsonl`) ||
+          entry.name === `${sessionId}.jsonl`
+        ) {
+          return path.join(root, entry.name);
+        }
+      }
+    }
+  } catch {
+    // Ignore read errors
+  }
+  return null;
+}
+
+function findSubagentBlobs(
+  tracePath: string,
+): Array<{ name: string; path: string }> {
+  const results: Array<{ name: string; path: string }> = [];
+  const stem = tracePath.endsWith(".jsonl")
+    ? tracePath.slice(0, -".jsonl".length)
+    : tracePath;
+
+  const subagentsDir = path.join(stem, "subagents");
+  if (existsSync(subagentsDir)) {
+    try {
+      for (const name of readdirSync(subagentsDir)) {
+        if (name.endsWith(".jsonl")) {
+          results.push({ name, path: path.join(subagentsDir, name) });
+        }
+      }
+    } catch {
+      // Ignore directory read errors
+    }
+  }
+
+  if (existsSync(stem)) {
+    try {
+      for (const childEntry of readdirSync(stem, { withFileTypes: true })) {
+        if (childEntry.isDirectory() && childEntry.name !== "subagents") {
+          const childDir = path.join(stem, childEntry.name);
+          for (const runEntry of readdirSync(childDir, {
+            withFileTypes: true,
+          })) {
+            if (runEntry.isDirectory() && runEntry.name.startsWith("run-")) {
+              const runFile = path.join(
+                childDir,
+                runEntry.name,
+                "session.jsonl",
+              );
+              if (isFile(runFile)) {
+                const shortChild = childEntry.name.slice(0, 8);
+                results.push({
+                  name: `pi-${runEntry.name}-${shortChild}.jsonl`,
+                  path: runFile,
+                });
+              }
+            }
+          }
+        }
+      }
+    } catch {
+      // Ignore Pi child directory read errors
+    }
+  }
+
+  return results.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function syncReviewTrace(input: {
+  sessionId: string;
+  cwd?: string;
+  repo?: string;
+  commits?: string[];
+}): Promise<ReviewTraceSyncResult> {
+  const sessionId = input.sessionId.trim();
+  if (!sessionIdSchema.safeParse(sessionId).success) {
+    throw new Error(
+      "Session id must be 8-128 characters of letters, digits, dots, dashes, or underscores.",
+    );
+  }
+  if (!isTraceR2Configured()) {
+    throw new Error(
+      "R2 storage is not configured. Use Review Agent Setup to configure trace capture.",
+    );
+  }
+
+  const local = await findLocalTrace(sessionId);
+  if (!local) {
+    throw new Error(`No local trace found for session ${sessionId}.`);
+  }
+
+  const workDir = input.cwd ?? process.cwd();
+  const repo = input.repo
+    ? parseRepo(input.repo)
+    : await inferRepoFromGit(workDir);
+
+  const uploads: ReviewTraceSyncUpload[] = [];
+
+  // Main trace upload
+  const mainKey = `by-session/${sessionId}/trace.jsonl`;
+  const mainGrown = await r2PutIfGrown(mainKey, local.tracePath);
+  const mainBytes = statSync(local.tracePath).size;
+  uploads.push({
+    blob: "trace.jsonl",
+    bytes_stored: mainBytes,
+    status: mainGrown ? "uploaded" : "unchanged",
+  });
+
+  // Subagent uploads
+  for (const sub of local.subagentPaths) {
+    const subKey = `by-session/${sessionId}/subagents/${sub.name}`;
+    const subGrown = await r2PutIfGrown(subKey, sub.path);
+    const subBytes = statSync(sub.path).size;
+    uploads.push({
+      blob: `subagents/${sub.name}`,
+      bytes_stored: subBytes,
+      status: subGrown ? "uploaded" : "unchanged",
+    });
+  }
+
+  // Update session metadata (read-merge-write)
+  const { author, branch } = await readRepoMetaFields(workDir);
+  const metaKey = `by-session/${sessionId}/meta.json`;
+  const existingMeta = await r2GetJson<SessionMeta>(metaKey);
+
+  const mergedCommits = deduplicateStrings([
+    ...(existingMeta?.commits ?? []),
+    ...(input.commits ?? []).filter(
+      (commit) => commitShaSchema.safeParse(commit).success,
+    ),
+  ]);
+  const mergedRepo = `${repo.owner}/${repo.repo}`;
+  const mergedBranch = branch ?? existingMeta?.branch ?? null;
+  const mergedAuthor = author ?? existingMeta?.author ?? null;
+  const mergedPr = existingMeta?.pr ?? null;
+
+  const newMeta: SessionMeta = {
+    session: sessionId,
+    repo: mergedRepo,
+    branch: mergedBranch,
+    pr: mergedPr,
+    commits: mergedCommits,
+    author: mergedAuthor,
+    ts: new Date().toISOString(),
+  };
+
+  const metaSaved = await r2PutBuffer(
+    metaKey,
+    Buffer.from(JSON.stringify(newMeta, null, 2), "utf8"),
+  );
+  if (!metaSaved) {
+    throw new Error(
+      `Failed to update session metadata for ${sessionId} in R2 storage.`,
+    );
+  }
+
+  return {
+    session: sessionId,
+    repo: mergedRepo,
+    uploads,
+  };
+}
+
+export async function writeReviewTraceCommitMapping(input: {
+  cwd: string;
+  commit: string;
+  sessions: string[];
+  branch: string | null;
+}): Promise<boolean> {
+  const commit = commitShaSchema.parse(input.commit);
+  const existing = await r2GetJson<unknown>(`by-commit/${commit}.json`);
+  if (existing !== null) return false;
+  const repo = await inferRepoFromGit(input.cwd);
+  const entry: ByCommitEntry = byCommitSchema.parse({
+    commit,
+    sessions: deduplicateStrings(input.sessions),
+    repo: `${repo.owner}/${repo.repo}`,
+    pr: await readSubjectPullNumber(input.cwd, commit),
+    branch: input.branch,
+    indexed_by: "hook",
+    ts: new Date().toISOString(),
+  });
+  const saved = await r2PutBuffer(
+    `by-commit/${commit}.json`,
+    Buffer.from(JSON.stringify(entry, null, 2), "utf8"),
+  );
+  if (!saved) {
+    throw new Error(`Failed to write by-commit/${commit}.json.`);
+  }
+  return true;
+}
+
+export async function checkReviewTraceDoctor(input?: {
+  cwd?: string;
+}): Promise<ReviewTraceDoctorResult> {
+  const envPath =
+    process.env.TRACE_ENV_FILE ??
+    path.join(homedir(), ".config", "dev-trace", "env");
+
+  if (
+    !existsSync(envPath) &&
+    !process.env.TRACE_R2_BUCKET &&
+    process.env.TRACE_R2_MODE !== "mock"
+  ) {
+    return {
+      ok: false,
+      envPath,
+      reachable: false,
+      error:
+        "No trace configuration found. Use Review Agent Setup to configure trace capture.",
+    };
+  }
+
+  if (process.env.TRACE_R2_MODE === "mock") {
+    return {
+      ok: true,
+      envPath,
+      config: {
+        endpoint: "mock://endpoint",
+        bucket: "mock-bucket",
+        accessKeyId: "mock-key",
+      },
+      reachable: true,
+    };
+  }
+
+  const config = traceR2Config();
+  if (!config) {
+    return {
+      ok: false,
+      envPath,
+      reachable: false,
+      error: "Configuration is missing one or more required R2 values.",
+    };
+  }
+
+  try {
+    await execFileAsync(
+      "aws",
+      [
+        "--region",
+        "auto",
+        "--endpoint-url",
+        config.endpoint,
+        "s3api",
+        "head-bucket",
+        "--bucket",
+        config.bucket,
+      ],
+      {
+        timeout: 15_000,
+        env: {
+          ...process.env,
+          AWS_ACCESS_KEY_ID: config.accessKeyId,
+          AWS_SECRET_ACCESS_KEY: config.secretAccessKey,
+        },
+      },
+    );
+    return {
+      ok: true,
+      envPath,
+      config: {
+        endpoint: config.endpoint,
+        bucket: config.bucket,
+        accessKeyId: config.accessKeyId,
+      },
+      reachable: true,
+    };
+  } catch (err: unknown) {
+    return {
+      ok: false,
+      envPath,
+      config: {
+        endpoint: config.endpoint,
+        bucket: config.bucket,
+        accessKeyId: config.accessKeyId,
+      },
+      reachable: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// --- Commit trailer resolution ---------------------------------------------
+
+interface CommitWithSessions extends ReviewTraceCommitRef {
+  sessions: string[];
+}
+
+export async function resolveCommitSha(
+  cwd: string,
+  rev: string,
+): Promise<string> {
+  const result = await git(
+    cwd,
+    ["rev-parse", "--verify", "--end-of-options", rev],
+    { allowFailure: true },
+  );
+  return result.ok && result.stdout.trim() ? result.stdout.trim() : rev;
+}
+
+export async function readTrailerSessions(
+  cwd: string,
+  rev: string,
+): Promise<string[]> {
+  const result = await git(
+    cwd,
+    [
+      "show",
+      "-s",
+      "--format=%(trailers:key=Agent-Session,valueonly)",
+      "--end-of-options",
+      rev,
+    ],
+    { allowFailure: true },
+  );
+  if (!result.ok) return [];
+  const sessions: string[] = [];
+  for (const line of result.stdout.split("\n")) {
+    const value = line.trim();
+    if (
+      value &&
+      sessionIdSchema.safeParse(value).success &&
+      !sessions.includes(value)
+    ) {
+      sessions.push(value);
+    }
+  }
+  return sessions;
+}
+
+export async function listRepositoryTraceSessionIds(
+  cwd: string,
+): Promise<string[]> {
+  const result = await runGit(cwd, [
+    "log",
+    "--all",
+    "--no-show-signature",
+    "--format=%(trailers:key=Agent-Session,valueonly,separator=%x1f)",
+  ]);
+  if (!result.ok) return [];
+
+  return deduplicateStrings(
+    result.stdout
+      .split(/[\n\x1f]+/)
+      .map((value) => value.trim())
+      .filter((value) => sessionIdSchema.safeParse(value).success),
+  );
+}
+
+export async function readSubjectPullNumber(
+  cwd: string,
+  rev: string,
+): Promise<number | null> {
+  const result = await git(
+    cwd,
+    ["show", "-s", "--format=%s", "--end-of-options", rev],
+    { allowFailure: true },
+  );
+  if (!result.ok) return null;
+  const subject = result.stdout.trim();
+  const match = /\(#(\d+)\)$/.exec(subject);
+  return match ? Number(match[1]) : null;
+}
+
+export async function readRepoMetaFields(
+  cwd: string,
+): Promise<{ author: string | null; branch: string | null }> {
+  const insideResult = await git(cwd, ["rev-parse", "--is-inside-work-tree"], {
+    allowFailure: true,
+  });
+  if (!insideResult.ok || insideResult.stdout.trim() !== "true") {
+    return { author: null, branch: null };
+  }
+  const branchResult = await git(cwd, ["branch", "--show-current"], {
+    allowFailure: true,
+  });
+  const branch = branchResult.ok ? branchResult.stdout.trim() : null;
+  const authorResult = await git(cwd, ["config", "user.email"], {
+    allowFailure: true,
+  });
+  const author = authorResult.ok ? authorResult.stdout.trim() : null;
+  return { author: author || null, branch: branch || null };
+}
+
+export function parseRepo(value: string): { owner: string; repo: string } {
+  const parts = value.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error("Repository must be OWNER/REPO.");
+  }
+  return { owner: parts[0], repo: parts[1] };
+}
+
+export async function inferRepoFromGit(
+  cwd: string,
+): Promise<{ owner: string; repo: string }> {
+  if (process.env.GITHUB_REPOSITORY) {
+    return parseRepo(process.env.GITHUB_REPOSITORY);
+  }
+  const slug = (await resolveRepoContext(cwd))?.githubSlug;
+  if (slug) {
+    return parseRepo(slug);
+  }
+  const result = await git(cwd, ["remote", "get-url", "origin"], {
+    allowFailure: true,
+  });
+  if (result.ok && result.stdout.trim()) {
+    const raw = result.stdout.trim();
+    const match = /[:/]([^/]+)\/([^/]+?)(?:\.git)?$/.exec(raw);
+    if (match && match[1] && match[2]) {
+      return parseRepo(`${match[1]}/${match[2]}`);
+    }
+  }
+  throw new Error("Could not infer GitHub repository from origin remote.");
+}
+
+async function commitsWithTrailers(input: {
+  rootPath: string;
+  baseCommit: string;
+  headCommit: string;
+}): Promise<CommitWithSessions[]> {
+  if (input.baseCommit === input.headCommit) return [];
+  const format = [
+    "%H",
+    "%s",
+    "%(trailers:key=Agent-Session,valueonly,separator=%x1f)",
+  ].join("%x1f");
+  const result = await git(
+    input.rootPath,
+    [
+      "log",
+      "--no-show-signature",
+      `--format=${format}${RECORD_SEPARATOR}`,
+      `${input.baseCommit}..${input.headCommit}`,
+    ],
+    { allowFailure: true },
+  );
+  if (!result.ok) return [];
+  const commits: CommitWithSessions[] = [];
+  for (const chunk of result.stdout.split(RECORD_SEPARATOR)) {
+    const record = chunk.replace(/^\s+/, "");
+    if (!record) continue;
+    const [sha, subject, ...trailerFields] = record.split(FIELD_SEPARATOR);
+    if (!sha || !/^[0-9a-f]{40,64}$/.test(sha)) continue;
+    const sessions = [
+      ...new Set(trailerFields.flatMap((field) => field.split("\n"))),
+    ]
+      .map((value) => value.trim())
+      .filter((value) => sessionIdSchema.safeParse(value).success);
+    commits.push({ sha, subject: subject ?? "", sessions });
+  }
+  return commits;
+}
+
+// --- R2 trace store and local materialization -------------------------------
+
+export interface TraceR2Config {
+  bucket: string;
+  endpoint: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+}
+
+let cachedTraceEnv: Record<string, string> | null = null;
+
+export function clearTraceEnvCache(): void {
+  cachedTraceEnv = null;
+  lastCheckedTimes.clear();
+}
+
+function traceEnvFile(): Record<string, string> {
+  if (cachedTraceEnv) return cachedTraceEnv;
+  const values: Record<string, string> = {};
+  const envPath =
+    process.env.TRACE_ENV_FILE ??
+    path.join(homedir(), ".config", "dev-trace", "env");
+  try {
+    for (const line of readFileSync(envPath, "utf8").split("\n")) {
+      const match = /^\s*(?:export\s+)?([A-Z0-9_]+)=(.*)$/.exec(line);
+      if (!match) continue;
+      values[match[1]] = match[2].replace(/^["']|["']$/g, "").trim();
+    }
+  } catch {
+    // No env file; exported variables may still be present.
+  }
+  cachedTraceEnv = values;
+  return values;
+}
+
+export function traceEnvValue(name: string): string | undefined {
+  return process.env[name] ?? traceEnvFile()[name];
+}
+
+export function traceR2Config(): TraceR2Config | null {
+  const bucket = traceEnvValue("TRACE_R2_BUCKET");
+  const endpoint = traceEnvValue("TRACE_R2_ENDPOINT");
+  const accessKeyId =
+    traceEnvValue("TRACE_R2_ACCESS_KEY_ID") ??
+    traceEnvValue("AWS_ACCESS_KEY_ID");
+  const secretAccessKey =
+    traceEnvValue("TRACE_R2_SECRET_ACCESS_KEY") ??
+    traceEnvValue("AWS_SECRET_ACCESS_KEY");
+  if (!bucket || !endpoint || !accessKeyId || !secretAccessKey) return null;
+  return { bucket, endpoint, accessKeyId, secretAccessKey };
+}
+
+const execFileAsync = promisify(execFile);
+
+export async function r2HeadObjectSize(key: string): Promise<number | null> {
+  if (process.env.TRACE_R2_MODE === "mock") {
+    const mockRoot = process.env.TRACE_R2_MOCK_DIR;
+    if (!mockRoot) return null;
+    const target = path.join(mockRoot, key);
+    try {
+      const stats = statSync(target);
+      return stats.isFile() ? stats.size : null;
+    } catch {
+      return null;
+    }
+  }
+
+  const config = traceR2Config();
+  if (!config) return null;
+  try {
+    const proc = await execFileAsync(
+      "aws",
+      [
+        "--region",
+        "auto",
+        "--endpoint-url",
+        config.endpoint,
+        "s3api",
+        "head-object",
+        "--bucket",
+        config.bucket,
+        "--key",
+        key,
+      ],
+      {
+        timeout: 10_000,
+        env: {
+          ...process.env,
+          AWS_ACCESS_KEY_ID: config.accessKeyId,
+          AWS_SECRET_ACCESS_KEY: config.secretAccessKey,
+        },
+      },
+    );
+    const parsed = JSON.parse(proc.stdout) as { ContentLength?: number };
+    return typeof parsed.ContentLength === "number"
+      ? parsed.ContentLength
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function r2GetObject(
+  key: string,
+  destPath: string,
+): Promise<boolean> {
+  mkdirSync(path.dirname(destPath), { recursive: true });
+
+  if (process.env.TRACE_R2_MODE === "mock") {
+    const mockRoot = process.env.TRACE_R2_MOCK_DIR;
+    if (!mockRoot) return false;
+    const target = path.join(mockRoot, key);
+    try {
+      const content = readFileSync(target);
+      writeFileSync(destPath, content);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  const config = traceR2Config();
+  if (!config) return false;
+  try {
+    await execFileAsync(
+      "aws",
+      [
+        "--region",
+        "auto",
+        "--endpoint-url",
+        config.endpoint,
+        "s3api",
+        "get-object",
+        "--bucket",
+        config.bucket,
+        "--key",
+        key,
+        destPath,
+      ],
+      {
+        timeout: 60_000,
+        maxBuffer: 16 * 1024 * 1024,
+        env: {
+          ...process.env,
+          AWS_ACCESS_KEY_ID: config.accessKeyId,
+          AWS_SECRET_ACCESS_KEY: config.secretAccessKey,
+        },
+      },
+    );
+    return existsSync(destPath);
+  } catch {
+    return false;
+  }
+}
+
+export async function r2GetBuffer(key: string): Promise<Buffer | null> {
+  const tmpPath = path.join(
+    tmpdir(),
+    `r2-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`,
+  );
+  try {
+    const ok = await r2GetObject(key, tmpPath);
+    if (!ok) return null;
+    return readFileSync(tmpPath);
+  } catch {
+    return null;
+  } finally {
+    try {
+      if (existsSync(tmpPath)) {
+        const { rmSync } = await import("node:fs");
+        rmSync(tmpPath, { force: true });
+      }
+    } catch {
+      // Ignore cleanup error
+    }
+  }
+}
+
+export async function r2GetJson<T>(key: string): Promise<T | null> {
+  const content = await r2GetBuffer(key);
+  if (!content) return null;
+  try {
+    return JSON.parse(content.toString("utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function r2PutFile(
+  key: string,
+  filePath: string,
+): Promise<boolean> {
+  if (process.env.TRACE_R2_MODE === "mock") {
+    const mockRoot = process.env.TRACE_R2_MOCK_DIR;
+    if (!mockRoot) return false;
+    try {
+      const target = path.join(mockRoot, key);
+      mkdirSync(path.dirname(target), { recursive: true });
+      writeFileSync(target, readFileSync(filePath));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  const config = traceR2Config();
+  if (!config) return false;
+  try {
+    await execFileAsync(
+      "aws",
+      [
+        "--region",
+        "auto",
+        "--endpoint-url",
+        config.endpoint,
+        "s3",
+        "cp",
+        "--only-show-errors",
+        filePath,
+        `s3://${config.bucket}/${key}`,
+      ],
+      {
+        timeout: 60_000,
+        env: {
+          ...process.env,
+          AWS_ACCESS_KEY_ID: config.accessKeyId,
+          AWS_SECRET_ACCESS_KEY: config.secretAccessKey,
+        },
+      },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function r2PutBuffer(
+  key: string,
+  content: Buffer,
+): Promise<boolean> {
+  if (process.env.TRACE_R2_MODE === "mock") {
+    const mockRoot = process.env.TRACE_R2_MOCK_DIR;
+    if (!mockRoot) return false;
+    try {
+      const target = path.join(mockRoot, key);
+      mkdirSync(path.dirname(target), { recursive: true });
+      writeFileSync(target, content);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  const tempFile = path.join(
+    tmpdir(),
+    `put-${process.pid}-${Math.random().toString(36).slice(2)}.tmp`,
+  );
+  writeFileSync(tempFile, content);
+  try {
+    return await r2PutFile(key, tempFile);
+  } finally {
+    try {
+      if (existsSync(tempFile)) {
+        const { rmSync } = await import("node:fs");
+        rmSync(tempFile, { force: true });
+      }
+    } catch {
+      // Ignore cleanup error
+    }
+  }
+}
+
+export async function r2PutIfGrown(
+  key: string,
+  filePath: string,
+): Promise<boolean> {
+  const remoteSize = await r2HeadObjectSize(key);
+  const localSize = statSync(filePath).size;
+  if (remoteSize !== null && localSize <= remoteSize) {
+    return false;
+  }
+  const uploaded = await r2PutFile(key, filePath);
+  if (!uploaded) {
+    throw new Error(`Failed to upload ${key} to R2 storage.`);
+  }
+  return true;
+}
+
+export async function listSessionSubagents(
+  sessionId: string,
+): Promise<string[]> {
+  const subagents = new Set<string>();
+  const prefix = `by-session/${sessionId}/subagents/`;
+
+  for (const localSessionDir of findNormalizedSessionDirs(sessionId)) {
+    try {
+      for (const entry of readdirSync(localSessionDir)) {
+        if (entry.endsWith(".jsonl") && entry !== "main.jsonl") {
+          subagents.add(entry.slice(0, -6));
+        }
+      }
+    } catch {
+      // Ignore local read errors
+    }
+  }
+
+  if (process.env.TRACE_R2_MODE === "mock") {
+    const mockRoot = process.env.TRACE_R2_MOCK_DIR;
+    if (mockRoot) {
+      const dir = path.join(mockRoot, prefix);
+      if (existsSync(dir)) {
+        try {
+          for (const entry of readdirSync(dir)) {
+            if (entry.endsWith(".jsonl")) {
+              subagents.add(entry.slice(0, -6));
+            }
+          }
+        } catch {
+          // Ignore mock readdir errors
+        }
+      }
+    }
+  } else {
+    const config = traceR2Config();
+    if (config) {
+      try {
+        const proc = await execFileAsync(
+          "aws",
+          [
+            "--region",
+            "auto",
+            "--endpoint-url",
+            config.endpoint,
+            "s3api",
+            "list-objects-v2",
+            "--bucket",
+            config.bucket,
+            "--prefix",
+            prefix,
+          ],
+          {
+            timeout: 10_000,
+            env: {
+              ...process.env,
+              AWS_ACCESS_KEY_ID: config.accessKeyId,
+              AWS_SECRET_ACCESS_KEY: config.secretAccessKey,
+            },
+          },
+        );
+        const parsed = JSON.parse(proc.stdout) as {
+          Contents?: Array<{ Key?: string }>;
+        };
+        for (const item of parsed.Contents ?? []) {
+          if (
+            item.Key &&
+            item.Key.startsWith(prefix) &&
+            item.Key.endsWith(".jsonl")
+          ) {
+            const subName = item.Key.slice(prefix.length, -6);
+            if (subName) subagents.add(subName);
+          }
+        }
+      } catch {
+        // Ignore remote list failure
+      }
+    }
+  }
+
+  return [...subagents].sort();
+}
+
+async function addSessionsFromR2Index(
+  commits: CommitWithSessions[],
+  sessions: Map<string, ReviewTraceSessionRef>,
+): Promise<void> {
+  if (!isTraceR2Configured()) return;
+  for (const commit of commits) {
+    const key = `by-commit/${commit.sha}.json`;
+    try {
+      const entry = await r2GetJson<{
+        sessions?: unknown;
+      }>(key);
+      if (!entry) continue;
+      if (!Array.isArray(entry.sessions)) continue;
+      for (const value of entry.sessions) {
+        if (
+          typeof value !== "string" ||
+          !sessionIdSchema.safeParse(value).success
+        ) {
+          continue;
+        }
+        const existing = sessions.get(value);
+        if (existing) {
+          existing.commits.push({ sha: commit.sha, subject: commit.subject });
+        } else {
+          sessions.set(value, {
+            sessionId: value,
+            commits: [{ sha: commit.sha, subject: commit.subject }],
+          });
+        }
+      }
+    } catch {
+      // Ignore malformed index entries.
+    }
+  }
+}
+
+function isFile(targetPath: string): boolean {
+  try {
+    return statSync(targetPath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isDirectory(targetPath: string): boolean {
+  try {
+    return statSync(targetPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function listFilesRecursive(dirPath: string): string[] {
+  const files: string[] = [];
+  try {
+    const entries = readdirSync(dirPath, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...listFilesRecursive(full));
+      } else if (entry.isFile()) {
+        files.push(full);
+      }
+    }
+  } catch {
+    // Ignore read errors
+  }
+  return files;
+}

--- a/packages/progressive-review/src/review-change-scope.ts
+++ b/packages/progressive-review/src/review-change-scope.ts
@@ -37,20 +37,25 @@ export async function actionableReviewsForCheckout(
       ) {
         return false;
       }
-      const identity = stored.review.sourceIdentity?.name;
-      const headRef =
-        !identity || POSITIONAL_REFS.has(identity)
-          ? stored.review.sourceCommit
-          : identity;
-      if (!headRef) return false;
-      const relationship = await resolveReviewHeadRelationship({
-        rootPath: reviewRoot,
-        headRef,
-      });
-      return (
-        relationship.kind === "exact" || relationship.kind === "descendant"
-      );
+      return reviewMatchesCheckout(stored, reviewRoot);
     }),
   );
   return reviews.filter((_, index) => matches[index]);
+}
+
+export async function reviewMatchesCheckout(
+  stored: StoredReview,
+  reviewRoot: string,
+): Promise<boolean> {
+  const identity = stored.review.sourceIdentity?.name;
+  const headRef =
+    !identity || POSITIONAL_REFS.has(identity)
+      ? stored.review.sourceCommit
+      : identity;
+  if (!headRef) return false;
+  const relationship = await resolveReviewHeadRelationship({
+    rootPath: reviewRoot,
+    headRef,
+  });
+  return relationship.kind === "exact" || relationship.kind === "descendant";
 }

--- a/packages/progressive-review/src/review-info.test.ts
+++ b/packages/progressive-review/src/review-info.test.ts
@@ -76,6 +76,7 @@ describe("review info", () => {
             uuid: expect.stringMatching(/^[0-9a-f-]{36}$/),
             change: expect.any(String),
             inSync: true,
+            matchesCheckout: true,
             unresolvedComments: 0,
             status: "draft",
             title: "Progressive Review",
@@ -117,6 +118,54 @@ describe("review info", () => {
     } finally {
       vi.unstubAllEnvs();
       closeAllReviewThreadStores();
+      await rm(home, { recursive: true, force: true });
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("lists a worktree review when the checkout does not match its change", async () => {
+    const root = await makeGitRepository();
+    const home = await mkdtemp(path.join(os.tmpdir(), "review-info-home-"));
+    vi.stubEnv("DEV_REVIEW_HOME", home);
+
+    try {
+      await git(root, ["checkout", "-b", "feature"]);
+      await writeFile(path.join(root, "README.md"), "# Feature\n", "utf8");
+      await git(root, ["commit", "-am", "feature"]);
+      await git(root, ["checkout", "main"]);
+      clearCommandOutputCacheForTests();
+
+      const created = await runReviewScaffold({
+        cwd: root,
+        baseRef: "main",
+        headRef: "feature",
+      });
+      expect(created.reviews[0]).toMatchObject({
+        inSync: false,
+        matchesCheckout: false,
+      });
+
+      const discovered = await resolveReviewInfo({ cwd: root });
+      expect(discovered.reviews).toHaveLength(1);
+      expect(discovered.reviews[0]).toMatchObject({
+        uuid: created.reviews[0]!.uuid,
+        inSync: false,
+        matchesCheckout: false,
+      });
+
+      await git(root, ["checkout", "feature"]);
+      clearCommandOutputCacheForTests();
+      await expect(resolveReviewInfo({ cwd: root })).resolves.toMatchObject({
+        reviews: [
+          {
+            uuid: created.reviews[0]!.uuid,
+            inSync: true,
+            matchesCheckout: true,
+          },
+        ],
+      });
+    } finally {
+      vi.unstubAllEnvs();
       await rm(home, { recursive: true, force: true });
       await rm(root, { recursive: true, force: true });
     }
@@ -673,8 +722,26 @@ describe("review info", () => {
     }
   });
 
+  it("warns when devfast.prepare is not configured", async () => {
+    const root = await makeGitRepository();
+    const home = await mkdtemp(path.join(os.tmpdir(), "review-info-home-"));
+    vi.stubEnv("DEV_REVIEW_HOME", home);
+
+    try {
+      const created = await runReviewScaffold({ cwd: root });
+      expect(created.warnings).toEqual([
+        "devfast.prepare is not configured. Configure it (git config devfast.prepare '<command>') and run `review scaffold --update` to prepare pinned worktrees.",
+      ]);
+    } finally {
+      vi.unstubAllEnvs();
+      await rm(home, { recursive: true, force: true });
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("scaffolds without warnings when the pinned head is on another branch", async () => {
     const root = await makeGitRepository();
+    await git(root, ["config", "devfast.prepare", "echo ok"]);
     const home = await mkdtemp(path.join(os.tmpdir(), "review-info-home-"));
     vi.stubEnv("DEV_REVIEW_HOME", home);
 
@@ -706,6 +773,69 @@ describe("review info", () => {
     }
   });
 
+  it("scaffolds a Git-only commit by full SHA in a colocated jj repo", async () => {
+    if (!(await commandAvailable("jj"))) return;
+
+    const root = await makeGitRepository();
+    const home = await mkdtemp(path.join(os.tmpdir(), "review-info-home-"));
+    vi.stubEnv("DEV_REVIEW_HOME", home);
+
+    try {
+      await jj(root, ["git", "init", "--colocate"]);
+      clearCommandOutputCacheForTests();
+      await git(root, ["config", "devfast.prepare", "echo ok"]);
+      const baseCommit = await git(root, ["rev-parse", "HEAD"]);
+      await writeFile(
+        path.join(root, "README.md"),
+        "# Git-only head\n",
+        "utf8",
+      );
+      await git(root, ["add", "README.md"]);
+      const tree = await git(root, ["write-tree"]);
+      const { stdout } = await execFilePromise(
+        "git",
+        [
+          "-C",
+          root,
+          "commit-tree",
+          tree,
+          "-p",
+          baseCommit,
+          "-m",
+          "Git-only head",
+        ],
+        { encoding: "utf8" },
+      );
+      const headCommit = stdout.trim();
+
+      await expect(
+        jj(root, ["log", "--no-graph", "-r", headCommit]),
+      ).rejects.toThrow(/./);
+
+      const created = await runReviewScaffold({
+        cwd: root,
+        baseRef: baseCommit,
+        headRef: headCommit,
+      });
+      const reviewJson = JSON.parse(
+        await readFile(
+          path.join(created.reviews[0]!.dir, "review.json"),
+          "utf8",
+        ),
+      );
+      expect(reviewJson.sourceCommit).toBe(headCommit);
+      expect(reviewJson.sourceIdentity).toEqual({
+        kind: "git-commit",
+        name: headCommit,
+      });
+    } finally {
+      vi.unstubAllEnvs();
+      clearCommandOutputCacheForTests();
+      await rm(home, { recursive: true, force: true });
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("hides terminal reviews from default info but lists them with --all", async () => {
     const root = await makeGitRepository();
     const home = await mkdtemp(path.join(os.tmpdir(), "review-info-home-"));
@@ -725,6 +855,14 @@ describe("review info", () => {
         resolveReviewInfo({ cwd: root, all: true }),
       ).resolves.toMatchObject({
         reviews: [{ status: "rejected" }],
+      });
+      await expect(
+        resolveReviewInfo({
+          cwd: path.join(home, "outside-repository"),
+          reviewUuid: created.reviews[0]!.uuid,
+        }),
+      ).resolves.toMatchObject({
+        reviews: [{ uuid: created.reviews[0]!.uuid, status: "rejected" }],
       });
     } finally {
       vi.unstubAllEnvs();

--- a/packages/progressive-review/src/review-info.ts
+++ b/packages/progressive-review/src/review-info.ts
@@ -4,6 +4,7 @@ import type { StoredReview } from "./review-home";
 export interface RunReviewInfoInput {
   cwd: string;
   all?: boolean;
+  reviewUuid?: string;
 }
 
 export interface ReviewInfoEvent {
@@ -14,6 +15,7 @@ export interface ReviewInfoEvent {
     dir: string;
     change: string | null;
     inSync: boolean;
+    matchesCheckout: boolean;
     unresolvedComments: number;
     status: StoredReview["review"]["status"];
     title: string;

--- a/packages/progressive-review/src/review-prepare.test.ts
+++ b/packages/progressive-review/src/review-prepare.test.ts
@@ -7,8 +7,10 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   prepareReviewPinnedCheckout,
+  resolveReviewPrepareCliEntryPath,
   reviewPrepareLogPath,
   reviewPrepareMarkerPath,
+  spawnReviewPrepareBackground,
 } from "./review-prepare";
 
 const COMMIT = "0123456789abcdef0123456789abcdef01234567";
@@ -175,6 +177,28 @@ describe("prepareReviewPinnedCheckout", () => {
 
     expect(result).toEqual({ prepared: false });
     expect(existsSync(reviewPrepareMarkerPath(checkoutPath))).toBe(false);
+  });
+
+  it("spawns background preparation gracefully without crashing", async () => {
+    const checkoutPath = await createCheckoutDir();
+    expect(() => {
+      spawnReviewPrepareBackground({
+        checkoutPath,
+        commit: COMMIT,
+        cliEntryPath: "/nonexistent/path/to/cli.js",
+      });
+    }).not.toThrow();
+  });
+
+  it("derives the CLI entry from a desktop server entry", () => {
+    expect(
+      resolveReviewPrepareCliEntryPath({
+        env: {
+          DEV_FAST_REVIEW_SERVER_ENTRY:
+            "/opt/review-runtime/dist/server/desktop-host.js",
+        },
+      }),
+    ).toBe("/opt/review-runtime/dist/cli.js");
   });
 
   it("runs real shell commands with the checkout as the cwd", async () => {

--- a/packages/progressive-review/src/review-prepare.ts
+++ b/packages/progressive-review/src/review-prepare.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import crypto from "node:crypto";
 import { readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
 
 import { withFileLock } from "./with-file-lock";
 
@@ -169,7 +170,7 @@ function formatPrepareFailure(input: {
   return `${base} Last output:\n${elided}${tail}${input.logNote}`;
 }
 
-async function markerMatches(
+export async function markerMatches(
   markerPath: string,
   expectedHash: string,
 ): Promise<boolean> {
@@ -179,6 +180,65 @@ async function markerMatches(
       return value.commandsHash === expectedHash;
     })
     .catch(() => false);
+}
+
+export interface SpawnReviewPrepareBackgroundInput {
+  checkoutPath: string;
+  commit: string;
+  cliEntryPath?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export function resolveReviewPrepareCliEntryPath(
+  input: Pick<SpawnReviewPrepareBackgroundInput, "cliEntryPath" | "env">,
+): string | undefined {
+  const configuredEntry =
+    input.cliEntryPath ??
+    input.env?.DEV_FAST_REVIEW_CLI_ENTRY_PATH ??
+    process.env.DEV_FAST_REVIEW_CLI_ENTRY_PATH;
+  if (configuredEntry) return configuredEntry;
+
+  const serverEntry =
+    input.env?.DEV_FAST_REVIEW_SERVER_ENTRY ??
+    process.env.DEV_FAST_REVIEW_SERVER_ENTRY;
+  if (serverEntry) {
+    return path.resolve(path.dirname(serverEntry), "..", "cli.js");
+  }
+
+  return process.argv[1];
+}
+
+export function spawnReviewPrepareBackground(
+  input: SpawnReviewPrepareBackgroundInput,
+): void {
+  const cliEntryPath = resolveReviewPrepareCliEntryPath(input);
+  if (!cliEntryPath) return;
+
+  try {
+    const child = spawn(
+      process.execPath,
+      [
+        cliEntryPath,
+        "prepare-worktree",
+        path.resolve(input.checkoutPath),
+        "--commit",
+        input.commit,
+      ],
+      {
+        cwd: input.checkoutPath,
+        detached: true,
+        env: {
+          ...(input.env ?? process.env),
+          DEV_FAST_REVIEW_CLI_NO_DELEGATE: "1",
+          ELECTRON_RUN_AS_NODE: "1",
+        },
+        stdio: "ignore",
+      },
+    );
+    child.unref();
+  } catch {
+    // Background preparation must never crash the caller.
+  }
 }
 
 function runPrepareShellCommand(

--- a/packages/progressive-review/src/review-publish-element-audit.ts
+++ b/packages/progressive-review/src/review-publish-element-audit.ts
@@ -2,8 +2,10 @@ import { z } from "zod";
 
 import {
   type CallStackDiffProps,
+  type TraceQuoteProps,
   callStackDiffPropsSchema,
   reviewAuthoringPropsSchemas,
+  traceQuotePropsSchema,
 } from "./authoring";
 
 // Publish-time element audit. The validation runtime's React substitute does
@@ -28,10 +30,12 @@ export interface PublishAuditElement {
 type AuthoringComponentName = keyof typeof reviewAuthoringPropsSchemas;
 
 function isAuditElement(value: unknown): value is PublishAuditElement {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
   return (
-    typeof value === "object" &&
-    value !== null &&
-    (value as Record<string, unknown>)[ELEMENT_MARKER] === true
+    obj[ELEMENT_MARKER] === true ||
+    obj.$$typeof === Symbol.for("react.element") ||
+    obj.$$typeof === Symbol.for("react.transitional.element")
   );
 }
 
@@ -157,6 +161,29 @@ export function createPublishValidationReact(): Record<string, unknown> {
   return react;
 }
 
+export interface PublishAuditTraceQuote {
+  sessionId: string;
+  trace?: string;
+  event?: number;
+  text: string;
+}
+
+export function extractAuditText(node: unknown): string {
+  if (node === null || node === undefined || typeof node === "boolean") {
+    return "";
+  }
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(extractAuditText).join("");
+  }
+  if (isAuditElement(node)) {
+    return extractAuditText(node.props.children);
+  }
+  return "";
+}
+
 export function auditReviewDocumentComponent(input: {
   Component: unknown;
   reportError: (message: string) => void;
@@ -164,6 +191,7 @@ export function auditReviewDocumentComponent(input: {
   // deleted and added lines; the audit is the one walk that sees each
   // element, so it hands the parsed props to the evaluation.
   collectCallStackDiff?: (props: CallStackDiffProps) => void;
+  collectTraceQuote?: (quote: PublishAuditTraceQuote) => void;
 }): void {
   if (typeof input.Component !== "function") return;
   const components = new Map<AuthoringComponentName, unknown>();
@@ -204,6 +232,18 @@ export function auditReviewDocumentComponent(input: {
         if (name === "CallStackDiff" && input.collectCallStackDiff) {
           const parsed = callStackDiffPropsSchema.safeParse(child.props);
           if (parsed.success) input.collectCallStackDiff(parsed.data);
+        }
+        if (name === "TraceQuote" && input.collectTraceQuote) {
+          const parsed = traceQuotePropsSchema.safeParse(child.props);
+          if (parsed.success) {
+            const text = extractAuditText(child.props.children);
+            input.collectTraceQuote({
+              sessionId: parsed.data.sessionId,
+              trace: parsed.data.trace,
+              event: parsed.data.event,
+              text,
+            });
+          }
         }
         walk(child.props.children, name);
         continue;

--- a/packages/progressive-review/src/review-publish-evaluate.test.ts
+++ b/packages/progressive-review/src/review-publish-evaluate.test.ts
@@ -2,8 +2,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { clearTraceEnvCache } from "./review-agent-traces";
 import {
   type ReviewPublishEvidenceTargets,
   evaluateReviewDocumentBundleForPublish,
@@ -89,6 +90,158 @@ describe("publish range evaluation", () => {
 
     expect(result).toMatchObject({ peekCount: 0, rangePeeks: [], errors: [] });
     expect(prepareEvidence).not.toHaveBeenCalled();
+  });
+
+  describe("TraceQuote validation", () => {
+    const sessionId = "72b3d130-2e72-41b6-8686-527a93d16647";
+    let mockR2Dir: string;
+
+    beforeEach(() => {
+      mockR2Dir = fixtureDir("mock-r2");
+      process.env.TRACE_R2_MODE = "mock";
+      process.env.TRACE_R2_MOCK_DIR = mockR2Dir;
+      process.env.REVIEW_TEST_TRACE_SEARCH_DIR = fixtureDir("trace-search");
+      clearTraceEnvCache();
+
+      const sessionDir = path.join(mockR2Dir, "by-session", sessionId);
+      fs.mkdirSync(sessionDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sessionDir, "meta.json"),
+        JSON.stringify({
+          session: sessionId,
+          repo: "acme/widgets",
+          branch: "main",
+          pr: null,
+          commits: [],
+          author: null,
+          ts: "2026-08-16T12:00:00Z",
+        }),
+      );
+      fs.writeFileSync(
+        path.join(sessionDir, "trace.jsonl"),
+        [
+          JSON.stringify({
+            type: "session",
+            id: sessionId,
+            cwd: "/repo",
+            timestamp: "2026-08-16T12:00:00Z",
+          }),
+          JSON.stringify({
+            type: "message",
+            timestamp: "2026-08-16T12:00:05Z",
+            message: { role: "user", content: "Optimize database queries" },
+          }),
+          JSON.stringify({
+            type: "message",
+            timestamp: "2026-08-16T12:01:00Z",
+            message: {
+              role: "assistant",
+              content: "I will rewrite the queries with batching.",
+            },
+          }),
+        ].join("\n"),
+      );
+    });
+
+    afterEach(() => {
+      delete process.env.TRACE_R2_MODE;
+      delete process.env.TRACE_R2_MOCK_DIR;
+      delete process.env.REVIEW_TEST_TRACE_SEARCH_DIR;
+      clearTraceEnvCache();
+    });
+
+    it("passes when quote text matches trace", async () => {
+      const reviewDir = fixtureDir("review");
+      const result = await evaluateReviewDocumentBundleForPublish({
+        reviewDir,
+        bundleCode: `
+          import React, {
+            createActiveReviewDocument,
+            createBrowserReviewDefinitionSession,
+          } from "review-doc-runtime";
+          const session = createBrowserReviewDefinitionSession({
+            softwareMap: null,
+            baseSoftwareMap: null,
+          });
+          await session.ready();
+          createActiveReviewDocument({
+            Component: ({ components }) => {
+              const TraceQuote = components.TraceQuote;
+              return React.createElement(
+                TraceQuote,
+                { sessionId: "${sessionId}" },
+                "Optimize database queries"
+              );
+            }
+          });
+        `,
+      });
+
+      expect(result.errors).toEqual([]);
+    });
+
+    it("fails when quote text is not found in trace", async () => {
+      const reviewDir = fixtureDir("review");
+      const result = await evaluateReviewDocumentBundleForPublish({
+        reviewDir,
+        bundleCode: `
+          import React, {
+            createActiveReviewDocument,
+            createBrowserReviewDefinitionSession,
+          } from "review-doc-runtime";
+          const session = createBrowserReviewDefinitionSession({
+            softwareMap: null,
+            baseSoftwareMap: null,
+          });
+          await session.ready();
+          createActiveReviewDocument({
+            Component: ({ components }) => {
+              const TraceQuote = components.TraceQuote;
+              return React.createElement(
+                TraceQuote,
+                { sessionId: "${sessionId}" },
+                "Nonexistent text that never happened"
+              );
+            }
+          });
+        `,
+      });
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toContain("not found in session");
+    });
+
+    it("emits warning when event hint is stale", async () => {
+      const reviewDir = fixtureDir("review");
+      const result = await evaluateReviewDocumentBundleForPublish({
+        reviewDir,
+        bundleCode: `
+          import React, {
+            createActiveReviewDocument,
+            createBrowserReviewDefinitionSession,
+          } from "review-doc-runtime";
+          const session = createBrowserReviewDefinitionSession({
+            softwareMap: null,
+            baseSoftwareMap: null,
+          });
+          await session.ready();
+          createActiveReviewDocument({
+            Component: ({ components }) => {
+              const TraceQuote = components.TraceQuote;
+              return React.createElement(
+                TraceQuote,
+                { sessionId: "${sessionId}", event: 99 },
+                "Optimize database queries"
+              );
+            }
+          });
+        `,
+      });
+
+      expect(result.errors).toEqual([]);
+      expect(result.warnings.length).toBeGreaterThan(0);
+      expect(result.warnings[0]).toContain("hint event={99} is stale");
+    });
   });
 
   function sourceFixture(source: string): string {

--- a/packages/progressive-review/src/review-publish-evaluate.ts
+++ b/packages/progressive-review/src/review-publish-evaluate.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url";
 
 import { init as initModuleLexer, parse as parseModule } from "es-module-lexer";
 
+import { extractTraceEventText } from "./agent-trace-parser";
 import {
   type CallStackDiffProps,
   type CodePeekProps,
@@ -20,7 +21,9 @@ import {
   callStackEvidenceErrors,
   diffCallStacks,
 } from "./call-stack-diff";
+import { loadReviewAgentTrace } from "./review-agent-traces";
 import {
+  type PublishAuditTraceQuote,
   auditReviewDocumentComponent,
   createPublishValidationReact,
 } from "./review-publish-element-audit";
@@ -88,6 +91,7 @@ export async function evaluateReviewDocumentBundleForPublish(input: {
   const failures: string[] = [];
   const rangePeeks: ReviewPublishRangePeek[] = [];
   const callStackProps: CallStackDiffProps[] = [];
+  const traceQuotes: PublishAuditTraceQuote[] = [];
   let peekCount = 0;
   let evidencePromise: Promise<ReviewPublishEvidenceTargets> | null = null;
   const sessions: ReviewDefinitionSession[] = [];
@@ -161,6 +165,9 @@ export async function evaluateReviewDocumentBundleForPublish(input: {
     },
     collectCallStackDiff: (props) => {
       callStackProps.push(props);
+    },
+    collectTraceQuote: (quote) => {
+      traceQuotes.push(quote);
     },
   });
 
@@ -241,15 +248,80 @@ export async function evaluateReviewDocumentBundleForPublish(input: {
     }
   }
 
+  // TraceQuote resolution: every quoted string is matched against the target
+  // normalized trace. Text found nowhere is a hard error; multiple matches
+  // without a deciding event hint emit a warning with the event index.
+  const traceQuoteWarnings: string[] = [];
+  if (traceQuotes.length > 0 && input.validateRanges !== false) {
+    const traceCwd = input.prepareEvidence
+      ? (await evidence()).head.sourceRootPath
+      : undefined;
+    for (const quote of traceQuotes) {
+      const cleanQuote = quote.text.trim();
+      if (!cleanQuote) {
+        failures.push(
+          `<TraceQuote> in session ${quote.sessionId} has empty quote text.`,
+        );
+        continue;
+      }
+      const loaded = await loadReviewAgentTrace({
+        sessionId: quote.sessionId,
+        trace: quote.trace,
+        cwd: traceCwd,
+      });
+      if (!loaded) {
+        failures.push(
+          `<TraceQuote> session ${quote.sessionId}${quote.trace ? ` (trace ${quote.trace})` : ""} has no normalized transcript.`,
+        );
+        continue;
+      }
+      const normQuote = cleanQuote.replace(/\s+/g, " ");
+      const matchingIndices: number[] = [];
+      for (let i = 0; i < loaded.trace.events.length; i++) {
+        const ev = loaded.trace.events[i];
+        const text = extractTraceEventText(ev).replace(/\s+/g, " ");
+        if (text.includes(normQuote)) {
+          matchingIndices.push(i);
+        }
+      }
+      const quoteLabel =
+        cleanQuote.length > 40 ? `${cleanQuote.slice(0, 39)}…` : cleanQuote;
+      if (matchingIndices.length === 0) {
+        failures.push(
+          `<TraceQuote> text "${quoteLabel}" not found in session ${quote.sessionId}${quote.trace ? ` (trace ${quote.trace})` : ""}.`,
+        );
+      } else if (quote.event !== undefined) {
+        if (!matchingIndices.includes(quote.event)) {
+          if (matchingIndices.length === 1) {
+            traceQuoteWarnings.push(
+              `<TraceQuote> text "${quoteLabel}" hint event={${quote.event}} is stale; matched event ${matchingIndices[0]}.`,
+            );
+          } else {
+            traceQuoteWarnings.push(
+              `<TraceQuote> text "${quoteLabel}" matched multiple events (${matchingIndices.join(", ")}). Update hint to event={${matchingIndices[0]}} to disambiguate.`,
+            );
+          }
+        }
+      } else if (matchingIndices.length > 1) {
+        traceQuoteWarnings.push(
+          `<TraceQuote> text "${quoteLabel}" matched multiple events (${matchingIndices.join(", ")}). Add event={${matchingIndices[0]}} to disambiguate.`,
+        );
+      }
+    }
+  }
+
   const errors =
     failures.length > 0
       ? failures
       : importError !== null
         ? [errorMessage(importError)]
         : [];
-  const warnings = sessions.flatMap((session) =>
-    session.diagnostics.map((diagnostic) => diagnostic.message),
-  );
+  const warnings = [
+    ...sessions.flatMap((session) =>
+      session.diagnostics.map((diagnostic) => diagnostic.message),
+    ),
+    ...traceQuoteWarnings,
+  ];
   return {
     peekCount,
     rangePeeks,
@@ -319,6 +391,7 @@ function validationRuntimeExports(input: {
   ) => Promise<CodePeekResolution>;
   reportAuditError: (message: string) => void;
   collectCallStackDiff: (props: CallStackDiffProps) => void;
+  collectTraceQuote: (quote: PublishAuditTraceQuote) => void;
 }): Record<string, unknown> {
   const noop = () => undefined;
   // The React substitute is not inert: `jsx` builds element records so the
@@ -355,6 +428,7 @@ function validationRuntimeExports(input: {
         Component: document.Component,
         reportError: input.reportAuditError,
         collectCallStackDiff: input.collectCallStackDiff,
+        collectTraceQuote: input.collectTraceQuote,
       });
       return document;
     },

--- a/packages/progressive-review/src/review-scaffold.ts
+++ b/packages/progressive-review/src/review-scaffold.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   changeIdentityForRevision,
   currentHead,
+  devfastPrepareCommands,
   diffNameStatusTrees,
   mergeBase,
   resolveRevision,
@@ -13,6 +14,7 @@ import {
   authoringSessionKey,
   resolveAuthoringSessionRef,
 } from "./authoring-session";
+import { listReviewTraceSessions } from "./review-agent-traces";
 import { isPositionalChangeIdentity } from "./review-change-scope";
 import { removeReviewManagedCheckouts } from "./review-head-checkout";
 import {
@@ -47,6 +49,15 @@ export interface RunReviewScaffoldInput {
   update?: boolean;
   reviewUuid?: string;
   newReview?: boolean;
+  background?: boolean;
+}
+
+// Scaffold's event carries the pinned commits and the managed checkout paths
+// so the authoring agent never has to know the on-disk layout. A checkout is
+// null only when its eager materialization degraded to a warning.
+export interface ReviewScaffoldEvent extends ReviewInfoEvent {
+  pins?: { baseCommit: string; sourceCommit: string };
+  checkouts?: { head: string | null; base: string | null };
 }
 
 /**
@@ -56,7 +67,7 @@ export interface RunReviewScaffoldInput {
  */
 export async function runReviewScaffold(
   input: RunReviewScaffoldInput,
-): Promise<ReviewInfoEvent> {
+): Promise<ReviewScaffoldEvent> {
   if (input.update) {
     const existing = await findUpdateTarget(input.cwd, input.reviewUuid);
     if (existing) return repinReview(existing, input);
@@ -66,7 +77,7 @@ export async function runReviewScaffold(
 
 async function createReview(
   input: RunReviewScaffoldInput,
-): Promise<ReviewInfoEvent> {
+): Promise<ReviewScaffoldEvent> {
   const source = await resolveReviewSource(input);
   if (!source.subject.headRef) {
     throw new Error("Review scaffold requires a resolved source head.");
@@ -113,6 +124,7 @@ async function createReview(
     headCommit: sourceCommit,
     baseCommit,
     progress: input.progress,
+    background: input.background,
   });
   const invokingAgent = resolveAuthoringSessionRef(input.env ?? process.env);
   let sourceAgentSession: string | null = null;
@@ -151,7 +163,24 @@ async function createReview(
     await deleteReviewSourceHeadRef(source.reviewRoot, sourceHeadRef);
     throw error;
   }
-  const event = await reviewInfoEvent([created]);
+  try {
+    const traceSessions = await listReviewTraceSessions({
+      rootPath: source.reviewRoot,
+      baseCommit,
+      headCommit: sourceCommit,
+    });
+    reportTraceSessionsProgress(traceSessions, input.progress);
+  } catch {
+    // Ignore trace resolution errors
+  }
+  const event: ReviewScaffoldEvent = {
+    ...(await reviewInfoEvent([created])),
+    pins: { baseCommit, sourceCommit },
+    checkouts: {
+      head: setup.headRootPath ?? null,
+      base: setup.baseRootPath ?? null,
+    },
+  };
   return setup.warnings.length > 0
     ? { ...event, warnings: setup.warnings }
     : event;
@@ -165,7 +194,7 @@ async function createReview(
 export async function repinReview(
   review: StoredReview,
   input: RunReviewScaffoldInput,
-): Promise<ReviewInfoEvent> {
+): Promise<ReviewScaffoldEvent> {
   const root = review.review.worktreePath;
   const uuid = review.review.uuid;
   const oldHeadCommit = review.review.sourceCommit;
@@ -210,6 +239,7 @@ export async function repinReview(
     headCommit: sourceCommit,
     baseCommit,
     progress: input.progress,
+    background: input.background,
   });
   const invokingAgent = resolveAuthoringSessionRef(input.env ?? process.env);
   let sourceSession = DISABLED_REVIEW_SOURCE_SESSION;
@@ -250,10 +280,53 @@ export async function repinReview(
       "Pins moved under a published revision. Publish again to present the new commits.",
     );
   }
-  const event = await reviewInfoEvent([updated]);
+  try {
+    const traceSessions = await listReviewTraceSessions({
+      rootPath: root,
+      baseCommit,
+      headCommit: sourceCommit,
+    });
+    reportTraceSessionsProgress(traceSessions, input.progress);
+  } catch {
+    // Ignore trace resolution errors
+  }
+  const event: ReviewScaffoldEvent = {
+    ...(await reviewInfoEvent([updated])),
+    pins: { baseCommit, sourceCommit },
+    checkouts: {
+      head: setup.headRootPath ?? null,
+      base: setup.baseRootPath ?? null,
+    },
+  };
   return setup.warnings.length > 0
     ? { ...event, warnings: setup.warnings }
     : event;
+}
+
+function reportTraceSessionsProgress(
+  sessions: import("@dev.fast/review-protocol").ReviewAgentTraceSession[],
+  progress?: (message: string) => void,
+): void {
+  if (!progress) return;
+  if (sessions.length === 0) {
+    progress("Sessions: none recorded for this change range");
+    return;
+  }
+  progress("Sessions:");
+  for (const s of sessions) {
+    const shortId =
+      s.sessionId.length > 8 ? `${s.sessionId.slice(0, 8)}…` : s.sessionId;
+    const harness =
+      s.harness === "claude-code"
+        ? "Claude Code"
+        : s.harness === "codex"
+          ? "Codex"
+          : s.harness === "pi"
+            ? "Pi"
+            : "unknown";
+    const syncLabel = s.available ? "[R2 synced]" : "[not synced]";
+    progress(`  ${shortId} (${harness})  ${syncLabel}`);
+  }
 }
 
 async function rejectDuplicateActiveReviews(
@@ -346,35 +419,58 @@ async function materializeReviewSetup(input: {
   headCommit: string;
   baseCommit?: string;
   progress?: (message: string) => void;
-}): Promise<{ warnings: string[]; headRootPath?: string }> {
+  background?: boolean;
+}): Promise<{
+  warnings: string[];
+  headRootPath?: string;
+  baseRootPath?: string;
+}> {
   const warnings: string[] = [];
-  let headRootPath: string | undefined;
+  const prepareCommands = await devfastPrepareCommands(input.reviewRoot).catch(
+    () => [] as string[],
+  );
+  if (prepareCommands.length === 0) {
+    warnings.push(
+      "devfast.prepare is not configured. Configure it (git config devfast.prepare '<command>') and run `review scaffold --update` to prepare pinned worktrees.",
+    );
+  }
   const pins = [
-    { role: "head", commit: input.headCommit },
+    { role: "head" as const, commit: input.headCommit },
     ...(input.baseCommit && input.baseCommit !== input.headCommit
-      ? [{ role: "base", commit: input.baseCommit }]
+      ? [{ role: "base" as const, commit: input.baseCommit }]
       : []),
   ];
   for (const pin of pins) {
     input.progress?.(
       `Review scaffold prepares the pinned-${pin.role} worktree.`,
     );
-    try {
-      const checkoutPath = await ensurePinnedReviewWorktreeAtCommit({
-        repoRoot: input.reviewRoot,
-        commit: pin.commit,
-        reviewUuid: input.uuid,
-        role: pin.role as "head" | "base",
-        warning: (message) => warnings.push(message),
-      });
-      if (pin.role === "head") headRootPath = checkoutPath;
-    } catch (error) {
-      warnings.push(
-        `Pinned-${pin.role} worktree creation failed. Review will retry it: ${formatError(error)}`,
-      );
-    }
   }
-  return { warnings: [...new Set(warnings)], headRootPath };
+  const results = await Promise.all(
+    pins.map(async (pin) => {
+      try {
+        const checkoutPath = await ensurePinnedReviewWorktreeAtCommit({
+          repoRoot: input.reviewRoot,
+          commit: pin.commit,
+          reviewUuid: input.uuid,
+          role: pin.role,
+          warning: (message) => warnings.push(message),
+          background: input.background,
+        });
+        return { role: pin.role, checkoutPath };
+      } catch (error) {
+        warnings.push(
+          `Pinned-${pin.role} worktree creation failed. Review will retry it: ${formatError(error)}`,
+        );
+        return { role: pin.role, checkoutPath: undefined };
+      }
+    }),
+  );
+  const headRootPath = results.find((r) => r.role === "head")?.checkoutPath;
+  const baseRootPath =
+    !input.baseCommit || input.baseCommit === input.headCommit
+      ? headRootPath
+      : results.find((r) => r.role === "base")?.checkoutPath;
+  return { warnings: [...new Set(warnings)], headRootPath, baseRootPath };
 }
 
 async function reportRangeStaleness(input: {

--- a/packages/progressive-review/src/review-worktree-target.ts
+++ b/packages/progressive-review/src/review-worktree-target.ts
@@ -14,7 +14,13 @@ import {
   type StoredReviewRecord,
   safeParseStoredReviewRecord,
 } from "./review-home";
-import { prepareReviewPinnedCheckout } from "./review-prepare";
+import {
+  markerMatches,
+  prepareReviewPinnedCheckout,
+  reviewPrepareCommandsHash,
+  reviewPrepareMarkerPath,
+  spawnReviewPrepareBackground,
+} from "./review-prepare";
 import {
   type ReviewCheckoutRole,
   reviewManagedCheckoutDir,
@@ -102,13 +108,19 @@ export async function prepareReviewSourceTargetForRef(input: {
   return { ref, sourceRootPath };
 }
 
-export async function ensurePinnedReviewWorktreeAtCommit(input: {
+export interface EnsurePinnedReviewWorktreeInput {
   repoRoot: string;
   commit: string;
   reviewUuid: string;
   role: ReviewCheckoutRole;
   warning?: (message: string) => void;
-}): Promise<string> {
+  background?: boolean;
+  cliEntryPath?: string;
+}
+
+export async function ensurePinnedReviewWorktreeAtCommit(
+  input: EnsurePinnedReviewWorktreeInput,
+): Promise<string> {
   const sourceRootPath = await span(
     "ensureReviewPinnedCheckout",
     () =>
@@ -132,6 +144,25 @@ export async function ensurePinnedReviewWorktreeAtCommit(input: {
   if (commands.length === 0) {
     return sourceRootPath;
   }
+
+  const markerPath = reviewPrepareMarkerPath(sourceRootPath);
+  const expectedHash = reviewPrepareCommandsHash(commands);
+  const alreadyPrepared = await markerMatches(markerPath, expectedHash).catch(
+    () => false,
+  );
+  if (alreadyPrepared) {
+    return sourceRootPath;
+  }
+
+  if (input.background !== false) {
+    spawnReviewPrepareBackground({
+      checkoutPath: sourceRootPath,
+      commit: input.commit,
+      cliEntryPath: input.cliEntryPath,
+    });
+    return sourceRootPath;
+  }
+
   await span(
     "prepareReviewPinnedCheckout",
     () =>

--- a/packages/progressive-review/src/server/cli-install.test.ts
+++ b/packages/progressive-review/src/server/cli-install.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -6,8 +6,11 @@ import type { ReviewCliInstallStamp } from "@dev.fast/review-protocol";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  applyCliInstall,
   cliInstallStampPath,
   readCliInstallStamp,
+  removeCliInstall,
+  resolveCliInstallStatus,
   skipCliInstall,
 } from "./cli-install";
 import { writePrivateJsonAtomic } from "./desktop-paths";
@@ -50,6 +53,57 @@ describe("skipCliInstall", () => {
       );
     },
   );
+});
+
+describe("trace capture installation", () => {
+  it("uses the shared installer and keeps credentials when disabled", async () => {
+    const homeDir = await mkdtemp(path.join(tmpdir(), "review-trace-install-"));
+    temporaryDirectories.push(homeDir);
+    const env: NodeJS.ProcessEnv = {
+      DEV_REVIEW_HOME: path.join(homeDir, ".dev"),
+      TRACE_ENV_FILE: path.join(homeDir, "trace.env"),
+      TRACE_SETTINGS_FILE: path.join(homeDir, "trace-settings.json"),
+      TRACE_R2_MODE: "mock",
+    };
+    const packageRoot = path.resolve(import.meta.dirname, "../..");
+
+    const applied = await applyCliInstall({
+      packageRoot,
+      targets: [],
+      homeDir,
+      env,
+      trace: {
+        endpoint: "mock://endpoint",
+        bucket: "mock-bucket",
+        key: "mock-key-id",
+        secret: "mock-secret-value",
+      },
+    });
+
+    expect(applied.code).toBe(0);
+    const status = await resolveCliInstallStatus({ packageRoot, homeDir, env });
+    expect(status.trace).toMatchObject({
+      enabled: true,
+      configured: true,
+      autoActivateRepositories: true,
+      accessKeyIdPrefix: "mock-k",
+    });
+    expect(JSON.stringify(status)).not.toContain("mock-secret-value");
+    expect(status.stamp?.traceManaged).toBe(true);
+
+    await removeCliInstall({ targets: [], trace: true, homeDir, env });
+
+    const disabled = await resolveCliInstallStatus({
+      packageRoot,
+      homeDir,
+      env,
+    });
+    expect(disabled.trace.enabled).toBe(false);
+    expect(disabled.trace.configured).toBe(true);
+    expect(await readFile(env.TRACE_ENV_FILE!, "utf8")).toContain(
+      "mock-secret-value",
+    );
+  });
 });
 
 async function isolatedEnvironment(): Promise<NodeJS.ProcessEnv> {

--- a/packages/progressive-review/src/server/cli-install.ts
+++ b/packages/progressive-review/src/server/cli-install.ts
@@ -17,8 +17,22 @@ import {
   type ReviewCliInstallStamp,
   ReviewCliInstallStampSchema,
   type ReviewCliInstallStatus,
+  type ReviewFffInstallTarget,
+  type ReviewFffManagedRegistration,
 } from "@dev.fast/review-protocol";
 
+import {
+  FFF_SERVER_NAME,
+  FFF_TARGETS,
+  fffBinaryPath,
+  fffCorpusRoot,
+  fffRegistration,
+  fffRegistrationMatches,
+  isFffTarget,
+  readFffRegistration,
+  removeFffRegistration,
+} from "../agent-fff";
+import { removeAgentTraceHook } from "../agent-trace-hooks";
 import {
   ALL_INSTALL_TARGETS,
   type InstallTarget,
@@ -27,14 +41,20 @@ import {
   runInstall,
 } from "../install";
 import { readProgressiveReviewPackageVersion } from "../package-paths";
+import {
+  type TraceCredentialsInput,
+  disableTraceMachine,
+  traceMachineStatus,
+} from "../trace-machine-setup";
+import { disableAllTraceRepositories } from "../trace-repository-hooks";
 import { reviewDesktopStateDir, writePrivateJsonAtomic } from "./desktop-paths";
 
 const AGENT_HOME_DIR: Record<InstallTarget, string> = {
   claude: ".claude",
   codex: ".codex",
   cursor: ".cursor",
+  pi: ".pi",
 };
-
 export function cliInstallStampPath(
   env: NodeJS.ProcessEnv = process.env,
 ): string {
@@ -52,15 +72,35 @@ export async function resolveCliInstallStatus(input: {
 }): Promise<ReviewCliInstallStatus> {
   const homeDir = input.homeDir ?? os.homedir();
   const env = input.env ?? process.env;
-  const [present, installed, fingerprint, stamp] = await Promise.all([
+  const [present, installed, fingerprint, stamp, trace] = await Promise.all([
     detectPresentAgents(homeDir),
     detectInstalledTargets(homeDir),
     installFingerprint(input.packageRoot),
     readCliInstallStamp(cliInstallStampPath(env)),
+    traceMachineStatus({ homeDir, env }),
   ]);
   const installedSet = new Set(installed);
   const shimPath = pathShimPath(homeDir);
   const cliPath = path.join(input.packageRoot, "dist", "cli.js");
+  const fffBinary = fffBinaryPath(homeDir);
+  const fffCorpus = fffCorpusRoot(homeDir);
+  const fffRegistrations = await Promise.all(
+    FFF_TARGETS.map(async (target) => {
+      const current = await readFffRegistration(target, homeDir, env);
+      const managedRecord = stamp?.fffRegistrations?.find(
+        (registration) => registration.target === target,
+      );
+      return {
+        target,
+        present: current.present,
+        managed: Boolean(
+          current.present &&
+          managedRecord &&
+          fffRegistrationMatches(current.output, managedRecord),
+        ),
+      };
+    }),
+  );
   return {
     agents: ALL_INSTALL_TARGETS.map((target) => ({
       target,
@@ -78,6 +118,13 @@ export async function resolveCliInstallStatus(input: {
           (entry) => entry && path.resolve(entry) === path.dirname(shimPath),
         ),
     },
+    fff: {
+      serverName: FFF_SERVER_NAME,
+      corpusRoot: fffCorpus,
+      binary: { path: fffBinary, installed: await isFile(fffBinary) },
+      registrations: fffRegistrations,
+    },
+    trace,
     cli: (await isFile(cliPath))
       ? {
           path: cliPath,
@@ -93,6 +140,8 @@ export async function applyCliInstall(input: {
   packageRoot: string;
   targets: InstallTarget[];
   shim?: boolean;
+  fff?: boolean;
+  trace?: true | TraceCredentialsInput;
   cliPath?: string;
   cliRuntimePath?: string;
   homeDir?: string;
@@ -104,11 +153,36 @@ export async function applyCliInstall(input: {
   const sink = {
     write: (chunk: string) => (chunks.push(chunk), true),
   } as NodeJS.WriteStream;
-  if (input.targets.length > 0) {
+  const fffTargets = input.fff ? input.targets.filter(isFffTarget) : [];
+  const fffPresentBefore = new Map(
+    await Promise.all(
+      fffTargets.map(
+        async (target) =>
+          [
+            target,
+            (await readFffRegistration(target, homeDir, env)).present,
+          ] as const,
+      ),
+    ),
+  );
+  if (input.targets.length > 0 || input.trace !== undefined) {
     const code = await runInstall({
       targets: input.targets,
       homeDir,
       packageRoot: input.packageRoot,
+      env,
+      fff: input.fff,
+      reviewCommand:
+        input.shim || (await isFile(pathShimPath(homeDir)))
+          ? pathShimPath(homeDir)
+          : "review",
+      ...(input.trace !== undefined
+        ? {
+            trace: {
+              credentials: input.trace === true ? undefined : input.trace,
+            },
+          }
+        : {}),
       stdout: sink,
       stderr: sink,
     });
@@ -128,6 +202,17 @@ export async function applyCliInstall(input: {
     chunks.push(`[ok] review command -> ${shimPath}\n`);
   }
 
+  const createdFffRegistrations: ReviewFffManagedRegistration[] = [];
+  for (const target of fffTargets) {
+    if (fffPresentBefore.get(target)) continue;
+    const current = await readFffRegistration(target, homeDir, env);
+    if (current.present) {
+      createdFffRegistrations.push(
+        fffRegistration(target, fffBinaryPath(homeDir), fffCorpusRoot(homeDir)),
+      );
+    }
+  }
+
   // The stamp is cumulative app-managed state: installing skills for one
   // agent must not drop other stamped agents or the command from re-sync.
   const previous = await readCliInstallStamp(cliInstallStampPath(env));
@@ -135,12 +220,28 @@ export async function applyCliInstall(input: {
     previous?.consent === "granted" ? (previous.targets ?? []) : [];
   const previousShimPath =
     previous?.consent === "granted" ? previous.shimPath : undefined;
+  const previousFffRegistrations =
+    previous?.consent === "granted" ? (previous.fffRegistrations ?? []) : [];
+  const createdFffTargets = new Set(
+    createdFffRegistrations.map((registration) => registration.target),
+  );
+  const fffRegistrations = [
+    ...previousFffRegistrations.filter(
+      (registration) => !createdFffTargets.has(registration.target),
+    ),
+    ...createdFffRegistrations,
+  ];
   const stampShimPath = shimPath ?? previousShimPath;
+  const traceManaged =
+    input.trace !== undefined ||
+    (previous?.consent === "granted" && previous.traceManaged === true);
   await writePrivateJsonAtomic(cliInstallStampPath(env), {
     consent: "granted",
     fingerprint: await installFingerprint(input.packageRoot),
     targets: [...new Set([...previousTargets, ...input.targets])],
     ...(stampShimPath ? { shimPath: stampShimPath } : {}),
+    ...(fffRegistrations.length > 0 ? { fffRegistrations } : {}),
+    ...(traceManaged ? { traceManaged: true } : {}),
     updatedAt: new Date().toISOString(),
   } satisfies ReviewCliInstallStamp);
   return {
@@ -182,6 +283,8 @@ const SHIM_MARKER = "Managed by Review Desktop";
 export async function removeCliInstall(input: {
   targets: InstallTarget[];
   shim?: boolean;
+  fff?: boolean;
+  trace?: boolean;
   homeDir?: string;
   env?: NodeJS.ProcessEnv;
 }): Promise<{ output: string }> {
@@ -190,6 +293,9 @@ export async function removeCliInstall(input: {
   const chunks: string[] = [];
   for (const target of input.targets) {
     await removeInstalledSkills(target, homeDir);
+    if (target === "claude" || target === "codex" || target === "pi") {
+      await removeAgentTraceHook(target, homeDir);
+    }
     chunks.push(`[ok] removed skills for ${target}\n`);
   }
 
@@ -208,18 +314,62 @@ export async function removeCliInstall(input: {
     }
   }
 
+  if (input.trace) {
+    await disableAllTraceRepositories(homeDir);
+    await disableTraceMachine({ homeDir, env });
+    chunks.push("[ok] disabled Review trace capture\n");
+  }
+
   const previous = await readCliInstallStamp(cliInstallStampPath(env));
+  const removedFffTargets = new Set<ReviewFffInstallTarget>();
+  const fffRemovalTargets = input.fff ? input.targets.filter(isFffTarget) : [];
+  if (fffRemovalTargets.length > 0 && previous?.consent === "granted") {
+    for (const target of fffRemovalTargets) {
+      const managed = previous.fffRegistrations?.find(
+        (registration) => registration.target === target,
+      );
+      if (!managed) {
+        chunks.push(
+          `The ${target} ${FFF_SERVER_NAME} registration is not managed by Review Desktop; left in place.\n`,
+        );
+        continue;
+      }
+      const current = await readFffRegistration(target, homeDir, env);
+      if (
+        !current.present ||
+        !fffRegistrationMatches(current.output, managed)
+      ) {
+        chunks.push(
+          `The ${target} ${FFF_SERVER_NAME} registration changed after installation; left in place.\n`,
+        );
+        removedFffTargets.add(target);
+        continue;
+      }
+      const result = await removeFffRegistration(target, homeDir, env);
+      if (!result.ok) {
+        chunks.push(result.output);
+        return { output: chunks.join("") };
+      }
+      chunks.push(`[ok] removed ${target} FFF integration\n`);
+      removedFffTargets.add(target);
+    }
+  }
   if (previous?.consent === "granted") {
     const removed = new Set(input.targets);
     const targets = (previous.targets ?? []).filter(
       (target) => !removed.has(target),
     );
     const shimPath = input.shim ? undefined : previous.shimPath;
+    const fffRegistrations = (previous.fffRegistrations ?? []).filter(
+      (registration) => !removedFffTargets.has(registration.target),
+    );
     await writePrivateJsonAtomic(cliInstallStampPath(env), {
       consent: "granted",
       ...(previous.fingerprint ? { fingerprint: previous.fingerprint } : {}),
       targets,
       ...(shimPath ? { shimPath } : {}),
+      ...(fffRegistrations.length > 0 ? { fffRegistrations } : {}),
+      ...(!input.trace && previous.traceManaged ? { traceManaged: true } : {}),
       updatedAt: new Date().toISOString(),
     } satisfies ReviewCliInstallStamp);
   }

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -657,6 +657,8 @@ export function createGlobalReviewServer(
       packageRoot: input.packageRoot,
       targets: request.targets,
       ...(request.shim ? { shim: true } : {}),
+      ...(request.fff ? { fff: true } : {}),
+      ...(request.trace !== undefined ? { trace: request.trace } : {}),
       ...(discovery.cliPath ? { cliPath: discovery.cliPath } : {}),
       ...(discovery.cliRuntimePath
         ? { cliRuntimePath: discovery.cliRuntimePath }
@@ -675,6 +677,8 @@ export function createGlobalReviewServer(
     const result = await removeCliInstall({
       targets: request.targets,
       ...(request.shim ? { shim: true } : {}),
+      ...(request.fff ? { fff: true } : {}),
+      ...(request.trace ? { trace: true } : {}),
     });
     return globalJson(200, { ok: true, output: result.output });
   });
@@ -1720,6 +1724,7 @@ export function createGlobalReviewServer(
 
 function reviewSourceKind(review: ReviewRecord): ProgressiveReviewSourceKind {
   if (review.pullRequestNumber) return "pull_request";
+  if (review.sourceIdentity?.kind === "git-commit") return "git_commit";
   if (review.sourceIdentity?.kind === "jj-bookmark") return "jj_bookmark";
   if (review.sourceIdentity?.kind === "jj-change") return "jj_change";
   return "git_branch";
@@ -1755,7 +1760,7 @@ function parseInfoRequest(value: unknown): RunReviewInfoInput {
     throw new HttpJsonError("Info request must be an object.", 400);
   }
   const input = value as Record<string, unknown>;
-  const allowed = new Set(["cwd", "all"]);
+  const allowed = new Set(["cwd", "all", "reviewUuid"]);
   if (Object.keys(input).some((key) => !allowed.has(key))) {
     throw new HttpJsonError("Info request has unexpected fields.", 400);
   }
@@ -1765,9 +1770,21 @@ function parseInfoRequest(value: unknown): RunReviewInfoInput {
   if (input.all !== undefined && typeof input.all !== "boolean") {
     throw new HttpJsonError("Info all must be boolean.", 400);
   }
+  if (
+    input.reviewUuid !== undefined &&
+    (typeof input.reviewUuid !== "string" || !input.reviewUuid.trim())
+  ) {
+    throw new HttpJsonError("Info reviewUuid must be a non-empty string.", 400);
+  }
+  if (input.all === true && input.reviewUuid !== undefined) {
+    throw new HttpJsonError("Info all and reviewUuid cannot be combined.", 400);
+  }
   return {
     cwd: input.cwd,
     ...(input.all ? { all: true } : {}),
+    ...(typeof input.reviewUuid === "string"
+      ? { reviewUuid: input.reviewUuid.trim() }
+      : {}),
   };
 }
 

--- a/packages/progressive-review/src/server/review-api-parsers.test.ts
+++ b/packages/progressive-review/src/server/review-api-parsers.test.ts
@@ -280,7 +280,7 @@ describe("parseReviewTabTelemetryInput", () => {
         reason: "route_change",
         app_session_id: "../review",
       }),
-    ).toThrow("tab must be review, map, or files");
+    ).toThrow("tab must be review, commits, map, files, or trace");
   });
 });
 

--- a/packages/progressive-review/src/server/review-api-parsers.ts
+++ b/packages/progressive-review/src/server/review-api-parsers.ts
@@ -123,8 +123,8 @@ export const ReviewSubmissionInputSchema = z.strictObject({
 
 export const ReviewTabTelemetryInputSchema = z
   .strictObject({
-    tab: z.enum(["review", "map", "files"], {
-      error: "must be review, map, or files",
+    tab: z.enum(["review", "commits", "map", "files", "trace"], {
+      error: "must be review, commits, map, files, or trace",
     }),
     reason: z.enum(["tab_change", "visibility_hidden", "pagehide", "unmount"], {
       error: "must be tab_change, visibility_hidden, pagehide, or unmount",

--- a/packages/progressive-review/src/server/review-api.ts
+++ b/packages/progressive-review/src/server/review-api.ts
@@ -30,6 +30,11 @@ import { mergeErrorTelemetryProperties } from "../error-telemetry";
 import { NativeMessageMirror } from "../native-agent/native-message-mirror";
 import type { ReviewThreadAgentBinding } from "../native-agent/native-session";
 import { NativeReviewTurnLauncher } from "../native-agent/native-turn-launcher";
+import {
+  isTraceR2Configured,
+  listReviewTraceSessions,
+  loadReviewAgentTrace,
+} from "../review-agent-traces";
 import { reviewCommentPrompt } from "../review-comment-agent";
 import { resolveReviewCommitScope } from "../review-commits";
 import type { ReviewDiffFile } from "../review-diff-files";
@@ -385,9 +390,78 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   app.get("/document-meta", route(documentMeta));
   app.post("/diff-files", route(diffFiles));
   app.get("/file-content", route(fileContent));
+  app.get("/agent-traces", route(agentTraces));
+  app.get("/agent-traces/:sessionId", route(agentTraceDetail));
   app.notFound(() =>
     reviewApiJsonResponse(404, { ok: false, error: "not found" }),
   );
+
+  async function resolveTraceSessionDescriptors() {
+    const review = readReviewStoreRecord(reviewRootPath);
+    const repoRootPath = resolveReviewRepoRootFromStore(reviewRootPath);
+    const headCommit = review.sourceCommit ?? review.baseCommit;
+    return listReviewTraceSessions({
+      rootPath: repoRootPath,
+      baseCommit: review.baseCommit,
+      headCommit,
+    });
+  }
+
+  async function agentTraces(): Promise<Response> {
+    const sessions = await resolveTraceSessionDescriptors();
+    return reviewApiJsonResponse(200, {
+      ok: true,
+      configured: isTraceR2Configured(),
+      sessions,
+    });
+  }
+
+  async function agentTraceDetail(
+    context: Context<ReviewHonoEnv>,
+  ): Promise<Response> {
+    const sessionId = context.req.param("sessionId");
+    if (!sessionId) {
+      return reviewApiJsonResponse(404, {
+        ok: false,
+        error: "Session is required.",
+      });
+    }
+    const trace =
+      new URL(context.req.url).searchParams.get("trace") ?? undefined;
+    const repoRootPath = resolveReviewRepoRootFromStore(reviewRootPath);
+    const loaded = await loadReviewAgentTrace({
+      sessionId,
+      trace,
+      cwd: repoRootPath,
+    });
+    if (!loaded) {
+      return reviewApiJsonResponse(404, {
+        ok: false,
+        error: `Trace not found for session ${sessionId}${trace ? ` (subagent ${trace})` : ""}.`,
+      });
+    }
+    const {
+      parserVersion,
+      descriptor,
+      trace: parsedTrace,
+      subagents,
+      traceName,
+    } = loaded;
+    return reviewApiJsonResponse(200, {
+      ok: true,
+      parserVersion,
+      session: descriptor,
+      trace: traceName,
+      subagents,
+      title: parsedTrace.title,
+      startedAt: parsedTrace.startedAt,
+      endedAt: parsedTrace.endedAt,
+      activeMs: parsedTrace.activeMs,
+      userTurns: parsedTrace.userTurns,
+      toolCalls: parsedTrace.toolCalls,
+      events: parsedTrace.events,
+    });
+  }
 
   async function telemetryTab(
     context: Context<ReviewHonoEnv>,

--- a/packages/progressive-review/src/server/review-info.ts
+++ b/packages/progressive-review/src/server/review-info.ts
@@ -1,7 +1,12 @@
 import path from "node:path";
 
-import { actionableReviewsForCheckout } from "../review-change-scope";
-import { type StoredReview, computeSync, listReviews } from "../review-home";
+import { reviewMatchesCheckout } from "../review-change-scope";
+import {
+  type StoredReview,
+  computeSync,
+  findReview,
+  listReviews,
+} from "../review-home";
 import { type ReviewInfoEvent, type RunReviewInfoInput } from "../review-info";
 import { readReviewComments } from "../review-state-store";
 import { resolveReviewRoot } from "../runtime";
@@ -10,6 +15,14 @@ import { resolveReviewRepositoryIdentity } from "./repository-identity";
 export async function resolveReviewInfo(
   input: RunReviewInfoInput,
 ): Promise<ReviewInfoEvent> {
+  if (input.all && input.reviewUuid) {
+    throw new Error("Review info cannot combine all and reviewUuid.");
+  }
+  if (input.reviewUuid) {
+    const review = await findReview(input.reviewUuid);
+    if (!review) throw new Error(`Review not found: ${input.reviewUuid}`);
+    return reviewInfoEvent([review]);
+  }
   const reviewRoot = await resolveReviewRoot(input.cwd);
   const repository = await resolveReviewRepositoryIdentity(reviewRoot);
   const filter = input.all
@@ -23,7 +36,11 @@ export async function resolveReviewInfo(
   }
   const reviews = input.all
     ? listed.reviews
-    : await actionableReviewsForCheckout(listed.reviews, reviewRoot);
+    : listed.reviews.filter(
+        (stored) =>
+          stored.review.status !== "accepted" &&
+          stored.review.status !== "rejected",
+      );
   return reviewInfoEvent(reviews);
 }
 
@@ -33,15 +50,22 @@ export async function reviewInfoEvent(
   return {
     event: "info",
     reviews: await Promise.all(
-      reviews.map(async (stored) => ({
-        uuid: stored.review.uuid,
-        dir: stored.dir,
-        change: stored.review.sourceIdentity?.name ?? null,
-        inSync: await computeSync(stored.review, stored.review.worktreePath),
-        unresolvedComments: countUnresolvedComments(stored.dir),
-        status: stored.review.status,
-        title: stored.review.title,
-      })),
+      reviews.map(async (stored) => {
+        const [inSync, matchesCheckout] = await Promise.all([
+          computeSync(stored.review, stored.review.worktreePath),
+          reviewMatchesCheckout(stored, stored.review.worktreePath),
+        ]);
+        return {
+          uuid: stored.review.uuid,
+          dir: stored.dir,
+          change: stored.review.sourceIdentity?.name ?? null,
+          inSync,
+          matchesCheckout,
+          unresolvedComments: countUnresolvedComments(stored.dir),
+          status: stored.review.status,
+          title: stored.review.title,
+        };
+      }),
     ),
   };
 }

--- a/packages/progressive-review/src/source-range-resolver.ts
+++ b/packages/progressive-review/src/source-range-resolver.ts
@@ -75,8 +75,7 @@ function parseSourceRange(input: SourceRangeSpec): SourceRangeSpec {
     !Number.isInteger(input.fromLine) ||
     !Number.isInteger(input.toLine) ||
     input.fromLine < 1 ||
-    input.toLine < input.fromLine ||
-    input.toLine - input.fromLine > 400
+    input.toLine < input.fromLine
   ) {
     throw new Error("invalid source range");
   }

--- a/packages/progressive-review/src/stored-review-document-audit.test.ts
+++ b/packages/progressive-review/src/stored-review-document-audit.test.ts
@@ -250,14 +250,14 @@ the selected surface still exists.
   <DbUseCase id="save-comment" label="Save a review comment">
     <DbWrite
       from={actors.composer}
-      to={stores.appDb.tables.threads.status}
+      to={stores.appDb.tables.threads.fields.status}
       label="write draft status"
       anchor={anchors.saveComment}
     />
   </DbUseCase>
   <DbUseCase id="answer-question" label="Answer an instant question">
     <DbRead
-      from={stores.appDb.tables.threads.status}
+      from={stores.appDb.tables.threads.fields.status}
       to={actors.agent}
       label="read current thread"
       anchor={anchors.askQuestion}

--- a/packages/progressive-review/src/telemetry-config.ts
+++ b/packages/progressive-review/src/telemetry-config.ts
@@ -9,6 +9,7 @@ export interface ProgressiveReviewTelemetryInstallConfig {
   createdAt: string;
   installationCreatedSent: boolean;
   enabled: boolean;
+  internal: boolean;
 }
 
 export const TELEMETRY_CONFIG_RELATIVE_PATH = path.join(
@@ -77,6 +78,7 @@ export function normalizeTelemetryInstallConfig(
         : now().toISOString(),
     installationCreatedSent: Boolean(parsed.installationCreatedSent),
     enabled: parsed.enabled !== false,
+    internal: parsed.internal === true,
   };
 }
 
@@ -89,6 +91,7 @@ export function createTelemetryInstallConfig(
     createdAt: now().toISOString(),
     installationCreatedSent: false,
     enabled: true,
+    internal: false,
   };
 }
 
@@ -129,12 +132,15 @@ function isWorkspaceCheckout(): boolean {
 
 /**
  * Whether telemetry from this process should carry `internal: true` so
- * partner-facing dashboards can exclude it. True for any workspace checkout
- * (local dev, eval harness, CI on the repo) and overridable in either
- * direction with PROGRESSIVE_REVIEW_TELEMETRY_INTERNAL=1|0.
+ * partner-facing dashboards can exclude it. The environment overrides a
+ * stored true marker, which overrides workspace detection.
  */
-export function isInternalTelemetry(env: NodeJS.ProcessEnv): boolean {
+export function isInternalTelemetry(
+  env: NodeJS.ProcessEnv,
+  config?: Pick<ProgressiveReviewTelemetryInstallConfig, "internal">,
+): boolean {
   if (env.PROGRESSIVE_REVIEW_TELEMETRY_INTERNAL === "1") return true;
   if (env.PROGRESSIVE_REVIEW_TELEMETRY_INTERNAL === "0") return false;
+  if (config?.internal === true) return true;
   return isWorkspaceCheckout();
 }

--- a/packages/progressive-review/src/trace-cli.test.ts
+++ b/packages/progressive-review/src/trace-cli.test.ts
@@ -1,0 +1,374 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { clearTraceEnvCache } from "./review-agent-traces";
+import {
+  runReviewTraceDoctor,
+  runReviewTraceEnable,
+  runReviewTraceLookupBlame,
+  runReviewTraceLookupCommit,
+  runReviewTraceLookupSession,
+  runReviewTraceSync,
+} from "./trace-cli";
+import { configureTraceMachine } from "./trace-machine-setup";
+
+describe("trace-cli", () => {
+  let tempDir: string;
+  let envFile: string;
+  let mockR2Dir: string;
+  let localTraceRoot: string;
+
+  beforeEach(() => {
+    tempDir = path.join(
+      tmpdir(),
+      `trace-cli-test-${process.pid}-${Math.random().toString(36).slice(2)}`,
+    );
+    envFile = path.join(tempDir, "env");
+    mockR2Dir = path.join(tempDir, "mock-r2");
+    localTraceRoot = path.join(tempDir, "local-traces");
+    mkdirSync(tempDir, { recursive: true });
+    mkdirSync(mockR2Dir, { recursive: true });
+    mkdirSync(localTraceRoot, { recursive: true });
+    process.env.TRACE_ENV_FILE = envFile;
+    process.env.TRACE_SETTINGS_FILE = path.join(tempDir, "settings.json");
+    process.env.TRACE_R2_MODE = "mock";
+    process.env.TRACE_R2_MOCK_DIR = mockR2Dir;
+    process.env.TRACE_LOCAL_TRACE_ROOT = localTraceRoot;
+    clearTraceEnvCache();
+  });
+
+  afterEach(() => {
+    delete process.env.TRACE_ENV_FILE;
+    delete process.env.TRACE_SETTINGS_FILE;
+    delete process.env.TRACE_R2_MODE;
+    delete process.env.TRACE_R2_MOCK_DIR;
+    delete process.env.TRACE_LOCAL_TRACE_ROOT;
+    clearTraceEnvCache();
+    vi.restoreAllMocks();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("writes configuration to env file and verifies options", async () => {
+    const status = await configureTraceMachine({
+      credentials: {
+        endpoint: "https://test-account.r2.cloudflarestorage.com",
+        bucket: "test-bucket",
+        key: "test-key-id",
+        secret: "test-secret-key",
+      },
+    });
+
+    expect(status.enabled).toBe(true);
+    const content = readFileSync(envFile, "utf8");
+    expect(content).toContain(
+      'export TRACE_R2_ENDPOINT="https://test-account.r2.cloudflarestorage.com"',
+    );
+    expect(content).toContain('export TRACE_R2_BUCKET="test-bucket"');
+    expect(content).toContain('export TRACE_R2_ACCESS_KEY_ID="test-key-id"');
+    expect(content).toContain(
+      'export TRACE_R2_SECRET_ACCESS_KEY="test-secret-key"',
+    );
+  });
+
+  it("fails setup when required options are missing in nonInteractive mode", async () => {
+    await expect(
+      configureTraceMachine({ credentials: { bucket: "test-bucket" } }),
+    ).rejects.toThrow("Trace setup needs");
+  });
+
+  it("handles husky git hook delegation without breaking core.hooksPath", async () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+
+    const huskyDir = path.join(tempDir, ".husky");
+    mkdirSync(path.join(huskyDir, "_"), { recursive: true });
+    writeFileSync(
+      path.join(huskyDir, "_", "prepare-commit-msg"),
+      "#!/bin/sh\nexit 0\n",
+    );
+    writeFileSync(path.join(huskyDir, "_", "pre-push"), "#!/bin/sh\nexit 0\n");
+
+    execFileSync("git", ["init"], { cwd: tempDir });
+    execFileSync("git", ["config", "core.hooksPath", ".husky/_"], {
+      cwd: tempDir,
+    });
+
+    await configureTraceMachine({
+      credentials: {
+        endpoint: "https://test-account.r2.cloudflarestorage.com",
+        bucket: "test-bucket",
+        key: "test-key-id",
+        secret: "test-secret-key",
+      },
+    });
+    const exitCode = await runReviewTraceEnable({
+      cwd: tempDir,
+      stdout: stdout as any,
+      stderr: stderr as any,
+    });
+
+    expect(exitCode).toBe(0);
+    const hooksPath = execFileSync("git", ["config", "core.hooksPath"], {
+      cwd: tempDir,
+    })
+      .toString()
+      .trim();
+    expect(hooksPath).toContain("dev-fast/trace-hooks/hooks");
+    const managedHook = readFileSync(
+      path.join(hooksPath, "prepare-commit-msg"),
+      "utf8",
+    );
+    expect(managedHook).toContain(
+      'root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"',
+    );
+    expect(managedHook).toContain(
+      "previous=\"$root\"/'.husky/_/prepare-commit-msg'",
+    );
+    expect(managedHook).not.toContain(tempDir);
+  });
+
+  it("runs doctor in mock mode", async () => {
+    let out = "";
+    const stdout = new PassThrough();
+    stdout.on("data", (d) => {
+      out += d.toString();
+    });
+    const stderr = new PassThrough();
+
+    const exitCode = await runReviewTraceDoctor({
+      cwd: tempDir,
+      stdout: stdout as any,
+      stderr: stderr as any,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(out).toContain("Checking trace configuration");
+  });
+
+  it("runs lookup commit and formats JSON and text outputs", async () => {
+    const sha = "0123456789abcdef0123456789abcdef01234567";
+    const sessionId = "12345678-aaaa-bbbb-cccc-000000000001";
+    const commitDir = path.join(mockR2Dir, "by-commit");
+    mkdirSync(commitDir, { recursive: true });
+    writeFileSync(
+      path.join(commitDir, `${sha}.json`),
+      JSON.stringify({
+        commit: sha,
+        sessions: [sessionId],
+        repo: "acme/widgets",
+        pr: 12,
+        branch: "feature-branch",
+        indexed_by: "ci",
+        ts: "2026-08-16T12:00:00Z",
+      }),
+    );
+
+    // JSON mode
+    let jsonOut = "";
+    const stdoutJson = new PassThrough();
+    stdoutJson.on("data", (d) => {
+      jsonOut += d.toString();
+    });
+    const exitCodeJson = await runReviewTraceLookupCommit({
+      cwd: tempDir,
+      sha,
+      json: true,
+      stdout: stdoutJson as any,
+    });
+    expect(exitCodeJson).toBe(0);
+    const parsed = JSON.parse(jsonOut);
+    expect(parsed.commit).toBe(sha);
+    expect(parsed.sessions).toEqual([sessionId]);
+    expect(parsed.source).toBe("index");
+
+    // Human text mode
+    let textOut = "";
+    const stdoutText = new PassThrough();
+    stdoutText.on("data", (d) => {
+      textOut += d.toString();
+    });
+    const exitCodeText = await runReviewTraceLookupCommit({
+      cwd: tempDir,
+      sha,
+      stdout: stdoutText as any,
+    });
+    expect(exitCodeText).toBe(0);
+    expect(textOut).toContain("via index PR #12");
+    expect(textOut).toContain(sessionId);
+  });
+
+  it("runs lookup session and returns session meta or 404", async () => {
+    const sessionId = "12345678-aaaa-bbbb-cccc-000000000002";
+    const sessionDir = path.join(mockR2Dir, "by-session", sessionId);
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(
+      path.join(sessionDir, "meta.json"),
+      JSON.stringify({
+        session: sessionId,
+        repo: "acme/widgets",
+        branch: "main",
+        pr: 10,
+        commits: ["1111111111111111111111111111111111111111"],
+        author: "alice@example.com",
+        ts: "2026-08-16T12:00:00Z",
+      }),
+    );
+
+    let jsonOut = "";
+    const stdout = new PassThrough();
+    stdout.on("data", (d) => {
+      jsonOut += d.toString();
+    });
+
+    const exitCode = await runReviewTraceLookupSession({
+      cwd: tempDir,
+      sessionId,
+      json: true,
+      stdout: stdout as any,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(jsonOut)).toMatchObject({
+      session: sessionId,
+      meta: {
+        repo: "acme/widgets",
+      },
+    });
+
+    // Unknown session
+    let missingOut = "";
+    const missingStdout = new PassThrough();
+    missingStdout.on("data", (d) => {
+      missingOut += d.toString();
+    });
+    const missingCode = await runReviewTraceLookupSession({
+      cwd: tempDir,
+      sessionId: "99999999-aaaa-bbbb-cccc-000000000099",
+      json: true,
+      stdout: missingStdout as any,
+    });
+    expect(missingCode).toBe(1);
+    expect(JSON.parse(missingOut)).toEqual({
+      session: "99999999-aaaa-bbbb-cccc-000000000099",
+      meta: null,
+      has_raw_trace: false,
+      subagents: [],
+    });
+  });
+
+  it("runs sync and uploads local traces to R2 with truthful status", async () => {
+    const sessionId = "11111111-aaaa-bbbb-cccc-000000000001";
+    writeFileSync(
+      path.join(localTraceRoot, `${sessionId}.jsonl`),
+      JSON.stringify({ type: "session", id: sessionId }) + "\n",
+    );
+
+    let jsonOut = "";
+    const stdout = new PassThrough();
+    stdout.on("data", (d) => {
+      jsonOut += d.toString();
+    });
+
+    const exitCode = await runReviewTraceSync({
+      cwd: tempDir,
+      sessionId,
+      repo: "acme/widgets",
+      json: true,
+      stdout: stdout as any,
+    });
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(jsonOut);
+    expect(parsed.session).toBe(sessionId);
+    expect(parsed.repo).toBe("acme/widgets");
+    expect(parsed.uploads).toEqual([
+      {
+        blob: "trace.jsonl",
+        bytes_stored: expect.any(Number),
+        status: "uploaded",
+      },
+    ]);
+
+    // Human output check
+    let textOut = "";
+    const stdoutText = new PassThrough();
+    stdoutText.on("data", (d) => {
+      textOut += d.toString();
+    });
+    await runReviewTraceSync({
+      cwd: tempDir,
+      sessionId,
+      repo: "acme/widgets",
+      stdout: stdoutText as any,
+    });
+    expect(textOut).toContain("trace.jsonl");
+    expect(textOut).toContain("bytes  unchanged");
+    expect(textOut).not.toContain("indexed");
+  });
+
+  it("runs blame lookup and formats JSON and text outputs", async () => {
+    const gitDir = path.join(tempDir, "cli-blame-repo");
+    mkdirSync(gitDir, { recursive: true });
+    execFileSync("git", ["init", "--quiet"], { cwd: gitDir });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: gitDir });
+    execFileSync("git", ["config", "user.email", "test@test.com"], {
+      cwd: gitDir,
+    });
+
+    writeFileSync(path.join(gitDir, "app.ts"), "const x = 1;\nconst y = 2;\n");
+    execFileSync("git", ["add", "app.ts"], { cwd: gitDir });
+    execFileSync(
+      "git",
+      [
+        "commit",
+        "-m",
+        "Add app\n\nAgent-Session: aaaa1111-bbbb-cccc-dddd-eeee00000001",
+      ],
+      { cwd: gitDir },
+    );
+
+    // JSON mode
+    let jsonOut = "";
+    const stdoutJson = new PassThrough();
+    stdoutJson.on("data", (d) => {
+      jsonOut += d.toString();
+    });
+    const exitCodeJson = await runReviewTraceLookupBlame({
+      cwd: gitDir,
+      file: "app.ts",
+      lines: "1,2",
+      json: true,
+      stdout: stdoutJson as any,
+      stderr: new PassThrough() as any,
+    });
+    expect(exitCodeJson).toBe(0);
+    const parsed = JSON.parse(jsonOut);
+    expect(parsed.file).toBe("app.ts");
+    expect(parsed.range).toBe("1,2");
+    expect(parsed.resolutions).toHaveLength(1);
+    expect(parsed.resolutions[0].sessions).toContain(
+      "aaaa1111-bbbb-cccc-dddd-eeee00000001",
+    );
+
+    // Human mode
+    let textOut = "";
+    const stdoutText = new PassThrough();
+    stdoutText.on("data", (d) => {
+      textOut += d.toString();
+    });
+    const exitCodeText = await runReviewTraceLookupBlame({
+      cwd: gitDir,
+      file: "app.ts",
+      stdout: stdoutText as any,
+      stderr: new PassThrough() as any,
+    });
+    expect(exitCodeText).toBe(0);
+    expect(textOut).toContain("→ 1 session(s) via trailer");
+    expect(textOut).toContain("aaaa1111-bbbb-cccc-dddd-eeee00000001");
+  });
+});

--- a/packages/progressive-review/src/trace-cli.ts
+++ b/packages/progressive-review/src/trace-cli.ts
@@ -1,0 +1,578 @@
+import {
+  type AgentTraceEvent,
+  extractTraceEventText,
+} from "./agent-trace-parser";
+import {
+  type ReviewTraceBlameLookupResult,
+  type ReviewTraceCommitLookupResult,
+  type ReviewTraceSessionDescriptor,
+  checkReviewTraceDoctor,
+  describeTraceSession,
+  inferRepoFromGit,
+  listRepositoryTraceSessionIds,
+  listReviewTraceSessions,
+  loadReviewAgentTrace,
+  lookupReviewTraceBlame,
+  lookupReviewTraceCommit,
+  lookupReviewTraceSession,
+  parseRepo,
+  pullReviewTraceCorpus,
+  syncReviewTrace,
+} from "./review-agent-traces";
+import { reviewUuidForManagedCheckout } from "./review-head-checkout";
+import { type StoredReview, findReview, listReviews } from "./review-home";
+import { resolveReviewRepoRootFromStore } from "./review-worktree-target";
+import { runReviewTraceGitHook } from "./trace-git-hook-runner";
+import { runReviewTraceHook } from "./trace-hook-runner";
+import { traceMachineStatus } from "./trace-machine-setup";
+import {
+  disableTraceRepository,
+  enableTraceRepository,
+  repairTraceRepository,
+  traceRepositoryStatus,
+} from "./trace-repository-hooks";
+
+export { runReviewTraceGitHook, runReviewTraceHook };
+
+export async function runReviewTraceStatus(input: {
+  cwd: string;
+  stdout: NodeJS.WriteStream;
+  stderr: NodeJS.WriteStream;
+}): Promise<number> {
+  const machine = await traceMachineStatus();
+  const repository = await traceRepositoryStatus(input.cwd);
+  input.stdout.write(
+    `Trace capture: ${machine.enabled ? "enabled" : "disabled"}\n`,
+  );
+  input.stdout.write(`Repository: ${repository.message}\n`);
+  const doctor = await checkReviewTraceDoctor({ cwd: input.cwd });
+  input.stdout.write(`Checking trace configuration (${doctor.envPath})…\n`);
+
+  if (!doctor.ok && !doctor.config) {
+    input.stderr.write(
+      `trace status: ${doctor.error ?? "No trace configuration found. Use Review Agent Setup to configure trace capture."}\n`,
+    );
+    return 1;
+  }
+
+  if (doctor.config) {
+    input.stdout.write(`  Endpoint: ${doctor.config.endpoint}\n`);
+    input.stdout.write(`  Bucket:   ${doctor.config.bucket}\n`);
+    input.stdout.write(
+      `  Key:      ${doctor.config.accessKeyId.slice(0, 6)}…\n`,
+    );
+  }
+
+  if (doctor.reachable && doctor.config) {
+    input.stdout.write(`✓ R2 bucket "${doctor.config.bucket}" is reachable.\n`);
+    return 0;
+  }
+
+  if (doctor.config) {
+    input.stderr.write(
+      `✗ Cannot reach R2 bucket "${doctor.config.bucket}": ${doctor.error ?? "unknown error"}\n`,
+    );
+  }
+  return 1;
+}
+
+export async function runReviewTraceEnable(input: {
+  cwd: string;
+  stdout: NodeJS.WriteStream;
+  stderr: NodeJS.WriteStream;
+}): Promise<number> {
+  if (!(await traceMachineStatus()).enabled) {
+    input.stderr.write(
+      "trace enable: Trace capture is not enabled. Use Review Agent Setup first.\n",
+    );
+    return 1;
+  }
+  const result = await enableTraceRepository({ cwd: input.cwd });
+  (result.enabled ? input.stdout : input.stderr).write(`${result.message}\n`);
+  return result.enabled ? 0 : 1;
+}
+
+export async function runReviewTraceDisable(input: {
+  cwd: string;
+  stdout: NodeJS.WriteStream;
+}): Promise<number> {
+  const result = await disableTraceRepository({ cwd: input.cwd });
+  input.stdout.write(`${result.message}\n`);
+  return result.repository ? 0 : 1;
+}
+
+export async function runReviewTraceRepair(input: {
+  cwd: string;
+  stdout: NodeJS.WriteStream;
+  stderr: NodeJS.WriteStream;
+}): Promise<number> {
+  if (!(await traceMachineStatus()).enabled) {
+    input.stderr.write(
+      "trace repair: Trace capture is not enabled. Use Review Agent Setup first.\n",
+    );
+    return 1;
+  }
+  const result = await repairTraceRepository({ cwd: input.cwd });
+  (result.enabled ? input.stdout : input.stderr).write(`${result.message}\n`);
+  return result.enabled ? 0 : 1;
+}
+
+export const runReviewTraceDoctor = runReviewTraceStatus;
+
+async function listSessionsForReview(review: StoredReview) {
+  const repoRootPath = resolveReviewRepoRootFromStore(review.dir);
+  const record = review.review;
+  const headCommit = record.sourceCommit ?? record.baseCommit;
+  return listReviewTraceSessions({
+    rootPath: repoRootPath,
+    baseCommit: record.baseCommit,
+    headCommit,
+  });
+}
+
+export async function runReviewTraceList(input: {
+  cwd: string;
+  reviewUuid?: string;
+  commitSha?: string;
+  json?: boolean;
+  stdout: NodeJS.WriteStream;
+}): Promise<number> {
+  let scope: { review: string } | { commit: string };
+  let sessions: ReviewTraceSessionDescriptor[];
+  let emptyExitCode = 0;
+  if (input.commitSha) {
+    const resolution = await lookupReviewTraceCommit({
+      cwd: input.cwd,
+      sha: input.commitSha,
+    });
+    scope = { commit: resolution.commit };
+    sessions = await Promise.all(
+      resolution.sessions.map((sessionId) =>
+        describeTraceSession({
+          sessionId,
+          commits: [{ sha: resolution.commit, subject: "" }],
+        }),
+      ),
+    );
+    emptyExitCode = 1;
+  } else {
+    const review = await resolveTraceReview(input.cwd, input.reviewUuid);
+    scope = { review: review.review.uuid };
+    sessions = await listSessionsForReview(review);
+  }
+
+  const publicSessions = sessions.map((session) => ({
+    id: session.sessionId,
+    harness: session.harness,
+    available: session.available,
+    traces: ["main", ...(session.subagents ?? [])],
+    commits: session.commits,
+  }));
+  if (input.json) {
+    input.stdout.write(
+      `${JSON.stringify({ ...scope, sessions: publicSessions })}\n`,
+    );
+    return sessions.length === 0 ? emptyExitCode : 0;
+  }
+  if (sessions.length === 0) {
+    const label =
+      "review" in scope ? `review ${scope.review}` : `commit ${scope.commit}`;
+    input.stdout.write(`No agent sessions recorded for ${label}.\n`);
+    return emptyExitCode;
+  }
+  for (const session of publicSessions) {
+    input.stdout.write(
+      `${session.id}  (${session.harness}, ${
+        session.available ? "R2 synced" : "not synced"
+      })\n`,
+    );
+    for (const commit of session.commits) {
+      input.stdout.write(
+        `  commit ${commit.sha.slice(0, 9)}  ${commit.subject}\n`,
+      );
+    }
+    for (const name of session.traces.slice(1)) {
+      input.stdout.write(`  trace ${name}\n`);
+    }
+  }
+  return 0;
+}
+
+export async function runReviewTraceShow(input: {
+  cwd: string;
+  sessionId: string;
+  trace?: string;
+  eventIndex?: number;
+  kind?: string;
+  json?: boolean;
+  stdout: NodeJS.WriteStream;
+  stderr: NodeJS.WriteStream;
+}): Promise<number> {
+  const traceName = input.trace === "main" ? undefined : input.trace;
+  const loaded = await loadReviewAgentTrace({
+    sessionId: input.sessionId,
+    trace: traceName,
+    cwd: input.cwd,
+  });
+  if (!loaded) {
+    throw new Error(
+      `No transcript is available for session ${input.sessionId}${traceName ? ` (trace ${traceName})` : ""}.`,
+    );
+  }
+  const { trace } = loaded;
+  if (input.eventIndex !== undefined) {
+    const event = trace.events[input.eventIndex];
+    if (!event) {
+      throw new Error(
+        `Event ${input.eventIndex} is out of range. Session ${input.sessionId} has ${trace.events.length} events.`,
+      );
+    }
+    const text = extractTraceEventText(event);
+    if (input.json) {
+      const traceQuoteProps = {
+        sessionId: input.sessionId,
+        event: input.eventIndex,
+        ...(traceName ? { trace: traceName } : {}),
+      };
+      input.stdout.write(
+        `${JSON.stringify({
+          session: input.sessionId,
+          trace: traceName ?? "main",
+          event: input.eventIndex,
+          kind: event.kind,
+          text,
+          trace_quote_props: traceQuoteProps,
+        })}\n`,
+      );
+      return 0;
+    }
+    input.stdout.write(`${text}\n`);
+    return 0;
+  }
+  const rows = trace.events
+    .map((event, index) => ({ event, index }))
+    .filter((row) => !input.kind || row.event.kind === input.kind);
+  if (input.json) {
+    input.stdout.write(
+      `${JSON.stringify({
+        session: input.sessionId,
+        trace: traceName ?? "main",
+        harness: trace.harness,
+        title: trace.title,
+        events: rows.map(({ event, index }) => ({
+          event: index,
+          kind: event.kind,
+          summary: compactEventLine(event),
+        })),
+      })}\n`,
+    );
+    return 0;
+  }
+  input.stdout.write(
+    `# session ${input.sessionId}${traceName ? ` (trace ${traceName})` : ""} (${trace.harness}) — ${
+      trace.title ?? "untitled"
+    }\n# ${trace.events.length} events${input.kind ? ` (${rows.length} shown, kind=${input.kind})` : ""}\n`,
+  );
+  for (const { event, index } of rows) {
+    input.stdout.write(
+      `${String(index).padStart(4, " ")}  ${compactEventLine(event)}\n`,
+    );
+  }
+  return 0;
+}
+
+export async function runReviewTracePull(input: {
+  cwd: string;
+  repo?: string;
+  reviewUuid?: string;
+  commitSha?: string;
+  session?: string;
+  mainOnly?: boolean;
+  json?: boolean;
+  stdout: NodeJS.WriteStream;
+  stderr: NodeJS.WriteStream;
+}): Promise<number> {
+  try {
+    let scope: Record<string, string>;
+    let sessions: Array<{ id: string; traces?: string[] }>;
+    let repoRoot = input.cwd;
+
+    if (input.reviewUuid) {
+      const review = await resolveTraceReview(input.cwd, input.reviewUuid);
+      repoRoot = resolveReviewRepoRootFromStore(review.dir);
+      const refs = await listSessionsForReview(review);
+      scope = { review: review.review.uuid };
+      sessions = refs.map((ref) => ({
+        id: ref.sessionId,
+        traces: ref.subagents,
+      }));
+    } else if (input.commitSha) {
+      const resolution = await lookupReviewTraceCommit({
+        cwd: input.cwd,
+        sha: input.commitSha,
+      });
+      scope = { commit: resolution.commit };
+      sessions = resolution.sessions.map((id) => ({ id }));
+    } else if (input.session) {
+      scope = { session: input.session };
+      sessions = [{ id: input.session }];
+    } else {
+      sessions = (await listRepositoryTraceSessionIds(input.cwd)).map((id) => ({
+        id,
+      }));
+      scope = { repository: input.repo ?? "current" };
+    }
+
+    const repo = input.repo
+      ? parseRepo(input.repo)
+      : await inferRepoFromGit(repoRoot);
+    const result = await pullReviewTraceCorpus({
+      repo,
+      sessions,
+      mainOnly: input.mainOnly,
+    });
+    const output = {
+      scope,
+      corpus_root: result.corpusRoot,
+      repository: result.repository,
+      sessions: result.sessions,
+      unavailable_sessions: result.unavailableSessions,
+      events: result.events,
+      files: result.files,
+      paths: result.paths,
+    };
+
+    if (input.json) {
+      input.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+    } else {
+      input.stdout.write(
+        `Pulled ${result.sessions.length} session(s) into ${result.corpusRoot}.\n`,
+      );
+      input.stdout.write(
+        `Materialized ${result.files} normalized trace file(s) with ${result.events} event(s) for ${result.repository}.\n`,
+      );
+      for (const filePath of result.paths) {
+        input.stdout.write(`  ${filePath}\n`);
+      }
+      if (result.unavailableSessions.length > 0) {
+        input.stderr.write(
+          `Unavailable sessions: ${result.unavailableSessions.join(", ")}\n`,
+        );
+      }
+    }
+    return sessions.length > 0 && result.sessions.length === 0 ? 1 : 0;
+  } catch (error) {
+    input.stderr.write(
+      `trace pull error: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    return 1;
+  }
+}
+
+export async function runReviewTraceLookupCommit(input: {
+  cwd: string;
+  sha: string;
+  json?: boolean;
+  stdout: NodeJS.WriteStream;
+}): Promise<number> {
+  const result = await lookupReviewTraceCommit({
+    cwd: input.cwd,
+    sha: input.sha,
+  });
+
+  if (input.json) {
+    input.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return result.sessions.length === 0 ? 1 : 0;
+  }
+
+  printCommitResolution(result, input.stdout);
+  return result.sessions.length === 0 ? 1 : 0;
+}
+
+export async function runReviewTraceBlame(input: {
+  cwd: string;
+  file: string;
+  lines?: string;
+  history?: boolean;
+  json?: boolean;
+  stdout: NodeJS.WriteStream;
+  stderr: NodeJS.WriteStream;
+}): Promise<number> {
+  let result: ReviewTraceBlameLookupResult;
+  try {
+    result = await lookupReviewTraceBlame({
+      cwd: input.cwd,
+      file: input.file,
+      lines: input.lines,
+      history: input.history,
+    });
+  } catch (err: unknown) {
+    input.stderr.write(
+      `trace blame error: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 1;
+  }
+
+  if (input.json) {
+    input.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    const hasAnySessions = result.resolutions.some(
+      (r) => r.sessions.length > 0,
+    );
+    return hasAnySessions ? 0 : 1;
+  }
+
+  if (result.resolutions.length === 0) {
+    input.stderr.write(`no commits found for ${input.file}\n`);
+    return 1;
+  }
+
+  for (const resolution of result.resolutions) {
+    printCommitResolution(resolution, input.stdout);
+  }
+
+  const hasAnySessions = result.resolutions.some((r) => r.sessions.length > 0);
+  return hasAnySessions ? 0 : 1;
+}
+
+export const runReviewTraceLookupBlame = runReviewTraceBlame;
+
+export async function runReviewTraceLookupSession(input: {
+  cwd: string;
+  sessionId: string;
+  json?: boolean;
+  stdout: NodeJS.WriteStream;
+}): Promise<number> {
+  const result = await lookupReviewTraceSession({
+    sessionId: input.sessionId,
+  });
+
+  if (input.json) {
+    input.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return result.meta === null && !result.has_raw_trace ? 1 : 0;
+  }
+
+  if (result.meta === null && !result.has_raw_trace) {
+    input.stdout.write(`no session meta found for ${result.session}\n`);
+    return 1;
+  }
+
+  if (result.meta) {
+    input.stdout.write(`${JSON.stringify(result.meta, null, 2)}\n`);
+  } else {
+    input.stdout.write(`Session: ${result.session}\n`);
+  }
+
+  if (result.has_raw_trace) {
+    input.stdout.write(
+      `  raw trace: by-session/${result.session}/trace.jsonl\n`,
+    );
+  }
+  if (result.subagents.length > 0) {
+    input.stdout.write(`  subagents: ${result.subagents.join(", ")}\n`);
+  }
+  return 0;
+}
+
+function printCommitResolution(
+  resolution: ReviewTraceCommitLookupResult,
+  stdout: NodeJS.WriteStream,
+): void {
+  const shortCommit = resolution.commit.slice(0, 12);
+  if (resolution.sessions.length === 0) {
+    stdout.write(
+      `${shortCommit}  no agent sessions found (source checked: trailer, index, pr-scan)\n`,
+    );
+    return;
+  }
+
+  const prSuffix = resolution.pr !== null ? ` PR #${resolution.pr}` : "";
+  stdout.write(
+    `${shortCommit}  → ${resolution.sessions.length} session(s) via ${resolution.source}${prSuffix}\n`,
+  );
+  for (const session of resolution.sessions) {
+    const meta = resolution.session_meta?.[session];
+    const metaSuffix = meta
+      ? `  (${meta.branch || "?"}, ${meta.author || "?"})`
+      : "";
+    stdout.write(`    ${session}${metaSuffix}\n`);
+    stdout.write(`      trace: by-session/${session}/trace.jsonl\n`);
+    stdout.write(
+      `      pull for FFF: review trace pull --session ${session}\n`,
+    );
+  }
+}
+
+export async function runReviewTraceSync(input: {
+  cwd: string;
+  sessionId: string;
+  repo?: string;
+  json?: boolean;
+  stdout: NodeJS.WriteStream;
+}): Promise<number> {
+  const result = await syncReviewTrace({
+    sessionId: input.sessionId,
+    cwd: input.cwd,
+    repo: input.repo,
+  });
+
+  if (input.json) {
+    input.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  for (const upload of result.uploads) {
+    input.stdout.write(
+      `${upload.blob}  ${upload.bytes_stored} bytes  ${upload.status}\n`,
+    );
+  }
+  input.stdout.write(
+    `Updated meta for session ${result.session} in ${result.repo}.\n`,
+  );
+  return 0;
+}
+
+function compactEventLine(event: AgentTraceEvent): string {
+  const oneLine = (text: string, limit: number): string => {
+    const collapsed = text.replace(/\s+/g, " ").trim();
+    return collapsed.length > limit
+      ? `${collapsed.slice(0, limit - 1)}…`
+      : collapsed;
+  };
+  if (event.kind === "user") return `user       ${oneLine(event.text, 160)}`;
+  if (event.kind === "assistant") {
+    return `${event.thinking ? "thinking  " : "assistant "} ${oneLine(event.markdown, 160)}`;
+  }
+  if (event.kind === "separator") return `separator  ${event.label}`;
+  const counts = [
+    event.additions ? `+${event.additions}` : null,
+    event.deletions ? `−${event.deletions}` : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return `tool       ${event.verb} ${oneLine(event.title, 120)}${
+    counts ? ` ${counts}` : ""
+  }${event.filePath ? ` [${event.filePath}]` : ""}`;
+}
+
+async function resolveTraceReview(
+  cwd: string,
+  reviewUuid: string | undefined,
+): Promise<StoredReview> {
+  const managedReviewUuid = await reviewUuidForManagedCheckout(cwd);
+  const wantedUuid = reviewUuid ?? managedReviewUuid ?? undefined;
+  if (wantedUuid) {
+    const review = await findReview(wantedUuid);
+    if (!review) throw new Error(`Review not found: ${wantedUuid}`);
+    return review;
+  }
+  const candidates = (await listReviews({ worktreePath: cwd })).reviews.filter(
+    (review) => review.review.status !== "rejected",
+  );
+  if (candidates.length === 0) {
+    throw new Error("No review found for this worktree.");
+  }
+  if (candidates.length > 1) {
+    throw new Error("Multiple reviews require --review <uuid>.");
+  }
+  return candidates[0];
+}

--- a/packages/progressive-review/src/trace-git-hook-runner.ts
+++ b/packages/progressive-review/src/trace-git-hook-runner.ts
@@ -1,0 +1,174 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+
+import { sessionIdSchema } from "@dev-fast/trace-shared";
+import { git } from "@dev.fast/local-vcs";
+
+import {
+  readTrailerSessions,
+  syncReviewTrace,
+  writeReviewTraceCommitMapping,
+} from "./review-agent-traces";
+
+const ZERO_OID = /^0+$/;
+
+export async function runReviewTraceGitHook(input: {
+  cwd: string;
+  hook: string;
+  args: string[];
+  stdin?: NodeJS.ReadableStream;
+  stderr: NodeJS.WriteStream;
+}): Promise<number> {
+  if (process.env.TRACE_DISABLE === "1") return 0;
+  try {
+    if (input.hook === "prepare-commit-msg") {
+      return runPrepareCommitMessage(input.cwd, input.args[0]);
+    }
+    if (input.hook === "pre-push") {
+      await runPrePush(input);
+      return 0;
+    }
+  } catch (cause) {
+    input.stderr.write(
+      `trace-sync: warning: ${cause instanceof Error ? cause.message : String(cause)}\n`,
+    );
+  }
+  return 0;
+}
+
+async function runPrepareCommitMessage(
+  cwd: string,
+  messagePath: string | undefined,
+): Promise<number> {
+  if (!messagePath) return 0;
+  const sessions = await activeSessions(cwd);
+  for (const session of sessions) {
+    await git(
+      cwd,
+      [
+        "interpret-trailers",
+        "--in-place",
+        "--if-exists",
+        "addIfDifferent",
+        "--trailer",
+        `Agent-Session: ${session}`,
+        messagePath,
+      ],
+      { allowFailure: true },
+    );
+  }
+  return 0;
+}
+
+async function activeSessions(cwd: string): Promise<string[]> {
+  const fromEnv = (process.env.AGENT_SESSION_ID ?? "").trim();
+  if (sessionIdSchema.safeParse(fromEnv).success) return [fromEnv];
+  const fileResult = await git(
+    cwd,
+    ["rev-parse", "--git-path", "agent-session"],
+    {
+      allowFailure: true,
+    },
+  );
+  if (!fileResult.ok) return [];
+  const filePath = fileResult.stdout.trim();
+  if (!filePath || !existsSync(filePath)) return [];
+  const sessions = (await readFile(filePath, "utf8").catch(() => ""))
+    .split("\n")
+    .map((value) => value.trim())
+    .filter((value) => sessionIdSchema.safeParse(value).success);
+  return [...new Set(sessions)];
+}
+
+async function runPrePush(input: {
+  cwd: string;
+  stdin?: NodeJS.ReadableStream;
+  stderr: NodeJS.WriteStream;
+}): Promise<void> {
+  const raw = await readStdin(input.stdin);
+  const commits = new Map<
+    string,
+    { branch: string | null; sessions: string[] }
+  >();
+  for (const line of raw.split("\n")) {
+    const [localRef, localSha, remoteRef, remoteSha] = line.trim().split(/\s+/);
+    if (
+      !localRef ||
+      !localSha ||
+      !remoteRef ||
+      !remoteSha ||
+      ZERO_OID.test(localSha)
+    )
+      continue;
+    const branch = remoteRef.startsWith("refs/heads/")
+      ? remoteRef.slice("refs/heads/".length)
+      : null;
+    const revisionArgs = await revisionRange(input.cwd, localSha, remoteSha);
+    const listed = await git(
+      input.cwd,
+      ["rev-list", "--max-count=500", ...revisionArgs],
+      { allowFailure: true },
+    );
+    if (!listed.ok) continue;
+    for (const commit of listed.stdout
+      .split("\n")
+      .map((value) => value.trim())
+      .filter(Boolean)) {
+      const sessions = await readTrailerSessions(input.cwd, commit);
+      if (sessions.length > 0) commits.set(commit, { branch, sessions });
+    }
+  }
+  if (commits.size === 0) return;
+
+  const sessionCommits = new Map<string, string[]>();
+  for (const [commit, value] of commits) {
+    await writeReviewTraceCommitMapping({
+      cwd: input.cwd,
+      commit,
+      sessions: value.sessions,
+      branch: value.branch,
+    }).catch((cause) => warn(input.stderr, cause));
+    for (const session of value.sessions) {
+      sessionCommits.set(session, [
+        ...(sessionCommits.get(session) ?? []),
+        commit,
+      ]);
+    }
+  }
+  for (const [sessionId, values] of sessionCommits) {
+    await syncReviewTrace({ sessionId, cwd: input.cwd, commits: values }).catch(
+      (cause) => warn(input.stderr, cause),
+    );
+  }
+}
+
+async function revisionRange(
+  cwd: string,
+  localSha: string,
+  remoteSha: string,
+): Promise<string[]> {
+  if (ZERO_OID.test(remoteSha)) return [localSha, "--not", "--remotes"];
+  const remoteExists = await git(cwd, ["cat-file", "-e", remoteSha], {
+    allowFailure: true,
+  });
+  return remoteExists.ok
+    ? [`${remoteSha}..${localSha}`]
+    : [localSha, "--not", "--remotes"];
+}
+
+async function readStdin(
+  stdin: NodeJS.ReadableStream | undefined,
+): Promise<string> {
+  if (!stdin) return "";
+  const chunks: Buffer[] = [];
+  for await (const chunk of stdin) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function warn(stderr: NodeJS.WriteStream, cause: unknown): void {
+  stderr.write(
+    `trace-sync: warning: ${cause instanceof Error ? cause.message : String(cause)}\n`,
+  );
+}

--- a/packages/progressive-review/src/trace-hook-runner.test.ts
+++ b/packages/progressive-review/src/trace-hook-runner.test.ts
@@ -1,0 +1,212 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runReviewTraceHook } from "./trace-hook-runner";
+import { configureTraceMachine } from "./trace-machine-setup";
+
+const execFilePromise = promisify(execFile);
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  while (tempRoots.length > 0) {
+    const dir = tempRoots.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function runGit(root: string, args: string[]): Promise<string> {
+  const { stdout } = await execFilePromise("git", ["-C", root, ...args], {
+    encoding: "utf8",
+  });
+  return stdout.trim();
+}
+
+async function runJj(root: string, args: string[]): Promise<string> {
+  const { stdout } = await execFilePromise("jj", args, {
+    cwd: root,
+    encoding: "utf8",
+  });
+  return stdout;
+}
+
+async function makeGitRepo(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "trace-hook-runner-test-"));
+  tempRoots.push(dir);
+  await runGit(dir, ["init", "-b", "main"]);
+  await runGit(dir, ["config", "user.name", "Test User"]);
+  await runGit(dir, ["config", "user.email", "test@example.com"]);
+  await writeFile(path.join(dir, "README.md"), "# Test\n");
+  await runGit(dir, ["add", "README.md"]);
+  await runGit(dir, ["commit", "-m", "initial"]);
+  await configureTraceMachine({
+    homeDir: dir,
+    env: { TRACE_R2_MODE: "mock" },
+    credentials: {
+      endpoint: "mock://endpoint",
+      bucket: "mock-bucket",
+      key: "mock-key",
+      secret: "mock-secret",
+    },
+  });
+  return dir;
+}
+
+describe("runReviewTraceHook", () => {
+  it("records session ID on SessionStart and removes on SessionEnd", async () => {
+    const repo = await makeGitRepo();
+    const sessionId = "01a015e4-0477-7055-a0fd-21a0f72a4ec6";
+
+    // 1. SessionStart via CLI args
+    const startCode = await runReviewTraceHook({
+      cwd: repo,
+      event: "SessionStart",
+      sessionId,
+      homeDir: repo,
+      env: { TRACE_R2_MODE: "mock" },
+    });
+    expect(startCode).toBe(0);
+
+    const agentSessionFile = path.join(repo, ".git", "agent-session");
+    expect(existsSync(agentSessionFile)).toBe(true);
+    expect(await readFile(agentSessionFile, "utf8")).toBe(`${sessionId}\n`);
+
+    // 2. Another session joins
+    const secondSessionId = "02b015e4-0477-7055-a0fd-21a0f72a4ec7";
+    await runReviewTraceHook({
+      cwd: repo,
+      event: "SessionStart",
+      sessionId: secondSessionId,
+      homeDir: repo,
+      env: { TRACE_R2_MODE: "mock" },
+    });
+    expect(await readFile(agentSessionFile, "utf8")).toBe(
+      `${sessionId}\n${secondSessionId}\n`,
+    );
+
+    // 3. First session ends
+    const endCode = await runReviewTraceHook({
+      cwd: repo,
+      event: "SessionEnd",
+      sessionId,
+      homeDir: repo,
+      env: { TRACE_R2_MODE: "mock" },
+    });
+    expect(endCode).toBe(0);
+    expect(await readFile(agentSessionFile, "utf8")).toBe(
+      `${secondSessionId}\n`,
+    );
+
+    // 4. Second session ends (file should be deleted)
+    await runReviewTraceHook({
+      cwd: repo,
+      event: "SessionEnd",
+      sessionId: secondSessionId,
+      homeDir: repo,
+      env: { TRACE_R2_MODE: "mock" },
+    });
+    expect(existsSync(agentSessionFile)).toBe(false);
+  });
+
+  it("parses Claude/Codex hook JSON from stdin", async () => {
+    const repo = await makeGitRepo();
+    const sessionId = "01a015e4-0477-7055-a0fd-21a0f72a4ec6";
+
+    const startPayload = JSON.stringify({
+      hook_event_name: "SessionStart",
+      session_id: sessionId,
+    });
+    const stdinStart = Readable.from([
+      startPayload,
+    ]) as unknown as NodeJS.ReadStream;
+
+    await runReviewTraceHook({
+      cwd: repo,
+      event: "unknown",
+      stdin: stdinStart,
+      homeDir: repo,
+      env: { TRACE_R2_MODE: "mock" },
+    });
+
+    const agentSessionFile = path.join(repo, ".git", "agent-session");
+    expect(existsSync(agentSessionFile)).toBe(true);
+    expect(await readFile(agentSessionFile, "utf8")).toBe(`${sessionId}\n`);
+
+    const endPayload = JSON.stringify({
+      hook_event_name: "SessionEnd",
+      session_id: sessionId,
+    });
+    const stdinEnd = Readable.from([
+      endPayload,
+    ]) as unknown as NodeJS.ReadStream;
+
+    await runReviewTraceHook({
+      cwd: repo,
+      event: "unknown",
+      stdin: stdinEnd,
+      homeDir: repo,
+      env: { TRACE_R2_MODE: "mock" },
+    });
+
+    expect(existsSync(agentSessionFile)).toBe(false);
+  });
+
+  it("writes valid Jujutsu commit trailer templates", async () => {
+    if (!(await commandAvailable("jj"))) return;
+    const repo = await makeGitRepo();
+    await runJj(repo, ["git", "init", "--colocate", "."]);
+    const firstSessionId = "01a015e4-0477-7055-a0fd-21a0f72a4ec6";
+    const secondSessionId = "02b015e4-0477-7055-a0fd-21a0f72a4ec7";
+
+    for (const sessionId of [firstSessionId, secondSessionId]) {
+      await runReviewTraceHook({
+        cwd: repo,
+        event: "SessionStart",
+        sessionId,
+        homeDir: repo,
+        env: { TRACE_R2_MODE: "mock" },
+      });
+    }
+
+    await runJj(repo, ["describe", "-m", "Trace work"]);
+    const description = await runJj(repo, [
+      "log",
+      "-r",
+      "@",
+      "--no-graph",
+      "-T",
+      "description",
+    ]);
+    expect(description).toBe(
+      `Trace work\n\nAgent-Session: ${firstSessionId}\nAgent-Session: ${secondSessionId}\n`,
+    );
+  });
+
+  it("ignores invalid or malformed session IDs safely", async () => {
+    const repo = await makeGitRepo();
+
+    const code = await runReviewTraceHook({
+      cwd: repo,
+      event: "SessionStart",
+      sessionId: "invalid!@#$%",
+      homeDir: repo,
+      env: { TRACE_R2_MODE: "mock" },
+    });
+    expect(code).toBe(0);
+
+    const agentSessionFile = path.join(repo, ".git", "agent-session");
+    expect(existsSync(agentSessionFile)).toBe(false);
+  });
+});
+
+async function commandAvailable(command: string): Promise<boolean> {
+  return execFilePromise(command, ["--version"])
+    .then(() => true)
+    .catch(() => false);
+}

--- a/packages/progressive-review/src/trace-hook-runner.ts
+++ b/packages/progressive-review/src/trace-hook-runner.ts
@@ -1,0 +1,204 @@
+import { execFile, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { git } from "@dev.fast/local-vcs";
+
+import { traceMachineEnabled } from "./trace-machine-setup";
+import { enableTraceRepository } from "./trace-repository-hooks";
+
+const execFileAsync = promisify(execFile);
+
+const SESSION_ID_REGEX = /^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/;
+
+export interface RunReviewTraceHookInput {
+  cwd: string;
+  event: string;
+  sessionId?: string;
+  stdin?: NodeJS.ReadStream;
+  homeDir?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export async function runReviewTraceHook(
+  input: RunReviewTraceHookInput,
+): Promise<number> {
+  if (process.env.TRACE_DISABLE === "1") {
+    return 0;
+  }
+  if (
+    !(await traceMachineEnabled({
+      homeDir: input.homeDir,
+      env: input.env,
+    }))
+  ) {
+    return 0;
+  }
+
+  let event = input.event;
+  let sessionId = input.sessionId;
+
+  // If stdin is provided, attempt to read JSON payload (Claude Code / Codex hook format)
+  if (input.stdin && !input.stdin.isTTY) {
+    try {
+      const chunks: Buffer[] = [];
+      for await (const chunk of input.stdin) {
+        chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+      }
+      const raw = Buffer.concat(chunks).toString("utf8").trim();
+      if (raw) {
+        const parsed = JSON.parse(raw) as {
+          hook_event_name?: string;
+          session_id?: string;
+        };
+        if (parsed.hook_event_name) event = parsed.hook_event_name;
+        if (parsed.session_id) sessionId = parsed.session_id;
+      }
+    } catch {
+      // Ignore JSON parse errors from stdin
+    }
+  }
+
+  sessionId = (sessionId || process.env.AGENT_SESSION_ID || "").trim();
+  if (!sessionId || !SESSION_ID_REGEX.test(sessionId)) {
+    return 0;
+  }
+
+  const isStart = event.toLowerCase().includes("start");
+  const isEnd = event.toLowerCase().includes("end");
+
+  if (!isStart && !isEnd) {
+    return 0;
+  }
+
+  if (isStart) {
+    await enableTraceRepository({
+      cwd: input.cwd,
+      homeDir: input.homeDir,
+    }).catch(() => undefined);
+  }
+
+  // 1. Git agent-session file handling
+  const gitPathResult = await git(
+    input.cwd,
+    ["rev-parse", "--git-path", "agent-session"],
+    { allowFailure: true },
+  );
+
+  let sessionFilePath: string | null = null;
+  if (gitPathResult.ok && gitPathResult.stdout.trim()) {
+    sessionFilePath = gitPathResult.stdout.trim();
+  }
+
+  const jjRootResult = await execFileAsync("jj", ["root"], {
+    cwd: input.cwd,
+  }).catch(() => null);
+  if (!sessionFilePath && jjRootResult?.stdout.trim()) {
+    sessionFilePath = path.join(
+      jjRootResult.stdout.trim(),
+      ".jj",
+      "agent-session",
+    );
+  }
+
+  let remainingSessions: string[] = [];
+
+  if (sessionFilePath) {
+    let existingContent = "";
+    if (existsSync(sessionFilePath)) {
+      existingContent = await readFile(sessionFilePath, "utf8").catch(() => "");
+    }
+    const currentSessions = existingContent
+      .split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s && SESSION_ID_REGEX.test(s));
+
+    if (isStart) {
+      if (!currentSessions.includes(sessionId)) {
+        currentSessions.push(sessionId);
+      }
+      remainingSessions = currentSessions;
+      await writeFile(
+        sessionFilePath,
+        `${currentSessions.join("\n")}\n`,
+        "utf8",
+      ).catch(() => undefined);
+    } else if (isEnd) {
+      remainingSessions = currentSessions.filter((s) => s !== sessionId);
+      if (remainingSessions.length > 0) {
+        await writeFile(
+          sessionFilePath,
+          `${remainingSessions.join("\n")}\n`,
+          "utf8",
+        ).catch(() => undefined);
+      } else {
+        await rm(sessionFilePath, { force: true }).catch(() => undefined);
+      }
+    }
+  }
+
+  // 2. Jujutsu (jj) templates.commit_trailers mirror handling
+  if (jjRootResult?.stdout.trim()) {
+    if (isStart && remainingSessions.length > 0) {
+      const templateVal = jjCommitTrailersConfigValue(remainingSessions);
+      await execFileAsync(
+        "jj",
+        ["config", "set", "--repo", "templates.commit_trailers", templateVal],
+        { cwd: input.cwd },
+      ).catch(() => undefined);
+    } else if (isEnd) {
+      if (remainingSessions.length > 0) {
+        const templateVal = jjCommitTrailersConfigValue(remainingSessions);
+        await execFileAsync(
+          "jj",
+          ["config", "set", "--repo", "templates.commit_trailers", templateVal],
+          { cwd: input.cwd },
+        ).catch(() => undefined);
+      } else {
+        await execFileAsync(
+          "jj",
+          ["config", "unset", "--repo", "templates.commit_trailers"],
+          { cwd: input.cwd },
+        ).catch(() => undefined);
+      }
+    }
+  }
+
+  // 3. On SessionEnd: detached background trace sync to R2
+  if (isEnd) {
+    try {
+      const installedCommand = path.join(
+        input.homeDir ?? process.env.TRACE_HOME_DIR ?? os.homedir(),
+        ".local",
+        "bin",
+        "review",
+      );
+      const command =
+        process.env.REVIEW_TRACE_COMMAND ??
+        (existsSync(installedCommand) ? installedCommand : "review");
+      const child = spawn(command, ["trace", "sync", sessionId], {
+        cwd: input.cwd,
+        detached: true,
+        stdio: "ignore",
+      });
+      child.unref();
+    } catch {
+      // Ignore sync spawn errors
+    }
+  }
+
+  return 0;
+}
+
+function jjCommitTrailersConfigValue(sessionIds: readonly string[]): string {
+  const trailers = `${sessionIds
+    .map((id) => `Agent-Session: ${id}`)
+    .join("\n")}\n`;
+  // `jj config set` parses TOML first. Jujutsu then parses the stored string
+  // as a template, so the trailer text needs one quote layer for each parser.
+  const templateExpression = JSON.stringify(trailers);
+  return JSON.stringify(templateExpression);
+}

--- a/packages/progressive-review/src/trace-machine-setup.ts
+++ b/packages/progressive-review/src/trace-machine-setup.ts
@@ -1,0 +1,259 @@
+import { execFile } from "node:child_process";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { clearTraceEnvCache } from "./review-agent-traces";
+
+const execFileAsync = promisify(execFile);
+
+export interface TraceCredentialsInput {
+  endpoint?: string;
+  bucket?: string;
+  key?: string;
+  secret?: string;
+}
+
+export interface TraceMachineStatus {
+  enabled: boolean;
+  configured: boolean;
+  autoActivateRepositories: boolean;
+  envPath: string;
+  settingsPath: string;
+  endpoint?: string;
+  bucket?: string;
+  accessKeyIdPrefix?: string;
+  verifiedAt?: string;
+  error?: string;
+}
+
+interface TraceMachineSettings {
+  version: 1;
+  enabled: boolean;
+  autoActivateRepositories: true;
+  verifiedAt?: string;
+  error?: string;
+}
+
+export function traceEnvPath(
+  homeDir = os.homedir(),
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return (
+    env.TRACE_ENV_FILE ?? path.join(homeDir, ".config", "dev-trace", "env")
+  );
+}
+
+export function traceSettingsPath(
+  homeDir = os.homedir(),
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return (
+    env.TRACE_SETTINGS_FILE ??
+    path.join(homeDir, ".config", "dev-trace", "settings.json")
+  );
+}
+
+export async function readTraceCredentials(
+  homeDir = os.homedir(),
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<Required<TraceCredentialsInput> | null> {
+  const values: Record<string, string> = {};
+  const contents = await readFile(traceEnvPath(homeDir, env), "utf8").catch(
+    () => "",
+  );
+  for (const line of contents.split("\n")) {
+    const match = /^\s*(?:export\s+)?([A-Z0-9_]+)=(.*)$/.exec(line);
+    if (!match) continue;
+    const raw = match[2].trim();
+    try {
+      values[match[1]] = JSON.parse(raw) as string;
+    } catch {
+      values[match[1]] = raw.replace(/^["']|["']$/g, "");
+    }
+  }
+  const credentials = {
+    endpoint: env.TRACE_R2_ENDPOINT ?? values.TRACE_R2_ENDPOINT ?? "",
+    bucket: env.TRACE_R2_BUCKET ?? values.TRACE_R2_BUCKET ?? "",
+    key: env.TRACE_R2_ACCESS_KEY_ID ?? values.TRACE_R2_ACCESS_KEY_ID ?? "",
+    secret:
+      env.TRACE_R2_SECRET_ACCESS_KEY ?? values.TRACE_R2_SECRET_ACCESS_KEY ?? "",
+  };
+  return Object.values(credentials).every(Boolean) ? credentials : null;
+}
+
+export async function traceMachineStatus(
+  input: {
+    homeDir?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): Promise<TraceMachineStatus> {
+  const homeDir = input.homeDir ?? os.homedir();
+  const env = input.env ?? process.env;
+  const envPath = traceEnvPath(homeDir, env);
+  const settingsPath = traceSettingsPath(homeDir, env);
+  const credentials = await readTraceCredentials(homeDir, env);
+  const settings = await readSettings(settingsPath);
+  return {
+    enabled: settings?.enabled === true,
+    configured: credentials !== null,
+    autoActivateRepositories:
+      settings?.enabled === true && settings.autoActivateRepositories === true,
+    envPath,
+    settingsPath,
+    ...(credentials
+      ? {
+          endpoint: credentials.endpoint,
+          bucket: credentials.bucket,
+          accessKeyIdPrefix: credentials.key.slice(0, 6),
+        }
+      : {}),
+    ...(settings?.verifiedAt ? { verifiedAt: settings.verifiedAt } : {}),
+    ...(settings?.error ? { error: settings.error } : {}),
+  };
+}
+
+export async function traceMachineEnabled(
+  input: {
+    homeDir?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): Promise<boolean> {
+  return (await traceMachineStatus(input)).enabled;
+}
+
+export async function configureTraceMachine(input: {
+  credentials?: TraceCredentialsInput;
+  homeDir?: string;
+  env?: NodeJS.ProcessEnv;
+  verify?: boolean;
+}): Promise<TraceMachineStatus> {
+  const homeDir = input.homeDir ?? os.homedir();
+  const env = input.env ?? process.env;
+  const existing = await readTraceCredentials(homeDir, env);
+  const credentials = {
+    endpoint: input.credentials?.endpoint ?? existing?.endpoint ?? "",
+    bucket: input.credentials?.bucket ?? existing?.bucket ?? "",
+    key: input.credentials?.key ?? existing?.key ?? "",
+    secret: input.credentials?.secret ?? existing?.secret ?? "",
+  };
+  if (!Object.values(credentials).every(Boolean)) {
+    throw new Error(
+      "Trace setup needs an R2 endpoint, bucket, access key ID, and secret access key.",
+    );
+  }
+
+  const envPath = traceEnvPath(homeDir, env);
+  await mkdir(path.dirname(envPath), { recursive: true });
+  await writeFile(
+    envPath,
+    [
+      `export TRACE_R2_ENDPOINT=${JSON.stringify(credentials.endpoint)}`,
+      `export TRACE_R2_BUCKET=${JSON.stringify(credentials.bucket)}`,
+      `export TRACE_R2_ACCESS_KEY_ID=${JSON.stringify(credentials.key)}`,
+      `export TRACE_R2_SECRET_ACCESS_KEY=${JSON.stringify(credentials.secret)}`,
+      "",
+    ].join("\n"),
+    { mode: 0o600 },
+  );
+  await chmod(envPath, 0o600);
+  clearTraceEnvCache();
+
+  let error: string | undefined;
+  let verifiedAt: string | undefined;
+  if (input.verify !== false) {
+    if (env.TRACE_R2_MODE === "mock") {
+      verifiedAt = new Date().toISOString();
+    } else {
+      try {
+        await execFileAsync(
+          "aws",
+          [
+            "--region",
+            "auto",
+            "--endpoint-url",
+            credentials.endpoint,
+            "s3api",
+            "head-bucket",
+            "--bucket",
+            credentials.bucket,
+          ],
+          {
+            timeout: 15_000,
+            env: {
+              ...env,
+              AWS_ACCESS_KEY_ID: credentials.key,
+              AWS_SECRET_ACCESS_KEY: credentials.secret,
+            },
+          },
+        );
+        verifiedAt = new Date().toISOString();
+      } catch (cause) {
+        error = cause instanceof Error ? cause.message : String(cause);
+      }
+    }
+  }
+
+  const settings: TraceMachineSettings = {
+    version: 1,
+    enabled: true,
+    autoActivateRepositories: true,
+    ...(verifiedAt ? { verifiedAt } : {}),
+    ...(error ? { error } : {}),
+  };
+  await writeSettings(traceSettingsPath(homeDir, env), settings);
+  return traceMachineStatus({ homeDir, env });
+}
+
+export async function disableTraceMachine(
+  input: {
+    homeDir?: string;
+    env?: NodeJS.ProcessEnv;
+    removeSettings?: boolean;
+  } = {},
+): Promise<void> {
+  const homeDir = input.homeDir ?? os.homedir();
+  const env = input.env ?? process.env;
+  const settingsPath = traceSettingsPath(homeDir, env);
+  if (input.removeSettings) {
+    await rm(settingsPath, { force: true });
+    return;
+  }
+  await writeSettings(settingsPath, {
+    version: 1,
+    enabled: false,
+    autoActivateRepositories: true,
+  });
+}
+
+async function readSettings(
+  filePath: string,
+): Promise<TraceMachineSettings | null> {
+  try {
+    const value = JSON.parse(
+      await readFile(filePath, "utf8"),
+    ) as Partial<TraceMachineSettings>;
+    return value.version === 1 && typeof value.enabled === "boolean"
+      ? (value as TraceMachineSettings)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeSettings(
+  filePath: string,
+  settings: TraceMachineSettings,
+): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const temporary = `${filePath}.${process.pid}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(settings, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  await rm(filePath, { force: true });
+  await import("node:fs/promises").then(({ rename }) =>
+    rename(temporary, filePath),
+  );
+  await chmod(filePath, 0o600);
+}

--- a/packages/progressive-review/src/trace-repository-hooks.test.ts
+++ b/packages/progressive-review/src/trace-repository-hooks.test.ts
@@ -1,0 +1,90 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  disableTraceRepository,
+  enableTraceRepository,
+  traceRepositoryStatus,
+} from "./trace-repository-hooks";
+
+const execFileAsync = promisify(execFile);
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("trace repository hooks", () => {
+  it("chains and restores the repository's existing hook path", async () => {
+    const { homeDir, repo } = await makeRepository();
+    await runGit(repo, ["config", "--local", "core.hooksPath", ".husky/_"]);
+
+    const first = await enableTraceRepository({
+      cwd: repo,
+      homeDir,
+      reviewCommand: "/opt/review/bin/review",
+    });
+    const second = await enableTraceRepository({
+      cwd: repo,
+      homeDir,
+      reviewCommand: "/opt/review/bin/review",
+    });
+
+    expect(first.enabled).toBe(true);
+    expect(second.managedHooksPath).toBe(first.managedHooksPath);
+    expect(await runGit(repo, ["config", "--get", "core.hooksPath"])).toBe(
+      first.managedHooksPath,
+    );
+    expect(
+      await readFile(path.join(first.managedHooksPath!, "pre-push"), "utf8"),
+    ).toContain(".husky/_/pre-push");
+    expect((await traceRepositoryStatus(repo)).enabled).toBe(true);
+
+    await disableTraceRepository({ cwd: repo, homeDir });
+
+    expect(await runGit(repo, ["config", "--get", "core.hooksPath"])).toBe(
+      ".husky/_",
+    );
+  });
+
+  it("does not replace a hook path that changed after activation", async () => {
+    const { homeDir, repo } = await makeRepository();
+    await enableTraceRepository({
+      cwd: repo,
+      homeDir,
+      reviewCommand: "review",
+    });
+    await runGit(repo, [
+      "config",
+      "--local",
+      "core.hooksPath",
+      ".custom-hooks",
+    ]);
+
+    await disableTraceRepository({ cwd: repo, homeDir });
+
+    expect(await runGit(repo, ["config", "--get", "core.hooksPath"])).toBe(
+      ".custom-hooks",
+    );
+  });
+});
+
+async function makeRepository(): Promise<{ homeDir: string; repo: string }> {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "trace-hooks-home-"));
+  const repo = await mkdtemp(path.join(os.tmpdir(), "trace-hooks-repo-"));
+  roots.push(homeDir, repo);
+  await runGit(repo, ["init", "-b", "main"]);
+  return { homeDir, repo };
+}
+
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["-C", cwd, ...args]);
+  return stdout.trim();
+}

--- a/packages/progressive-review/src/trace-repository-hooks.ts
+++ b/packages/progressive-review/src/trace-repository-hooks.ts
@@ -1,0 +1,372 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+interface RepositoryHookState {
+  version: 1;
+  root: string;
+  managedHooksPath: string;
+  previousHooksPath: string;
+  previousHookDirectory: string;
+  previousWasConfigured: boolean;
+}
+
+export interface TraceRepositoryStatus {
+  repository: boolean;
+  enabled: boolean;
+  root?: string;
+  managedHooksPath?: string;
+  previousHooksPath?: string;
+  message: string;
+}
+
+export async function enableTraceRepository(input: {
+  cwd: string;
+  homeDir?: string;
+  reviewCommand?: string;
+}): Promise<TraceRepositoryStatus> {
+  const resolved = await resolveRepository(input.cwd);
+  if (!resolved) {
+    return {
+      repository: false,
+      enabled: false,
+      message: "Not inside a Git repository.",
+    };
+  }
+  const statePath = path.join(
+    resolved.commonDir,
+    "dev-fast",
+    "trace-hooks",
+    "state.json",
+  );
+  const hooksPath = path.join(
+    resolved.commonDir,
+    "dev-fast",
+    "trace-hooks",
+    "hooks",
+  );
+  const current = await configuredHooksPath(resolved.root);
+  const oldState = await readState(statePath);
+  const alreadyManaged =
+    path.resolve(resolved.root, current.value || ".") ===
+    path.resolve(hooksPath);
+  const previousWasConfigured = alreadyManaged
+    ? (oldState?.previousWasConfigured ?? false)
+    : current.configured;
+  const previousHooksPath = alreadyManaged
+    ? (oldState?.previousHooksPath ?? path.join(resolved.commonDir, "hooks"))
+    : current.configured
+      ? current.value
+      : path.join(resolved.commonDir, "hooks");
+  const previousHookDirectory = alreadyManaged
+    ? (oldState?.previousHookDirectory ??
+      resolveHooksPath(resolved.root, previousHooksPath))
+    : previousHooksPath;
+  const state: RepositoryHookState = {
+    version: 1,
+    root: resolved.root,
+    managedHooksPath: hooksPath,
+    previousHooksPath,
+    previousHookDirectory,
+    previousWasConfigured,
+  };
+
+  const homeDir = input.homeDir ?? traceHomeDir();
+  const installedCommand = path.join(homeDir, ".local", "bin", "review");
+  const reviewCommand =
+    input.reviewCommand ??
+    process.env.REVIEW_TRACE_COMMAND ??
+    (existsSync(installedCommand) ? installedCommand : "review");
+  await mkdir(hooksPath, { recursive: true });
+  await writeHook(
+    path.join(hooksPath, "prepare-commit-msg"),
+    prepareCommitMessageHook(previousHookDirectory, reviewCommand),
+  );
+  await writeHook(
+    path.join(hooksPath, "pre-push"),
+    prePushHook(previousHookDirectory, reviewCommand),
+  );
+  await writePrivateJson(statePath, state);
+  await runGit(resolved.root, [
+    "config",
+    "--local",
+    "core.hooksPath",
+    hooksPath,
+  ]);
+  await registerRepository(homeDir, resolved.root);
+  return {
+    repository: true,
+    enabled: true,
+    root: resolved.root,
+    managedHooksPath: hooksPath,
+    previousHooksPath,
+    message: "Review trace hooks are enabled for this repository.",
+  };
+}
+
+export async function repairTraceRepository(input: {
+  cwd: string;
+  homeDir?: string;
+  reviewCommand?: string;
+}): Promise<TraceRepositoryStatus> {
+  return enableTraceRepository(input);
+}
+
+export async function disableTraceRepository(input: {
+  cwd: string;
+  homeDir?: string;
+}): Promise<TraceRepositoryStatus> {
+  const resolved = await resolveRepository(input.cwd);
+  if (!resolved) {
+    return {
+      repository: false,
+      enabled: false,
+      message: "Not inside a Git repository.",
+    };
+  }
+  const stateDir = path.join(resolved.commonDir, "dev-fast", "trace-hooks");
+  const state = await readState(path.join(stateDir, "state.json"));
+  if (!state) {
+    return {
+      repository: true,
+      enabled: false,
+      root: resolved.root,
+      message: "Review trace hooks are not enabled for this repository.",
+    };
+  }
+  const current = await configuredHooksPath(resolved.root);
+  if (
+    path.resolve(resolved.root, current.value || ".") ===
+    path.resolve(state.managedHooksPath)
+  ) {
+    if (state.previousWasConfigured) {
+      await runGit(resolved.root, [
+        "config",
+        "--local",
+        "core.hooksPath",
+        state.previousHooksPath,
+      ]);
+    } else {
+      await runGit(
+        resolved.root,
+        ["config", "--local", "--unset", "core.hooksPath"],
+        true,
+      );
+    }
+  }
+  await rm(stateDir, { recursive: true, force: true });
+  await unregisterRepository(input.homeDir ?? traceHomeDir(), resolved.root);
+  return {
+    repository: true,
+    enabled: false,
+    root: resolved.root,
+    message: "Review trace hooks are disabled for this repository.",
+  };
+}
+
+export async function traceRepositoryStatus(
+  cwd: string,
+): Promise<TraceRepositoryStatus> {
+  const resolved = await resolveRepository(cwd);
+  if (!resolved)
+    return {
+      repository: false,
+      enabled: false,
+      message: "Not inside a Git repository.",
+    };
+  const state = await readState(
+    path.join(resolved.commonDir, "dev-fast", "trace-hooks", "state.json"),
+  );
+  const current = await configuredHooksPath(resolved.root);
+  const enabled = Boolean(
+    state &&
+    path.resolve(resolved.root, current.value || ".") ===
+      path.resolve(state.managedHooksPath),
+  );
+  return {
+    repository: true,
+    enabled,
+    root: resolved.root,
+    ...(state
+      ? {
+          managedHooksPath: state.managedHooksPath,
+          previousHooksPath: state.previousHooksPath,
+        }
+      : {}),
+    message: enabled
+      ? "Review trace hooks are enabled for this repository."
+      : "Review trace hooks are not enabled for this repository.",
+  };
+}
+
+export async function disableAllTraceRepositories(
+  homeDir = os.homedir(),
+): Promise<void> {
+  const registry = await readRegistry(homeDir);
+  for (const root of registry) {
+    await disableTraceRepository({ cwd: root, homeDir }).catch(() => undefined);
+  }
+}
+
+function traceHomeDir(): string {
+  return process.env.TRACE_HOME_DIR ?? os.homedir();
+}
+
+async function resolveRepository(
+  cwd: string,
+): Promise<{ root: string; commonDir: string } | null> {
+  const rootResult = await runGit(cwd, ["rev-parse", "--show-toplevel"], true);
+  const commonResult = await runGit(
+    cwd,
+    ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    true,
+  );
+  if (!rootResult.ok || !commonResult.ok) return null;
+  return {
+    root: rootResult.stdout.trim(),
+    commonDir: commonResult.stdout.trim(),
+  };
+}
+
+async function configuredHooksPath(
+  root: string,
+): Promise<{ configured: boolean; value: string }> {
+  const result = await runGit(
+    root,
+    ["config", "--local", "--get", "core.hooksPath"],
+    true,
+  );
+  return {
+    configured: result.ok && Boolean(result.stdout.trim()),
+    value: result.stdout.trim(),
+  };
+}
+
+function resolveHooksPath(root: string, hooksPath: string): string {
+  return path.isAbsolute(hooksPath) ? hooksPath : path.resolve(root, hooksPath);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function previousHookSetup(pathValue: string, name: string): string {
+  if (path.isAbsolute(pathValue)) {
+    return `previous=${shellQuote(path.join(pathValue, name))}`;
+  }
+  return [
+    'root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"',
+    `previous="$root"/${shellQuote(path.join(pathValue, name))}`,
+  ].join("\n");
+}
+
+function prepareCommitMessageHook(
+  previousPath: string,
+  reviewCommand: string,
+): string {
+  const previous = previousHookSetup(previousPath, "prepare-commit-msg");
+  const review = shellQuote(reviewCommand);
+  return `#!/bin/sh\n${previous}\nif [ -x "$previous" ]; then\n  "$previous" "$@" || exit $?\nfi\n${review} trace git-hook prepare-commit-msg "$@" || true\nexit 0\n`;
+}
+
+function prePushHook(previousPath: string, reviewCommand: string): string {
+  const previous = previousHookSetup(previousPath, "pre-push");
+  const review = shellQuote(reviewCommand);
+  return `#!/bin/sh\n${previous}\ntmp="$(mktemp "\${TMPDIR:-/tmp}/review-pre-push.XXXXXX")" || exit 0\ntrap 'rm -f "$tmp"' EXIT HUP INT TERM\ncat > "$tmp"\nif [ -x "$previous" ]; then\n  "$previous" "$@" < "$tmp" || exit $?\nfi\n${review} trace git-hook pre-push "$@" < "$tmp" || true\nexit 0\n`;
+}
+
+async function writeHook(filePath: string, contents: string): Promise<void> {
+  await writeFile(filePath, contents, { mode: 0o755 });
+  await chmod(filePath, 0o755);
+}
+
+async function readState(
+  filePath: string,
+): Promise<RepositoryHookState | null> {
+  try {
+    const value = JSON.parse(
+      await readFile(filePath, "utf8"),
+    ) as RepositoryHookState;
+    return value.version === 1 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writePrivateJson(
+  filePath: string,
+  value: unknown,
+): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  await chmod(filePath, 0o600);
+}
+
+function registryPath(homeDir: string): string {
+  return path.join(homeDir, ".config", "dev-trace", "repositories.json");
+}
+
+async function readRegistry(homeDir: string): Promise<string[]> {
+  try {
+    const value = JSON.parse(
+      await readFile(registryPath(homeDir), "utf8"),
+    ) as unknown;
+    return Array.isArray(value)
+      ? value.filter((item): item is string => typeof item === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+async function registerRepository(
+  homeDir: string,
+  root: string,
+): Promise<void> {
+  const current = await readRegistry(homeDir);
+  await writePrivateJson(registryPath(homeDir), [
+    ...new Set([...current, root]),
+  ]);
+}
+
+async function unregisterRepository(
+  homeDir: string,
+  root: string,
+): Promise<void> {
+  await writePrivateJson(
+    registryPath(homeDir),
+    (await readRegistry(homeDir)).filter((entry) => entry !== root),
+  );
+}
+
+async function runGit(
+  cwd: string,
+  args: string[],
+  allowFailure = false,
+): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      "git",
+      ["-C", cwd, ...args],
+      {
+        maxBuffer: 64 * 1024 * 1024,
+      },
+    );
+    return { ok: true, stdout, stderr };
+  } catch (cause) {
+    if (!allowFailure) throw cause;
+    const error = cause as { stdout?: string; stderr?: string };
+    return {
+      ok: false,
+      stdout: error.stdout ?? "",
+      stderr: error.stderr ?? String(cause),
+    };
+  }
+}

--- a/packages/progressive-review/src/ui-telemetry-events.ts
+++ b/packages/progressive-review/src/ui-telemetry-events.ts
@@ -118,7 +118,7 @@ const THREAD_INTENT = ["comment", "ask-agent"] as const;
 const NEW_ASK_VIA = ["topbar", "threads_panel"] as const;
 const SOURCE_TREE_OPENED_VIA = ["topbar", "home"] as const;
 const THREAD_RESOLUTION_KIND = ["comment"] as const;
-const TAB = ["review", "commits", "map", "files"] as const;
+const TAB = ["review", "commits", "map", "files", "trace"] as const;
 const COMMIT_DIFF_VIA = ["row", "file", "footer"] as const;
 export const CLIENT_ERROR_SOURCE = [
   "window",
@@ -497,9 +497,7 @@ export function isReportableCleanedMessage(value: string): boolean {
   // once the markers are removed. The marker shape is deliberately narrow, so a
   // producer cannot hide content inside a marker of its own.
   const remainder = value.replaceAll(REDACTION_MARKER_PATTERN, " ");
-  return (
-    !containsFilePathShape(remainder) && !hasPossibleUserInfo(remainder)
-  );
+  return !containsFilePathShape(remainder) && !hasPossibleUserInfo(remainder);
 }
 
 /**

--- a/packages/progressive-review/tsdown.config.ts
+++ b/packages/progressive-review/tsdown.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
     alwaysBundle: [
       /^@dev-fast\/local-vcs$/,
       /^@dev\.fast\/review-protocol$/,
+      /^@dev-fast\/trace-shared$/,
       /^isomorphic-git$/,
     ],
     onlyBundle: false,

--- a/packages/progressive-review/tutorial/review.mdx
+++ b/packages/progressive-review/tutorial/review.mdx
@@ -49,7 +49,7 @@ The database lens shows the `orders` record that the write path owns.
   <DbUseCase id="create-order" label="Create an order">
     <DbWrite
       from={actors.orderService}
-      to={stores.orderDatabase.tables.orders.status}
+      to={stores.orderDatabase.tables.orders.fields.status}
       label="write pending order"
       anchor={anchors.insertOrder}
     />
@@ -57,7 +57,7 @@ The database lens shows the `orders` record that the write path owns.
   <DbUseCase id="fulfill-order" label="Fulfill an order">
     <DbWrite
       from={actors.worker}
-      to={stores.orderDatabase.tables.orders.status}
+      to={stores.orderDatabase.tables.orders.fields.status}
       label="write fulfilled status"
       anchor={anchors.ship}
     />

--- a/packages/progressive-review/vitest.config.ts
+++ b/packages/progressive-review/vitest.config.ts
@@ -1,8 +1,15 @@
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { configDefaults, defineConfig } from "vitest/config";
+
+const require = createRequire(import.meta.url);
+const decodeNamedCharacterReferenceIndex = path.join(
+  path.dirname(require.resolve("decode-named-character-reference")),
+  "index.js",
+);
 
 const isolatedTests = [
   "app/src/review-document-boundary.test.tsx",
@@ -23,6 +30,10 @@ export default defineConfig({
       "@dev.fast/local-vcs": fileURLToPath(
         new URL("../local-vcs/src/index.ts", import.meta.url),
       ),
+      "@dev-fast/trace-shared": fileURLToPath(
+        new URL("../trace-shared/src/index.ts", import.meta.url),
+      ),
+      "decode-named-character-reference": decodeNamedCharacterReferenceIndex,
     },
   },
   test: {

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -795,10 +795,21 @@ export interface ReviewCanvasInstallContent {
   apply(request: {
     targets: readonly ReviewCliInstallTarget[];
     shim?: boolean;
+    fff?: boolean;
+    trace?:
+      | true
+      | {
+          endpoint?: string;
+          bucket?: string;
+          key?: string;
+          secret?: string;
+        };
   }): Promise<ReviewCliInstallStatus>;
   remove(request: {
     targets: readonly ReviewCliInstallTarget[];
     shim?: boolean;
+    fff?: boolean;
+    trace?: true;
   }): Promise<ReviewCliInstallStatus>;
   decline(): Promise<ReviewCliInstallStatus>;
   skip(): Promise<ReviewCliInstallStatus>;
@@ -1049,7 +1060,7 @@ export const ReviewStatusSchema = z.enum([
 ]);
 
 export const ReviewSourceIdentitySchema = z.strictObject({
-  kind: z.enum(["git-branch", "jj-bookmark", "jj-change"]),
+  kind: z.enum(["git-branch", "git-commit", "jj-bookmark", "jj-change"]),
   name: requiredString,
 });
 export type ReviewSourceIdentity = z.infer<typeof ReviewSourceIdentitySchema>;
@@ -1297,11 +1308,27 @@ export type ReviewListResponse = z.infer<typeof ReviewListResponseSchema>;
 export type ReviewListError = ReviewListResponse["errors"][number];
 
 export const ReviewCliInstallTargetSchema = z.enum(
-  ["claude", "codex", "cursor"],
-  { error: "must be claude, codex, or cursor" },
+  ["claude", "codex", "cursor", "pi"],
+  { error: "must be claude, codex, cursor, or pi" },
 );
 export type ReviewCliInstallTarget = z.infer<
   typeof ReviewCliInstallTargetSchema
+>;
+
+export const ReviewFffInstallTargetSchema = z.enum(["claude", "codex", "pi"], {
+  error: "must be claude, codex, or pi",
+});
+export type ReviewFffInstallTarget = z.infer<
+  typeof ReviewFffInstallTargetSchema
+>;
+
+export const ReviewFffManagedRegistrationSchema = z.strictObject({
+  target: ReviewFffInstallTargetSchema,
+  command: requiredString,
+  args: z.array(requiredString),
+});
+export type ReviewFffManagedRegistration = z.infer<
+  typeof ReviewFffManagedRegistrationSchema
 >;
 
 export const ReviewCliInstallStampSchema = z.strictObject({
@@ -1311,6 +1338,8 @@ export const ReviewCliInstallStampSchema = z.strictObject({
   fingerprint: requiredString.optional(),
   targets: z.array(ReviewCliInstallTargetSchema).optional(),
   shimPath: requiredString.optional(),
+  fffRegistrations: z.array(ReviewFffManagedRegistrationSchema).optional(),
+  traceManaged: z.boolean().optional(),
   updatedAt: requiredString,
 });
 export type ReviewCliInstallStamp = z.infer<typeof ReviewCliInstallStampSchema>;
@@ -1327,6 +1356,30 @@ export const ReviewCliInstallStatusSchema = z.strictObject({
   stamp: ReviewCliInstallStampSchema.nullable(),
   stale: z.boolean(),
   shim: z.strictObject({ path: requiredString, onPath: z.boolean() }),
+  fff: z.strictObject({
+    serverName: z.literal("fff"),
+    corpusRoot: requiredString,
+    binary: z.strictObject({ path: requiredString, installed: z.boolean() }),
+    registrations: z.array(
+      z.strictObject({
+        target: ReviewFffInstallTargetSchema,
+        present: z.boolean(),
+        managed: z.boolean(),
+      }),
+    ),
+  }),
+  trace: z.strictObject({
+    enabled: z.boolean(),
+    configured: z.boolean(),
+    autoActivateRepositories: z.boolean(),
+    envPath: requiredString,
+    settingsPath: requiredString,
+    endpoint: requiredString.optional(),
+    bucket: requiredString.optional(),
+    accessKeyIdPrefix: requiredString.optional(),
+    verifiedAt: requiredString.optional(),
+    error: requiredString.optional(),
+  }),
   // Null when the serving package has no built CLI (a source-run dev server).
   cli: z
     .strictObject({ path: requiredString, version: requiredString })
@@ -1336,17 +1389,34 @@ export type ReviewCliInstallStatus = z.infer<
   typeof ReviewCliInstallStatusSchema
 >;
 
-// Skills are per-agent; the review terminal command is per-machine. The two
-// install independently: `targets` may be empty for a command-only install,
-// and the command is only ever written when `shim` is explicitly true.
+// Skills and FFF integrations are per-agent. The review command, FFF binary,
+// and trace configuration are per-machine. Silent app updates omit `fff` and
+// `trace`, so they do not run an installer or contact R2.
 export const ReviewCliInstallApplyRequestSchema = z
   .strictObject({
     targets: z.array(ReviewCliInstallTargetSchema),
     shim: z.boolean().optional(),
+    fff: z.boolean().optional(),
+    trace: z
+      .union([
+        z.literal(true),
+        z.strictObject({
+          endpoint: requiredString.optional(),
+          bucket: requiredString.optional(),
+          key: requiredString.optional(),
+          secret: requiredString.optional(),
+        }),
+      ])
+      .optional(),
   })
-  .refine((request) => request.targets.length > 0 || request.shim === true, {
-    message: "must install skills for at least one agent or the command",
-  });
+  .refine(
+    (request) =>
+      request.targets.length > 0 ||
+      request.shim === true ||
+      request.fff === true ||
+      request.trace !== undefined,
+    { message: "must install skills, the command, FFF, or trace capture" },
+  );
 export type ReviewCliInstallApplyRequest = z.infer<
   typeof ReviewCliInstallApplyRequestSchema
 >;
@@ -1927,3 +1997,86 @@ export const ReviewSurfaceEventSchema = z.discriminatedUnion("event", [
   }),
 ]);
 export type ReviewSurfaceEvent = z.infer<typeof ReviewSurfaceEventSchema>;
+
+// --- Agent trace view & trace quotes ----------------------------------------
+
+export const ReviewAgentTraceEventSchema = z.discriminatedUnion("kind", [
+  z.strictObject({
+    kind: z.literal("user"),
+    text: stringAllowEmpty,
+    at: z.string().optional(),
+  }),
+  z.strictObject({
+    kind: z.literal("assistant"),
+    markdown: stringAllowEmpty,
+    thinking: z.boolean().optional(),
+    at: z.string().optional(),
+  }),
+  z.strictObject({
+    kind: z.literal("tool"),
+    tool: requiredString,
+    verb: requiredString,
+    title: stringAllowEmpty,
+    filePath: z.string().optional(),
+    additions: z.number().optional(),
+    deletions: z.number().optional(),
+    command: z.string().optional(),
+    input: z.string().optional(),
+    output: z.string().optional(),
+    error: z.boolean().optional(),
+    at: z.string().optional(),
+  }),
+  z.strictObject({
+    kind: z.literal("separator"),
+    label: requiredString,
+  }),
+]);
+export type ReviewAgentTraceEvent = z.infer<typeof ReviewAgentTraceEventSchema>;
+
+export const ReviewAgentTraceSessionSchema = z.strictObject({
+  sessionId: requiredString,
+  harness: z.enum(["claude-code", "codex", "pi", "unknown"]),
+  available: z.boolean(),
+  source: z.enum(["r2"]).nullable(),
+  notSynced: z.boolean().optional(),
+  subagents: z.array(requiredString).optional(),
+  commits: z.array(
+    z.strictObject({ sha: requiredString, subject: stringAllowEmpty }),
+  ),
+});
+export type ReviewAgentTraceSession = z.infer<
+  typeof ReviewAgentTraceSessionSchema
+>;
+
+export const ReviewAgentTraceListResponseSchema = z.discriminatedUnion("ok", [
+  z.strictObject({
+    ok: z.literal(true),
+    configured: z.boolean().default(true),
+    sessions: z.array(ReviewAgentTraceSessionSchema),
+  }),
+  ReviewErrorResponseSchema,
+]);
+export type ReviewAgentTraceListResponse = z.infer<
+  typeof ReviewAgentTraceListResponseSchema
+>;
+
+export const ReviewAgentTraceResponseSchema = z.discriminatedUnion("ok", [
+  z.strictObject({
+    ok: z.literal(true),
+    parserVersion: requiredString,
+    session: ReviewAgentTraceSessionSchema,
+    trace: stringAllowEmpty.nullable().optional(),
+    subagents: z.array(requiredString).default([]),
+    title: z.string().nullable(),
+    startedAt: z.string().nullable(),
+    endedAt: z.string().nullable(),
+    activeMs: z.number().nullable(),
+    userTurns: z.number(),
+    toolCalls: z.number(),
+    events: z.array(ReviewAgentTraceEventSchema),
+  }),
+  ReviewErrorResponseSchema,
+]);
+export type ReviewAgentTraceResponse = z.infer<
+  typeof ReviewAgentTraceResponseSchema
+>;

--- a/packages/review-protocol/src/index.ts
+++ b/packages/review-protocol/src/index.ts
@@ -1,6 +1,14 @@
 import { z } from "zod";
 
 import {
+  type ReviewAgentTraceEvent,
+  ReviewAgentTraceEventSchema,
+  type ReviewAgentTraceListResponse,
+  ReviewAgentTraceListResponseSchema,
+  type ReviewAgentTraceResponse,
+  ReviewAgentTraceResponseSchema,
+  type ReviewAgentTraceSession,
+  ReviewAgentTraceSessionSchema,
   type ReviewCliInstallApplyRequest,
   ReviewCliInstallApplyRequestSchema,
   type ReviewCliInstallApplyResponse,
@@ -51,6 +59,8 @@ import {
   ReviewSessionResponseSchema,
   ReviewSessionSchema,
   type ReviewSessionWire,
+  ReviewSubmissionResponseSchema,
+  ReviewSubmissionWireSchema,
   type ReviewSurfaceEvent,
   ReviewSurfaceEventSchema,
   type ReviewThreadAnchorsResponse,
@@ -220,6 +230,30 @@ export function parseReviewDesktopState(value: unknown): ReviewDesktopState {
 
 export function parseReviewRange(value: unknown): ReviewRangeWire {
   return parseContract(ReviewRangeSchema, value);
+}
+
+export function parseReviewAgentTraceEvent(
+  value: unknown,
+): ReviewAgentTraceEvent {
+  return parseContract(ReviewAgentTraceEventSchema, value);
+}
+
+export function parseReviewAgentTraceSession(
+  value: unknown,
+): ReviewAgentTraceSession {
+  return parseContract(ReviewAgentTraceSessionSchema, value);
+}
+
+export function parseReviewAgentTraceListResponse(
+  value: unknown,
+): ReviewAgentTraceListResponse {
+  return parseContract(ReviewAgentTraceListResponseSchema, value);
+}
+
+export function parseReviewAgentTraceResponse(
+  value: unknown,
+): ReviewAgentTraceResponse {
+  return parseContract(ReviewAgentTraceResponseSchema, value);
 }
 
 function parseContract<T>(schema: z.ZodType<T>, value: unknown): T {

--- a/packages/trace-shared/package.json
+++ b/packages/trace-shared/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dev-fast/trace-shared",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run --config vitest.config.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "typescript": "npm:@typescript/typescript6@6.0.1",
+    "typescript-7": "npm:typescript@7.0.1-rc",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/trace-shared/src/contracts.ts
+++ b/packages/trace-shared/src/contracts.ts
@@ -1,0 +1,242 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Protocol version
+// ---------------------------------------------------------------------------
+
+export const TRACE_PROTOCOL_VERSION = 1;
+export const TRACE_API_VERSION_HEADER = "x-trace-api-version";
+
+// Upload blobs record the scrub pass applied before upload. 0 = none.
+export const TRACE_SCRUB_VERSION = 0;
+
+// ---------------------------------------------------------------------------
+// Core value schemas
+// ---------------------------------------------------------------------------
+
+export const ownerSchema = z
+  .string()
+  .min(1)
+  .max(39)
+  .regex(/^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/)
+  .transform((value) => value.toLowerCase());
+export const repoSchema = z
+  .string()
+  .min(1)
+  .max(100)
+  .regex(/^[A-Za-z0-9._-]+$/)
+  .transform((value) => value.toLowerCase());
+
+export const sessionIdSchema = z
+  .string()
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/);
+
+export const commitShaSchema = z.string().regex(/^[0-9a-f]{40,64}$/);
+
+export const traceAccessSchema = z.enum(["read", "write"]);
+export type TraceAccess = z.infer<typeof traceAccessSchema>;
+
+// ---------------------------------------------------------------------------
+// Stored object shapes (byte-compatible with the internal R2 layout)
+// ---------------------------------------------------------------------------
+
+export const byCommitSchema = z.object({
+  commit: commitShaSchema,
+  sessions: z.array(sessionIdSchema),
+  repo: z.string(),
+  pr: z.number().int().nullable(),
+  branch: z.string().nullable(),
+  indexed_by: z.enum(["hook", "ci"]),
+  ts: z.string(),
+});
+export type ByCommitEntry = z.infer<typeof byCommitSchema>;
+
+export const sessionMetaSchema = z.object({
+  session: sessionIdSchema,
+  repo: z.string().nullable(),
+  branch: z.string().nullable(),
+  pr: z.number().int().nullable(),
+  commits: z.array(commitShaSchema),
+  author: z.string().nullable(),
+  ts: z.string(),
+});
+export type SessionMeta = z.infer<typeof sessionMetaSchema>;
+
+// ---------------------------------------------------------------------------
+// API request/response shapes
+// ---------------------------------------------------------------------------
+
+export const errorEnvelopeSchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+  }),
+});
+export type ErrorEnvelope = z.infer<typeof errorEnvelopeSchema>;
+
+export const uploadTraceResponseSchema = z.object({
+  ok: z.literal(true),
+  bytes_stored: z.number().int().nonnegative(),
+  stored: z.enum(["written", "unchanged"]),
+});
+export type UploadTraceResponse = z.infer<typeof uploadTraceResponseSchema>;
+
+export const postSessionMetaRequestSchema = sessionMetaSchema
+  .omit({ ts: true })
+  .partial({ repo: true, branch: true, pr: true, author: true })
+  .extend({ commits: z.array(commitShaSchema).default([]) });
+export type PostSessionMetaRequest = z.infer<
+  typeof postSessionMetaRequestSchema
+>;
+
+export const postCommitRequestSchema = byCommitSchema.omit({ ts: true });
+export type PostCommitRequest = z.infer<typeof postCommitRequestSchema>;
+
+export const mintTokenRequestSchema = z.object({
+  owner: ownerSchema,
+  repo: repoSchema,
+  access: traceAccessSchema,
+});
+export const mintTokenResponseSchema = z.object({
+  token: z.string(),
+  expires_at: z.string(),
+});
+export type MintTokenResponse = z.infer<typeof mintTokenResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Capability tokens
+// ---------------------------------------------------------------------------
+
+export const traceTokenPayloadSchema = z.object({
+  owner: ownerSchema,
+  repo: repoSchema,
+  access: traceAccessSchema,
+  exp: z.number().int(),
+});
+export type TraceTokenPayload = z.infer<typeof traceTokenPayloadSchema>;
+
+export interface CreateSignedTraceTokenInput {
+  owner: string;
+  repo: string;
+  access: TraceAccess;
+  expiresAt: Date;
+  secret: string;
+}
+
+export async function createSignedTraceToken(
+  input: CreateSignedTraceTokenInput,
+): Promise<string> {
+  const payload: TraceTokenPayload = traceTokenPayloadSchema.parse({
+    owner: input.owner,
+    repo: input.repo,
+    access: input.access,
+    exp: Math.floor(input.expiresAt.getTime() / 1000),
+  });
+  const encoded = base64UrlEncode(
+    new TextEncoder().encode(JSON.stringify(payload)),
+  );
+  const signature = await signTraceTokenPayload(encoded, input.secret);
+
+  return `v1.${encoded}.${signature}`;
+}
+
+export interface VerifySignedTraceTokenInput {
+  token: string;
+  secret: string;
+  now?: Date;
+}
+
+export async function verifySignedTraceToken(
+  input: VerifySignedTraceTokenInput,
+): Promise<TraceTokenPayload | null> {
+  const parts = input.token.split(".");
+  if (parts.length !== 3 || parts[0] !== "v1") {
+    return null;
+  }
+  const [, encoded, signature] = parts;
+
+  const expectedSignature = await signTraceTokenPayload(encoded, input.secret);
+  if (!timingSafeEqual(signature, expectedSignature)) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(base64UrlDecode(encoded)));
+  } catch {
+    return null;
+  }
+  const payload = traceTokenPayloadSchema.safeParse(parsed);
+  if (!payload.success) {
+    return null;
+  }
+
+  const nowSeconds = Math.floor((input.now ?? new Date()).getTime() / 1000);
+  if (payload.data.exp < nowSeconds) {
+    return null;
+  }
+
+  return payload.data;
+}
+
+// ---------------------------------------------------------------------------
+// Internal crypto helpers
+// ---------------------------------------------------------------------------
+
+async function signTraceTokenPayload(
+  payload: string,
+  secret: string,
+): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(payload),
+  );
+
+  return base64UrlEncode(new Uint8Array(signature));
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function base64UrlDecode(encoded: string): Uint8Array {
+  const padded = encoded.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(padded + "=".repeat((4 - (padded.length % 4)) % 4));
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+
+  return bytes;
+}
+
+function timingSafeEqual(left: string, right: string): boolean {
+  const encoder = new TextEncoder();
+  const leftBytes = encoder.encode(left);
+  const rightBytes = encoder.encode(right);
+  const length = Math.max(leftBytes.length, rightBytes.length);
+  let diff = leftBytes.length ^ rightBytes.length;
+
+  for (let index = 0; index < length; index += 1) {
+    diff |= (leftBytes[index] ?? 0) ^ (rightBytes[index] ?? 0);
+  }
+
+  return diff === 0;
+}

--- a/packages/trace-shared/src/index.ts
+++ b/packages/trace-shared/src/index.ts
@@ -1,0 +1,7 @@
+// @dev-fast/trace-shared — the trace product's storage API contract.
+//
+// Shared by apps/trace (the worker), apps/web (token minting), and
+// the review CLI (`review trace …`). Object shapes mirror the internal
+// R2 layout in scripts/trace-git.
+
+export * from "./contracts.js";

--- a/packages/trace-shared/test/index.test.ts
+++ b/packages/trace-shared/test/index.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  byCommitSchema,
+  createSignedTraceToken,
+  sessionMetaSchema,
+  verifySignedTraceToken,
+} from "../src/index.js";
+
+const SECRET = "test-secret";
+const FUTURE = new Date(Date.now() + 60_000);
+
+describe("capability tokens", () => {
+  it("round-trips an authentic token", async () => {
+    const token = await createSignedTraceToken({
+      owner: "Fix-Fast",
+      repo: "dev",
+      access: "write",
+      expiresAt: FUTURE,
+      secret: SECRET,
+    });
+    const payload = await verifySignedTraceToken({ token, secret: SECRET });
+    expect(payload).toMatchObject({
+      owner: "fix-fast",
+      repo: "dev",
+      access: "write",
+    });
+  });
+
+  it("survives repo names with dots", async () => {
+    const token = await createSignedTraceToken({
+      owner: "vercel",
+      repo: "next.js",
+      access: "read",
+      expiresAt: FUTURE,
+      secret: SECRET,
+    });
+    const payload = await verifySignedTraceToken({ token, secret: SECRET });
+    expect(payload?.repo).toBe("next.js");
+  });
+
+  it("rejects an expired token", async () => {
+    const token = await createSignedTraceToken({
+      owner: "Fix-Fast",
+      repo: "dev",
+      access: "read",
+      expiresAt: new Date(Date.now() - 1_000),
+      secret: SECRET,
+    });
+    expect(await verifySignedTraceToken({ token, secret: SECRET })).toBeNull();
+  });
+
+  it("rejects a tampered payload", async () => {
+    const token = await createSignedTraceToken({
+      owner: "Fix-Fast",
+      repo: "dev",
+      access: "read",
+      expiresAt: FUTURE,
+      secret: SECRET,
+    });
+    const [version, payload, signature] = token.split(".");
+    const forged = btoa(
+      atob(payload.replace(/-/g, "+").replace(/_/g, "/")).replace(
+        '"read"',
+        '"write"',
+      ),
+    )
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(
+      await verifySignedTraceToken({
+        token: `${version}.${forged}.${signature}`,
+        secret: SECRET,
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects the wrong secret and malformed tokens", async () => {
+    const token = await createSignedTraceToken({
+      owner: "Fix-Fast",
+      repo: "dev",
+      access: "read",
+      expiresAt: FUTURE,
+      secret: SECRET,
+    });
+    expect(await verifySignedTraceToken({ token, secret: "other" })).toBeNull();
+    expect(
+      await verifySignedTraceToken({ token: "v1.garbage", secret: SECRET }),
+    ).toBeNull();
+    expect(
+      await verifySignedTraceToken({ token: "v2.a.b", secret: SECRET }),
+    ).toBeNull();
+  });
+});
+
+describe("stored object schemas", () => {
+  it("parses a live by-commit entry shape", () => {
+    const entry = byCommitSchema.parse({
+      commit: "30a8056bd32bf5686b7094e3b19c3e07aa9ff17c",
+      sessions: ["49df4ae6-a245-4f47-94b8-183928fcefd0"],
+      repo: "Fix-Fast/dev",
+      pr: 875,
+      branch: "main",
+      indexed_by: "ci",
+      ts: "2026-08-10T20:39:16Z",
+    });
+    expect(entry.sessions).toHaveLength(1);
+  });
+
+  it("parses session meta with nullable fields", () => {
+    const meta = sessionMetaSchema.parse({
+      session: "49df4ae6-a245-4f47-94b8-183928fcefd0",
+      repo: null,
+      branch: null,
+      pr: null,
+      commits: [],
+      author: null,
+      ts: "2026-08-10T20:39:16Z",
+    });
+    expect(meta.commits).toEqual([]);
+  });
+});
+
+describe("tenant casing", () => {
+  it("normalizes owner and repo to lowercase at the schema", async () => {
+    const token = await createSignedTraceToken({
+      owner: "Fix-Fast",
+      repo: "Next.JS",
+      access: "read",
+      expiresAt: FUTURE,
+      secret: SECRET,
+    });
+    const payload = await verifySignedTraceToken({ token, secret: SECRET });
+    expect(payload).toMatchObject({ owner: "fix-fast", repo: "next.js" });
+  });
+});

--- a/packages/trace-shared/tsconfig.build.json
+++ b/packages/trace-shared/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/trace-shared/tsconfig.json
+++ b/packages/trace-shared/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"]
+}

--- a/packages/trace-shared/vitest.config.ts
+++ b/packages/trace-shared/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
         specifier: 4.5.7
         version: 4.5.7(@types/react@19.2.14)(react@19.2.5)
     devDependencies:
+      '@dev-fast/trace-shared':
+        specifier: workspace:*
+        version: link:../trace-shared
       '@dev.fast/review-protocol':
         specifier: workspace:*
         version: link:../review-protocol
@@ -258,6 +261,22 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      typescript-7:
+        specifier: npm:typescript@7.0.1-rc
+        version: typescript@7.0.1-rc
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.10(@types/node@24.12.2)(esbuild@0.28.1)(jsdom@29.1.1)(tsx@4.21.0)
+
+  packages/trace-shared:
+    dependencies:
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      typescript:
+        specifier: npm:@typescript/typescript6@6.0.1
+        version: '@typescript/typescript6@6.0.1'
       typescript-7:
         specifier: npm:typescript@7.0.1-rc
         version: typescript@7.0.1-rc


### PR DESCRIPTION
## Summary

- Add trace quotes, the raw trace view, local normalized trace storage, and the trace CLI.
- Add FFF search setup and trace hooks for Claude Code, Codex, and Pi.
- Add the trace archaeology skill and update the Review authoring skills.
- Port today’s authoring, worktree preparation, discovery, cache, and UI fixes.
- Add the shared trace package required by the standalone workspace.
- Preserve the standalone repository’s Review branding changes.

## Source

This ports the Review product changes from `Fix-Fast/dev` after the standalone import snapshot through source commit `dcdefa0e`.

Source pull requests: Fix-Fast/dev#979, #981, #982, #983, #986, #989, #991, #993, #994, #995, #996, #997, #998, #1002, #1003, #1004, #1005, #1007, and #1008.

Source-only web, trace worker, legacy CLI, and pre-push changes are not included.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- Tests for local VCS, Review protocol, shared trace, and Progressive Review
- Targeted format checks for changed files

The full format check still reports five unchanged files that were already present on `main`.
