### PR TITLE
Polish light-mode comments and TOC

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/browser/media/review.css
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/media/review.css
@@ -1075,8 +1075,14 @@ body
   --review-comment-accent-hover: #5d7cf7;
   --review-comment-accent-wash: rgb(77 110 245 / 14%);
   --review-comment-accent-outline: rgb(77 110 245 / 48%);
+  --review-comment-chip-ink: color-mix(
+    in srgb,
+    var(--review-comment-accent) 70%,
+    white
+  );
   --review-comment-range: rgb(35 71 178 / 58%);
   --review-comment-range-active: rgb(48 91 226 / 68%);
+  --review-comment-range-line-number: #e7edff;
   --review-comment-surface: #0f1217;
   --review-comment-input: #0f1217;
   --review-comment-rule: #272c35;
@@ -1084,6 +1090,8 @@ body
   --review-comment-composer-rule: #3d444d;
   --review-comment-footer: #151922;
   --review-comment-footer-rule: #566171;
+  --review-comment-shadow: rgb(0 0 0 / 55%);
+  --review-comment-shadow-active: rgb(0 0 0 / 60%);
   --review-comment-ink: var(--vscode-editor-foreground, #e8eaee);
   --review-comment-muted: var(--vscode-descriptionForeground, #9ba1ac);
   --vscode-editorGutter-commentRangeForeground: var(--review-comment-accent);
@@ -1100,6 +1108,37 @@ body
   --vscode-editorCommentsWidget-rangeActiveBackground: var(
     --review-comment-range-active
   );
+}
+
+/* On a light editor, the dark-theme comment palette obscures syntax, shifts
+   diff row colors toward a muddy blue, and leaves inherited dark text on dark
+   composer surfaces. Use native light surfaces and a restrained accent wash
+   while leaving high-contrast themes on the stronger defaults above. */
+.monaco-workbench.review-workbench.vs {
+  --review-comment-chip-ink: var(--review-comment-accent);
+  --review-comment-range: rgb(43 79 224 / 12%);
+  --review-comment-range-active: rgb(43 79 224 / 18%);
+  --review-comment-range-line-number: var(
+    --vscode-editorLineNumber-activeForeground,
+    #2448ca
+  );
+  --review-comment-surface: var(--vscode-editorWidget-background, #ffffff);
+  --review-comment-input: var(--vscode-input-background, #ffffff);
+  --review-comment-rule: var(--vscode-editorWidget-border, #c8c8c8);
+  --review-comment-metadata-rule: color-mix(
+    in srgb,
+    var(--vscode-foreground) 12%,
+    var(--review-comment-surface)
+  );
+  --review-comment-composer-rule: var(--review-comment-metadata-rule);
+  --review-comment-footer: color-mix(
+    in srgb,
+    var(--vscode-foreground) 4%,
+    var(--review-comment-surface)
+  );
+  --review-comment-footer-rule: var(--review-comment-metadata-rule);
+  --review-comment-shadow: rgb(0 0 0 / 12%);
+  --review-comment-shadow-active: rgb(0 0 0 / 16%);
 }
 
 .monaco-workbench.review-workbench
@@ -1139,7 +1178,7 @@ body
     .comment-range-selection-line-number,
     .comment-range-selection-line-number-current
   ) {
-  color: #e7edff !important;
+  color: var(--review-comment-range-line-number) !important;
   font-weight: 600;
 }
 
@@ -1219,7 +1258,7 @@ body
   border: 1px solid var(--review-comment-accent-outline);
   border-radius: 999px;
   background: var(--review-comment-accent-wash);
-  color: color-mix(in srgb, var(--review-comment-accent) 68%, white);
+  color: var(--review-comment-chip-ink);
   font-size: 10px;
   font-weight: 600;
   line-height: 18px;
@@ -1256,7 +1295,7 @@ body
   border-top-color: var(--review-comment-metadata-rule) !important;
   border-radius: 0 0 8px 8px;
   background: var(--review-comment-surface);
-  box-shadow: 0 10px 28px rgb(0 0 0 / 55%);
+  box-shadow: 0 10px 28px var(--review-comment-shadow);
 }
 
 .monaco-workbench.review-workbench
@@ -1283,7 +1322,7 @@ body
   border-left-color: var(--review-comment-accent) !important;
   box-shadow:
     0 0 0 1px rgb(76 141 246 / 16%),
-    0 10px 28px rgb(0 0 0 / 60%);
+    0 10px 28px var(--review-comment-shadow-active);
 }
 
 .monaco-workbench.review-workbench
@@ -1367,7 +1406,7 @@ body
   border: 1px solid var(--review-comment-accent-outline);
   border-radius: 999px;
   background: transparent;
-  color: color-mix(in srgb, var(--review-comment-accent) 74%, white);
+  color: var(--review-comment-chip-ink);
   font-size: 10px;
   font-style: normal;
   font-weight: 500;

--- a/apps/review-desktop/scripts/inline-diff-editor-contract.test.mjs
+++ b/apps/review-desktop/scripts/inline-diff-editor-contract.test.mjs
@@ -153,6 +153,33 @@ test("authored CodePeeks use one unified native comment editor", () => {
   assert.doesNotMatch(resourceSource, /instance:\s*generateUuid/);
 });
 
+test("light-theme comments use light surfaces and preserve the diff tint", () => {
+  assert.match(
+    reviewStyles,
+    /\.monaco-workbench\.review-workbench\.vs\s*{[^}]*--review-comment-range:\s*rgb\(43 79 224 \/ 12%\);[^}]*--review-comment-range-active:\s*rgb\(43 79 224 \/ 18%\);/s,
+  );
+  assert.match(
+    reviewStyles,
+    /--review-comment-range-line-number:\s*var\([\s\S]*?--vscode-editorLineNumber-activeForeground/,
+  );
+  assert.match(
+    reviewStyles,
+    /color:\s*var\(--review-comment-range-line-number\)\s*!important;/,
+  );
+  assert.match(
+    reviewStyles,
+    /\.monaco-workbench\.review-workbench\.vs\s*{[^}]*--review-comment-surface:\s*var\(--vscode-editorWidget-background, #ffffff\);[^}]*--review-comment-footer:[^}]*--review-comment-shadow:\s*rgb\(0 0 0 \/ 12%\);/s,
+  );
+  assert.match(
+    reviewStyles,
+    /color:\s*var\(--review-comment-chip-ink\);/,
+  );
+  assert.match(
+    reviewStyles,
+    /box-shadow:\s*0 10px 28px var\(--review-comment-shadow\);/,
+  );
+});
+
 test("long authored ranges initially reveal their first line", () => {
   assert.match(
     widgetImplementationSource,

--- a/packages/progressive-review/app/src/review-toc.test.tsx
+++ b/packages/progressive-review/app/src/review-toc.test.tsx
@@ -94,6 +94,12 @@ describe("ReviewToc", () => {
     });
     await settle();
     expect(tocLabels()).toEqual(["Interface change", "Scheduling sequence"]);
+    expect(
+      document.querySelector(".review-toc-toggle-number")?.textContent?.trim(),
+    ).toBe("1");
+    expect(
+      document.querySelector(".review-toc-toggle")?.textContent,
+    ).not.toContain("§");
 
     // A session switch or live recompile replaces the article node. Observing
     // the article itself strands the MutationObserver on the detached node, so

--- a/packages/progressive-review/app/src/review-toc.tsx
+++ b/packages/progressive-review/app/src/review-toc.tsx
@@ -291,7 +291,7 @@ export function ReviewToc(): ReactElement | null {
         {activeEntry && (
           <>
             <span className="review-toc-toggle-number">
-              § {activeEntry.number}
+              {activeEntry.number}
             </span>
             <strong className="review-toc-toggle-title">
               {activeEntry.text}


### PR DESCRIPTION
## Summary

- reduce comment range overlays in the standard light theme so syntax and diff tints remain visible
- give the comment composer native light surfaces, borders, footer, foregrounds, and restrained shadows
- remove the redundant section symbol from the compact TOC pill while retaining its section number
- preserve the stronger existing comment treatment for dark and high-contrast themes

## Root cause

Review applied one hard-coded dark comment palette to every workbench theme. Light mode inherited dark text from the editor while keeping near-black composer surfaces, and its high-opacity cobalt range overlay overwhelmed added or removed line tints. Separately, the compact TOC toggle hard-coded a section symbol before its already-numbered active entry.

## Validation

- `pnpm --filter @dev-fast/review-desktop test`
- `pnpm --filter @dev.fast/review test`
- `node --test apps/review-desktop/scripts/inline-diff-editor-contract.test.mjs`
- `pnpm --filter @dev.fast/review exec vitest run app/src/review-toc.test.tsx`