### PR TITLE
Fix keyless language extension telemetry

### DIFF
--- a/apps/review-desktop/code-oss/extensions/html-language-features/client/src/node/htmlClientMain.ts
+++ b/apps/review-desktop/code-oss/extensions/html-language-features/client/src/node/htmlClientMain.ts
@@ -18,7 +18,12 @@ let client: AsyncDisposable | undefined;
 export async function activate(context: ExtensionContext) {
 
 	const clientPackageJSON = getPackageInfo(context);
-	telemetry = new TelemetryReporter(clientPackageJSON.aiKey);
+	telemetry = clientPackageJSON.aiKey
+		? new TelemetryReporter(clientPackageJSON.aiKey)
+		: undefined;
+	if (telemetry) {
+		context.subscriptions.push(telemetry);
+	}
 
 	const serverMain = `./server/${clientPackageJSON.main.indexOf('/dist/') !== -1 ? 'dist' : 'out'}/node/htmlServerMain`;
 	const serverModule = context.asAbsolutePath(serverMain);
@@ -61,7 +66,7 @@ export async function deactivate(): Promise<void> {
 interface IPackageInfo {
 	name: string;
 	version: string;
-	aiKey: string;
+	aiKey?: string;
 	main: string;
 }
 

--- a/apps/review-desktop/code-oss/extensions/json-language-features/client/src/node/jsonClientMain.ts
+++ b/apps/review-desktop/code-oss/extensions/json-language-features/client/src/node/jsonClientMain.ts
@@ -19,8 +19,12 @@ let client: AsyncDisposable | undefined;
 // this method is called when vs code is activated
 export async function activate(context: ExtensionContext) {
 	const clientPackageJSON = await getPackageInfo(context);
-	const telemetry = new TelemetryReporter(clientPackageJSON.aiKey);
-	context.subscriptions.push(telemetry);
+	const telemetry = clientPackageJSON.aiKey
+		? new TelemetryReporter(clientPackageJSON.aiKey)
+		: undefined;
+	if (telemetry) {
+		context.subscriptions.push(telemetry);
+	}
 
 	const logOutputChannel = window.createOutputChannel(languageServerDescription, { log: true });
 	context.subscriptions.push(logOutputChannel);
@@ -67,7 +71,7 @@ export async function deactivate(): Promise<any> {
 interface IPackageInfo {
 	name: string;
 	version: string;
-	aiKey: string;
+	aiKey?: string;
 	main: string;
 }
 

--- a/apps/review-desktop/scripts/language-intelligence-contract.test.mjs
+++ b/apps/review-desktop/scripts/language-intelligence-contract.test.mjs
@@ -83,6 +83,46 @@ const reviewCanvas = readFileSync(
   ),
   "utf8",
 );
+const keylessTelemetryClients = [
+  {
+    name: "JSON",
+    manifest: JSON.parse(
+      readFileSync(
+        new URL(
+          "../code-oss/extensions/json-language-features/package.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ),
+    source: readFileSync(
+      new URL(
+        "../code-oss/extensions/json-language-features/client/src/node/jsonClientMain.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  },
+  {
+    name: "HTML",
+    manifest: JSON.parse(
+      readFileSync(
+        new URL(
+          "../code-oss/extensions/html-language-features/package.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ),
+    source: readFileSync(
+      new URL(
+        "../code-oss/extensions/html-language-features/client/src/node/htmlClientMain.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  },
+];
 
 test("Review exposes a language-provider-generic extension host seam", () => {
   assert.match(reviewMain, /languageFeaturesService/);
@@ -130,6 +170,17 @@ test("Review exposes a language-provider-generic extension host seam", () => {
     `${reviewServices}\n${resources}`,
     /typescript-language-features|javascript-language-features/,
   );
+});
+
+test("keyless bundled language clients skip their telemetry reporters", () => {
+  for (const { name, manifest, source } of keylessTelemetryClients) {
+    assert.equal(manifest.aiKey, undefined, `${name} manifest must stay keyless`);
+    assert.match(
+      source,
+      /clientPackageJSON\.aiKey\s*\?\s*new TelemetryReporter\(clientPackageJSON\.aiKey\)\s*:\s*undefined/,
+      `${name} must not construct telemetry with an absent key`,
+    );
+  }
 });
 
 test("CodePeeks retain the same file-backed models as native file diffs", () => {


### PR DESCRIPTION
## Summary

- skip JSON and HTML extension telemetry reporters when their bundled manifests intentionally omit Microsoft telemetry keys
- keep the reporters disposable when a future build provides a key
- add a contract test covering both keyless language clients

## Root cause

The open-source hardening change removed the Microsoft `aiKey` values from bundled extension manifests, but the JSON and HTML clients still passed the now-undefined values to `@vscode/extension-telemetry`. That package reads `key.length` during construction, so extension activation aborted before either language server could start.

## Impact

JSON/JSONC activation no longer fails, and the same latent failure is prevented for HTML/Handlebars. Microsoft telemetry keys remain absent.

## Validation

- `pnpm --filter @dev-fast/review-desktop test` — 133 tests passed
- compiled the JSON and HTML language-feature clients — 0 TypeScript errors
- `git diff --check`
