### PR TITLE
Add Review Desktop update lifecycle telemetry

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/platform/update/common/darwinUpdateRecovery.ts
+++ b/apps/review-desktop/code-oss/src/vs/platform/update/common/darwinUpdateRecovery.ts
@@ -5,16 +5,25 @@
 
 export const DARWIN_UPDATE_ATTEMPT_STORAGE_KEY = 'update/darwin/attempt.v1';
 export const DARWIN_FAILED_UPDATE_STORAGE_KEY = 'update/darwin/failed.v1';
+export const DARWIN_UPDATE_OUTCOME_STORAGE_KEY = 'update/darwin/outcome.v1';
 
 export interface IDarwinUpdateAttempt {
 	readonly sourceCommit: string;
 	readonly targetCommit: string;
 	readonly productVersion?: string;
 	readonly attemptedAt: number;
+	readonly attemptId?: string;
+	readonly shipItLogOffset?: number;
 }
 
 export interface IDarwinFailedUpdate extends IDarwinUpdateAttempt {
 	readonly failedAt: number;
+}
+
+export interface IDarwinUpdateOutcomeRecord {
+	readonly kind: 'applied' | 'failed';
+	readonly attempt: IDarwinUpdateAttempt;
+	readonly resolvedAt: number;
 }
 
 export function parseDarwinUpdateAttempt(raw: string | undefined): IDarwinUpdateAttempt | undefined {
@@ -23,7 +32,7 @@ export function parseDarwinUpdateAttempt(raw: string | undefined): IDarwinUpdate
 		return undefined;
 	}
 
-	const { sourceCommit, targetCommit, productVersion, attemptedAt } = parsed;
+	const { sourceCommit, targetCommit, productVersion, attemptedAt, attemptId, shipItLogOffset } = parsed;
 	if (
 		typeof sourceCommit !== 'string' || !sourceCommit ||
 		typeof targetCommit !== 'string' || !targetCommit ||
@@ -37,6 +46,8 @@ export function parseDarwinUpdateAttempt(raw: string | undefined): IDarwinUpdate
 		targetCommit,
 		productVersion: typeof productVersion === 'string' && productVersion ? productVersion : undefined,
 		attemptedAt,
+		attemptId: typeof attemptId === 'string' && attemptId ? attemptId : undefined,
+		shipItLogOffset: typeof shipItLogOffset === 'number' && Number.isFinite(shipItLogOffset) && shipItLogOffset >= 0 ? shipItLogOffset : undefined,
 	};
 }
 
@@ -48,6 +59,18 @@ export function parseDarwinFailedUpdate(raw: string | undefined): IDarwinFailedU
 	}
 
 	return { ...attempt, failedAt: parsed.failedAt };
+}
+
+export function parseDarwinUpdateOutcomeRecord(raw: string | undefined): IDarwinUpdateOutcomeRecord | undefined {
+	const parsed = parseObject(raw);
+	if (!parsed || (parsed.kind !== 'applied' && parsed.kind !== 'failed')) {
+		return undefined;
+	}
+	const attempt = parseDarwinUpdateAttempt(JSON.stringify(parsed.attempt));
+	if (!attempt || typeof parsed.resolvedAt !== 'number' || !Number.isFinite(parsed.resolvedAt)) {
+		return undefined;
+	}
+	return { kind: parsed.kind, attempt, resolvedAt: parsed.resolvedAt };
 }
 
 export type DarwinUpdateOutcome =

--- a/apps/review-desktop/code-oss/src/vs/platform/update/common/update.ts
+++ b/apps/review-desktop/code-oss/src/vs/platform/update/common/update.ts
@@ -68,9 +68,11 @@ export const enum DisablementReason {
 	RunningAsAdmin,
 }
 
+export type UpdateErrorSource = 'electron' | 'request';
+
 export type Uninitialized = { type: StateType.Uninitialized };
 export type Disabled = { type: StateType.Disabled; reason: DisablementReason };
-export type Idle = { type: StateType.Idle; updateType: UpdateType; error?: string; notAvailable?: boolean };
+export type Idle = { type: StateType.Idle; updateType: UpdateType; error?: string; notAvailable?: boolean; errorSource?: UpdateErrorSource };
 export type CheckingForUpdates = { type: StateType.CheckingForUpdates; explicit: boolean };
 export type AvailableForDownload = { type: StateType.AvailableForDownload; update: IUpdate; canInstall?: boolean };
 export type Downloading = { type: StateType.Downloading; update?: IUpdate; explicit: boolean; overwrite: boolean; downloadedBytes?: number; totalBytes?: number; startTime?: number };
@@ -86,7 +88,7 @@ export type State = Uninitialized | Disabled | Idle | CheckingForUpdates | Avail
 export const State = {
 	Uninitialized: upcast<Uninitialized>({ type: StateType.Uninitialized }),
 	Disabled: (reason: DisablementReason): Disabled => ({ type: StateType.Disabled, reason }),
-	Idle: (updateType: UpdateType, error?: string, notAvailable?: boolean): Idle => ({ type: StateType.Idle, updateType, error, notAvailable }),
+	Idle: (updateType: UpdateType, error?: string, notAvailable?: boolean, errorSource?: UpdateErrorSource): Idle => ({ type: StateType.Idle, updateType, error, notAvailable, errorSource }),
 	CheckingForUpdates: (explicit: boolean): CheckingForUpdates => ({ type: StateType.CheckingForUpdates, explicit }),
 	AvailableForDownload: (update: IUpdate, canInstall?: boolean): AvailableForDownload => ({ type: StateType.AvailableForDownload, update, canInstall }),
 	Downloading: (update: IUpdate | undefined, explicit: boolean, overwrite: boolean, downloadedBytes?: number, totalBytes?: number, startTime?: number): Downloading => ({ type: StateType.Downloading, update, explicit, overwrite, downloadedBytes, totalBytes, startTime }),

--- a/apps/review-desktop/code-oss/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/apps/review-desktop/code-oss/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -4,10 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as electron from 'electron';
+import { statSync } from 'node:fs';
+import { join } from 'node:path';
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { memoize } from '../../../base/common/decorators.js';
+import { getErrorMessage } from '../../../base/common/errors.js';
 import { Event } from '../../../base/common/event.js';
 import { hash } from '../../../base/common/hash.js';
+import { generateUuid } from '../../../base/common/uuid.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { IEnvironmentMainService } from '../../environment/electron-main/environmentMainService.js';
 import { ILifecycleMainService, IRelaunchHandler, IRelaunchOptions } from '../../lifecycle/electron-main/lifecycleMainService.js';
@@ -21,6 +25,7 @@ import {
 	blocksAutomaticDarwinUpdate,
 	DARWIN_FAILED_UPDATE_STORAGE_KEY,
 	DARWIN_UPDATE_ATTEMPT_STORAGE_KEY,
+	DARWIN_UPDATE_OUTCOME_STORAGE_KEY,
 	parseDarwinFailedUpdate,
 	resolveDarwinUpdateAttempt,
 	type IDarwinFailedUpdate,
@@ -31,6 +36,7 @@ import { IMeteredConnectionService } from '../../meteredConnection/common/metere
 import { AbstractUpdateService, createUpdateURL, getUpdateRequestHeaders, IUpdateURLOptions, UpdateErrorClassification } from './abstractUpdateService.js';
 
 export class DarwinUpdateService extends AbstractUpdateService implements IRelaunchHandler {
+	private feedUrlError: string | undefined;
 
 	@memoize private get onRawError(): Event<string> { return Event.fromNodeEventEmitter(electron.autoUpdater, 'error', (_, message) => message); }
 	@memoize private get onRawCheckingForUpdate(): Event<void> { return Event.fromNodeEventEmitter<void>(electron.autoUpdater, 'checking-for-update'); }
@@ -102,12 +108,11 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 			return;
 		}
 
-		// only show message when explicitly checking for updates
-		const message = (this.state.type === StateType.CheckingForUpdates && this.state.explicit) ? err : undefined;
-		this.setState(State.Idle(UpdateType.Archive, message));
+		this.setState(State.Idle(UpdateType.Archive, err, undefined, 'electron'));
 	}
 
 	protected buildUpdateFeedUrl(quality: string, commit: string, options?: IUpdateURLOptions): string | undefined {
+		this.feedUrlError = undefined;
 		const assetID = this.productService.darwinUniversalAssetId ?? (process.arch === 'x64' ? 'darwin' : 'darwin-arm64');
 		const url = createUpdateURL(this.productService.updateUrl!, assetID, quality, commit, options);
 		const headers = getUpdateRequestHeaders(this.productService.version);
@@ -117,6 +122,7 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 		} catch (e) {
 			// application is very likely not signed
 			this.logService.error('Failed to set update feed URL', e);
+			this.feedUrlError = getErrorMessage(e);
 			return undefined;
 		}
 		return url;
@@ -134,7 +140,7 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 		const url = this.buildUpdateFeedUrl(this.quality, pendingCommit ?? this.productService.commit!, { background, internalOrg });
 
 		if (!url) {
-			this.setState(State.Idle(UpdateType.Archive));
+			this.setState(State.Idle(UpdateType.Archive, this.takeFeedUrlError(), undefined, 'electron'));
 			return;
 		}
 
@@ -200,7 +206,7 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 			}
 		} catch (err) {
 			this.logService.error('update#checkForUpdateNoDownload - failed to check for update', err);
-			this.setState(State.Idle(UpdateType.Archive));
+			this.setState(State.Idle(UpdateType.Archive, getErrorMessage(err), undefined, 'request'));
 		}
 	}
 
@@ -242,8 +248,12 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 		// The dev.fast feed answers 204/200 based on the caller's installed
 		// commit, so this re-check must send the installed commit — sending the
 		// target commit (state.update.version) would read as "up to date".
-		this.buildUpdateFeedUrl(this.quality!, this.productService.commit!, { internalOrg: this.getInternalOrg() });
 		this.setState(State.CheckingForUpdates(true));
+		const url = this.buildUpdateFeedUrl(this.quality!, this.productService.commit!, { internalOrg: this.getInternalOrg() });
+		if (!url) {
+			this.setState(State.Idle(UpdateType.Archive, this.takeFeedUrlError(), undefined, 'electron'));
+			return;
+		}
 		electron.autoUpdater.checkForUpdates();
 	}
 
@@ -261,6 +271,7 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 
 		this.applicationStorageMainService.remove(DARWIN_UPDATE_ATTEMPT_STORAGE_KEY, StorageScope.APPLICATION);
 		if (outcome.kind === 'failed') {
+			this.storeUpdateOutcome('failed', outcome.failure, outcome.failure.failedAt);
 			this.applicationStorageMainService.store(
 				DARWIN_FAILED_UPDATE_STORAGE_KEY,
 				JSON.stringify(outcome.failure),
@@ -269,6 +280,7 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 			);
 			this.logService.error(`update#recovery - update ${outcome.failure.targetCommit} did not apply; automatic retries are disabled for this release`);
 		} else if (outcome.kind === 'applied') {
+			this.storeUpdateOutcome('applied', outcome.attempt, Date.now());
 			const failedUpdate = this.getFailedUpdate();
 			if (failedUpdate?.targetCommit === outcome.attempt.targetCommit) {
 				this.clearFailedUpdate();
@@ -296,6 +308,8 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 			targetCommit: update.version,
 			productVersion: update.productVersion,
 			attemptedAt: Date.now(),
+			attemptId: generateUuid(),
+			shipItLogOffset: this.getShipItLogOffset(),
 		};
 		this.applicationStorageMainService.store(
 			DARWIN_UPDATE_ATTEMPT_STORAGE_KEY,
@@ -316,5 +330,32 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 
 	private clearFailedUpdate(): void {
 		this.applicationStorageMainService.remove(DARWIN_FAILED_UPDATE_STORAGE_KEY, StorageScope.APPLICATION);
+	}
+
+	private storeUpdateOutcome(kind: 'applied' | 'failed', attempt: IDarwinUpdateAttempt, resolvedAt: number): void {
+		this.applicationStorageMainService.store(
+			DARWIN_UPDATE_OUTCOME_STORAGE_KEY,
+			JSON.stringify({ kind, attempt, resolvedAt }),
+			StorageScope.APPLICATION,
+			StorageTarget.MACHINE,
+		);
+	}
+
+	private getShipItLogOffset(): number | undefined {
+		const bundleIdentifier = this.productService.darwinBundleIdentifier;
+		if (!bundleIdentifier) {
+			return undefined;
+		}
+		try {
+			return statSync(join(this.environmentMainService.userHome.fsPath, 'Library', 'Caches', `${bundleIdentifier}.ShipIt`, 'ShipIt_stderr.log')).size;
+		} catch (error) {
+			return (error as NodeJS.ErrnoException).code === 'ENOENT' ? 0 : undefined;
+		}
+	}
+
+	private takeFeedUrlError(): string | undefined {
+		const error = this.feedUrlError;
+		this.feedUrlError = undefined;
+		return error;
 	}
 }

--- a/apps/review-desktop/code-oss/src/vs/review/common/darwinUpdateRecovery.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/darwinUpdateRecovery.test.ts
@@ -10,6 +10,8 @@ import {
 	blocksAutomaticDarwinUpdate,
 	darwinFailedUpdateNoticeId,
 	parseDarwinFailedUpdate,
+	parseDarwinUpdateAttempt,
+	parseDarwinUpdateOutcomeRecord,
 	resolveDarwinUpdateAttempt,
 	shouldAnnounceDarwinFailedUpdate,
 } from '../../platform/update/common/darwinUpdateRecovery.js';
@@ -19,6 +21,8 @@ const attempt = {
 	targetCommit: 'target',
 	productVersion: '1.2.3',
 	attemptedAt: 100,
+	attemptId: '12345678-1234-1234-1234-123456789abc',
+	shipItLogOffset: 2048,
 };
 
 test('records an update that did not replace its source build', () => {
@@ -66,4 +70,24 @@ test('ignores invalid stored update data', () => {
 		{ kind: 'none' },
 	);
 	assert.equal(parseDarwinFailedUpdate(JSON.stringify({ ...attempt, failedAt: 'now' })), undefined);
+	assert.equal(parseDarwinUpdateOutcomeRecord(JSON.stringify({ kind: 'unknown', attempt, resolvedAt: 200 })), undefined);
+});
+
+test('keeps new attempt metadata while accepting legacy attempts', () => {
+	assert.deepEqual(parseDarwinUpdateAttempt(JSON.stringify(attempt)), attempt);
+	assert.deepEqual(
+		parseDarwinUpdateAttempt(JSON.stringify({
+			sourceCommit: 'source',
+			targetCommit: 'target',
+			attemptedAt: 100,
+		})),
+		{ sourceCommit: 'source', targetCommit: 'target', attemptedAt: 100, productVersion: undefined, attemptId: undefined, shipItLogOffset: undefined },
+	);
+});
+
+test('parses a persisted terminal outcome', () => {
+	assert.deepEqual(
+		parseDarwinUpdateOutcomeRecord(JSON.stringify({ kind: 'failed', attempt, resolvedAt: 300 })),
+		{ kind: 'failed', attempt, resolvedAt: 300 },
+	);
 });

--- a/apps/review-desktop/code-oss/src/vs/review/electron-main/reviewDesktopHost.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/electron-main/reviewDesktopHost.ts
@@ -10,12 +10,18 @@ import { ILifecycleMainService } from "../../platform/lifecycle/electron-main/li
 import { ILogService } from "../../platform/log/common/log.js";
 import { IProductService } from "../../platform/product/common/productService.js";
 import { getResolvedShellEnv } from "../../platform/shell/node/shellEnv.js";
+import { IApplicationStorageMainService } from "../../platform/storage/electron-main/storageMainService.js";
 import { NullTelemetryService } from "../../platform/telemetry/common/telemetryUtils.js";
+import { IUpdateService } from "../../platform/update/common/update.js";
 import { UtilityProcess } from "../../platform/utilityProcess/electron-main/utilityProcess.js";
 import type { ReviewDesktopConnection } from "../common/reviewDesktopBootstrap.js";
 import { REVIEW_TELEMETRY_SETTING } from "../common/reviewConfigurationDefaults.js";
 import { ReviewMainErrorTelemetry } from "./reviewMainErrorTelemetry.js";
 import { ReviewServerSupervisor } from "./reviewServerSupervisor.js";
+import {
+  darwinShipItLogPath,
+  ReviewUpdateTelemetry,
+} from "./reviewUpdateTelemetry.js";
 
 /**
  * Binds the embedded Review server's lifetime to the application's. All of the
@@ -41,6 +47,9 @@ export class ReviewDesktopHost extends Disposable {
     @IEnvironmentMainService
     private readonly environmentMainService: IEnvironmentMainService,
     @IProductService private readonly productService: IProductService,
+    @IUpdateService private readonly updateService: IUpdateService,
+    @IApplicationStorageMainService
+    private readonly applicationStorageMainService: IApplicationStorageMainService,
   ) {
     super();
     let resolvedEnvironment: Promise<NodeJS.ProcessEnv> | undefined;
@@ -98,6 +107,24 @@ export class ReviewDesktopHost extends Disposable {
       logError: (message) => this.logService.error(message),
     });
     this._register(toDisposable(() => errorTelemetry.dispose()));
+    this._register(
+      new ReviewUpdateTelemetry({
+        updateService: this.updateService,
+        storageService: this.applicationStorageMainService,
+        telemetry: errorTelemetry,
+        isTelemetryEnabled: () =>
+          this.configurationService.getValue<boolean>(
+            REVIEW_TELEMETRY_SETTING,
+          ) !== false,
+        shipItLogPath: this.productService.darwinBundleIdentifier
+          ? darwinShipItLogPath(
+              this.environmentMainService.userHome.fsPath,
+              this.productService.darwinBundleIdentifier,
+            )
+          : undefined,
+        logError: (message) => this.logService.error(message),
+      }),
+    );
     process.once("SIGINT", this.onTerminationSignal);
     process.once("SIGTERM", this.onTerminationSignal);
     this.supervisor.start();

--- a/apps/review-desktop/code-oss/src/vs/review/electron-main/reviewMainErrorTelemetry.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/electron-main/reviewMainErrorTelemetry.test.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ReviewMainErrorTelemetry } from "./reviewMainErrorTelemetry.js";
+
+test("posts named main-process telemetry through the embedded server", async () => {
+  const requests: RequestInit[] = [];
+  const telemetry = new ReviewMainErrorTelemetry({
+    whenConnected: async () => ({
+      version: 3,
+      url: "http://127.0.0.1:1234/__progressive-review",
+      token: "secret",
+      instanceId: "instance",
+    }),
+    isTelemetryEnabled: () => true,
+    fetchImpl: async (_input, init) => {
+      requests.push(init ?? {});
+      return new Response(null, { status: 204 });
+    },
+  });
+  telemetry.capture(
+    "update_failed",
+    { phase: "download", message_source: "electron" },
+    {
+      name: "UpdateDownloadError",
+      message: "Download failed",
+      stack: "Update lifecycle telemetry",
+    },
+  );
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(requests.length, 1);
+  assert.deepEqual(JSON.parse(String(requests[0].body)), {
+    name: "update_failed",
+    properties: { phase: "download", message_source: "electron" },
+    error: {
+      name: "UpdateDownloadError",
+      message: "Download failed",
+      stack: "Update lifecycle telemetry",
+    },
+  });
+  telemetry.dispose();
+});

--- a/apps/review-desktop/code-oss/src/vs/review/electron-main/reviewMainErrorTelemetry.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/electron-main/reviewMainErrorTelemetry.ts
@@ -30,13 +30,14 @@ export interface ReviewMainErrorTelemetryOptions {
 const DEFAULT_MAX_QUEUED = 20;
 const MAX_BOOTSTRAP_REPORTS = 5;
 
-interface PendingReviewErrorReport {
-  readonly errorSource: string;
-  readonly report: ReviewErrorReport;
+interface PendingReviewTelemetryEvent {
+  readonly name: string;
+  readonly properties: Readonly<Record<string, string | number | boolean>>;
+  readonly error?: ReviewErrorReport;
 }
 
 /**
- * Reports Electron main-process errors through the embedded Review server.
+ * Reports Electron main-process telemetry through the embedded Review server.
  *
  * The upstream `ErrorTelemetry` already routes `uncaughtException` and
  * `unhandledRejection` into `onUnexpectedError`, so listening on the shared
@@ -51,7 +52,7 @@ export class ReviewMainErrorTelemetry {
   readonly appSessionId = generateUuid();
 
   private readonly limiter = new ReviewErrorReportLimiter();
-  private readonly queued: PendingReviewErrorReport[] = [];
+  private readonly queued: PendingReviewTelemetryEvent[] = [];
   private readonly unbind: () => void;
   private connection: ReviewDesktopConnection | undefined;
   private disposed = false;
@@ -70,12 +71,29 @@ export class ReviewMainErrorTelemetry {
 
   /** Report an error that Review packed itself, such as a startup crash note. */
   send(errorSource: string, report: ReviewErrorReport): void {
+    this.capture(
+      "client_error",
+      {
+        error_source: errorSource,
+        error_process: "main",
+      },
+      report,
+    );
+  }
+
+  /** Queue a named Review telemetry event for the embedded server. */
+  capture(
+    name: string,
+    properties: Readonly<Record<string, string | number | boolean>> = {},
+    error?: ReviewErrorReport,
+  ): void {
     if (this.disposed) return;
+    const pending = { name, properties, error };
     if (this.connection) {
-      this.post({ errorSource, report });
+      this.post(pending);
       return;
     }
-    this.queued.push({ errorSource, report });
+    this.queued.push(pending);
     // The connection never resolves when the server cannot start, so the cap is
     // what bounds this queue.
     if (this.queued.length > (this.options.maxQueued ?? DEFAULT_MAX_QUEUED)) {
@@ -123,7 +141,7 @@ export class ReviewMainErrorTelemetry {
     for (const pending of this.queued.splice(0)) this.post(pending);
   }
 
-  private post(pending: PendingReviewErrorReport): void {
+  private post(pending: PendingReviewTelemetryEvent): void {
     const connection = this.connection;
     if (!connection) return;
     // Read the setting at send time, not at construction: a user may turn
@@ -139,17 +157,14 @@ export class ReviewMainErrorTelemetry {
           "x-review-app-session-id": this.appSessionId,
         },
         body: JSON.stringify({
-          name: "client_error",
-          properties: {
-            error_source: pending.errorSource,
-            error_process: "main",
-          },
-          error: pending.report,
+          name: pending.name,
+          properties: pending.properties,
+          error: pending.error,
         }),
       }).catch(() => undefined);
     } catch (error) {
       this.options.logError?.(
-        `[Review Desktop] could not report a main-process error: ${error}`,
+        `[Review Desktop] could not report a main-process telemetry event: ${error}`,
       );
     }
   }

--- a/apps/review-desktop/code-oss/src/vs/review/electron-main/reviewUpdateTelemetry.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/electron-main/reviewUpdateTelemetry.test.ts
@@ -1,0 +1,325 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import { appendFile, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { Emitter } from "../../base/common/event.js";
+import { toDisposable } from "../../base/common/lifecycle.js";
+import {
+  DARWIN_UPDATE_ATTEMPT_STORAGE_KEY,
+  DARWIN_UPDATE_OUTCOME_STORAGE_KEY,
+} from "../../platform/update/common/darwinUpdateRecovery.js";
+import {
+  State,
+  type IUpdateService,
+  type State as UpdateState,
+  UpdateType,
+} from "../../platform/update/common/update.js";
+import {
+  StorageScope,
+  type IStorageValueChangeEvent,
+} from "../../platform/storage/common/storage.js";
+import type { IApplicationStorageMainService } from "../../platform/storage/electron-main/storageMainService.js";
+import type { ReviewMainErrorTelemetry } from "./reviewMainErrorTelemetry.js";
+import {
+  extractDarwinShipItFailureMessage,
+  readDarwinShipItFailure,
+  ReviewUpdateTelemetry,
+} from "./reviewUpdateTelemetry.js";
+
+const attempt = {
+  sourceCommit: "source",
+  targetCommit: "target",
+  productVersion: "0.0.27",
+  attemptedAt: 100,
+  attemptId: "12345678-1234-1234-1234-123456789abc",
+  shipItLogOffset: 4096,
+};
+
+test("extracts only the last concise ShipIt NSError summary", () => {
+  const log = [
+    'Installation error: Error Domain=NSPOSIXErrorDomain Code=13 "Permission denied" UserInfo={private=/Users/alice/repo}',
+    "retrying",
+    'Installation error: Error Domain=SQRLInstallerErrorDomain Code=-1 "Failed to copy bundle file:///Users/alice/Review.app to directory file:///Applications" UserInfo={private=secret}',
+  ].join("\n");
+  const message = extractDarwinShipItFailureMessage(log);
+  assert.equal(
+    message,
+    'Error Domain=SQRLInstallerErrorDomain Code=-1 "Failed to copy bundle file:///Users/alice/Review.app to directory file:///Applications"',
+  );
+  assert.equal(message?.includes("UserInfo"), false);
+  assert.equal(message?.includes("private=secret"), false);
+});
+
+test("uses the bounded ShipIt retry summary when NSError parsing fails", () => {
+  assert.equal(
+    extractDarwinShipItFailureMessage(
+      "details\nToo many attempts to install, aborting update\n",
+    ),
+    "Too many attempts to install, aborting update",
+  );
+});
+
+test("reads only ShipIt output appended after the matching attempt", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "review-shipit-"));
+  const path = join(directory, "ShipIt_stderr.log");
+  try {
+    const oldError =
+      'Installation error: Error Domain=OldDomain Code=1 "Old failure"\n';
+    await writeFile(path, oldError, "utf8");
+    await appendFile(
+      path,
+      'Installation error: Error Domain=NewDomain Code=13 "Permission denied" UserInfo={private=secret}\n',
+      "utf8",
+    );
+    assert.deepEqual(await readDarwinShipItFailure(path, oldError.length), {
+      message: 'Error Domain=NewDomain Code=13 "Permission denied"',
+      source: "shipit",
+    });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("reports staged, immediate failure, and terminal update events", async () => {
+  const harness = createHarness();
+  const telemetry = new ReviewUpdateTelemetry(harness.options);
+  await turn();
+
+  harness.storage.storeValue(
+    DARWIN_UPDATE_ATTEMPT_STORAGE_KEY,
+    JSON.stringify(attempt),
+  );
+  harness.update.setState(
+    State.Ready(
+      { version: attempt.targetCommit, productVersion: attempt.productVersion },
+      false,
+      false,
+    ),
+  );
+  harness.update.setState(
+    State.Ready(
+      { version: attempt.targetCommit, productVersion: attempt.productVersion },
+      false,
+      false,
+    ),
+  );
+
+  harness.update.setState(State.CheckingForUpdates(false));
+  harness.update.setState(
+    State.Idle(UpdateType.Archive, "Feed unavailable", undefined, "request"),
+  );
+
+  harness.storage.storeValue(
+    DARWIN_UPDATE_OUTCOME_STORAGE_KEY,
+    JSON.stringify({ kind: "applied", attempt, resolvedAt: 600 }),
+  );
+  await turn();
+
+  assert.deepEqual(
+    harness.events.map((event) => event.name),
+    ["update_started", "update_failed", "update_completed"],
+  );
+  assert.deepEqual(harness.events[1], {
+    name: "update_failed",
+    properties: { phase: "check", message_source: "request" },
+    error: {
+      name: "UpdateCheckError",
+      message: "Feed unavailable",
+      stack: "Update lifecycle telemetry",
+    },
+  });
+  assert.deepEqual(harness.events[2].properties, {
+    update_attempt_id: attempt.attemptId,
+    target_version: attempt.productVersion,
+    duration_ms: 500,
+  });
+  assert.equal(
+    harness.storage.getValue(DARWIN_UPDATE_OUTCOME_STORAGE_KEY),
+    undefined,
+  );
+  telemetry.dispose();
+});
+
+test("reports an install failure with the matched ShipIt message", async () => {
+  const harness = createHarness({
+    outcome: { kind: "failed", attempt, resolvedAt: 700 },
+    readInstallFailure: async () => ({
+      message: 'Error Domain=NSPOSIXErrorDomain Code=13 "Permission denied"',
+      source: "shipit",
+    }),
+  });
+  const telemetry = new ReviewUpdateTelemetry(harness.options);
+  await turn();
+
+  assert.deepEqual(harness.events, [
+    {
+      name: "update_failed",
+      properties: {
+        update_attempt_id: attempt.attemptId,
+        target_version: attempt.productVersion,
+        duration_ms: 600,
+        phase: "install",
+        message_source: "shipit",
+      },
+      error: {
+        name: "UpdateInstallError",
+        message: 'Error Domain=NSPOSIXErrorDomain Code=13 "Permission denied"',
+        stack: "Update lifecycle telemetry",
+      },
+    },
+  ]);
+  telemetry.dispose();
+});
+
+test("consumes disabled lifecycle records without reporting them later", async () => {
+  let enabled = false;
+  const harness = createHarness({
+    enabled: () => enabled,
+    outcome: { kind: "applied", attempt, resolvedAt: 600 },
+  });
+  const telemetry = new ReviewUpdateTelemetry(harness.options);
+  await turn();
+  assert.deepEqual(harness.events, []);
+  assert.equal(
+    harness.storage.getValue(DARWIN_UPDATE_OUTCOME_STORAGE_KEY),
+    undefined,
+  );
+
+  harness.storage.storeValue(
+    DARWIN_UPDATE_ATTEMPT_STORAGE_KEY,
+    JSON.stringify(attempt),
+  );
+  harness.update.setState(
+    State.Ready(
+      { version: attempt.targetCommit, productVersion: attempt.productVersion },
+      false,
+      false,
+    ),
+  );
+  assert.deepEqual(harness.events, []);
+
+  enabled = true;
+  harness.update.setState(
+    State.Ready(
+      { version: attempt.targetCommit, productVersion: attempt.productVersion },
+      false,
+      false,
+    ),
+  );
+  assert.deepEqual(harness.events, []);
+  telemetry.dispose();
+});
+
+function createHarness(options?: {
+  readonly enabled?: () => boolean;
+  readonly outcome?: unknown;
+  readonly readInstallFailure?: () => Promise<{
+    message: string;
+    source: "shipit";
+  }>;
+}) {
+  const storage = new FakeStorage();
+  if (options?.outcome) {
+    storage.storeValue(
+      DARWIN_UPDATE_OUTCOME_STORAGE_KEY,
+      JSON.stringify(options.outcome),
+    );
+  }
+  const update = new FakeUpdateService();
+  const events: Array<{
+    name: string;
+    properties: Readonly<Record<string, string | number | boolean>>;
+    error?: unknown;
+  }> = [];
+  const telemetry = {
+    capture(name: string, properties: Record<string, string | number | boolean>, error?: unknown) {
+      events.push({ name, properties, error });
+    },
+  } as unknown as ReviewMainErrorTelemetry;
+  return {
+    storage,
+    update,
+    events,
+    options: {
+      updateService: update as unknown as IUpdateService,
+      storageService: storage as unknown as IApplicationStorageMainService,
+      telemetry,
+      isTelemetryEnabled: options?.enabled ?? (() => true),
+      shipItLogPath: "/tmp/ShipIt_stderr.log",
+      readInstallFailure: options?.readInstallFailure,
+    },
+  };
+}
+
+class FakeUpdateService {
+  private readonly emitter = new Emitter<UpdateState>();
+  readonly onStateChange = this.emitter.event;
+  state: UpdateState = State.Idle(UpdateType.Archive);
+
+  setState(state: UpdateState): void {
+    this.state = state;
+    this.emitter.fire(this.state);
+  }
+}
+
+class FakeStorage {
+  readonly whenReady = Promise.resolve();
+  private readonly values = new Map<string, string>();
+  private readonly emitters = new Map<string, Emitter<IStorageValueChangeEvent>>();
+
+  getValue(key: string): string | undefined {
+    return this.values.get(key);
+  }
+
+  storeValue(key: string, value: string): void {
+    this.values.set(key, value);
+    this.fire(key);
+  }
+
+  get(key: string): string | undefined {
+    return this.values.get(key);
+  }
+
+  store(key: string, value: string): void {
+    this.storeValue(key, value);
+  }
+
+  remove(key: string): void {
+    this.values.delete(key);
+    this.fire(key);
+  }
+
+  flush(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  onDidChangeValue(_scope: StorageScope, key: string | undefined) {
+    if (!key) return () => toDisposable(() => undefined);
+    let emitter = this.emitters.get(key);
+    if (!emitter) {
+      emitter = new Emitter<IStorageValueChangeEvent>();
+      this.emitters.set(key, emitter);
+    }
+    return emitter.event;
+  }
+
+  private fire(key: string): void {
+    this.emitters.get(key)?.fire({
+      key,
+      scope: StorageScope.APPLICATION,
+      target: undefined,
+      external: false,
+    });
+  }
+}
+
+async function turn(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}

--- a/apps/review-desktop/code-oss/src/vs/review/electron-main/reviewUpdateTelemetry.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/electron-main/reviewUpdateTelemetry.ts
@@ -1,0 +1,310 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { open } from "node:fs/promises";
+import { join } from "node:path";
+
+import { Disposable, DisposableStore } from "../../base/common/lifecycle.js";
+import {
+  DARWIN_UPDATE_ATTEMPT_STORAGE_KEY,
+  DARWIN_UPDATE_OUTCOME_STORAGE_KEY,
+  parseDarwinUpdateAttempt,
+  parseDarwinUpdateOutcomeRecord,
+  type IDarwinUpdateAttempt,
+} from "../../platform/update/common/darwinUpdateRecovery.js";
+import {
+  type IUpdateService,
+  type State,
+  StateType,
+} from "../../platform/update/common/update.js";
+import {
+  StorageScope,
+  StorageTarget,
+} from "../../platform/storage/common/storage.js";
+import type { IApplicationStorageMainService } from "../../platform/storage/electron-main/storageMainService.js";
+import type { ReviewMainErrorTelemetry } from "./reviewMainErrorTelemetry.js";
+
+const UPDATE_STARTED_STORAGE_KEY = "review/update/telemetry/started.v1";
+const MAX_SHIPIT_LOG_BYTES = 64 * 1024;
+const INSTALL_FALLBACK_MESSAGE =
+  "The downloaded update did not replace the running application.";
+
+export type ReviewUpdateFailurePhase = "check" | "download" | "install";
+export type ReviewUpdateMessageSource =
+  | "electron"
+  | "request"
+  | "shipit"
+  | "fallback";
+
+interface ReviewUpdateTelemetryOptions {
+  readonly updateService: IUpdateService;
+  readonly storageService: IApplicationStorageMainService;
+  readonly telemetry: ReviewMainErrorTelemetry;
+  readonly isTelemetryEnabled: () => boolean;
+  readonly shipItLogPath?: string;
+  readonly readInstallFailure?: (
+    path: string,
+    offset: number | undefined,
+  ) => Promise<{ message: string; source: ReviewUpdateMessageSource }>;
+  readonly logError?: (message: string) => void;
+}
+
+/**
+ * Converts updater state and persisted Darwin restart outcomes into the three
+ * Review update lifecycle events. Raw ShipIt output never leaves this module.
+ */
+export class ReviewUpdateTelemetry extends Disposable {
+  private lastState: State;
+
+  constructor(private readonly options: ReviewUpdateTelemetryOptions) {
+    super();
+    this.lastState = options.updateService.state;
+    this._register(
+      options.updateService.onStateChange((state) => {
+        this.onStateChange(state);
+        this.lastState = state;
+      }),
+    );
+
+    const storageListeners = this._register(new DisposableStore());
+    const onOutcomeChanged = options.storageService.onDidChangeValue(
+      StorageScope.APPLICATION,
+      DARWIN_UPDATE_OUTCOME_STORAGE_KEY,
+      storageListeners,
+    );
+    this._register(onOutcomeChanged(() => void this.processOutcome()));
+
+    void options.storageService.whenReady
+      .then(() => {
+        if (options.updateService.state.type === StateType.Ready) {
+          this.recordStarted();
+        }
+        return this.processOutcome();
+      })
+      .catch((error) =>
+        options.logError?.(
+          `[Review Desktop] could not process update telemetry: ${error}`,
+        ),
+      );
+  }
+
+  private onStateChange(state: State): void {
+    if (state.type === StateType.Ready) {
+      this.recordStarted();
+      return;
+    }
+    if (state.type !== StateType.Idle || !state.error) {
+      return;
+    }
+    const phase = updateFailurePhase(this.lastState);
+    if (!phase || !this.options.isTelemetryEnabled()) {
+      return;
+    }
+    this.captureFailure(
+      phase,
+      state.errorSource ?? "electron",
+      state.error,
+    );
+  }
+
+  private recordStarted(): void {
+    const attempt = parseDarwinUpdateAttempt(
+      this.options.storageService.get(
+        DARWIN_UPDATE_ATTEMPT_STORAGE_KEY,
+        StorageScope.APPLICATION,
+      ),
+    );
+    if (!attempt?.attemptId || !attempt.productVersion) {
+      return;
+    }
+    const lastStarted = this.options.storageService.get(
+      UPDATE_STARTED_STORAGE_KEY,
+      StorageScope.APPLICATION,
+    );
+    if (lastStarted === attempt.attemptId) {
+      return;
+    }
+
+    // Mark it observed even when telemetry is disabled. Enabling telemetry
+    // later must not send an event for an earlier update.
+    this.options.storageService.store(
+      UPDATE_STARTED_STORAGE_KEY,
+      attempt.attemptId,
+      StorageScope.APPLICATION,
+      StorageTarget.MACHINE,
+    );
+    void this.options.storageService.flush().catch(() => undefined);
+    if (!this.options.isTelemetryEnabled()) {
+      return;
+    }
+    this.options.telemetry.capture("update_started", {
+      update_attempt_id: attempt.attemptId,
+      target_version: attempt.productVersion,
+    });
+  }
+
+  private async processOutcome(): Promise<void> {
+    const raw = this.options.storageService.get(
+      DARWIN_UPDATE_OUTCOME_STORAGE_KEY,
+      StorageScope.APPLICATION,
+    );
+    const outcome = parseDarwinUpdateOutcomeRecord(raw);
+    if (!outcome) {
+      return;
+    }
+
+    // Consume first for both consent states, so a crash or later opt-in cannot
+    // turn this into a duplicate or retroactive event.
+    this.options.storageService.remove(
+      DARWIN_UPDATE_OUTCOME_STORAGE_KEY,
+      StorageScope.APPLICATION,
+    );
+    void this.options.storageService.flush().catch(() => undefined);
+
+    const { attempt } = outcome;
+    if (
+      !attempt.attemptId ||
+      !attempt.productVersion ||
+      !this.options.isTelemetryEnabled()
+    ) {
+      return;
+    }
+    const properties = lifecycleProperties(attempt, outcome.resolvedAt);
+    if (outcome.kind === "applied") {
+      this.options.telemetry.capture("update_completed", properties);
+      return;
+    }
+
+    const failure = await this.readInstallFailure(attempt.shipItLogOffset);
+    this.captureFailure("install", failure.source, failure.message, properties);
+  }
+
+  private async readInstallFailure(
+    offset: number | undefined,
+  ): Promise<{ message: string; source: ReviewUpdateMessageSource }> {
+    const path = this.options.shipItLogPath;
+    if (!path) {
+      return { message: INSTALL_FALLBACK_MESSAGE, source: "fallback" };
+    }
+    try {
+      return await (
+        this.options.readInstallFailure ?? readDarwinShipItFailure
+      )(path, offset);
+    } catch {
+      return { message: INSTALL_FALLBACK_MESSAGE, source: "fallback" };
+    }
+  }
+
+  private captureFailure(
+    phase: ReviewUpdateFailurePhase,
+    source: ReviewUpdateMessageSource,
+    message: string,
+    properties: Readonly<Record<string, string | number>> = {},
+  ): void {
+    this.options.telemetry.capture(
+      "update_failed",
+      { ...properties, phase, message_source: source },
+      {
+        name: `Update${phase[0].toUpperCase()}${phase.slice(1)}Error`,
+        message,
+        stack: "Update lifecycle telemetry",
+      },
+    );
+  }
+}
+
+export function darwinShipItLogPath(
+  userHomePath: string,
+  bundleIdentifier: string,
+): string {
+  return join(
+    userHomePath,
+    "Library",
+    "Caches",
+    `${bundleIdentifier}.ShipIt`,
+    "ShipIt_stderr.log",
+  );
+}
+
+export function extractDarwinShipItFailureMessage(
+  appendedLog: string,
+): string | undefined {
+  const lines = appendedLog.split(/\r?\n/);
+  for (let index = lines.length - 1; index >= 0; index--) {
+    const line = lines[index];
+    const marker = line.lastIndexOf("Installation error:");
+    if (marker < 0) continue;
+    const error = line.slice(marker + "Installation error:".length).trim();
+    const summary = error.match(
+      /Error Domain=([A-Za-z0-9._-]{1,80}) Code=(-?\d{1,10}) "([^"\r\n]{1,2000})"/,
+    );
+    if (summary) {
+      return `Error Domain=${summary[1]} Code=${summary[2]} "${summary[3]}"`;
+    }
+  }
+  for (let index = lines.length - 1; index >= 0; index--) {
+    if (lines[index].includes("Too many attempts to install, aborting update")) {
+      return "Too many attempts to install, aborting update";
+    }
+  }
+  return undefined;
+}
+
+export async function readDarwinShipItFailure(
+  path: string,
+  offset: number | undefined,
+): Promise<{ message: string; source: ReviewUpdateMessageSource }> {
+  if (offset === undefined) {
+    return { message: INSTALL_FALLBACK_MESSAGE, source: "fallback" };
+  }
+  const file = await open(path, "r");
+  try {
+    const size = (await file.stat()).size;
+    if (size < offset) {
+      return { message: INSTALL_FALLBACK_MESSAGE, source: "fallback" };
+    }
+    const start = Math.max(offset, size - MAX_SHIPIT_LOG_BYTES);
+    const length = size - start;
+    if (length <= 0) {
+      return { message: INSTALL_FALLBACK_MESSAGE, source: "fallback" };
+    }
+    const buffer = Buffer.alloc(length);
+    const { bytesRead } = await file.read(buffer, 0, length, start);
+    const message = extractDarwinShipItFailureMessage(
+      buffer.subarray(0, bytesRead).toString("utf8"),
+    );
+    return message
+      ? { message, source: "shipit" }
+      : { message: INSTALL_FALLBACK_MESSAGE, source: "fallback" };
+  } finally {
+    await file.close();
+  }
+}
+
+function updateFailurePhase(
+  previous: State,
+): Exclude<ReviewUpdateFailurePhase, "install"> | undefined {
+  if (previous.type === StateType.CheckingForUpdates) {
+    return "check";
+  }
+  if (
+    previous.type === StateType.Downloading ||
+    previous.type === StateType.Overwriting
+  ) {
+    return "download";
+  }
+  return undefined;
+}
+
+function lifecycleProperties(
+  attempt: IDarwinUpdateAttempt,
+  resolvedAt: number,
+): Record<string, string | number> {
+  return {
+    update_attempt_id: attempt.attemptId!,
+    target_version: attempt.productVersion!,
+    duration_ms: Math.max(0, resolvedAt - attempt.attemptedAt),
+  };
+}

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -57,6 +57,12 @@ Review can automatically report failures in its own app, canvas, server, or
 background process. These reports may contain an error class, a cleaned message,
 a one-way fingerprint, and up to ten stack frames from Review's own program.
 
+Update telemetry records when an update is staged, when that exact target next
+launches, or when checking, downloading, or installing fails. For a macOS
+install failure, Review reads only log bytes appended after that update was
+staged, extracts one concise ShipIt error summary, and passes it through the
+same local cleaner. The raw ShipIt log is never stored in telemetry or sent.
+
 Before sending, Review cleans paths, home and temporary directories, web
 addresses, email addresses, and known secret formats. It drops repository,
 dependency, and extension stack frames. It also drops any message that quotes a

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -201,8 +201,8 @@ Publish binds immediately after target resolution, before validation and mount.
 
 Error names and categories are closed enums. A failed command sends no exception
 message, stack, path, process output, project identifier, or remediation text.
-Only the `review_client_error` event carries message text, and only as described
-in "Error reports".
+Only the `review_client_error` and `review_update_failed` events carry message
+text, and only as described in "Error reports".
 
 - Error names: `usage_error`, `review_not_found`, `review_state_error`,
   `repository_error`, `desktop_connection_error`, `network_error`,
@@ -215,9 +215,9 @@ in "Error reports".
   `jj_change`. Agent kinds are `codex`, `claude`, `pi`, and `other`. Outcomes
   are `approve`, `request-changes`, and `dismissed`.
 
-### Canvas events
+### Desktop and canvas events
 
-The server checks all canvas properties against
+The server checks all properties in this table against
 `packages/progressive-review/src/ui-telemetry-events.ts`.
 
 | Event                                         | Additional properties                                                                                    | When                                      |
@@ -242,6 +242,9 @@ The server checks all canvas properties against
 | `review_agent_run_started`        | None                                                                                                     | A user starts an agent run                |
 | `review_thread_resolved`          | `kind: comment`                                                                                          | A user resolves a comment                 |
 | `review_client_error`             | See "Error reports"                                                                                      | A part of Review reports an error         |
+| `review_update_started`           | Random `update_attempt_id`, `target_version`                                                              | An update is downloaded and ready to install |
+| `review_update_completed`         | Start properties plus `duration_ms`                                                                      | The downloaded target launches after restart |
+| `review_update_failed`            | `phase` in check, download, install; `message_source` in electron, request, shipit, fallback; optional start properties and `duration_ms`; see "Error reports" | An update check, download, or install fails |
 | `review_bug_report_dialog_opened` | None                                                                                                     | A user opens the bug report dialog        |
 | `review_bug_report_cancelled`     | None                                                                                                     | A user closes the dialog without a report |
 | `review_bug_report_send_failed`   | Short `error_name`                                                                                       | A bug report request fails                |
@@ -304,7 +307,12 @@ machine can still be found and fixed. Four parts of Review report an error: the
 app window, the canvas, the background process, and a crash that happens before
 Review can start.
 
-Review sends these properties with the `review_client_error` event.
+Review sends these properties with the `review_client_error` event. A
+`review_update_failed` event uses the same server-side message cleaning and
+fingerprinting, plus the closed update phase and message-source fields above.
+Install failures read at most 64 KiB appended to ShipIt's stderr log after the
+matching update was staged. Review extracts only the last NSError summary (or
+the fixed retry-exhausted line); it neither stores nor uploads the raw log.
 
 | Property        | Value                                                                                     |
 | --------------- | ----------------------------------------------------------------------------------------- |

--- a/packages/progressive-review/src/error-telemetry.test.ts
+++ b/packages/progressive-review/src/error-telemetry.test.ts
@@ -279,4 +279,26 @@ describe("deriveErrorTelemetryProperties", () => {
       ].join("|"),
     });
   });
+
+  it("cleans a concise ShipIt failure before update telemetry is allowed", () => {
+    const sanitized = sanitizeUiTelemetryEvent({
+      name: "update_failed",
+      properties: mergeErrorTelemetryProperties(
+        { phase: "install", message_source: "shipit" },
+        {
+          name: "UpdateInstallError",
+          message:
+            'Error Domain=SQRLInstallerErrorDomain Code=-1 "Failed to copy bundle file:///Users/alice/Review.app to directory file:///Applications"',
+        },
+      ),
+    });
+    expect(sanitized?.properties).toEqual({
+      phase: "install",
+      message_source: "shipit",
+      error_name: "UpdateInstallError",
+      message: expect.stringContaining("<REDACTED:"),
+      message_hash: expect.stringMatching(/^[0-9a-f]{16}$/),
+    });
+    expect(JSON.stringify(sanitized)).not.toContain("alice");
+  });
 });

--- a/packages/progressive-review/src/error-telemetry.ts
+++ b/packages/progressive-review/src/error-telemetry.ts
@@ -123,9 +123,9 @@ const SERVER_DERIVED_PROPERTIES = [
 
 /**
  * Merge a client's event properties with the ones derived from its raw error.
- * This is the only supported way to build a client_error payload: it removes
- * any server-derived property the client tried to assert before adding the real
- * ones.
+ * This is the only supported way to build an error-bearing telemetry payload:
+ * it removes any server-derived property the client tried to assert before
+ * adding the real ones.
  */
 export function mergeErrorTelemetryProperties(
   clientProperties: Record<string, unknown>,

--- a/packages/progressive-review/src/ui-telemetry-events.test.ts
+++ b/packages/progressive-review/src/ui-telemetry-events.test.ts
@@ -167,6 +167,77 @@ describe("sanitizeUiTelemetryEvent", () => {
     expect(sanitizeUiTelemetryEvent({ name: "made_up" })).toBeNull();
   });
 
+  it("allows the three update lifecycle events", () => {
+    const update_attempt_id = "12345678-1234-1234-1234-123456789abc";
+    expect(
+      sanitizeUiTelemetryEvent({
+        name: "update_started",
+        properties: { update_attempt_id, target_version: "0.0.27" },
+      }),
+    ).toEqual({
+      event: "review_update_started",
+      properties: { update_attempt_id, target_version: "0.0.27" },
+    });
+    expect(
+      sanitizeUiTelemetryEvent({
+        name: "update_completed",
+        properties: {
+          update_attempt_id,
+          target_version: "0.0.27-beta.1",
+          duration_ms: 1234,
+        },
+      }),
+    ).toEqual({
+      event: "review_update_completed",
+      properties: {
+        update_attempt_id,
+        target_version: "0.0.27-beta.1",
+        duration_ms: 1234,
+      },
+    });
+    expect(
+      sanitizeUiTelemetryEvent({
+        name: "update_failed",
+        properties: {
+          phase: "install",
+          message_source: "shipit",
+          update_attempt_id,
+          target_version: "0.0.27",
+          duration_ms: 2345,
+          error_name: "UpdateInstallError",
+          message: "Failed to copy <REDACTED: user-file-path>",
+          message_hash: "0123456789abcdef",
+        },
+      }),
+    ).toEqual({
+      event: "review_update_failed",
+      properties: {
+        phase: "install",
+        message_source: "shipit",
+        update_attempt_id,
+        target_version: "0.0.27",
+        duration_ms: 2345,
+        error_name: "UpdateInstallError",
+        message: "Failed to copy <REDACTED: user-file-path>",
+        message_hash: "0123456789abcdef",
+      },
+    });
+  });
+
+  it("rejects invalid update dimensions and raw update errors", () => {
+    expect(
+      sanitizeUiTelemetryEvent({
+        name: "update_failed",
+        properties: {
+          phase: "restart",
+          message_source: "raw_log",
+          target_version: "private version",
+          message: "Failed at /Users/alice/private/Review.app",
+        },
+      }),
+    ).toEqual({ event: "review_update_failed", properties: {} });
+  });
+
   it("drops unknown property keys", () => {
     const output = sanitizeUiTelemetryEvent({
       name: "lsp_used",

--- a/packages/progressive-review/src/ui-telemetry-events.ts
+++ b/packages/progressive-review/src/ui-telemetry-events.ts
@@ -1,4 +1,4 @@
-// Contract for UI-originated telemetry events.
+// Contract for app-originated telemetry events.
 //
 // Privacy invariant: telemetry must never carry user content — no review
 // prose, code, symbol names, file paths, locators, quotes, or node labels. The
@@ -27,6 +27,8 @@ export type UiTelemetryPropertySpec =
   | "number"
   | "boolean"
   | "opaque_id"
+  // A bounded semantic release version, never a commit or authored value.
+  | "release_version"
   // A short identifier-like string (e.g. a JS error class name). The only
   // free-form value allowed anywhere, still length- and charset-capped.
   | "enum_free_short"
@@ -131,6 +133,13 @@ export const CLIENT_ERROR_SOURCE = [
   "bootstrap",
 ] as const;
 export const ERROR_PROCESS = ["main", "renderer", "canvas", "server"] as const;
+export const UPDATE_FAILURE_PHASE = ["check", "download", "install"] as const;
+export const UPDATE_MESSAGE_SOURCE = [
+  "electron",
+  "request",
+  "shipit",
+  "fallback",
+] as const;
 
 /**
  * Directories that exist only in the shipped Review bundle. A stack frame is
@@ -306,6 +315,34 @@ export const UI_TELEMETRY_EVENTS = {
       frames: "bundle_frames",
     },
   },
+  update_started: {
+    event: "review_update_started",
+    properties: {
+      update_attempt_id: "opaque_id",
+      target_version: "release_version",
+    },
+  },
+  update_completed: {
+    event: "review_update_completed",
+    properties: {
+      update_attempt_id: "opaque_id",
+      target_version: "release_version",
+      duration_ms: "number",
+    },
+  },
+  update_failed: {
+    event: "review_update_failed",
+    properties: {
+      phase: UPDATE_FAILURE_PHASE,
+      message_source: UPDATE_MESSAGE_SOURCE,
+      update_attempt_id: "opaque_id",
+      target_version: "release_version",
+      duration_ms: "number",
+      error_name: "enum_free_short",
+      message: "cleaned_message",
+      message_hash: "hash_hex",
+    },
+  },
   lsp_used: {
     event: "review_lsp_used",
     properties: {
@@ -394,6 +431,8 @@ export type UiTelemetryEventName = keyof typeof UI_TELEMETRY_EVENTS;
 const MAX_FREE_STRING_LENGTH = 40;
 const FREE_STRING_PATTERN = /^[A-Za-z0-9_$-]+$/;
 const OPAQUE_ID_PATTERN = /^[A-Za-z0-9_-]{8,64}$/;
+const RELEASE_VERSION_PATTERN =
+  /^\d{1,10}\.\d{1,10}\.\d{1,10}(?:[-+][0-9A-Za-z.-]{1,40})?$/;
 const COMMON_PROPERTIES = {
   app_session_id: "opaque_id",
 } as const satisfies Record<string, UiTelemetryPropertySpec>;
@@ -441,6 +480,12 @@ export function sanitizeUiTelemetryEvent(input: {
     }
     if (propSpec === "opaque_id") {
       if (isValidReviewAppSessionId(value)) {
+        properties[key] = value;
+      }
+      continue;
+    }
+    if (propSpec === "release_version") {
+      if (typeof value === "string" && RELEASE_VERSION_PATTERN.test(value)) {
         properties[key] = value;
       }
       continue;


### PR DESCRIPTION
## Summary

- emit `review_update_started`, `review_update_completed`, and `review_update_failed`
- correlate staged macOS updates with exact-target outcomes across restart
- report check, download, and install failure phases with bounded message sources
- extract only the matching appended ShipIt NSError summary and pass it through the existing local redaction and consent path
- consume telemetry records while opted out to prevent retrospective events
- document the update telemetry and privacy boundary

## Validation

- `pnpm --filter @dev-fast/review-desktop app:build`
- `pnpm --filter @dev-fast/review-desktop test`
- `pnpm --filter @dev.fast/review test:telemetry-privacy`
- `npm --prefix apps/review-desktop/code-oss run test-review-harness`
- `pnpm lint`
- `pnpm format:check`