### PR TITLE
Auto-pull review traces during scaffold

### DIFF
--- a/packages/progressive-review/skills/dev-review/SKILL.md
+++ b/packages/progressive-review/skills/dev-review/SKILL.md
@@ -22,7 +22,7 @@ Read [Document authoring](references/document-authoring.md) for writing rules an
 
 Read [Component API](references/component-api.md) before you write `data.ts`. It defines every component's props and every helper's input shape.
 
-Read [Trace quoting](references/trace-quoting.md) when `review trace list --review <uuid> --json` reports an available session.
+Read [Trace quoting](references/trace-quoting.md) when the scaffold event reports a non-empty `traces.paths` array, or when the compatibility fallback below reports an available session.
 
 Read [Lifecycle and storage](references/lifecycle-and-storage.md) when you must select or update the binding. It also defines publication, state, migration, and thread behavior.
 
@@ -48,6 +48,7 @@ Read the scaffold JSON event and `<review-dir>/review.json`. Together they carry
 - source worktree
 - `baseCommit` and `sourceCommit` (the scaffold event prints them under `pins`)
 - both pinned checkout paths (the scaffold event prints them under `checkouts`)
+- materialized agent trace paths (the scaffold event prints them under `traces.paths`)
 - source binding and status
 
 `inSync: false` in `review info` means only that the source worktree does not sit on the pinned commit. That alone requires no action. Use `review scaffold --update --review <uuid>` only when the bound branch or pull request gained commits past the pin. Re-read each file whose anchored range changed after the update.
@@ -82,7 +83,9 @@ If no sub-agent facility exists, publish the document. Report that the map is no
 
 Read [Document authoring](references/document-authoring.md) before you edit `review.mdx` or `data.ts`.
 
-Run `review trace list --review <uuid> --json`. When it reports an available session, run `review trace pull --review <uuid> --json`. Then read [Trace quoting](references/trace-quoting.md) and complete its intent pass before authoring. Use FFF for candidate discovery.
+Use the materialized files in `traces.paths` from the scaffold event. When that array is non-empty, read [Trace quoting](references/trace-quoting.md) and complete its intent pass before authoring. Use FFF for candidate discovery.
+
+Run `review trace list --review <uuid> --json` followed by `review trace pull --review <uuid> --json` only when reusing a Review without a scaffold event from this run, or when the event has no `traces` field because the installed CLI predates automatic trace materialization. Do not repeat those commands after a current scaffold event; `review scaffold --update` refreshes the corpus and prints its paths again.
 
 Use the smallest document that explains the important change. Default to `AnchorLink` for source evidence. Use `CodePeek` only when readers must see the code inline to understand the main claim.
 

--- a/packages/progressive-review/src/cli.test.ts
+++ b/packages/progressive-review/src/cli.test.ts
@@ -147,11 +147,8 @@ describe("Review CLI", () => {
     const runReviewPublish = vi.fn<typeof runReviewPublishActual>(
       async () => 0,
     );
-    const runReviewScaffold = vi.fn<typeof runReviewScaffoldActual>(
-      async () => ({
-        event: "info" as const,
-        reviews: [],
-      }),
+    const runReviewScaffold = vi.fn<typeof runReviewScaffoldActual>(async () =>
+      emptyScaffoldEvent(),
     );
 
     await runProgressiveReviewCli({
@@ -458,7 +455,7 @@ describe("Review CLI", () => {
     const runReviewScaffold = vi.fn<typeof runReviewScaffoldActual>(
       async (input) => {
         await input.onReviewBound?.(reviewUuid);
-        return { event: "info", reviews: [] };
+        return emptyScaffoldEvent();
       },
     );
 
@@ -519,11 +516,8 @@ describe("Review CLI", () => {
   });
 
   it("accepts --json on scaffold and keeps stdout to one JSON line", async () => {
-    const runReviewScaffold = vi.fn<typeof runReviewScaffoldActual>(
-      async () => ({
-        event: "info" as const,
-        reviews: [],
-      }),
+    const runReviewScaffold = vi.fn<typeof runReviewScaffoldActual>(async () =>
+      emptyScaffoldEvent(),
     );
     const stdout = outputStream();
     let output = "";
@@ -540,7 +534,20 @@ describe("Review CLI", () => {
 
     const lines = output.trimEnd().split("\n");
     expect(lines).toHaveLength(1);
-    expect(JSON.parse(lines[0]!)).toEqual({ event: "info", reviews: [] });
+    expect(JSON.parse(lines[0]!)).toEqual({
+      event: "info",
+      reviews: [],
+      traces: {
+        sessions: [],
+        corpusRoot: null,
+        repository: null,
+        materializedSessions: [],
+        unavailableSessions: [],
+        events: 0,
+        files: 0,
+        paths: [],
+      },
+    });
   });
 
   it("rejects the removed info --new option", async () => {
@@ -554,11 +561,8 @@ describe("Review CLI", () => {
   });
 
   it("passes scaffold update options to the runtime", async () => {
-    const runReviewScaffold = vi.fn<typeof runReviewScaffoldActual>(
-      async () => ({
-        event: "info" as const,
-        reviews: [],
-      }),
+    const runReviewScaffold = vi.fn<typeof runReviewScaffoldActual>(async () =>
+      emptyScaffoldEvent(),
     );
 
     await expect(
@@ -804,6 +808,25 @@ describe("Review CLI", () => {
     );
   });
 });
+
+function emptyScaffoldEvent(): Awaited<
+  ReturnType<typeof runReviewScaffoldActual>
+> {
+  return {
+    event: "info",
+    reviews: [],
+    traces: {
+      sessions: [],
+      corpusRoot: null,
+      repository: null,
+      materializedSessions: [],
+      unavailableSessions: [],
+      events: 0,
+      files: 0,
+      paths: [],
+    },
+  };
+}
 
 function outputStream(): NodeJS.WriteStream {
   return new PassThrough() as unknown as NodeJS.WriteStream;

--- a/packages/progressive-review/src/review-info.test.ts
+++ b/packages/progressive-review/src/review-info.test.ts
@@ -1,5 +1,12 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -118,6 +125,89 @@ describe("review info", () => {
     } finally {
       vi.unstubAllEnvs();
       closeAllReviewThreadStores();
+      await rm(home, { recursive: true, force: true });
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("materializes available agent traces and reports their paths", async () => {
+    const root = await makeGitRepository();
+    const home = await mkdtemp(path.join(os.tmpdir(), "review-info-home-"));
+    const mockR2Dir = path.join(home, "mock-r2");
+    const traceSearchDir = path.join(home, "trace-search");
+    const sessionId = "11111111-1111-4111-8111-111111111111";
+    vi.stubEnv("DEV_REVIEW_HOME", home);
+    vi.stubEnv("TRACE_R2_MODE", "mock");
+    vi.stubEnv("TRACE_R2_MOCK_DIR", mockR2Dir);
+    vi.stubEnv("REVIEW_TEST_TRACE_SEARCH_DIR", traceSearchDir);
+    vi.stubEnv("GITHUB_REPOSITORY", "acme/widgets");
+
+    try {
+      await git(root, ["config", "devfast.prepare", "echo ok"]);
+      await git(root, ["checkout", "-b", "feature"]);
+      await writeFile(path.join(root, "README.md"), "# Feature\n", "utf8");
+      await git(root, [
+        "commit",
+        "-am",
+        `feature\n\nAgent-Session: ${sessionId}`,
+      ]);
+
+      const remoteTraceDir = path.join(mockR2Dir, "by-session", sessionId);
+      await mkdir(remoteTraceDir, { recursive: true });
+      await writeFile(
+        path.join(remoteTraceDir, "trace.jsonl"),
+        [
+          JSON.stringify({
+            type: "session_meta",
+            payload: { id: sessionId, cwd: root },
+          }),
+          JSON.stringify({
+            type: "event_msg",
+            payload: { type: "user_message", message: "Build the feature" },
+          }),
+        ].join("\n") + "\n",
+      );
+
+      const progress: string[] = [];
+      const created = await runReviewScaffold({
+        cwd: root,
+        baseRef: "main",
+        headRef: "feature",
+        progress: (message) => progress.push(message),
+      });
+      const expectedPath = path.join(
+        traceSearchDir,
+        "acme",
+        "widgets",
+        sessionId,
+        "main.jsonl",
+      );
+
+      expect(created.traces).toMatchObject({
+        sessions: [
+          {
+            id: sessionId,
+            available: true,
+            traces: ["main"],
+          },
+        ],
+        corpusRoot: traceSearchDir,
+        repository: "acme/widgets",
+        materializedSessions: [
+          { session: sessionId, traces: 1, events: 1, files: 1 },
+        ],
+        unavailableSessions: [],
+        events: 1,
+        files: 1,
+        paths: [expectedPath],
+      });
+      expect(progress).toContain("Trace paths:");
+      expect(progress).toContain(`  ${expectedPath}`);
+      await expect(readFile(expectedPath, "utf8")).resolves.toContain(
+        '"repository":"acme/widgets"',
+      );
+    } finally {
+      vi.unstubAllEnvs();
       await rm(home, { recursive: true, force: true });
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/progressive-review/src/review-scaffold.ts
+++ b/packages/progressive-review/src/review-scaffold.ts
@@ -8,13 +8,21 @@ import {
   mergeBase,
   resolveRevision,
 } from "@dev.fast/local-vcs";
-import type { ReviewSourceIdentity } from "@dev.fast/review-protocol";
+import type {
+  ReviewAgentTraceSession,
+  ReviewSourceIdentity,
+} from "@dev.fast/review-protocol";
 
 import {
   authoringSessionKey,
   resolveAuthoringSessionRef,
 } from "./authoring-session";
-import { listReviewTraceSessions } from "./review-agent-traces";
+import {
+  type ReviewTracePullSessionResult,
+  inferRepoFromGit,
+  listReviewTraceSessions,
+  pullReviewTraceCorpus,
+} from "./review-agent-traces";
 import { isPositionalChangeIdentity } from "./review-change-scope";
 import { removeReviewManagedCheckouts } from "./review-head-checkout";
 import {
@@ -53,12 +61,32 @@ export interface RunReviewScaffoldInput {
   onReviewBound?: (uuid: string) => void | Promise<void>;
 }
 
-// Scaffold's event carries the pinned commits and the managed checkout paths
-// so the authoring agent never has to know the on-disk layout. A checkout is
-// null only when its eager materialization degraded to a warning.
+// Scaffold's event carries pinned commits, managed checkouts, and normalized
+// trace paths so the authoring agent never has to rediscover on-disk layout.
+// A checkout is null only when its eager materialization degraded to a warning.
 export interface ReviewScaffoldEvent extends ReviewInfoEvent {
   pins?: { baseCommit: string; sourceCommit: string };
   checkouts?: { head: string | null; base: string | null };
+  traces: ReviewScaffoldTraces;
+}
+
+export interface ReviewScaffoldTraceSession {
+  id: string;
+  harness: ReviewAgentTraceSession["harness"];
+  available: boolean;
+  traces: string[];
+  commits: ReviewAgentTraceSession["commits"];
+}
+
+export interface ReviewScaffoldTraces {
+  sessions: ReviewScaffoldTraceSession[];
+  corpusRoot: string | null;
+  repository: string | null;
+  materializedSessions: ReviewTracePullSessionResult[];
+  unavailableSessions: string[];
+  events: number;
+  files: number;
+  paths: string[];
 }
 
 /**
@@ -168,16 +196,13 @@ async function createReview(
     throw error;
   }
   await input.onReviewBound?.(created.review.uuid);
-  try {
-    const traceSessions = await listReviewTraceSessions({
-      rootPath: source.reviewRoot,
-      baseCommit,
-      headCommit: sourceCommit,
-    });
-    reportTraceSessionsProgress(traceSessions, input.progress);
-  } catch {
-    // Ignore trace resolution errors
-  }
+  const traceSetup = await discoverAndPullScaffoldTraces({
+    rootPath: source.reviewRoot,
+    baseCommit,
+    headCommit: sourceCommit,
+    progress: input.progress,
+  });
+  setup.warnings.push(...traceSetup.warnings);
   const event: ReviewScaffoldEvent = {
     ...(await reviewInfoEvent([created])),
     pins: { baseCommit, sourceCommit },
@@ -185,6 +210,7 @@ async function createReview(
       head: setup.headRootPath ?? null,
       base: setup.baseRootPath ?? null,
     },
+    traces: traceSetup.traces,
   };
   return setup.warnings.length > 0
     ? { ...event, warnings: setup.warnings }
@@ -285,16 +311,13 @@ export async function repinReview(
       "Pins moved under a published revision. Publish again to present the new commits.",
     );
   }
-  try {
-    const traceSessions = await listReviewTraceSessions({
-      rootPath: root,
-      baseCommit,
-      headCommit: sourceCommit,
-    });
-    reportTraceSessionsProgress(traceSessions, input.progress);
-  } catch {
-    // Ignore trace resolution errors
-  }
+  const traceSetup = await discoverAndPullScaffoldTraces({
+    rootPath: root,
+    baseCommit,
+    headCommit: sourceCommit,
+    progress: input.progress,
+  });
+  setup.warnings.push(...traceSetup.warnings);
   const event: ReviewScaffoldEvent = {
     ...(await reviewInfoEvent([updated])),
     pins: { baseCommit, sourceCommit },
@@ -302,6 +325,7 @@ export async function repinReview(
       head: setup.headRootPath ?? null,
       base: setup.baseRootPath ?? null,
     },
+    traces: traceSetup.traces,
   };
   return setup.warnings.length > 0
     ? { ...event, warnings: setup.warnings }
@@ -309,7 +333,7 @@ export async function repinReview(
 }
 
 function reportTraceSessionsProgress(
-  sessions: import("@dev.fast/review-protocol").ReviewAgentTraceSession[],
+  sessions: ReviewAgentTraceSession[],
   progress?: (message: string) => void,
 ): void {
   if (!progress) return;
@@ -331,6 +355,128 @@ function reportTraceSessionsProgress(
             : "unknown";
     const syncLabel = s.available ? "[R2 synced]" : "[not synced]";
     progress(`  ${shortId} (${harness})  ${syncLabel}`);
+  }
+}
+
+async function discoverAndPullScaffoldTraces(input: {
+  rootPath: string;
+  baseCommit: string;
+  headCommit: string;
+  progress?: (message: string) => void;
+}): Promise<{ traces: ReviewScaffoldTraces; warnings: string[] }> {
+  let resolvedSessions: ReviewAgentTraceSession[];
+  try {
+    resolvedSessions = await listReviewTraceSessions(input);
+  } catch (error) {
+    return traceSetupFailure(
+      [],
+      `Agent trace discovery failed: ${formatError(error)}`,
+      input.progress,
+    );
+  }
+
+  reportTraceSessionsProgress(resolvedSessions, input.progress);
+  const sessions = resolvedSessions.map(scaffoldTraceSession);
+  const availableSessions = resolvedSessions.filter(
+    (session) => session.available,
+  );
+  const unavailableSessions = resolvedSessions
+    .filter((session) => !session.available)
+    .map((session) => session.sessionId);
+  if (availableSessions.length === 0) {
+    return {
+      traces: emptyScaffoldTraces(sessions, unavailableSessions),
+      warnings: [],
+    };
+  }
+
+  try {
+    const repo = await inferRepoFromGit(input.rootPath);
+    const pulled = await pullReviewTraceCorpus({
+      repo,
+      sessions: availableSessions.map((session) => ({
+        id: session.sessionId,
+        traces: session.subagents,
+      })),
+    });
+    const traces: ReviewScaffoldTraces = {
+      sessions,
+      corpusRoot: pulled.corpusRoot,
+      repository: pulled.repository,
+      materializedSessions: pulled.sessions,
+      unavailableSessions: [
+        ...new Set([...unavailableSessions, ...pulled.unavailableSessions]),
+      ],
+      events: pulled.events,
+      files: pulled.files,
+      paths: pulled.paths,
+    };
+    reportTracePathsProgress(traces, input.progress);
+    return { traces, warnings: [] };
+  } catch (error) {
+    return traceSetupFailure(
+      sessions,
+      `Agent trace materialization failed: ${formatError(error)}`,
+      input.progress,
+    );
+  }
+}
+
+function scaffoldTraceSession(
+  session: ReviewAgentTraceSession,
+): ReviewScaffoldTraceSession {
+  return {
+    id: session.sessionId,
+    harness: session.harness,
+    available: session.available,
+    traces: ["main", ...(session.subagents ?? [])],
+    commits: session.commits,
+  };
+}
+
+function emptyScaffoldTraces(
+  sessions: ReviewScaffoldTraceSession[],
+  unavailableSessions: string[] = [],
+): ReviewScaffoldTraces {
+  return {
+    sessions,
+    corpusRoot: null,
+    repository: null,
+    materializedSessions: [],
+    unavailableSessions,
+    events: 0,
+    files: 0,
+    paths: [],
+  };
+}
+
+function traceSetupFailure(
+  sessions: ReviewScaffoldTraceSession[],
+  warning: string,
+  progress?: (message: string) => void,
+): { traces: ReviewScaffoldTraces; warnings: string[] } {
+  progress?.(`Warning: ${warning}`);
+  return {
+    traces: emptyScaffoldTraces(
+      sessions,
+      sessions.map((session) => session.id),
+    ),
+    warnings: [warning],
+  };
+}
+
+function reportTracePathsProgress(
+  traces: ReviewScaffoldTraces,
+  progress?: (message: string) => void,
+): void {
+  if (!progress) return;
+  if (traces.paths.length === 0) {
+    progress("Trace paths: none materialized");
+    return;
+  }
+  progress("Trace paths:");
+  for (const tracePath of traces.paths) {
+    progress(`  ${tracePath}`);
   }
 }
 


### PR DESCRIPTION
## What changed

- Discover and materialize available agent traces during `review scaffold` and `review scaffold --update`.
- Emit a structured `traces` object in scaffold JSON, including absolute normalized trace paths, session metadata, corpus details, and unavailable sessions.
- Print materialized paths through scaffold progress output while keeping trace failures non-fatal.
- Update the `dev-review` skill to consume scaffold-provided paths and retain manual list/pull only as a compatibility fallback.

## Why

Scaffold already discovered the sessions associated with the pinned change range, but discarded that result after printing a short status list. Review authors then had to repeat discovery and pull commands before they could search the traces. This makes scaffold the single setup step and gives agents authoritative corpus paths directly.

## Impact

Review authors can start trace archaeology from the scaffold event without rediscovering sessions or inferring the trace corpus layout. Older clients and reused Reviews retain the existing manual workflow.

## Validation

- `pnpm --filter @dev.fast/review typecheck`
- Full `@dev.fast/review` test suite: 1,092 tests passed
- Focused scaffold/CLI suite: 56 tests passed
- Targeted `oxlint`, `oxfmt --check`, and `git diff --check`