### PR TITLE
Refine dev-review authoring and trace guidance

### DIFF
--- a/packages/progressive-review/skills/dev-review/SKILL.md
+++ b/packages/progressive-review/skills/dev-review/SKILL.md
@@ -42,6 +42,8 @@ Run `review app launch --json` to start Review Desktop. Then run `review info --
 
 Pass resolved commit ids to `--base` and `--head`. Parent suffixes like `<rev>^` do not resolve in a jj workspace; resolve the parent first with `jj log -r '<rev>-'`.
 
+If scaffold warns that `devfast.prepare` is not configured, set up that command according to [Prepared worktrees](references/prepared-worktrees.md).
+
 Read the scaffold JSON event and `<review-dir>/review.json`. Together they carry these values; record them:
 
 - Review UUID and directory
@@ -85,9 +87,7 @@ Read [Document authoring](references/document-authoring.md) before you edit `rev
 
 Use the materialized files in `traces.paths` from the scaffold event. When that array is non-empty, read [Trace quoting](references/trace-quoting.md) and complete its intent pass before authoring. Use FFF for candidate discovery.
 
-Run `review trace list --review <uuid> --json` followed by `review trace pull --review <uuid> --json` only when reusing a Review without a scaffold event from this run, or when the event has no `traces` field because the installed CLI predates automatic trace materialization. Do not repeat those commands after a current scaffold event; `review scaffold --update` refreshes the corpus and prints its paths again.
-
-Use the smallest document that explains the important change. Default to `AnchorLink` for source evidence. Use `CodePeek` only when readers must see the code inline to understand the main claim.
+Use the smallest document that explains the important change. Default to `AnchorLink` for source evidence, and use this to hyperlink any text in the review that refers to a specific piece of code. Use `CodePeek` only when readers must see the code inline to understand the main claim.
 
 Read every referenced range from the correct pinned checkout before you add it. Use the `checkouts` paths from the scaffold event: the head checkout for a head range, the base checkout for a base range.
 

--- a/packages/progressive-review/skills/dev-review/references/document-authoring.md
+++ b/packages/progressive-review/skills/dev-review/references/document-authoring.md
@@ -10,13 +10,13 @@ Assume raw prose will confuse the reader. Spend substantial reasoning effort dec
 
 Remember that the reader can ONLY see the 'user' prompts _before_ coding started and the document you write to explain what changed. This means jargon in the middle - references to specific parts of code, especially any and all abstractions, changes, and code referenced _during_ the editing process - is confusing and not helpful. More words do not help. Progressive disclosure of complexity is key.
 
-Open the document with a landing section. The landing section merges the problem statement and the summary in one paragraph of two to four sentences:
+Open the document with a landing section. The landing section should be brief, and include both of the following, on separate lines:
 
-- State the context, then the gap, then the change, in that order. For a bugfix, the gap is what was wrong before. For a new feature, the gap is what was missing and why it matters.
-- Answer why completely. Answer what briefly. The detail belongs in the later sections.
+**Problem**: [What problem does this change solve? (What problem(s) is this change not trying to solve?) For a bugfix, this can be what was wrong before; for a new feature, this can be what this adds.]
+**Summary**: [A short description of the change, two to three sentences at most.]
+
+- Answer the 'why' behind the change completely (in the developer's own words, if we have agent traces,) capturing the intent behind the pr. Answer the 'what' briefly. The detail belongs in the later sections.
 - Define each domain term at its first mention.
-
-Add implementation detail only when it helps the reader check an important claim.
 
 After the landing section, use fewer than five further sections when practical. Choose the sections that fit this change. Good section choices are:
 
@@ -28,7 +28,9 @@ After the landing section, use fewer than five further sections when practical. 
 - testing evidence
 - decision log
 
-In the decision log, preserve important user requirements in the user's language. Add only implementation decisions that affect the result.
+Add implementation detail only when it helps the reader check an important claim.
+
+In the decision log, preserve important user requirements in the user's language. Add significant implementation decisions that affect the result.
 
 When the change has synced agent sessions, build the landing, requirements, design, and decision-log sections from trace quotes. Read [Trace quoting](trace-quoting.md) for the workflow and rules. Without sessions, the same structure holds in authored prose.
 

--- a/packages/progressive-review/skills/dev-review/references/trace-quoting.md
+++ b/packages/progressive-review/skills/dev-review/references/trace-quoting.md
@@ -2,20 +2,11 @@
 
 A Review can quote the agent sessions that produced the change. The reader then learns the intent from the user's own words, and each quote opens the trace at that moment.
 
-Read this reference when the pinned change has at least one available session. Skip it when `review trace list` reports none.
+The dev-review workflow provides materialized trace paths through the current scaffold event or its compatibility fallback. Skip this reference when no trace paths were materialized.
 
-## Find the sessions
+## Use the materialized sessions
 
-Run in the source worktree:
-
-```sh
-review trace list --review <uuid> --json
-review trace pull --review <uuid> --json
-```
-
-The command resolves sessions from `Agent-Session` commit trailers in the pinned range. Each entry reports its id, availability, commits, and trace names.
-
-Quote only sessions with `"available": true`. An unsynced session has no transcript in R2, and publish rejects quotes from it. Report unsynced sessions. Do not guess their content.
+Read `traces.sessions`, `traces.unavailableSessions`, and `traces.paths` from the scaffold JSON event. Scaffolding has already resolved the sessions from `Agent-Session` commit trailers in the pinned range and pulled each available transcript.
 
 ## Complete the intent pass
 
@@ -39,28 +30,26 @@ Do not filter the first pass to user events. Agent actions and tool use explain 
 
 The intent pass is complete when every available main trace has been surveyed and each relevant subagent trace has been surveyed.
 
-The pull command writes one normalized JSONL file per trace under:
+Scaffold or `review trace pull` writes one normalized JSONL file per trace under:
 
 ```text
 ~/.dev/trace-search/<owner>/<repo>/<session>/main.jsonl
 ~/.dev/trace-search/<owner>/<repo>/<session>/<subagent>.jsonl
 ```
 
-Its JSON output returns each absolute file path in `paths`. Use these paths directly. Do not derive them from the corpus layout.
+The scaffold event returns each absolute file path in `traces.paths`; `review trace pull` returns them in `paths`. Use these paths directly. Do not derive them from the corpus layout.
 
 The first line contains trace metadata. Each later line contains one event with its index, kind, exact projected text, and structured event.
 
-If the pull command reports missing trace configuration, ask the user to use Review Agent Setup. Do not change setup autonomously.
+If scaffold warnings or the compatibility pull report missing trace configuration, ask the user to use Review Agent Setup. Do not change setup autonomously.
 
 ## Find supporting events
 
-After the intent pass, use FFF to search the files returned in `paths` for each important requirement or decision.
+After the intent pass, use the FFF MCP (in its absence, falling back to tools like `rg`, and then `grep`) to search the files returned in `paths` for each important requirement or decision.
 
-Ignore a match on physical line 1 because it is trace metadata. Each later physical line contains one event. For a match on line `<L>`, the event index is `<L> - 2`. Use the record's `index` when the excerpt shows it. Otherwise, derive the index from the physical line number.
+Each physical line (except for line 1) contains one event. For a match on line `<L>`, the event index is `<L> - 2`. Use the record's `index` when the excerpt shows it. Otherwise, derive the index from the physical line number.
 
-Prefer user event records for requirements and corrections. Use assistant event records only when the assistant stated a decision that the user accepted. Confirm the kind with `review trace show --event` when the FFF excerpt omits it.
-
-FFF results locate candidates. Never copy quote text from a search result.
+Prefer user event records for requirements and corrections. Use assistant event records only when the assistant stated a decision that the user accepted. Confirm the kind with `review trace show --event` when the search excerpt omits it.
 
 ## Read exact quote text
 
@@ -87,11 +76,11 @@ Use `trace_quote_props` from the response without reconstructing it. Every `Trac
 
 ## Quote density by section
 
-- Landing section: build it almost entirely from quotes — the gap and the change especially. The two-to-four-sentence cap holds; short quotes beat long ones here.
+- Landing section: This section should almost entirely be composed from user (or, maybe, agent-written, but user-approved later on) quotes, save for some glue words connecting the quotes. The two-to-four-sentence cap holds; short quotes beat long ones here. the most important thing is to capture the user's intent, in their words, which led to the code change in the pinned diff.
 - Requirements: at least one quote per bullet.
 - Design: a quote states each decision. An `AnchorLink` shows the decision in code.
 - Implementation: authored prose with `AnchorLink` evidence. Quotes are optional.
-- Decision log: the full replay. Quote the turns in trace order. Include decisions the user later reversed, each with the quote that reversed it. Quote both decisions that the user made, as well as decisions that the agent made.
+- Decision log: the full replay. Quote the turns in trace order. Include decisions that later got invalidated or reversed, each with the quote that reversed it. Quote both decisions that the user made, as well as decisions that the agent made.
 
 ## Decisions that changed
 
@@ -99,7 +88,7 @@ Outside the decision log, quote only decisions that the pinned diff confirms. Wh
 
 ## Example texture
 
-A landing paragraph reads like this:
+An excerpt from a landing paragraph can read like this:
 
 ```mdx
 <TraceQuote sessionId="019fdb00-f032-79d2-9ee8-0b8fe0e86a9e" event={62}>


### PR DESCRIPTION
## What changed

- make the Review landing contract explicitly separate the problem from the summary
- align trace-quoting guidance with scaffold-time trace materialization and document the fallback search order
- require source-linked prose for code-specific claims and route missing prepared-worktree setup to its reference
- clarify that decision logs should retain significant implementation decisions

## Why

The dev-review guidance still described a manual trace-list/pull flow after scaffolding even though scaffold now materializes available traces. The authoring instructions also left the landing structure and source-link expectations open to interpretation. This update makes the workflow match the current CLI behavior and keeps generated Reviews focused on intent, concise summaries, and navigable evidence.

## Impact

Review authors should avoid redundant trace pulls, capture PR intent more consistently, and link code-specific explanations to exact source ranges.

## Validation

- `git diff --check`
- documentation-only change; no runtime test suite was required
