### PR TITLE
Improve bug report attachments and tutorial controls

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
@@ -1911,6 +1911,10 @@ export const ReviewVerbRequestSchema = z.discriminatedUnion("name", [
   z.strictObject({ name: z.literal("focusCanvas"), args: z.strictObject({}) }),
   z.strictObject({ name: z.literal("focusWindow"), args: z.strictObject({}) }),
   z.strictObject({
+    name: z.literal("captureScreenshot"),
+    args: z.strictObject({}),
+  }),
+  z.strictObject({
     name: z.literal("openReviewRevision"),
     args: z.strictObject({
       revision: z

--- a/apps/review-desktop/code-oss/src/vs/review/contrib/verbs/reviewVerbs.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/verbs/reviewVerbs.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { encodeBase64 } from "../../../base/common/buffer.js";
 import { Emitter, Event } from "../../../base/common/event.js";
 import { Disposable, DisposableStore } from "../../../base/common/lifecycle.js";
 import {
@@ -38,6 +39,7 @@ import {
   IWorkbenchLayoutService,
   Parts,
 } from "../../../workbench/services/layout/browser/layoutService.js";
+import { IHostService } from "../../../workbench/services/host/browser/host.js";
 import {
   type ReviewDesktopState,
   type ReviewDiffSide,
@@ -133,6 +135,7 @@ export class ReviewVerbsService
     private readonly tabsService: IReviewCanvasEditorTabsService,
     @IReviewExplorerPartsService
     private readonly explorerParts: IReviewExplorerPartsService,
+    @IHostService private readonly hostService: IHostService,
   ) {
     super();
     for (const editor of codeEditorService.listCodeEditors())
@@ -198,6 +201,8 @@ export class ReviewVerbsService
         case "focusCanvas":
           this._onDidRequestCanvasFocus.fire();
           break;
+        case "captureScreenshot":
+          return { ok: true, result: await this.captureScreenshot() };
         case "openReviewRevision": {
           const descriptor = this.sessionService.sessions.find(
             (candidate) => candidate.sessionId === sessionId,
@@ -232,6 +237,20 @@ export class ReviewVerbsService
         ok: false,
         error: error instanceof Error ? error.message : String(error),
       };
+    }
+  }
+
+  private async captureScreenshot(): Promise<
+    { dataUrl: string } | undefined
+  > {
+    try {
+      const screenshot = await this.hostService.getScreenshot();
+      if (!screenshot) return undefined;
+      return {
+        dataUrl: `data:image/jpeg;base64,${encodeBase64(screenshot)}`,
+      };
+    } catch {
+      return undefined;
     }
   }
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -66,22 +66,30 @@ Review document or does not pass a second local path-and-secret check.
 
 The **Report bug** dialog sends a report only after you select **Send**.
 
-![The Review bug-report dialog with all three diagnostic attachments selected by default.](assets/bug-report-consent.png)
+![The previous Review bug-report dialog with all three diagnostic attachments selected by default.](assets/bug-report-consent.png)
 
-Under **Include diagnostic attachments**, three independent checkboxes control
+> This image is stale. Re-capture `docs/assets/bug-report-consent.png` with the
+> two-checkbox dialog and screenshot preview after the UI lands.
+
+Under **Include diagnostic attachments**, two independent checkboxes control
 whether Review attaches:
 
-- the current Review source
-- the head software-map source
+- **Review**: the current Review source and head software-map source
 - changed-file diffs used by the review codepeeks (only the diff lines)
 
-You can turn off any or all of them before sending.
+Review captures a screenshot before the dialog opens, so the dialog itself is
+not in the image. The screenshot is attached by default with a visible preview.
+You can remove it with the × button, or paste or drag an image to replace it.
+Pasted and dropped PNG, JPEG, and WebP images are normalized to JPEG and limited
+to 3 MiB.
+
+You can turn off either checkbox and remove the screenshot before sending.
 
 The checkboxes control only those optional attachments. Every submitted report
-also includes the description, app and CLI versions, operating-system category,
-a random app-session ID, and up to 20 sanitized JavaScript error class names
-seen during that canvas session. It does not include error messages in that
-list.
+also includes the optional description (which may be empty), app and CLI
+versions, operating-system category, a random app-session ID, and up to 20
+sanitized JavaScript error class names seen during that canvas session. It does
+not include error messages in that list.
 
 If a selected attachment is unavailable, Review omits it and sends the other
 available data. The report never attaches Review metadata, comment threads, or

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -364,10 +364,13 @@ frame a second time. Both steps run on your machine, before anything is sent.
 ## User-initiated bug reports
 
 The **Report bug** dialog sends data only after the user selects **Send**. The
-dialog requires a description. It has separate consent controls for the
-current review source, head software map source, and changed-file diffs. All
-three controls are on by default. A selected attachment can be unavailable.
-The report still sends the other available data.
+description is optional. It has one **Review** consent control for both the
+current review source and head software map source, plus a separate control for
+changed-file diffs. Both controls are on by default. Review also captures a
+screenshot before the dialog opens and attaches it by default. The dialog shows
+a removable preview and accepts a replacement image by paste or drag. A
+selected attachment can be unavailable. The report still sends the other
+available data.
 
 A review does not always have a software map. The report then omits the map and
 records no error, because an absent map is a normal state.
@@ -377,7 +380,9 @@ The report payload contains these fields:
 | Field                              | Value                                                                               |
 | ---------------------------------- | ----------------------------------------------------------------------------------- |
 | `schema_version`                   | Payload schema version `2`                                                          |
-| `description`                      | The user-entered description, limited to 64 KiB of UTF-8 data                       |
+| `description`                      | Optional user-entered description, limited to 64 KiB of UTF-8 data                  |
+| `screenshot.mime`                  | `image/jpeg` when a screenshot is attached                                          |
+| `screenshot.base64`                | JPEG screenshot data, limited to 3 MiB decoded                                      |
 | `review`                           | Current selected review source, when the user consents and it is available          |
 | `review["<file name>"]`            | One review source file as text: the current document and its TypeScript modules     |
 | `map`                              | Canonical head software map note source, when the user consents and it is available |
@@ -417,9 +422,10 @@ operators can read this bucket. An R2 lifecycle rule deletes objects under
 
 The Worker sends a `review_bug_report` PostHog event after the R2
 write. The event contains the report ID, UTC report date, description byte
-length, attachment presence flags, compressed payload size, app version,
-platform, and map or diff truncation flags. It does not contain the
-description or attachments.
+length, attachment presence flags (including `has_screenshot`), compressed
+payload size, app version, platform, and map, diff, or screenshot truncation
+flags (including `truncated_screenshot`). It does not contain the description
+or attachments.
 
 Cloudflare uses `CF-Connecting-IP` only as the rate-limit key. The Worker does
 not store that value in R2. The Worker does not send it to PostHog as report

--- a/packages/progressive-review/app/src/bug-report-dialog.test.tsx
+++ b/packages/progressive-review/app/src/bug-report-dialog.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+
+import type { ReviewCanvasTutorialBridge } from "@dev.fast/review-protocol";
+import { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  type Mock,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { BugReportControl } from "./bug-report-dialog";
+import {
+  captureWindowScreenshot,
+  imageFileFromDataTransfer,
+  normalizeScreenshot,
+} from "./bug-report-screenshot";
+import {
+  type ReviewSession,
+  ReviewSessionProvider,
+} from "./host/review-session";
+import { testReviewSession } from "./review-session-test-utils";
+import { TutorialProvider } from "./tutorial-context";
+
+vi.mock("./bug-report-screenshot", () => ({
+  ScreenshotTooLargeError: class ScreenshotTooLargeError extends Error {},
+  captureWindowScreenshot: vi.fn<typeof captureWindowScreenshot>(),
+  imageFileFromDataTransfer: vi.fn<typeof imageFileFromDataTransfer>(),
+  normalizeScreenshot: vi.fn<typeof normalizeScreenshot>(),
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const captureScreenshotMock = vi.mocked(captureWindowScreenshot);
+const imageFileMock = vi.mocked(imageFileFromDataTransfer);
+const normalizeScreenshotMock = vi.mocked(normalizeScreenshot);
+const screenshotDataUrl = "data:image/jpeg;base64,c2NyZWVuc2hvdA==";
+
+describe("BugReportControl", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let request: Mock<(url: string, init?: RequestInit) => Promise<Response>>;
+  let session: ReviewSession;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    request = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async (url) => {
+        if (url.includes("/telemetry/bug-report")) {
+          return jsonResponse({
+            ok: true,
+            report_id: "00000000-0000-4000-8000-000000000000",
+            short_id: "123456789012",
+          });
+        }
+        return jsonResponse({ ok: true });
+      },
+    );
+    session = testReviewSession({}, { request });
+    captureScreenshotMock.mockResolvedValue(null);
+    imageFileMock.mockReturnValue(null);
+    normalizeScreenshotMock.mockResolvedValue(screenshotDataUrl);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("enables Send with an empty description", async () => {
+    await renderAndOpen();
+
+    expect(sendButton().disabled).toBe(false);
+  });
+
+  it("disables Send when the description exceeds the byte limit", async () => {
+    await renderAndOpen();
+
+    await setDescription("a".repeat(64 * 1024 + 1));
+
+    expect(sendButton().disabled).toBe(true);
+  });
+
+  it("maps the Review checkbox to both wire flags", async () => {
+    await renderAndOpen();
+    const reviewCheckbox = [...container.querySelectorAll("label")]
+      .find((label) => label.textContent?.trim() === "Review")
+      ?.querySelector<HTMLInputElement>('input[type="checkbox"]');
+
+    await act(async () => reviewCheckbox?.click());
+    await act(async () => sendButton().click());
+
+    expect(reportBody()).toMatchObject({
+      description: "",
+      include_review: false,
+      include_map: false,
+      include_diff: true,
+    });
+  });
+
+  it("shows an automatic screenshot and omits it after removal", async () => {
+    captureScreenshotMock.mockResolvedValue(screenshotDataUrl);
+    await renderAndOpen();
+
+    expect(
+      container.querySelector<HTMLImageElement>('img[alt="Screenshot preview"]')
+        ?.src,
+    ).toBe(screenshotDataUrl);
+
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(
+          'button[aria-label="Remove screenshot"]',
+        )
+        ?.click(),
+    );
+    expect(container.querySelector('img[alt="Screenshot preview"]')).toBeNull();
+
+    await act(async () => sendButton().click());
+    expect(reportBody()).not.toHaveProperty("screenshot");
+  });
+
+  it("still opens when automatic capture returns no result", async () => {
+    captureScreenshotMock.mockResolvedValue(null);
+
+    await renderAndOpen();
+
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    expect(container.textContent).toContain(
+      "Paste or drop an image to attach a screenshot.",
+    );
+  });
+
+  it("disables reporting in the tutorial", async () => {
+    await renderControl(tutorialBridge());
+
+    expect(reportButton().disabled).toBe(true);
+    await act(async () => reportButton().click());
+
+    expect(captureScreenshotMock).not.toHaveBeenCalled();
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(request).not.toHaveBeenCalledWith(
+      expect.stringContaining("/telemetry/event"),
+      expect.anything(),
+    );
+  });
+
+  async function renderControl(tutorial?: ReviewCanvasTutorialBridge) {
+    await act(async () => {
+      root.render(
+        <ReviewSessionProvider session={session}>
+          <TutorialProvider tutorial={tutorial}>
+            <BugReportControl />
+          </TutorialProvider>
+        </ReviewSessionProvider>,
+      );
+    });
+  }
+
+  async function renderAndOpen() {
+    await renderControl();
+    await act(async () => reportButton().click());
+  }
+
+  async function setDescription(value: string) {
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    await act(async () => {
+      if (!textarea) return;
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )?.set;
+      valueSetter?.call(textarea, value);
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+
+  function sendButton() {
+    const button = [
+      ...container.querySelectorAll<HTMLButtonElement>("button"),
+    ].find((candidate) => candidate.textContent === "Send");
+    if (!button) throw new Error("Send button not found");
+    return button;
+  }
+
+  function reportButton() {
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Report a bug"]',
+    );
+    if (!button) throw new Error("Report bug button not found");
+    return button;
+  }
+
+  function reportBody(): Record<string, unknown> {
+    const call = request.mock.calls.find(([url]) =>
+      String(url).includes("/telemetry/bug-report"),
+    );
+    if (!call) throw new Error("Bug-report request not found");
+    return JSON.parse(String(call[1]?.body)) as Record<string, unknown>;
+  }
+});
+
+function tutorialBridge(): ReviewCanvasTutorialBridge {
+  return {
+    content: {
+      reviewUuid: "tutorial-review",
+      progress: { version: 1, checked: [], dismissed: false },
+    },
+    setStep() {},
+    dismiss() {},
+    reopen() {},
+    async selectKeymap() {},
+    close() {},
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/packages/progressive-review/app/src/bug-report-dialog.tsx
+++ b/packages/progressive-review/app/src/bug-report-dialog.tsx
@@ -1,8 +1,22 @@
 import { parseReviewBugReportResponse } from "@dev.fast/review-protocol";
-import { type FormEvent, useEffect, useState } from "react";
+import {
+  type ClipboardEvent,
+  type DragEvent,
+  type FormEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
+import {
+  ScreenshotTooLargeError,
+  captureWindowScreenshot,
+  imageFileFromDataTransfer,
+  normalizeScreenshot,
+} from "./bug-report-screenshot";
 import { useReviewSession } from "./host/review-session";
 import { BugIcon } from "./icons";
+import { useTutorial } from "./tutorial-context";
 import { captureUiEvent, clientErrorName } from "./ui-telemetry";
 
 const MAX_DESCRIPTION_BYTES = 64 * 1024;
@@ -11,18 +25,19 @@ type Toast = { kind: "success" | "error"; text: string };
 
 export function BugReportControl() {
   const session = useReviewSession();
+  const tutorial = useTutorial();
   const [open, setOpen] = useState(false);
   const [description, setDescription] = useState("");
-  const [includeReview, setIncludeReview] = useState(true);
-  const [includeMap, setIncludeMap] = useState(true);
+  const [includeContext, setIncludeContext] = useState(true);
   const [includeDiff, setIncludeDiff] = useState(true);
+  const [screenshot, setScreenshot] = useState<string | null>(null);
+  const [dropActive, setDropActive] = useState(false);
+  const [capturing, setCapturing] = useState(false);
   const [sending, setSending] = useState(false);
   const [toast, setToast] = useState<Toast | null>(null);
+  const capturePending = useRef(false);
   const descriptionBytes = new TextEncoder().encode(description).byteLength;
-  const canSend =
-    description.trim().length > 0 &&
-    descriptionBytes <= MAX_DESCRIPTION_BYTES &&
-    !sending;
+  const canSend = descriptionBytes <= MAX_DESCRIPTION_BYTES && !sending;
 
   useEffect(() => {
     if (!toast) return;
@@ -32,9 +47,10 @@ export function BugReportControl() {
 
   const reset = () => {
     setDescription("");
-    setIncludeReview(true);
-    setIncludeMap(true);
+    setIncludeContext(true);
     setIncludeDiff(true);
+    setScreenshot(null);
+    setDropActive(false);
     setSending(false);
   };
   const cancel = () => {
@@ -52,9 +68,17 @@ export function BugReportControl() {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           description,
-          include_review: includeReview,
-          include_map: includeMap,
+          include_review: includeContext,
+          include_map: includeContext,
           include_diff: includeDiff,
+          ...(screenshot
+            ? {
+                screenshot: {
+                  mime: "image/jpeg",
+                  base64: screenshot.slice("data:image/jpeg;base64,".length),
+                },
+              }
+            : {}),
           app_session_id: session.appSessionId,
           app_version: session.config.appVersion,
         }),
@@ -96,6 +120,59 @@ export function BugReportControl() {
     }
   };
 
+  const attachScreenshot = async (image: Blob) => {
+    try {
+      const normalized = await normalizeScreenshot(image);
+      if (!normalized) throw new Error("Screenshot could not be decoded.");
+      setScreenshot(normalized);
+    } catch (error) {
+      setToast({
+        kind: "error",
+        text:
+          error instanceof ScreenshotTooLargeError
+            ? "The screenshot is too large. Use an image under 3 MiB."
+            : "That image could not be attached. Use a PNG, JPEG, or WebP image.",
+      });
+    }
+  };
+
+  const pasteScreenshot = (event: ClipboardEvent<HTMLElement>) => {
+    const image = imageFileFromDataTransfer(event.clipboardData);
+    if (!image) return;
+    event.preventDefault();
+    void attachScreenshot(image);
+  };
+
+  const dropScreenshot = (event: DragEvent<HTMLElement>) => {
+    event.preventDefault();
+    setDropActive(false);
+    const image = imageFileFromDataTransfer(event.dataTransfer);
+    if (!image) {
+      setToast({
+        kind: "error",
+        text: "That image could not be attached. Use a PNG, JPEG, or WebP image.",
+      });
+      return;
+    }
+    void attachScreenshot(image);
+  };
+
+  const openDialog = async () => {
+    if (tutorial || capturePending.current) return;
+    capturePending.current = true;
+    setCapturing(true);
+    captureUiEvent(session, "bug_report_dialog_opened");
+    let captured: string | null = null;
+    try {
+      captured = await captureWindowScreenshot(session.bridge);
+    } finally {
+      setScreenshot(captured);
+      setOpen(true);
+      setCapturing(false);
+      capturePending.current = false;
+    }
+  };
+
   return (
     <>
       <button
@@ -103,29 +180,43 @@ export function BugReportControl() {
         className="topbar-report-bug-button"
         aria-label="Report a bug"
         title="Report a bug"
-        onClick={() => {
-          captureUiEvent(session, "bug_report_dialog_opened");
-          setOpen(true);
-        }}
+        disabled={tutorial !== null || capturing}
+        onClick={() => void openDialog()}
       >
         <BugIcon />
       </button>
       {open && (
         <div className="bug-report-backdrop" onMouseDown={cancel}>
           <section
-            className="bug-report-dialog"
+            className={
+              dropActive
+                ? "bug-report-dialog bug-report-dialog--drop-target"
+                : "bug-report-dialog"
+            }
             role="dialog"
             aria-modal="true"
             aria-labelledby="bug-report-title"
             onMouseDown={(event) => event.stopPropagation()}
+            onPaste={pasteScreenshot}
+            onDragOver={(event) => {
+              event.preventDefault();
+              setDropActive(true);
+            }}
+            onDragLeave={(event) => {
+              const next = event.relatedTarget;
+              if (next instanceof Node && event.currentTarget.contains(next)) {
+                return;
+              }
+              setDropActive(false);
+            }}
+            onDrop={dropScreenshot}
           >
             <form onSubmit={submit}>
               <h2 id="bug-report-title">Report a bug</h2>
               <label className="bug-report-description">
-                <span>What happened?</span>
+                <span>What happened? (optional)</span>
                 <textarea
                   autoFocus
-                  required
                   rows={7}
                   value={description}
                   onChange={(event) => setDescription(event.target.value)}
@@ -146,18 +237,12 @@ export function BugReportControl() {
                 <label>
                   <input
                     type="checkbox"
-                    checked={includeReview}
-                    onChange={(event) => setIncludeReview(event.target.checked)}
+                    checked={includeContext}
+                    onChange={(event) =>
+                      setIncludeContext(event.target.checked)
+                    }
                   />
-                  Current review source
-                </label>
-                <label>
-                  <input
-                    type="checkbox"
-                    checked={includeMap}
-                    onChange={(event) => setIncludeMap(event.target.checked)}
-                  />
-                  Head software map source
+                  Review
                 </label>
                 <label>
                   <input
@@ -167,11 +252,32 @@ export function BugReportControl() {
                   />
                   Changed-file diffs used by CodePeeks
                 </label>
+                <div className="bug-report-screenshot">
+                  {screenshot ? (
+                    <>
+                      <img src={screenshot} alt="Screenshot preview" />
+                      <button
+                        type="button"
+                        className="bug-report-screenshot-remove"
+                        aria-label="Remove screenshot"
+                        title="Remove screenshot"
+                        onClick={() => setScreenshot(null)}
+                      >
+                        ×
+                      </button>
+                    </>
+                  ) : (
+                    <span className="bug-report-screenshot-hint">
+                      Paste or drop an image to attach a screenshot.
+                    </span>
+                  )}
+                </div>
               </fieldset>
               <p className="bug-report-privacy">
                 Reports are sent securely to /dev/fast. Only authorized
                 /dev/fast team members can access them. Reports are deleted
-                after 90 days.
+                after 90 days. The screenshot above is included unless you
+                remove it.
               </p>
               <div className="bug-report-actions">
                 <button type="button" onClick={cancel} disabled={sending}>

--- a/packages/progressive-review/app/src/bug-report-screenshot.ts
+++ b/packages/progressive-review/app/src/bug-report-screenshot.ts
@@ -1,0 +1,110 @@
+import type { ReviewCanvasBridge } from "@dev.fast/review-protocol";
+
+const MAX_SCREENSHOT_BYTES = 3 * 1024 * 1024;
+const MAX_SCREENSHOT_DIMENSION = 1600;
+const CAPTURE_TIMEOUT_MS = 1_500;
+const SUPPORTED_IMAGE_MIMES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+
+export class ScreenshotTooLargeError extends Error {
+  constructor() {
+    super("Screenshot exceeds the 3 MiB attachment limit.");
+    this.name = "ScreenshotTooLargeError";
+  }
+}
+
+export async function normalizeScreenshot(
+  source: Blob | string,
+): Promise<string | null> {
+  const blob = typeof source === "string" ? dataUrlBlob(source) : source;
+  if (!SUPPORTED_IMAGE_MIMES.has(blob.type.toLowerCase())) {
+    throw new Error("Screenshot must be a PNG, JPEG, or WebP image.");
+  }
+
+  const bitmap = await createImageBitmap(blob);
+  try {
+    if (bitmap.width < 1 || bitmap.height < 1) return null;
+    const scale = Math.min(
+      1,
+      MAX_SCREENSHOT_DIMENSION / Math.max(bitmap.width, bitmap.height),
+    );
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.max(1, Math.round(bitmap.width * scale));
+    canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+    const context = canvas.getContext("2d");
+    if (!context) return null;
+    context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+    const dataUrl = canvas.toDataURL("image/jpeg", 0.8);
+    if (!dataUrl.startsWith("data:image/jpeg;base64,")) return null;
+    if (
+      decodedBase64Bytes(dataUrl.split(",", 2)[1] ?? "") > MAX_SCREENSHOT_BYTES
+    ) {
+      throw new ScreenshotTooLargeError();
+    }
+    return dataUrl;
+  } finally {
+    bitmap.close();
+  }
+}
+
+export async function captureWindowScreenshot(
+  bridge: Pick<ReviewCanvasBridge, "post">,
+): Promise<string | null> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const response = await Promise.race([
+      bridge.post({ name: "captureScreenshot", args: {} }),
+      new Promise<null>((resolve) => {
+        timeout = setTimeout(() => resolve(null), CAPTURE_TIMEOUT_MS);
+      }),
+    ]);
+    if (!response?.ok) return null;
+    const result = response.result;
+    if (
+      !result ||
+      typeof result !== "object" ||
+      typeof (result as { dataUrl?: unknown }).dataUrl !== "string"
+    ) {
+      return null;
+    }
+    return await normalizeScreenshot((result as { dataUrl: string }).dataUrl);
+  } catch {
+    return null;
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+export function imageFileFromDataTransfer(
+  dataTransfer: DataTransfer,
+): Blob | null {
+  for (const item of dataTransfer.items) {
+    if (item.kind !== "file" || !item.type.startsWith("image/")) continue;
+    const file = item.getAsFile();
+    if (file) return file;
+  }
+  for (const file of dataTransfer.files) {
+    if (file.type.startsWith("image/")) return file;
+  }
+  return null;
+}
+
+function dataUrlBlob(dataUrl: string): Blob {
+  const match = /^data:([^;,]+);base64,([A-Za-z0-9+/]*={0,2})$/.exec(dataUrl);
+  if (!match) throw new Error("Screenshot data URL is invalid.");
+  const mime = match[1]?.toLowerCase() ?? "";
+  const binary = atob(match[2] ?? "");
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return new Blob([bytes], { type: mime });
+}
+
+function decodedBase64Bytes(base64: string): number {
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  return Math.floor((base64.length * 3) / 4) - padding;
+}

--- a/packages/progressive-review/app/src/review-history-control.test.tsx
+++ b/packages/progressive-review/app/src/review-history-control.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import type {
+  ReviewCanvasTutorialBridge,
+  ReviewDocumentVersionWire,
+} from "@dev.fast/review-protocol";
+import { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ReviewSessionProvider } from "./host/review-session";
+import { ReviewHistoryControl } from "./review-history-control";
+import { testReviewSession } from "./review-session-test-utils";
+import { TutorialProvider } from "./tutorial-context";
+
+const { listVersionsMock } = vi.hoisted(() => ({
+  listVersionsMock: vi.fn<() => Promise<ReviewDocumentVersionWire[] | null>>(),
+}));
+
+vi.mock("./review-context", () => ({
+  useReview: () => ({
+    historicalRevision: null,
+    listVersions: listVersionsMock,
+  }),
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ReviewHistoryControl", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    listVersionsMock.mockResolvedValue([
+      {
+        revision: "a".repeat(40),
+        sealedAt: Date.UTC(2026, 7, 19),
+        isCurrent: true,
+      },
+    ]);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("stays visible and disabled without loading versions in the tutorial", async () => {
+    await renderControl(tutorialBridge());
+
+    expect(historyButton().disabled).toBe(true);
+    expect(listVersionsMock).not.toHaveBeenCalled();
+
+    await act(async () => historyButton().click());
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+  });
+
+  it("loads versions and stays enabled for a regular Review", async () => {
+    await renderControl();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(listVersionsMock).toHaveBeenCalledTimes(1);
+    expect(historyButton().disabled).toBe(false);
+  });
+
+  async function renderControl(tutorial?: ReviewCanvasTutorialBridge) {
+    await act(async () => {
+      root.render(
+        <ReviewSessionProvider session={testReviewSession()}>
+          <TutorialProvider tutorial={tutorial}>
+            <ReviewHistoryControl />
+          </TutorialProvider>
+        </ReviewSessionProvider>,
+      );
+    });
+  }
+
+  function historyButton() {
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Version history"]',
+    );
+    if (!button) throw new Error("Version history button not found");
+    return button;
+  }
+});
+
+function tutorialBridge(): ReviewCanvasTutorialBridge {
+  return {
+    content: {
+      reviewUuid: "tutorial-review",
+      progress: { version: 1, checked: [], dismissed: false },
+    },
+    setStep() {},
+    dismiss() {},
+    reopen() {},
+    async selectKeymap() {},
+    close() {},
+  };
+}

--- a/packages/progressive-review/app/src/review-history-control.tsx
+++ b/packages/progressive-review/app/src/review-history-control.tsx
@@ -9,12 +9,14 @@ import {
 
 import { useReviewSession } from "./host/review-session";
 import { useReview } from "./review-context";
+import { useTutorial } from "./tutorial-context";
 
 type VersionList = ReviewDocumentVersionWire[] | null | "unavailable";
 
 export function ReviewHistoryControl(): ReactElement | null {
   const { historicalRevision, listVersions } = useReview();
   const session = useReviewSession();
+  const tutorial = useTutorial();
   const controlRef = useRef<HTMLDivElement | null>(null);
   const [open, setOpen] = useState(false);
   const [versions, setVersions] = useState<VersionList>(null);
@@ -29,9 +31,9 @@ export function ReviewHistoryControl(): ReactElement | null {
   }, [listVersions]);
 
   useEffect(() => {
-    if (historicalRevision) return;
+    if (historicalRevision || tutorial) return;
     void loadVersions();
-  }, [historicalRevision, loadVersions]);
+  }, [historicalRevision, loadVersions, tutorial]);
 
   useEffect(() => {
     if (!open) return;
@@ -52,7 +54,10 @@ export function ReviewHistoryControl(): ReactElement | null {
     };
   }, [open]);
 
-  if (historicalRevision || !Array.isArray(versions)) return null;
+  if (historicalRevision || (!tutorial && !Array.isArray(versions))) {
+    return null;
+  }
+  const versionItems = Array.isArray(versions) ? versions : [];
 
   return (
     <div ref={controlRef} className="review-history">
@@ -63,7 +68,9 @@ export function ReviewHistoryControl(): ReactElement | null {
         title="Version history"
         aria-haspopup="menu"
         aria-expanded={open}
+        disabled={tutorial !== null}
         onClick={() => {
+          if (tutorial) return;
           setOpen((current) => !current);
           if (!open) void loadVersions();
         }}
@@ -72,7 +79,7 @@ export function ReviewHistoryControl(): ReactElement | null {
       </button>
       {open ? (
         <ul className="review-history-list" role="menu">
-          {versions.map((version) => (
+          {versionItems.map((version) => (
             <li key={version.revision}>
               <button
                 type="button"

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -2528,12 +2528,17 @@ button {
   height: var(--chrome-icon-size);
 }
 
-.review-history-button:hover,
-.review-history-button:focus-visible,
+.review-history-button:hover:not(:disabled),
+.review-history-button:focus-visible:not(:disabled),
 .review-history-button[aria-expanded="true"] {
   background: var(--chrome-hover-bg);
   color: var(--chrome-fg);
   outline: none;
+}
+
+.review-history-button:disabled {
+  opacity: 0.45;
+  cursor: default;
 }
 
 .review-history-list {
@@ -2625,6 +2630,11 @@ button {
   color: var(--ink);
 }
 
+.bug-report-dialog--drop-target {
+  outline: 2px dashed var(--accent);
+  outline-offset: -7px;
+}
+
 .bug-report-dialog form {
   display: grid;
   gap: 14px;
@@ -2685,6 +2695,50 @@ button {
   display: flex;
   gap: 8px;
   align-items: center;
+}
+
+.bug-report-screenshot {
+  display: flex;
+  min-height: 54px;
+  align-items: center;
+  gap: 8px;
+  border: 1px dashed var(--rule-soft);
+  border-radius: 5px;
+  padding: 8px;
+}
+
+.bug-report-screenshot img {
+  display: block;
+  max-width: calc(100% - 34px);
+  max-height: 72px;
+  border: 1px solid var(--chrome-border);
+  border-radius: 4px;
+}
+
+.bug-report-screenshot-remove {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border: 1px solid var(--chrome-border);
+  border-radius: 4px;
+  padding: 0;
+  background: var(--bg-2);
+  color: var(--ink-faint);
+  font: 18px/1 var(--chrome-font);
+  cursor: pointer;
+}
+
+.bug-report-screenshot-remove:hover,
+.bug-report-screenshot-remove:focus-visible {
+  border-color: var(--chrome-active-border);
+  color: var(--ink);
+  outline: none;
+}
+
+.bug-report-screenshot-hint {
+  color: var(--ink-faint);
+  font: 11px/1.45 var(--font-mono);
 }
 
 .bug-report-privacy {
@@ -3672,11 +3726,16 @@ button {
   height: var(--chrome-icon-size);
 }
 
-.topbar-report-bug-button:hover,
-.topbar-report-bug-button:focus-visible {
+.topbar-report-bug-button:hover:not(:disabled),
+.topbar-report-bug-button:focus-visible:not(:disabled) {
   background: var(--chrome-hover-bg);
   color: var(--chrome-fg);
   outline: none;
+}
+
+.topbar-report-bug-button:disabled {
+  opacity: 0.45;
+  cursor: default;
 }
 
 .review-document {

--- a/packages/progressive-review/src/server/bug-report.ts
+++ b/packages/progressive-review/src/server/bug-report.ts
@@ -47,6 +47,7 @@ type AttachmentError = {
 interface BugReportPayload {
   schema_version: 2;
   description: string;
+  screenshot?: { mime: "image/jpeg"; base64: string };
   // File name to text. The document alone cannot render: every anchor lives in
   // a sibling TypeScript module.
   review?: Record<string, string>;
@@ -87,6 +88,7 @@ export async function submitReviewBugReport(input: {
   const payload: BugReportPayload = {
     schema_version: 2,
     description: input.report.description,
+    ...(input.report.screenshot ? { screenshot: input.report.screenshot } : {}),
     diagnostics: {
       app_version: input.report.app_version,
       cli_version: cliVersion,
@@ -166,11 +168,13 @@ export async function submitReviewBugReport(input: {
 
   let truncatedDiff = false;
   let truncatedMap = false;
+  let truncatedScreenshot = false;
   let request = buildBugReportRequest(payload, {
     appVersion: input.report.app_version,
     cliVersion,
     truncatedDiff,
     truncatedMap,
+    truncatedScreenshot,
   });
   if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.diff) {
     delete payload.diff;
@@ -180,6 +184,7 @@ export async function submitReviewBugReport(input: {
       cliVersion,
       truncatedDiff,
       truncatedMap,
+      truncatedScreenshot,
     });
   }
   if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.map) {
@@ -190,6 +195,18 @@ export async function submitReviewBugReport(input: {
       cliVersion,
       truncatedDiff,
       truncatedMap,
+      truncatedScreenshot,
+    });
+  }
+  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.screenshot) {
+    delete payload.screenshot;
+    truncatedScreenshot = true;
+    request = buildBugReportRequest(payload, {
+      appVersion: input.report.app_version,
+      cliVersion,
+      truncatedDiff,
+      truncatedMap,
+      truncatedScreenshot,
     });
   }
   if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.review) {
@@ -199,6 +216,7 @@ export async function submitReviewBugReport(input: {
       cliVersion,
       truncatedDiff,
       truncatedMap,
+      truncatedScreenshot,
     });
   }
   if (request.body.byteLength > MAX_MULTIPART_BYTES) {
@@ -312,6 +330,7 @@ function buildBugReportRequest(
     cliVersion: string;
     truncatedDiff: boolean;
     truncatedMap: boolean;
+    truncatedScreenshot: boolean;
   },
 ) {
   const payloadBytes = gzipSync(Buffer.from(JSON.stringify(payload)), {
@@ -323,12 +342,14 @@ function buildBugReportRequest(
     has_review: payload.review !== undefined,
     has_map: payload.map !== undefined,
     has_diff: payload.diff !== undefined,
+    has_screenshot: payload.screenshot !== undefined,
     payload_bytes: payloadBytes.byteLength,
     app_version: input.appVersion,
     cli_version: input.cliVersion,
     platform: process.platform,
     truncated_diff: input.truncatedDiff,
     truncated_map: input.truncatedMap,
+    truncated_screenshot: input.truncatedScreenshot,
   };
   const body = Buffer.concat([
     Buffer.from(

--- a/packages/progressive-review/src/server/review-api-parsers.test.ts
+++ b/packages/progressive-review/src/server/review-api-parsers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  parseReviewBugReportInput,
   parseReviewCommentMessagePath,
   parseReviewSubmissionInput,
   parseReviewTabTelemetryInput,
@@ -15,6 +16,80 @@ const selection = {
   hash: "f55c314b",
   quote: "Hello",
 };
+
+const bugReport = {
+  description: "",
+  include_review: true,
+  include_map: true,
+  include_diff: true,
+  app_session_id: "session-1234567890",
+  app_version: "1.2.3",
+};
+
+describe("parseReviewBugReportInput", () => {
+  it("accepts an empty description", () => {
+    expect(parseReviewBugReportInput(bugReport).description).toBe("");
+  });
+
+  it("rejects a description over 64 KiB with 413", () => {
+    expectBugReportStatus(
+      { ...bugReport, description: "a".repeat(64 * 1024 + 1) },
+      413,
+    );
+  });
+
+  it("accepts a valid JPEG screenshot", () => {
+    const screenshot = {
+      mime: "image/jpeg" as const,
+      base64: Buffer.from("jpeg bytes").toString("base64"),
+    };
+    expect(
+      parseReviewBugReportInput({ ...bugReport, screenshot }),
+    ).toMatchObject({ screenshot });
+  });
+
+  it("rejects a screenshot over 3 MiB with 413", () => {
+    expectBugReportStatus(
+      {
+        ...bugReport,
+        screenshot: {
+          mime: "image/jpeg",
+          base64: Buffer.alloc(3 * 1024 * 1024 + 1).toString("base64"),
+        },
+      },
+      413,
+    );
+  });
+
+  it("rejects a screenshot with the wrong mime", () => {
+    expect(() =>
+      parseReviewBugReportInput({
+        ...bugReport,
+        screenshot: { mime: "image/png", base64: "cG5n" },
+      }),
+    ).toThrow(/image\/jpeg|Invalid input/i);
+  });
+
+  it("rejects malformed screenshot base64", () => {
+    expectBugReportStatus(
+      {
+        ...bugReport,
+        screenshot: { mime: "image/jpeg", base64: "not base64" },
+      },
+      400,
+    );
+  });
+});
+
+function expectBugReportStatus(value: unknown, statusCode: number) {
+  let thrown: unknown;
+  try {
+    parseReviewBugReportInput(value);
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toMatchObject({ statusCode });
+}
 
 describe("parseThreadTarget", () => {
   it("round-trips document targets and rejects unknown kinds", () => {

--- a/packages/progressive-review/src/server/review-api-parsers.ts
+++ b/packages/progressive-review/src/server/review-api-parsers.ts
@@ -21,6 +21,7 @@ const MIN_REVIEW_TAB_DWELL_MS = 250;
 const MAX_REVIEW_TAB_DWELL_MS = 4 * 60 * 60 * 1_000;
 const APP_SESSION_ID_PATTERN = /^[A-Za-z0-9_-][A-Za-z0-9_.-]{15,127}$/;
 const MAX_BUG_REPORT_DESCRIPTION_BYTES = 64 * 1024;
+const MAX_BUG_REPORT_SCREENSHOT_BYTES = 3 * 1024 * 1024;
 
 const nonEmptyStringSchema = z
   .string({ error: "must be a non-empty string" })
@@ -62,6 +63,18 @@ export function parseReviewBugReportInput(value: unknown) {
       `description must not exceed ${MAX_BUG_REPORT_DESCRIPTION_BYTES} UTF-8 bytes`,
       413,
     );
+  }
+  if (parsed.screenshot) {
+    const screenshot = Buffer.from(parsed.screenshot.base64, "base64");
+    if (screenshot.toString("base64") !== parsed.screenshot.base64) {
+      throw new HttpJsonError("screenshot.base64 must be valid base64", 400);
+    }
+    if (screenshot.byteLength > MAX_BUG_REPORT_SCREENSHOT_BYTES) {
+      throw new HttpJsonError(
+        `screenshot must not exceed ${MAX_BUG_REPORT_SCREENSHOT_BYTES} decoded bytes`,
+        413,
+      );
+    }
   }
   return parsed;
 }

--- a/packages/progressive-review/src/server/review-api.ts
+++ b/packages/progressive-review/src/server/review-api.ts
@@ -505,7 +505,9 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
 
   async function bugReport(context: Context<ReviewHonoEnv>): Promise<Response> {
     try {
-      const report = parseReviewBugReportInput(await readJson(context.req.raw));
+      const report = parseReviewBugReportInput(
+        await readBoundedRequestJson(context.req.raw, 6 * 1024 * 1024, {}),
+      );
       const reviewDocumentPath = resolveReviewDocumentPath(
         new URL(context.req.url),
         {

--- a/packages/review-protocol/src/bug-report.ts
+++ b/packages/review-protocol/src/bug-report.ts
@@ -5,10 +5,16 @@ const requiredString = z
   .refine((value) => value.trim().length > 0, "must be a string");
 
 export const ReviewBugReportRequestSchema = z.strictObject({
-  description: requiredString,
+  description: z.string(),
   include_review: z.boolean(),
   include_map: z.boolean(),
   include_diff: z.boolean(),
+  screenshot: z
+    .strictObject({
+      mime: z.literal("image/jpeg"),
+      base64: z.string(),
+    })
+    .optional(),
   app_session_id: requiredString
     .min(16)
     .max(128)
@@ -25,6 +31,7 @@ export const ReviewBugReportMetaSchema = z.strictObject({
   has_review: z.boolean(),
   has_map: z.boolean(),
   has_diff: z.boolean(),
+  has_screenshot: z.boolean(),
   payload_bytes: z
     .number()
     .int()
@@ -47,6 +54,7 @@ export const ReviewBugReportMetaSchema = z.strictObject({
   ]),
   truncated_diff: z.boolean(),
   truncated_map: z.boolean(),
+  truncated_screenshot: z.boolean(),
 });
 export type ReviewBugReportMeta = z.infer<typeof ReviewBugReportMetaSchema>;
 

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1908,6 +1908,10 @@ export const ReviewVerbRequestSchema = z.discriminatedUnion("name", [
   z.strictObject({ name: z.literal("focusCanvas"), args: z.strictObject({}) }),
   z.strictObject({ name: z.literal("focusWindow"), args: z.strictObject({}) }),
   z.strictObject({
+    name: z.literal("captureScreenshot"),
+    args: z.strictObject({}),
+  }),
+  z.strictObject({
     name: z.literal("openReviewRevision"),
     args: z.strictObject({
       revision: z


### PR DESCRIPTION
## Summary

- make bug reports near-zero-friction with an optional description, a merged Review attachment toggle, and automatic removable screenshots
- normalize pasted, dropped, and captured images to bounded JPEG payloads and carry screenshot metadata through the server submission pipeline
- keep Report bug and Version history visible but disabled during the tutorial
- update privacy/telemetry documentation and add focused UI and parser coverage

## Validation

- `pnpm --filter @dev.fast/review-protocol build`
- `pnpm --filter @dev-fast/review-desktop protocol:sync`
- `pnpm --filter @dev-fast/review-desktop test`
- `pnpm --filter @dev.fast/review typecheck`
- focused Vitest: 25/25 dialog, tutorial-control, and parser tests
- `pnpm --filter @dev.fast/review app:desktop:build`
- focused `oxfmt --check` and `oxlint`

## Test note

The full progressive-review suite currently trips three unrelated `review-info` cases only in the parallel full run. The same file passes 22/22 in isolation; all changed-path tests pass.