### PR TITLE
Add Review hang correlation telemetry

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
@@ -1412,6 +1412,7 @@ export class ReviewCanvasEditorPane extends EditorPane {
 				if (generation !== this.loadGeneration || !this.targetDocument) return;
 				this.targetDocument.body.dataset["reviewCanvasReady"] = "true";
 				lifecycle?.ready();
+				void this.captureReviewPresented(model);
 			},
 			reportDiagnostic: (diagnostic) => {
 				if (generation === this.loadGeneration && diagnostic.level === "error") {
@@ -1426,6 +1427,24 @@ export class ReviewCanvasEditorPane extends EditorPane {
 				lifecycle?.reportDiagnostic(diagnostic);
 			},
 		};
+	}
+
+	private async captureReviewPresented(model: ReviewSessionModel): Promise<void> {
+		const session = model.session;
+		const headers = new Headers({
+			"content-type": "application/json",
+			"x-review-token": session.token,
+			"x-review-app-session-id": this.reviewTelemetryService.appSessionId,
+		});
+		await model.request(
+			`${session.sessionUrl}/__progressive-review/telemetry/event`,
+			{
+				method: "POST",
+				headers,
+				body: JSON.stringify({ name: "review_presented" }),
+				keepalive: true,
+			},
+		).catch(() => undefined);
 	}
 
 	/**

--- a/apps/review-desktop/scripts/review-presented-telemetry-contract.test.mjs
+++ b/apps/review-desktop/scripts/review-presented-telemetry-contract.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const canvasPartUrl = new URL(
+  "../code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts",
+  import.meta.url,
+);
+const desktopEntryUrl = new URL(
+  "../../../packages/progressive-review/app/src/desktop-entry.tsx",
+  import.meta.url,
+);
+
+test("presented telemetry follows a successful visible canvas ready signal", async () => {
+  const [canvasPart, desktopEntry] = await Promise.all([
+    readFile(canvasPartUrl, "utf8"),
+    readFile(desktopEntryUrl, "utf8"),
+  ]);
+
+  assert.match(
+    desktopEntry,
+    /Promise\.all\(\[documentBundle, softwareMapBundle\]\)/,
+  );
+  assert.match(
+    desktopEntry,
+    /if \(document && softwareMapLoaded && !error\) session\.signalReady\(\)/,
+  );
+
+  const visibleBridge = canvasPart.slice(
+    canvasPart.indexOf("private createBridge("),
+    canvasPart.indexOf("private async validateSessionMount("),
+  );
+  assert.match(
+    visibleBridge,
+    /lifecycle\?\.ready\(\);\s*void this\.captureReviewPresented\(model\);/,
+  );
+
+  const validationMount = canvasPart.slice(
+    canvasPart.indexOf("private async validateSessionMount("),
+  );
+  assert.doesNotMatch(validationMount, /captureReviewPresented/);
+});

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -24,10 +24,12 @@ state under `~/.dev/review-desktop/` by default.
 Passive product telemetry never includes:
 
 - source code or changed-file diffs;
-- paths, repository names, refs, symbols, or declarations;
+- paths, repository names, Review titles, refs, revision hashes, symbols, or
+  declarations;
 - review documents, comments, questions, or thread text;
 - prompts or model output; or
-- email, username, hostname, or a machine identifier.
+- email, username, hostname, machine identifier, raw Review UUID, or coding-agent
+  session identifier.
 
 The canvas talks to Review's local server. It does not connect directly to
 PostHog.
@@ -38,9 +40,12 @@ Anonymous telemetry is enabled by default. Review creates a random installation
 UUID and does not associate it with a person profile.
 
 Telemetry can include closed enums, booleans, counts, durations, the Review and
-app versions, operating-system and architecture categories, feature usage, and
-sanitized product errors. PostHog may derive coarse location at ingestion, but the
-project discards the source IP.
+app versions, operating-system and architecture categories, feature usage,
+opaque lifecycle-correlation identifiers, and sanitized product errors.
+Review derives Review and presentation correlation IDs locally with a
+namespaced HMAC keyed by the random installation ID. Raw Review UUIDs and
+Desktop Review-session IDs never reach PostHog. PostHog may derive coarse
+location at ingestion, but the project discards the source IP.
 
 Pending events are stored in a bounded local queue under
 `~/.dev/telemetry/events` by default. Review retries temporary

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -14,9 +14,10 @@ Last checked against this repository: 2026-08-18.
 - Anonymous telemetry is on by default and can be turned off at any time.
 - Review records actions such as opening a review, changing tabs, using code
   navigation, or completing a CLI command. Values are limited to fixed
-  categories, booleans, counts, durations, versions, and random identifiers.
+  categories, booleans, counts, durations, versions, and opaque identifiers.
 - Passive telemetry never includes your code, diffs, file paths, repository
-  name, branches, Review text, comments, questions, prompts, or model output.
+  name, Review title, refs, revision hashes, raw Review UUID, coding-agent
+  session ID, Review text, comments, questions, prompts, or model output.
 - Review uses a random installation ID. It does not use your email, username,
   hostname, or a hardware identifier, and it does not create a PostHog person
   profile.
@@ -82,6 +83,19 @@ Pending events are kept in a local queue under
 events, retries temporary failures, and deletes events after seven days.
 Telemetry is best-effort and never blocks Review from working.
 
+Three identifiers support exact lifecycle correlation without PostHog identity
+or group profiles:
+
+- `command_run_id` is a new random UUID for each CLI invocation.
+- `review_id` is `rv_` plus 128 bits of a namespaced HMAC of the Review UUID.
+- `presentation_id` is `pr_` plus 128 bits of a namespaced HMAC of the Desktop
+  Review-session ID.
+
+The HMAC key is the random installation ID. The same Review therefore has a
+stable `review_id` only on one installation; copying it to another installation
+produces a different value. The raw Review UUID and Desktop Review-session ID
+are used only inside the local server and never reach the capture client.
+
 Review Desktop disables the built-in Microsoft telemetry inherited from Code -
 OSS. A hardening test enforces that rule.
 
@@ -142,6 +156,11 @@ Every event from the Review telemetry API includes these properties:
 UI events also include `source: review_app` and a random `app_session_id`. The
 app creates a new app session identifier for each renderer lifetime.
 
+Review-scoped events can also include `review_id`. Events routed through a
+specific Desktop Review session can include both `review_id` and
+`presentation_id`. Global main-process and renderer errors remain unscoped;
+Review does not guess which open Review caused them.
+
 The embedded Desktop server adds `app_version` to all of its telemetry events.
 Standalone CLI events omit this property.
 
@@ -153,9 +172,11 @@ event includes only `reason`, `count`, and the random installation identifier.
 | Event                                     | Additional properties                                                      | When                               |
 | ----------------------------------------- | -------------------------------------------------------------------------- | ---------------------------------- |
 | `review_installation_created` | None                                                                       | The first enabled Review use       |
-| `review_command_succeeded`    | `command_path`, `exit_code`, `duration_ms`, and closed command flags       | A public CLI command succeeds      |
+| `review_command_started`      | `command_path`, `command_run_id`, `agent_kind`                             | A public CLI handler is about to run |
+| `review_command_bound`        | Start properties plus `review_id`                                          | Scaffold or publish resolves its Review |
+| `review_command_succeeded`    | `command_path`, `command_run_id`, `exit_code`, `duration_ms`, optional `review_id`, and closed command flags | A public CLI command succeeds      |
 | `review_command_failed`       | The success properties plus `error_name` and `error_category` closed enums | A public CLI command fails         |
-| `review_session_started`      | `source_kind`, `agent_kind`, optional `app_session_id`                     | A Desktop review session opens     |
+| `review_session_started`      | `source_kind`, `agent_kind`, `review_id`, `presentation_id`, optional `app_session_id` | A Desktop review session opens     |
 | `review_session_ended`        | Start properties plus `outcome`, `duration_ms`                             | A review submits or is dismissed   |
 | `review_review_deleted`       | None                                                                       | A user deletes a stored review     |
 | `review_review_reaped`        | `retention_days`                                                           | Retention deletes a dismissed review |
@@ -171,6 +192,12 @@ arguments or refs.
 
 The `command`, `subcommand`, `mode`, `has_base_ref`, `has_head_ref`, and
 `force` flags accompany only `map.*` commands.
+
+The CLI writes `review_command_started` to the disk queue before entering the
+command handler. The queue normally begins its background flush after five
+seconds; Review does not wait for network delivery before starting the command.
+Scaffold binds after a new Review is persisted or an update target is resolved.
+Publish binds immediately after target resolution, before validation and mount.
 
 Error names and categories are closed enums. A failed command sends no exception
 message, stack, path, process output, project identifier, or remediation text.
@@ -220,6 +247,7 @@ The server checks all canvas properties against
 | `review_bug_report_send_failed`   | Short `error_name`                                                                                       | A bug report request fails                |
 | `review_setting_changed`          | `setting` in telemetry_enabled, keymap, dismissed_retention_days, software_map_enabled; `enabled`        | A user changes a Review setting           |
 | `review_review_opened`            | `via` in home, cli, other                                                                                | A user opens a review                     |
+| `review_review_presented`         | `review_id`, `presentation_id`                                                                           | A visible canvas loads and signals ready  |
 | `review_home_empty_state_viewed`  | None                                                                                                     | The empty Home state opens                |
 
 The server emits `review_review_submitted` after it stores a submission. Its
@@ -230,6 +258,23 @@ review_topbar, home.
 The server emits `review_review_restored` when a dismissal ends. Its property
 is `via` in home, open. The `home` value is the Undo button. The `open` value
 is the implicit undo: a reader who opens a dismissed review brings it back.
+
+“Presented” does not mean `review publish` returned successfully. It means the
+visible canvas loaded both the Review document and its optional software map,
+reported no render error, and fired the existing canvas-ready signal. The
+off-screen mount used by the publish validation gate does not emit this event.
+
+## Suspected hangs
+
+Operational queries classify a lifecycle start as a suspected hang after five
+minutes without its matching terminal event:
+
+- a command start with no success or failure sharing `command_run_id`; or
+- a session start with no presentation sharing `presentation_id`.
+
+This observes lifecycle gaps; it does not time out or kill work. A suspected
+hang can also be a crash, force-kill, or telemetry delivery loss. A late
+terminal or ready event removes the match automatically.
 
 ### Workbench events
 

--- a/packages/progressive-review/src/cli-runner.ts
+++ b/packages/progressive-review/src/cli-runner.ts
@@ -173,8 +173,10 @@ export async function runProgressiveReviewCli(
   let activeTelemetry:
     | {
         command: ProgressiveReviewCommandPath;
+        commandRunId: string;
         startedAt: number;
         finished: boolean;
+        reviewUuid?: string;
       }
     | undefined;
 
@@ -289,6 +291,18 @@ export async function runProgressiveReviewCli(
     writeAppEvent(event, options.json);
     state.exitCode = 0;
   };
+  const bindActiveReview = async (reviewUuid: string): Promise<void> => {
+    const active = activeTelemetry;
+    if (!active || active.finished || active.reviewUuid) return;
+    active.reviewUuid = reviewUuid;
+    await attemptTelemetry(() =>
+      telemetry.captureCommandBound({
+        command: active.command,
+        commandRunId: active.commandRunId,
+        reviewUuid,
+      }),
+    );
+  };
   const app = configureJsonOutput(
     program
       .command("app")
@@ -350,6 +364,7 @@ export async function runProgressiveReviewCli(
       stdout: input.stdout,
       stderr: input.stderr,
       env,
+      onReviewBound: bindActiveReview,
     });
   });
 
@@ -507,6 +522,7 @@ export async function runProgressiveReviewCli(
         update: options.update,
         reviewUuid: options.review,
         newReview: options.new,
+        onReviewBound: bindActiveReview,
       });
       input.stdout.write(`${JSON.stringify(event)}\n`);
       state.exitCode = 0;
@@ -965,8 +981,17 @@ export async function runProgressiveReviewCli(
     }
     const command = telemetryCommandPath(actionCommand, input.argv);
     if (!command) return;
-    activeTelemetry = { command, startedAt: Date.now(), finished: false };
+    const commandRunId = telemetry.createCommandRunId();
+    activeTelemetry = {
+      command,
+      commandRunId,
+      startedAt: Date.now(),
+      finished: false,
+    };
     await attemptTelemetry(() => telemetry.captureInstallationCreated());
+    await attemptTelemetry(() =>
+      telemetry.captureCommandStarted({ command, commandRunId }),
+    );
   });
   program.hook("postAction", async () => {
     await finishActiveTelemetry(
@@ -1313,8 +1338,10 @@ async function finishActiveTelemetry(
   active:
     | {
         command: ProgressiveReviewCommandPath;
+        commandRunId: string;
         startedAt: number;
         finished: boolean;
+        reviewUuid?: string;
       }
     | undefined,
   exitCode: number,
@@ -1328,15 +1355,19 @@ async function finishActiveTelemetry(
     exitCode === 0
       ? telemetry.captureCommandSucceeded({
           command: active.command,
+          commandRunId: active.commandRunId,
           exitCode,
           durationMs: Date.now() - active.startedAt,
           properties,
+          reviewUuid: active.reviewUuid,
         })
       : telemetry.captureCommandFailed({
           command: active.command,
+          commandRunId: active.commandRunId,
           exitCode,
           durationMs: Date.now() - active.startedAt,
           properties,
+          reviewUuid: active.reviewUuid,
           ...classification,
         }),
   );
@@ -1348,13 +1379,23 @@ async function captureOneOffCommand(
   exitCode: number,
   error?: unknown,
 ): Promise<void> {
+  const commandRunId = telemetry.createCommandRunId();
   await attemptTelemetry(() => telemetry.captureInstallationCreated());
+  await attemptTelemetry(() =>
+    telemetry.captureCommandStarted({ command, commandRunId }),
+  );
   const classification = errorClassification(command, error);
   await attemptTelemetry(() =>
     exitCode === 0
-      ? telemetry.captureCommandSucceeded({ command, exitCode, durationMs: 0 })
+      ? telemetry.captureCommandSucceeded({
+          command,
+          commandRunId,
+          exitCode,
+          durationMs: 0,
+        })
       : telemetry.captureCommandFailed({
           command,
+          commandRunId,
           exitCode,
           durationMs: 0,
           ...classification,

--- a/packages/progressive-review/src/cli.test.ts
+++ b/packages/progressive-review/src/cli.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { PassThrough } from "node:stream";
 
 import { describe, expect, it, vi } from "vitest";
@@ -5,7 +8,8 @@ import { describe, expect, it, vi } from "vitest";
 import { runProgressiveReviewCli } from "./cli-runner";
 import { runInstall as runInstallActual } from "./install";
 import { runReviewMigration as runReviewMigrationActual } from "./migrate";
-import type { ProgressiveReviewTelemetry } from "./progressive-review-telemetry";
+import { PostHogCaptureClient } from "./posthog-capture-client";
+import { ProgressiveReviewTelemetry } from "./progressive-review-telemetry";
 import { runReviewApp as runReviewAppActual } from "./review-app";
 import { runReviewAppLaunch as runReviewAppLaunchActual } from "./review-app-launcher";
 import {
@@ -240,7 +244,16 @@ describe("Review CLI", () => {
       async () => undefined,
     );
     const telemetry = {
+      createCommandRunId: vi.fn<
+        ProgressiveReviewTelemetry["createCommandRunId"]
+      >(() => "run-12345678"),
       captureInstallationCreated: vi.fn<() => Promise<undefined>>(
+        async () => undefined,
+      ),
+      captureCommandStarted: vi.fn<() => Promise<undefined>>(
+        async () => undefined,
+      ),
+      captureCommandBound: vi.fn<() => Promise<undefined>>(
         async () => undefined,
       ),
       captureCommandSucceeded,
@@ -274,6 +287,202 @@ describe("Review CLI", () => {
     ).resolves.toBe(0);
     expect(captureCommandSucceeded).toHaveBeenCalledWith(
       expect.objectContaining({ command }),
+    );
+  });
+
+  it("persists command start before an unresolved handler and completes the same run", async () => {
+    const rootPath = await mkdtemp(path.join(os.tmpdir(), "review-cli-run-"));
+    const queueDir = path.join(rootPath, "queue");
+    let queueId = 0;
+    const fetchMock = vi.fn<typeof fetch>(
+      async () => new Response(null, { status: 200 }),
+    );
+    const captureClient = new PostHogCaptureClient({
+      apiKey: "test-key",
+      fetch: fetchMock,
+      queueDir,
+      idFactory: () => `queue-${queueId++}`,
+    });
+    const telemetry = new ProgressiveReviewTelemetry({
+      captureClient,
+      env: {},
+      installConfigPath: path.join(rootPath, "telemetry.json"),
+      idFactory: () => "install-123",
+      randomUUID: () => "8b733d48-1172-46a7-9df0-3cc71930c25a",
+    });
+    let entered!: () => void;
+    const handlerEntered = new Promise<void>((resolve) => (entered = resolve));
+    let release!: (
+      value: Awaited<ReturnType<typeof runReviewInfoActual>>,
+    ) => void;
+    const handlerResult = new Promise<
+      Awaited<ReturnType<typeof runReviewInfoActual>>
+    >((resolve) => (release = resolve));
+    const runReviewInfo = vi.fn<typeof runReviewInfoActual>(async () => {
+      entered();
+      return handlerResult;
+    });
+
+    try {
+      const running = runProgressiveReviewCli({
+        argv: ["info"],
+        stdout: outputStream(),
+        stderr: outputStream(),
+        telemetry,
+        runtime: { runReviewInfo },
+      });
+      await handlerEntered;
+
+      const queued = await Promise.all(
+        (await readdir(queueDir))
+          .filter((file) => file.endsWith(".json"))
+          .map(async (file) =>
+            JSON.parse(await readFile(path.join(queueDir, file), "utf8")),
+          ),
+      );
+      expect(queued).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: "review_command_started",
+            properties: expect.objectContaining({
+              command_path: "info",
+              command_run_id: "8b733d48-1172-46a7-9df0-3cc71930c25a",
+            }),
+          }),
+        ]),
+      );
+
+      release({ event: "info", reviews: [] });
+      await expect(running).resolves.toBe(0);
+      const sent = fetchMock.mock.calls.flatMap(
+        ([, init]) =>
+          JSON.parse(String(init?.body)).batch as Array<{
+            event: string;
+            properties: Record<string, unknown>;
+          }>,
+      );
+      const lifecycle = sent.filter((event) =>
+        ["review_command_started", "review_command_succeeded"].includes(
+          event.event,
+        ),
+      );
+      expect(lifecycle).toHaveLength(2);
+      expect(lifecycle.map((event) => event.properties.command_run_id)).toEqual(
+        [
+          "8b733d48-1172-46a7-9df0-3cc71930c25a",
+          "8b733d48-1172-46a7-9df0-3cc71930c25a",
+        ],
+      );
+    } finally {
+      await rm(rootPath, { recursive: true, force: true });
+    }
+  });
+
+  it("emits a failed terminal event when a handler rejects", async () => {
+    const captureCommandStarted = vi.fn<
+      ProgressiveReviewTelemetry["captureCommandStarted"]
+    >(async () => undefined);
+    const captureCommandFailed = vi.fn<
+      ProgressiveReviewTelemetry["captureCommandFailed"]
+    >(async () => undefined);
+    const telemetry = {
+      createCommandRunId: () => "8b733d48-1172-46a7-9df0-3cc71930c25a",
+      captureInstallationCreated: vi.fn<
+        ProgressiveReviewTelemetry["captureInstallationCreated"]
+      >(async () => undefined),
+      captureCommandStarted,
+      captureCommandBound: vi.fn<
+        ProgressiveReviewTelemetry["captureCommandBound"]
+      >(async () => undefined),
+      captureCommandSucceeded: vi.fn<
+        ProgressiveReviewTelemetry["captureCommandSucceeded"]
+      >(async () => undefined),
+      captureCommandFailed,
+      shutdown: vi.fn<ProgressiveReviewTelemetry["shutdown"]>(
+        async () => undefined,
+      ),
+    } as unknown as ProgressiveReviewTelemetry;
+
+    await expect(
+      runProgressiveReviewCli({
+        argv: ["info"],
+        stdout: outputStream(),
+        stderr: outputStream(),
+        telemetry,
+        runtime: {
+          runReviewInfo: async () => {
+            throw new Error("controlled failure");
+          },
+        },
+      }),
+    ).resolves.toBe(1);
+
+    expect(captureCommandStarted).toHaveBeenCalledWith({
+      command: "info",
+      commandRunId: "8b733d48-1172-46a7-9df0-3cc71930c25a",
+    });
+    expect(captureCommandFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "info",
+        commandRunId: "8b733d48-1172-46a7-9df0-3cc71930c25a",
+        exitCode: 1,
+      }),
+    );
+  });
+
+  it("binds scaffold telemetry and enriches the terminal event", async () => {
+    const reviewUuid = "86df96ed-65ef-46de-9348-c94811e3bb46";
+    const captureCommandBound = vi.fn<
+      ProgressiveReviewTelemetry["captureCommandBound"]
+    >(async () => undefined);
+    const captureCommandSucceeded = vi.fn<
+      ProgressiveReviewTelemetry["captureCommandSucceeded"]
+    >(async () => undefined);
+    const telemetry = {
+      createCommandRunId: () => "8b733d48-1172-46a7-9df0-3cc71930c25a",
+      captureInstallationCreated: vi.fn<
+        ProgressiveReviewTelemetry["captureInstallationCreated"]
+      >(async () => undefined),
+      captureCommandStarted: vi.fn<
+        ProgressiveReviewTelemetry["captureCommandStarted"]
+      >(async () => undefined),
+      captureCommandBound,
+      captureCommandSucceeded,
+      captureCommandFailed: vi.fn<
+        ProgressiveReviewTelemetry["captureCommandFailed"]
+      >(async () => undefined),
+      shutdown: vi.fn<ProgressiveReviewTelemetry["shutdown"]>(
+        async () => undefined,
+      ),
+    } as unknown as ProgressiveReviewTelemetry;
+    const runReviewScaffold = vi.fn<typeof runReviewScaffoldActual>(
+      async (input) => {
+        await input.onReviewBound?.(reviewUuid);
+        return { event: "info", reviews: [] };
+      },
+    );
+
+    await expect(
+      runProgressiveReviewCli({
+        argv: ["scaffold"],
+        stdout: outputStream(),
+        stderr: outputStream(),
+        telemetry,
+        runtime: { runReviewScaffold },
+      }),
+    ).resolves.toBe(0);
+
+    expect(captureCommandBound).toHaveBeenCalledWith({
+      command: "scaffold",
+      commandRunId: "8b733d48-1172-46a7-9df0-3cc71930c25a",
+      reviewUuid,
+    });
+    expect(captureCommandSucceeded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "scaffold",
+        commandRunId: "8b733d48-1172-46a7-9df0-3cc71930c25a",
+        reviewUuid,
+      }),
     );
   });
 

--- a/packages/progressive-review/src/progressive-review-telemetry.test.ts
+++ b/packages/progressive-review/src/progressive-review-telemetry.test.ts
@@ -35,6 +35,7 @@ describe("ProgressiveReviewTelemetry", () => {
     await telemetry.captureInstallationCreated();
     await telemetry.captureCommandSucceeded({
       command: "scaffold",
+      commandRunId: "run-12345678",
       exitCode: 0,
       properties: { has_base_ref: false },
     });
@@ -64,6 +65,7 @@ describe("ProgressiveReviewTelemetry", () => {
 
     await telemetry.captureCommandSucceeded({
       command: "info",
+      commandRunId: "run-12345678",
       exitCode: 0,
     });
 
@@ -152,7 +154,11 @@ describe("ProgressiveReviewTelemetry", () => {
     cleanupPaths.push(rootPath);
     await writeStoredConfig(configPath, storedConfig({ internal: true }));
 
-    await telemetry.captureCommandSucceeded({ command: "info", exitCode: 0 });
+    await telemetry.captureCommandSucceeded({
+      command: "info",
+      commandRunId: "run-12345678",
+      exitCode: 0,
+    });
 
     expect(events[0].properties).toMatchObject({ internal: false });
   });
@@ -164,7 +170,11 @@ describe("ProgressiveReviewTelemetry", () => {
     cleanupPaths.push(rootPath);
     await writeStoredConfig(configPath, storedConfig({ internal: false }));
 
-    await telemetry.captureCommandSucceeded({ command: "info", exitCode: 0 });
+    await telemetry.captureCommandSucceeded({
+      command: "info",
+      commandRunId: "run-12345678",
+      exitCode: 0,
+    });
 
     expect(events[0].properties).toMatchObject({ internal: true });
   });
@@ -175,7 +185,11 @@ describe("ProgressiveReviewTelemetry", () => {
     await writeStoredConfig(configPath, storedConfig({ internal: true }));
 
     await telemetry.captureInstallationCreated();
-    await telemetry.captureCommandSucceeded({ command: "info", exitCode: 0 });
+    await telemetry.captureCommandSucceeded({
+      command: "info",
+      commandRunId: "run-12345678",
+      exitCode: 0,
+    });
     await telemetry.captureReviewReaped({ retentionDays: 30 });
     await telemetry.captureUiEvent("review_app_opened", {});
 
@@ -257,10 +271,19 @@ describe("ProgressiveReviewTelemetry", () => {
     cleanupPaths.push(rootPath);
 
     await telemetry.captureInstallationCreated();
+    await telemetry.captureCommandStarted({
+      command: "info",
+      commandRunId: telemetry.createCommandRunId(),
+    });
     await telemetry.captureCommandFailed({
       command: "info",
+      commandRunId: "run-12345678",
       exitCode: 1,
       properties: { healthy: false },
+    });
+    await telemetry.captureReviewPresented({
+      reviewUuid: "86df96ed-65ef-46de-9348-c94811e3bb46",
+      presentationSessionId: "0f98956f-ec90-45b5-ae21-19acbcd8b6ef",
     });
 
     expect(events).toEqual([]);
@@ -275,6 +298,7 @@ describe("ProgressiveReviewTelemetry", () => {
 
     await telemetry.captureCommandFailed({
       command: "publish",
+      commandRunId: "run-12345678",
       exitCode: 1,
       errorName: "review_state_error",
       errorCategory: "local_state",
@@ -295,15 +319,127 @@ describe("ProgressiveReviewTelemetry", () => {
     cleanupPaths.push(rootPath);
 
     await telemetry.setEnabled(false);
-    await telemetry.captureCommandSucceeded({ command: "info", exitCode: 0 });
+    await telemetry.captureCommandSucceeded({
+      command: "info",
+      commandRunId: "run-12345678",
+      exitCode: 0,
+    });
     expect(events).toEqual([]);
     await expect(readFile(configPath, "utf8")).resolves.toContain(
       '"enabled": false',
     );
 
     await telemetry.setEnabled(true);
-    await telemetry.captureCommandSucceeded({ command: "info", exitCode: 0 });
+    await telemetry.captureCommandSucceeded({
+      command: "info",
+      commandRunId: "run-12345678",
+      exitCode: 0,
+    });
     expect(events).toHaveLength(1);
+  });
+
+  it("keeps one command run id across start, binding, and completion", async () => {
+    const { events, rootPath, telemetry } = createTelemetry({
+      env: { CODEX_THREAD_ID: "agent-session-secret" },
+      commandRunId: "8b733d48-1172-46a7-9df0-3cc71930c25a",
+    });
+    cleanupPaths.push(rootPath);
+    const commandRunId = telemetry.createCommandRunId();
+    const reviewUuid = "86df96ed-65ef-46de-9348-c94811e3bb46";
+
+    await telemetry.captureCommandStarted({
+      command: "scaffold",
+      commandRunId,
+    });
+    await telemetry.captureCommandBound({
+      command: "scaffold",
+      commandRunId,
+      reviewUuid,
+    });
+    await telemetry.captureCommandSucceeded({
+      command: "scaffold",
+      commandRunId,
+      reviewUuid,
+      exitCode: 0,
+    });
+
+    expect(events.map((event) => event.event)).toEqual([
+      "review_command_started",
+      "review_command_bound",
+      "review_command_succeeded",
+    ]);
+    expect(events.map((event) => event.properties?.command_run_id)).toEqual([
+      commandRunId,
+      commandRunId,
+      commandRunId,
+    ]);
+    expect(events[0].properties).toMatchObject({ agent_kind: "codex" });
+    expect(events[1].properties?.review_id).toBe(
+      events[2].properties?.review_id,
+    );
+    expect(JSON.stringify(events)).not.toContain(reviewUuid);
+    expect(JSON.stringify(events)).not.toContain("agent-session-secret");
+  });
+
+  it("derives installation-scoped opaque review and presentation ids", async () => {
+    const reviewUuid = "86df96ed-65ef-46de-9348-c94811e3bb46";
+    const otherReviewUuid = "9d64ac3b-4de8-432c-b715-e338492553b9";
+    const presentationSessionId = "0f98956f-ec90-45b5-ae21-19acbcd8b6ef";
+    const otherPresentationSessionId = "512810fb-dd2a-4f56-9da3-bb5c3e3a5bcf";
+    const first = createTelemetry({ installationId: "install-123" });
+    const second = createTelemetry({ installationId: "install-456" });
+    cleanupPaths.push(first.rootPath, second.rootPath);
+
+    await first.telemetry.captureSessionStarted({
+      reviewUuid,
+      presentationSessionId,
+    });
+    await first.telemetry.captureUiEvent(
+      "review_client_error",
+      { error_name: "TypeError" },
+      { reviewUuid, presentationSessionId },
+    );
+    await first.telemetry.captureSessionStarted({
+      reviewUuid: otherReviewUuid,
+      presentationSessionId: otherPresentationSessionId,
+    });
+    await second.telemetry.captureSessionStarted({
+      reviewUuid,
+      presentationSessionId,
+    });
+
+    const firstIds = first.events[0].properties!;
+    const repeatedIds = first.events[1].properties!;
+    const otherEntityIds = first.events[2].properties!;
+    const otherInstallIds = second.events[0].properties!;
+    expect(firstIds.review_id).toMatch(/^rv_[A-Za-z0-9_-]{22}$/);
+    expect(firstIds.presentation_id).toMatch(/^pr_[A-Za-z0-9_-]{22}$/);
+    expect(repeatedIds.review_id).toBe(firstIds.review_id);
+    expect(repeatedIds.presentation_id).toBe(firstIds.presentation_id);
+    expect(otherEntityIds.review_id).not.toBe(firstIds.review_id);
+    expect(otherEntityIds.presentation_id).not.toBe(firstIds.presentation_id);
+    expect(otherInstallIds.review_id).not.toBe(firstIds.review_id);
+    expect(otherInstallIds.presentation_id).not.toBe(firstIds.presentation_id);
+    expect(JSON.stringify([...first.events, ...second.events])).not.toContain(
+      reviewUuid,
+    );
+    expect(JSON.stringify([...first.events, ...second.events])).not.toContain(
+      presentationSessionId,
+    );
+  });
+
+  it("leaves global client errors unscoped", async () => {
+    const { events, rootPath, telemetry } = createTelemetry();
+    cleanupPaths.push(rootPath);
+
+    await telemetry.captureUiEvent("review_client_error", {
+      error_process: "main",
+      error_name: "TypeError",
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].properties).not.toHaveProperty("review_id");
+    expect(events[0].properties).not.toHaveProperty("presentation_id");
   });
 
   it("returns the stable installation id without sending telemetry", async () => {
@@ -318,7 +454,11 @@ describe("ProgressiveReviewTelemetry", () => {
   });
 });
 
-function createTelemetry(input?: { env?: NodeJS.ProcessEnv }): {
+function createTelemetry(input?: {
+  env?: NodeJS.ProcessEnv;
+  installationId?: string;
+  commandRunId?: string;
+}): {
   configPath: string;
   events: PostHogCaptureInput[];
   legacyConfigPath: string;
@@ -345,7 +485,8 @@ function createTelemetry(input?: { env?: NodeJS.ProcessEnv }): {
     env: input?.env ?? {},
     installConfigPath: configPath,
     legacyInstallConfigPath: legacyConfigPath,
-    idFactory: () => "install-123",
+    idFactory: () => input?.installationId ?? "install-123",
+    ...(input?.commandRunId ? { randomUUID: () => input.commandRunId! } : {}),
     now: () => new Date("2026-01-02T03:04:05.000Z"),
   });
   return { configPath, events, legacyConfigPath, rootPath, telemetry };

--- a/packages/progressive-review/src/progressive-review-telemetry.ts
+++ b/packages/progressive-review/src/progressive-review-telemetry.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHmac, randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -106,11 +106,27 @@ export interface ReviewTabTelemetryEvent {
 
 export interface ProgressiveReviewCommandTelemetryInput {
   command: ProgressiveReviewCommandPath;
+  commandRunId: string;
   exitCode: number;
   durationMs?: number;
   properties?: PostHogCaptureProperties;
+  reviewUuid?: string;
   errorName?: ProgressiveReviewTelemetryErrorName;
   errorCategory?: ProgressiveReviewTelemetryErrorCategory;
+}
+
+export interface ProgressiveReviewCommandStartedInput {
+  command: ProgressiveReviewCommandPath;
+  commandRunId: string;
+}
+
+export interface ProgressiveReviewCommandBoundInput extends ProgressiveReviewCommandStartedInput {
+  reviewUuid: string;
+}
+
+export interface ProgressiveReviewTelemetryContext {
+  reviewUuid?: string;
+  presentationSessionId?: string;
 }
 
 export interface ProgressiveReviewSessionStartedInput {
@@ -118,6 +134,8 @@ export interface ProgressiveReviewSessionStartedInput {
   agentKind?: ProgressiveReviewSessionAgent;
   mode?: "pr" | "refs" | "branch";
   appSessionId?: string;
+  reviewUuid?: string;
+  presentationSessionId?: string;
 }
 
 export interface ProgressiveReviewSessionEndedInput extends ProgressiveReviewSessionStartedInput {
@@ -181,6 +199,7 @@ export class ProgressiveReviewTelemetry {
   private readonly installConfigPath: string;
   private readonly legacyInstallConfigPath: string;
   private readonly idFactory: () => string;
+  private readonly commandRunIdFactory: () => string;
   private readonly now: () => Date;
   private installConfig: ProgressiveReviewTelemetryInstallConfig | undefined;
   private packageVersion: Promise<string> | undefined;
@@ -198,7 +217,8 @@ export class ProgressiveReviewTelemetry {
       progressiveReviewTelemetryConfigPath(this.env);
     this.legacyInstallConfigPath =
       options.legacyInstallConfigPath ?? legacyAppTelemetryConfigPath(this.env);
-    this.idFactory = options.idFactory ?? options.randomUUID ?? randomUUID;
+    this.commandRunIdFactory = options.randomUUID ?? randomUUID;
+    this.idFactory = options.idFactory ?? this.commandRunIdFactory;
     this.now = options.now ?? (() => new Date());
   }
 
@@ -210,6 +230,10 @@ export class ProgressiveReviewTelemetry {
 
   async getInstallationId(): Promise<string> {
     return (await this.loadInstallConfig()).installationId;
+  }
+
+  createCommandRunId(): string {
+    return this.commandRunIdFactory();
   }
 
   async setEnabled(enabled: boolean): Promise<void> {
@@ -259,26 +283,72 @@ export class ProgressiveReviewTelemetry {
     await this.captureCommandEvent("review_command_failed", input);
   }
 
+  async captureCommandStarted(
+    input: ProgressiveReviewCommandStartedInput,
+  ): Promise<void> {
+    await this.captureEvent("review_command_started", {
+      command_path: input.command,
+      command_run_id: input.commandRunId,
+      agent_kind: this.sessionAgent(),
+    });
+  }
+
+  async captureCommandBound(
+    input: ProgressiveReviewCommandBoundInput,
+  ): Promise<void> {
+    await this.captureEvent(
+      "review_command_bound",
+      {
+        command_path: input.command,
+        command_run_id: input.commandRunId,
+        agent_kind: this.sessionAgent(),
+      },
+      { reviewUuid: input.reviewUuid },
+    );
+  }
+
   async captureSessionStarted(
     input: ProgressiveReviewSessionStartedInput,
   ): Promise<void> {
-    await this.captureEvent("review_session_started", {
-      source_kind: sourceKind(input),
-      agent_kind: input.agentKind ?? this.sessionAgent(),
-      ...(input.appSessionId ? { app_session_id: input.appSessionId } : {}),
-    });
+    await this.captureEvent(
+      "review_session_started",
+      {
+        source_kind: sourceKind(input),
+        agent_kind: input.agentKind ?? this.sessionAgent(),
+        ...(input.appSessionId ? { app_session_id: input.appSessionId } : {}),
+      },
+      sessionTelemetryContext(input),
+    );
   }
 
   async captureSessionEnded(
     input: ProgressiveReviewSessionEndedInput,
   ): Promise<void> {
-    await this.captureEvent("review_session_ended", {
-      source_kind: sourceKind(input),
-      agent_kind: input.agentKind ?? this.sessionAgent(),
-      outcome: input.outcome === "accepted" ? "approve" : input.outcome,
-      duration_ms: input.durationMs,
-      ...(input.appSessionId ? { app_session_id: input.appSessionId } : {}),
-    });
+    await this.captureEvent(
+      "review_session_ended",
+      {
+        source_kind: sourceKind(input),
+        agent_kind: input.agentKind ?? this.sessionAgent(),
+        outcome: input.outcome === "accepted" ? "approve" : input.outcome,
+        duration_ms: input.durationMs,
+        ...(input.appSessionId ? { app_session_id: input.appSessionId } : {}),
+      },
+      sessionTelemetryContext(input),
+    );
+  }
+
+  async captureReviewPresented(
+    context: Required<ProgressiveReviewTelemetryContext>,
+    input: { appSessionId?: string } = {},
+  ): Promise<void> {
+    await this.captureEvent(
+      "review_review_presented",
+      {
+        source: "review_app",
+        ...(input.appSessionId ? { app_session_id: input.appSessionId } : {}),
+      },
+      context,
+    );
   }
 
   async captureReviewDeleted(): Promise<void> {
@@ -303,29 +373,42 @@ export class ProgressiveReviewTelemetry {
     });
   }
 
-  async captureTabViewed(event: ReviewTabTelemetryEvent): Promise<void> {
-    await this.captureEvent("review_tab_viewed", {
-      tab: event.tab,
-      duration_ms: event.durationMs,
-      reason: event.reason,
-      source: "review_app",
-      app_session_id: event.appSessionId,
-    });
+  async captureTabViewed(
+    event: ReviewTabTelemetryEvent,
+    context?: ProgressiveReviewTelemetryContext,
+  ): Promise<void> {
+    await this.captureEvent(
+      "review_tab_viewed",
+      {
+        tab: event.tab,
+        duration_ms: event.durationMs,
+        reason: event.reason,
+        source: "review_app",
+        app_session_id: event.appSessionId,
+      },
+      context,
+    );
   }
 
   async captureUiEvent(
     event: string,
     properties: Record<string, string | number | boolean>,
+    context?: ProgressiveReviewTelemetryContext,
   ): Promise<void> {
-    await this.captureEvent(event, {
-      source: "review_app",
-      ...properties,
-    });
+    await this.captureEvent(
+      event,
+      {
+        source: "review_app",
+        ...properties,
+      },
+      context,
+    );
   }
 
   async captureEvent(
     event: string,
     properties: PostHogCaptureProperties = {},
+    context?: ProgressiveReviewTelemetryContext,
   ): Promise<void> {
     await this.withTelemetry(async (config) => {
       await this.captureClient.capture({
@@ -334,6 +417,7 @@ export class ProgressiveReviewTelemetry {
         properties: {
           ...(await this.commonProperties(config)),
           ...properties,
+          ...correlationProperties(config.installationId, context),
         },
       });
     });
@@ -353,16 +437,21 @@ export class ProgressiveReviewTelemetry {
     event: "review_command_succeeded" | "review_command_failed",
     input: ProgressiveReviewCommandTelemetryInput,
   ): Promise<void> {
-    await this.captureEvent(event, {
-      command_path: input.command,
-      exit_code: input.exitCode,
-      ...(input.durationMs === undefined
-        ? {}
-        : { duration_ms: input.durationMs }),
-      ...(input.properties ?? {}),
-      ...(input.errorName ? { error_name: input.errorName } : {}),
-      ...(input.errorCategory ? { error_category: input.errorCategory } : {}),
-    });
+    await this.captureEvent(
+      event,
+      {
+        command_path: input.command,
+        exit_code: input.exitCode,
+        ...(input.durationMs === undefined
+          ? {}
+          : { duration_ms: input.durationMs }),
+        ...(input.properties ?? {}),
+        command_run_id: input.commandRunId,
+        ...(input.errorName ? { error_name: input.errorName } : {}),
+        ...(input.errorCategory ? { error_category: input.errorCategory } : {}),
+      },
+      { reviewUuid: input.reviewUuid },
+    );
   }
 
   private async withTelemetry(
@@ -528,6 +617,58 @@ function sourceKind(
   if (input.sourceKind) return input.sourceKind;
   if (input.mode === "pr") return "pull_request";
   return "git_branch";
+}
+
+function sessionTelemetryContext(
+  input: ProgressiveReviewSessionStartedInput,
+): ProgressiveReviewTelemetryContext {
+  return {
+    reviewUuid: input.reviewUuid,
+    presentationSessionId: input.presentationSessionId,
+  };
+}
+
+function correlationProperties(
+  installationId: string,
+  context: ProgressiveReviewTelemetryContext | undefined,
+): PostHogCaptureProperties {
+  if (!context) return {};
+  return {
+    ...(context.reviewUuid
+      ? {
+          review_id: opaqueCorrelationId(
+            "rv_",
+            installationId,
+            "review",
+            context.reviewUuid,
+          ),
+        }
+      : {}),
+    ...(context.presentationSessionId
+      ? {
+          presentation_id: opaqueCorrelationId(
+            "pr_",
+            installationId,
+            "presentation",
+            context.presentationSessionId,
+          ),
+        }
+      : {}),
+  };
+}
+
+function opaqueCorrelationId(
+  prefix: "rv_" | "pr_",
+  installationId: string,
+  namespace: "review" | "presentation",
+  value: string,
+): string {
+  const digest = createHmac("sha256", installationId)
+    .update(`dev.fast.review.telemetry.v1\0${namespace}\0${value}`)
+    .digest()
+    .subarray(0, 16)
+    .toString("base64url");
+  return `${prefix}${digest}`;
 }
 
 function directCaptureClient(

--- a/packages/progressive-review/src/review-info.test.ts
+++ b/packages/progressive-review/src/review-info.test.ts
@@ -171,6 +171,46 @@ describe("review info", () => {
     }
   });
 
+  it("binds only after creation persists and as soon as an update target resolves", async () => {
+    const root = await makeGitRepository();
+    const home = await mkdtemp(path.join(os.tmpdir(), "review-info-home-"));
+    vi.stubEnv("DEV_REVIEW_HOME", home);
+
+    try {
+      const createdBindings: string[] = [];
+      const created = await runReviewScaffold({
+        cwd: root,
+        onReviewBound: async (uuid) => {
+          await readFile(
+            path.join(home, "reviews", uuid, "review.json"),
+            "utf8",
+          );
+          createdBindings.push(uuid);
+        },
+      });
+      expect(createdBindings).toEqual([created.reviews[0]!.uuid]);
+
+      const updateBindings: string[] = [];
+      await expect(
+        runReviewScaffold({
+          cwd: root,
+          update: true,
+          reviewUuid: created.reviews[0]!.uuid,
+          baseRef: "missing-review-base",
+          onReviewBound: (uuid) => {
+            updateBindings.push(uuid);
+          },
+        }),
+      ).rejects.toThrow("missing-review-base");
+      expect(updateBindings).toEqual([created.reviews[0]!.uuid]);
+    } finally {
+      vi.unstubAllEnvs();
+      closeAllReviewThreadStores();
+      await rm(home, { recursive: true, force: true });
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("blocks a duplicate active review unless --new is present", async () => {
     const root = await makeGitRepository();
     const home = await mkdtemp(path.join(os.tmpdir(), "review-info-home-"));

--- a/packages/progressive-review/src/review-publish-thread-gate.test.ts
+++ b/packages/progressive-review/src/review-publish-thread-gate.test.ts
@@ -95,6 +95,7 @@ describe("requireClosedThreadsForRepublish", () => {
     const stdout = new PassThrough();
     let output = "";
     stdout.on("data", (chunk) => (output += String(chunk)));
+    const onReviewBound = vi.fn<(reviewUuid: string) => void>();
 
     await expect(
       runReviewPublish({
@@ -102,8 +103,11 @@ describe("requireClosedThreadsForRepublish", () => {
         reviewUuid: review.review.uuid,
         json: true,
         stdout: stdout as unknown as NodeJS.WriteStream,
+        onReviewBound,
       }),
     ).resolves.toBe(1);
+    expect(onReviewBound).toHaveBeenCalledOnce();
+    expect(onReviewBound).toHaveBeenCalledWith(review.review.uuid);
     expect(JSON.parse(output.trim())).toEqual({
       event: "error",
       stage: "publish",

--- a/packages/progressive-review/src/review-publish.ts
+++ b/packages/progressive-review/src/review-publish.ts
@@ -22,6 +22,7 @@ export async function runReviewPublish(input: {
   stdout: NodeJS.WriteStream;
   stderr?: NodeJS.WriteStream;
   env?: NodeJS.ProcessEnv;
+  onReviewBound?: (uuid: string) => void | Promise<void>;
 }): Promise<number> {
   const reporter = createPublishReporter({
     json: input.json ?? false,
@@ -44,6 +45,7 @@ async function publish(
     reviewUuid?: string;
     toolingRoot?: string;
     env?: NodeJS.ProcessEnv;
+    onReviewBound?: (uuid: string) => void | Promise<void>;
   },
   reporter: PublishReporter,
 ): Promise<number> {
@@ -51,6 +53,7 @@ async function publish(
   const prepared = await prepareReviewPublish({
     cwd: reviewRoot,
     reviewUuid: input.reviewUuid,
+    onReviewBound: input.onReviewBound,
   });
   const review = prepared.review;
   if (prepared.warnings?.length) {

--- a/packages/progressive-review/src/review-scaffold.ts
+++ b/packages/progressive-review/src/review-scaffold.ts
@@ -50,6 +50,7 @@ export interface RunReviewScaffoldInput {
   reviewUuid?: string;
   newReview?: boolean;
   background?: boolean;
+  onReviewBound?: (uuid: string) => void | Promise<void>;
 }
 
 // Scaffold's event carries the pinned commits and the managed checkout paths
@@ -70,7 +71,10 @@ export async function runReviewScaffold(
 ): Promise<ReviewScaffoldEvent> {
   if (input.update) {
     const existing = await findUpdateTarget(input.cwd, input.reviewUuid);
-    if (existing) return repinReview(existing, input);
+    if (existing) {
+      await input.onReviewBound?.(existing.review.uuid);
+      return repinReview(existing, input);
+    }
   }
   return createReview(input);
 }
@@ -163,6 +167,7 @@ async function createReview(
     await deleteReviewSourceHeadRef(source.reviewRoot, sourceHeadRef);
     throw error;
   }
+  await input.onReviewBound?.(created.review.uuid);
   try {
     const traceSessions = await listReviewTraceSessions({
       rootPath: source.reviewRoot,

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -1281,6 +1281,7 @@ export function createGlobalReviewServer(
         routePath: "/",
         token,
         sessionId,
+        reviewUuid: registration.review.review.uuid,
         historicalRevision: registration.historicalRevision,
         listDocumentVersions: async () => {
           const latest = await findReview(registration.review.review.uuid);
@@ -1522,6 +1523,8 @@ export function createGlobalReviewServer(
       outcome,
       durationMs: Date.now() - active.descriptor.startedAt,
       appSessionId: active.appSessionId,
+      reviewUuid: active.review.review.uuid,
+      presentationSessionId: active.descriptor.sessionId,
     });
   }
 
@@ -1534,6 +1537,8 @@ export function createGlobalReviewServer(
       sourceKind: reviewSourceKind(active.review.review),
       agentKind: reviewAgentKind(active.review.review),
       appSessionId: active.appSessionId,
+      reviewUuid: active.review.review.uuid,
+      presentationSessionId: active.descriptor.sessionId,
     });
   }
 

--- a/packages/progressive-review/src/server/publish-preparation.ts
+++ b/packages/progressive-review/src/server/publish-preparation.ts
@@ -21,8 +21,10 @@ export interface PreparedReviewPublish {
 export async function prepareReviewPublish(input: {
   cwd: string;
   reviewUuid?: string;
+  onReviewBound?: (uuid: string) => void | Promise<void>;
 }): Promise<PreparedReviewPublish> {
   const review = await resolvePublishReview(input.cwd, input.reviewUuid);
+  await input.onReviewBound?.(review.review.uuid);
   requireClosedThreadsForRepublish(review);
   requireCompletedAgentResponsesForRepublish(review);
   const sourceBranch = requireSourceBranch(review);

--- a/packages/progressive-review/src/server/session-handler.test.ts
+++ b/packages/progressive-review/src/server/session-handler.test.ts
@@ -5,6 +5,11 @@ import path from "node:path";
 import type { ReviewThreadsCommit } from "@dev.fast/review-protocol";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { PostHogCaptureInput } from "../posthog-capture-client";
+import {
+  ProgressiveReviewTelemetry,
+  type ProgressiveReviewTelemetryCaptureClient,
+} from "../progressive-review-telemetry";
 import { writeReviewDocumentBundle } from "../review-bundle";
 import { readReviewComments } from "../review-state-store";
 import {
@@ -28,6 +33,98 @@ afterEach(async () => {
 });
 
 describe("createReviewSessionHandler", () => {
+  it("scopes routed UI telemetry and presents a session only once", async () => {
+    rootPath = await mkdtemp(path.join(tmpdir(), "review-session-handler-"));
+    const reviewPath = path.join(rootPath, "review.mdx");
+    const sessionId = "0f98956f-ec90-45b5-ae21-19acbcd8b6ef";
+    const reviewUuid = "86df96ed-65ef-46de-9348-c94811e3bb46";
+    const sessionUrl = `http://127.0.0.1:5570/sessions/${sessionId}`;
+    const token = "session-secret";
+    const events: PostHogCaptureInput[] = [];
+    const captureClient: ProgressiveReviewTelemetryCaptureClient = {
+      enabled: true,
+      capture: async (event) => {
+        events.push(event);
+      },
+    };
+    const telemetry = new ProgressiveReviewTelemetry({
+      captureClient,
+      env: {},
+      installConfigPath: path.join(rootPath, "telemetry.json"),
+      idFactory: () => "install-123",
+    });
+    const handler = await createReviewSessionHandler({
+      ...unusedAgentServices,
+      rootPath,
+      toolingRoot: rootPath,
+      reviewPath,
+      routePath: "/",
+      token,
+      sessionId,
+      reviewUuid,
+      telemetry,
+      session: {
+        rootPath,
+        baseRef: "HEAD",
+        appUrl: sessionUrl,
+        reviewPath,
+        startedAt: Date.now(),
+      },
+    });
+    const capture = (name: string, properties?: Record<string, unknown>) =>
+      handler.handle(
+        new Request(
+          new URL("/__progressive-review/telemetry/event", sessionUrl),
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "x-review-token": token,
+              "x-review-app-session-id": "app-session-12345678",
+            },
+            body: JSON.stringify({ name, properties }),
+          },
+        ),
+      );
+
+    try {
+      await expect(capture("review_presented")).resolves.toHaveProperty(
+        "status",
+        200,
+      );
+      await expect(capture("review_presented")).resolves.toHaveProperty(
+        "status",
+        200,
+      );
+      await expect(
+        capture("client_error", {
+          error_source: "render",
+          error_process: "canvas",
+          error_name: "TypeError",
+        }),
+      ).resolves.toHaveProperty("status", 200);
+
+      expect(events.map((event) => event.event)).toEqual([
+        "review_review_presented",
+        "review_client_error",
+      ]);
+      expect(events[0].properties).toMatchObject({
+        source: "review_app",
+        app_session_id: "app-session-12345678",
+        review_id: expect.stringMatching(/^rv_/),
+        presentation_id: expect.stringMatching(/^pr_/),
+      });
+      expect(events[1].properties).toMatchObject({
+        review_id: events[0].properties?.review_id,
+        presentation_id: events[0].properties?.presentation_id,
+      });
+      expect(JSON.stringify(events)).not.toContain(reviewUuid);
+      expect(JSON.stringify(events)).not.toContain(sessionId);
+    } finally {
+      await handler.close();
+    }
+  });
+
   it("rejects writes against a historical session with 409", async () => {
     rootPath = await mkdtemp(path.join(tmpdir(), "review-session-handler-"));
     const reviewPath = path.join(rootPath, "review.mdx");

--- a/packages/progressive-review/src/server/session-handler.ts
+++ b/packages/progressive-review/src/server/session-handler.ts
@@ -20,7 +20,10 @@ import {
   type ReviewSoftwareMapBundle,
   readReviewSoftwareMapBundle,
 } from "../software-map-bundle";
-import type { ProgressiveReviewTelemetry } from "../telemetry";
+import type {
+  ProgressiveReviewTelemetry,
+  ProgressiveReviewTelemetryContext,
+} from "../telemetry";
 import type { ReviewSubmissionEvent } from "../types";
 import type { ReviewDocumentBundle } from "./doc-bundler";
 import {
@@ -51,6 +54,7 @@ export interface ReviewSessionHandlerInput {
   routePath: string;
   token?: string;
   sessionId?: string;
+  reviewUuid?: string;
   reviewCliPath?: string;
   reviewCliRuntimePath?: string;
   submitHook?: string;
@@ -107,6 +111,49 @@ export async function createReviewSessionHandler(
   let softwareMapBundlePromise: Promise<ReviewSoftwareMapBundle | null> | null =
     null;
   const eventClients = new Set<ReviewEventClient>();
+  const telemetryContext: ProgressiveReviewTelemetryContext = {
+    reviewUuid: input.reviewUuid,
+    presentationSessionId: input.sessionId,
+  };
+  let reviewPresented = false;
+  const sessionTelemetry = input.telemetry
+    ? {
+        captureTabViewed: (
+          event: Parameters<ProgressiveReviewTelemetry["captureTabViewed"]>[0],
+        ) => input.telemetry!.captureTabViewed(event, telemetryContext),
+        captureUiEvent: async (
+          event: string,
+          properties: Record<string, string | number | boolean>,
+        ) => {
+          if (
+            event === "review_review_presented" &&
+            input.reviewUuid &&
+            input.sessionId
+          ) {
+            if (reviewPresented) return;
+            reviewPresented = true;
+            await input.telemetry!.captureReviewPresented(
+              {
+                reviewUuid: input.reviewUuid,
+                presentationSessionId: input.sessionId,
+              },
+              {
+                appSessionId:
+                  typeof properties.app_session_id === "string"
+                    ? properties.app_session_id
+                    : undefined,
+              },
+            );
+            return;
+          }
+          await input.telemetry!.captureUiEvent(
+            event,
+            properties,
+            telemetryContext,
+          );
+        },
+      }
+    : undefined;
 
   const getBundle = async (): Promise<ReviewDocumentBundle> => {
     if (currentBundle) return currentBundle;
@@ -332,7 +379,7 @@ export async function createReviewSessionHandler(
     reviewRootPath,
     toolingRoot: input.toolingRoot,
     stateReviewPath: input.stateReviewPath,
-    telemetry: input.telemetry,
+    telemetry: sessionTelemetry,
     onSubmission: async (event) => {
       broadcast({
         event: "submitted",

--- a/packages/progressive-review/src/telemetry.ts
+++ b/packages/progressive-review/src/telemetry.ts
@@ -9,4 +9,5 @@ export {
   type ReviewTabTelemetryEvent,
   type ReviewTabTelemetryReason,
   type ReviewTelemetryTab,
+  type ProgressiveReviewTelemetryContext,
 } from "./progressive-review-telemetry";

--- a/packages/progressive-review/src/ui-telemetry-events.ts
+++ b/packages/progressive-review/src/ui-telemetry-events.ts
@@ -376,6 +376,10 @@ export const UI_TELEMETRY_EVENTS = {
     event: "review_review_opened",
     properties: { via: REVIEW_OPENED_VIA },
   },
+  review_presented: {
+    event: "review_review_presented",
+    properties: {},
+  },
   home_empty_state_viewed: {
     event: "review_home_empty_state_viewed",
     properties: {},


### PR DESCRIPTION
## Summary

- add privacy-safe command, Review, and presentation correlation IDs
- emit command start/bind and canvas-presented lifecycle events for hang analysis
- scope session-routed UI telemetry without attaching global errors
- document the privacy contract and suspected-hang definition

## Validation

- `pnpm typecheck`
- `pnpm lint`
- changed-file `oxfmt --check`
- 71 focused telemetry/CLI/session tests
- 22 scaffold/review-info tests
- Review Desktop tests: 111 script tests + 22 Code OSS tests
- clean native Review Desktop build
- native Electron smoke: scaffold -> publish -> canvas ready -> scoped client error, with opaque matching IDs and no raw identifiers/repository data