### PR TITLE
Expire idle agent trace sessions

### DIFF
--- a/packages/progressive-review/src/agent-trace-hooks.test.ts
+++ b/packages/progressive-review/src/agent-trace-hooks.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -39,6 +39,9 @@ describe("agent-trace-hooks", () => {
     expect(content.hooks.SessionStart[0].hooks[0].command).toBe(
       "review trace hook SessionStart",
     );
+    expect(content.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+      "review trace hook UserPromptSubmit",
+    );
     expect(content.hooks.SessionEnd[0].hooks[0].command).toBe(
       "review trace hook SessionEnd",
     );
@@ -72,11 +75,52 @@ describe("agent-trace-hooks", () => {
     const content = await readFile(first.path, "utf8");
     expect(content).toContain("[[hooks.SessionStart]]");
     expect(content).toContain("review trace hook SessionStart");
+    expect(content).toContain("[[hooks.UserPromptSubmit]]");
+    expect(content).toContain("review trace hook UserPromptSubmit");
     expect(content).toContain("[[hooks.SessionEnd]]");
     expect(content).toContain("review trace hook SessionEnd");
 
     const second = await installCodexTraceHook(homeDir);
     expect(second.modified).toBe(false);
+  });
+
+  it("adds the Codex heartbeat to an existing lifecycle-only setup", async () => {
+    const homeDir = await makeTempHome();
+    const codexDir = path.join(homeDir, ".codex");
+    const configPath = path.join(codexDir, "config.toml");
+    await mkdir(codexDir, { recursive: true });
+    await writeFile(
+      configPath,
+      `model = "gpt-5"
+
+[[hooks.SessionStart]]
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "review trace hook SessionStart"
+statusMessage = "Recording agent session id for trace stamping"
+
+[hooks.state]
+keep = "yes"
+
+[[hooks.SessionEnd]]
+[[hooks.SessionEnd.hooks]]
+type = "command"
+command = "review trace hook SessionEnd"
+`,
+    );
+
+    expect((await installCodexTraceHook(homeDir)).modified).toBe(true);
+    const installed = await readFile(configPath, "utf8");
+    expect(installed).toContain("review trace hook UserPromptSubmit");
+    expect(installed.match(/review trace hook SessionStart/g)).toHaveLength(1);
+    expect(installed.match(/review trace hook SessionEnd/g)).toHaveLength(1);
+    expect((await installCodexTraceHook(homeDir)).modified).toBe(false);
+
+    expect(await removeAgentTraceHook("codex", homeDir)).toBe(true);
+    const removed = await readFile(configPath, "utf8");
+    expect(removed).toContain('model = "gpt-5"');
+    expect(removed).toContain('keep = "yes"');
+    expect(removed).not.toContain("review trace hook");
   });
 
   it("installs Pi trace extension in ~/.pi/agent/extensions/review-trace.ts idempotently", async () => {
@@ -88,6 +132,8 @@ describe("agent-trace-hooks", () => {
 
     const content = await readFile(first.path, "utf8");
     expect(content).toContain("session_start");
+    expect(content).toContain('pi.on("turn_start"');
+    expect(content).toContain('runTraceHook("TurnStart"');
     expect(content).toContain("session_shutdown");
     expect(content).toContain("review");
 

--- a/packages/progressive-review/src/agent-trace-hooks.ts
+++ b/packages/progressive-review/src/agent-trace-hooks.ts
@@ -23,6 +23,12 @@ export default function (pi: ExtensionAPI) {
     runTraceHook("SessionStart", sessionId, ctx.cwd);
   });
 
+  pi.on("turn_start", async (_event, ctx) => {
+    const sessionId = ctx.sessionManager.getSessionId();
+    if (!sessionId) return;
+    runTraceHook("TurnStart", sessionId, ctx.cwd);
+  });
+
   pi.on("session_shutdown", async (_event, ctx) => {
     const sessionId = ctx.sessionManager.getSessionId();
     if (!sessionId) return;
@@ -54,6 +60,11 @@ type = "command"
 command = "review trace hook SessionStart"
 statusMessage = "Recording agent session id for trace stamping"
 
+[[hooks.UserPromptSubmit]]
+[[hooks.UserPromptSubmit.hooks]]
+type = "command"
+command = "review trace hook UserPromptSubmit"
+
 [[hooks.SessionEnd]]
 [[hooks.SessionEnd.hooks]]
 type = "command"
@@ -84,12 +95,18 @@ export async function installClaudeTraceHook(
   const hooks = (parsed.hooks as Record<string, unknown>) ?? {};
   let modified = false;
 
-  const hookCommand = (eventName: "SessionStart" | "SessionEnd") => ({
+  const hookCommand = (
+    eventName: "SessionStart" | "UserPromptSubmit" | "SessionEnd",
+  ) => ({
     type: "command",
     command: `${shellCommand(reviewCommand)} trace hook ${eventName}`,
   });
 
-  for (const eventName of ["SessionStart", "SessionEnd"] as const) {
+  for (const eventName of [
+    "SessionStart",
+    "UserPromptSubmit",
+    "SessionEnd",
+  ] as const) {
     const existingGroup = (hooks[eventName] as unknown[]) ?? [];
     const hasHook = existingGroup.some((entry) => {
       if (typeof entry !== "object" || !entry) return false;
@@ -137,7 +154,16 @@ export async function installCodexTraceHook(
     existing = await readFile(configPath, "utf8");
   }
 
-  if (existing.includes(" trace hook SessionStart")) {
+  const hookEvents = [
+    "SessionStart",
+    "UserPromptSubmit",
+    "SessionEnd",
+  ] as const;
+  const missingEvents = hookEvents.filter(
+    (eventName) =>
+      !existing.includes(` trace hook ${eventName}`),
+  );
+  if (missingEvents.length === 0) {
     return { agent: "codex", path: configPath, modified: false };
   }
 
@@ -145,11 +171,14 @@ export async function installCodexTraceHook(
     "review trace hook",
     `${shellCommand(reviewCommand)} trace hook`,
   );
+  const missingHookToml = missingEvents
+    .map((eventName) => codexTraceHookToml(eventName, reviewCommand))
+    .join("\n\n");
   await mkdir(codexDir, { recursive: true });
   await writeFile(
     configPath,
     existing
-      ? `${existing.trimEnd()}\n${codexHookToml}`
+      ? `${existing.trimEnd()}\n\n${missingHookToml.trim()}\n`
       : codexHookToml.trimStart(),
     "utf8",
   );
@@ -203,7 +232,11 @@ export async function removeAgentTraceHook(
     const hooks = parsed.hooks as Record<string, unknown> | undefined;
     if (!hooks) return false;
     let changed = false;
-    for (const eventName of ["SessionStart", "SessionEnd"] as const) {
+    for (const eventName of [
+      "SessionStart",
+      "UserPromptSubmit",
+      "SessionEnd",
+    ] as const) {
       const groups = Array.isArray(hooks[eventName]) ? hooks[eventName] : [];
       const keptGroups = groups.flatMap((group) => {
         if (!group || typeof group !== "object") return [group];
@@ -239,23 +272,15 @@ export async function removeAgentTraceHook(
     const existing = await readFile(configPath, "utf8");
     const marked =
       /# review-trace-hooks:start\n[\s\S]*?# review-trace-hooks:end\n?/;
-    const defaultHookText = CODEX_HOOK_TOML.trim();
-    const legacyHookText = CODEX_HOOK_TOML.replace(
-      /# review-trace-hooks:(?:start|end)\n/g,
-      "",
-    ).trim();
-    if (
-      !marked.test(existing) &&
-      !existing.includes(defaultHookText) &&
-      !existing.includes(legacyHookText)
-    ) {
-      return false;
-    }
-    const next = existing
+    const withoutMarkedBlock = existing
       .replace(marked, "")
-      .replace(defaultHookText, "")
-      .replace(legacyHookText, "")
-      .replace(/\n{3,}/g, "\n\n");
+      .replace(CODEX_HOOK_TOML.trim(), "");
+    const removed = ["SessionStart", "UserPromptSubmit", "SessionEnd"].reduce(
+      (content, eventName) => removeCodexTraceHook(content, eventName),
+      withoutMarkedBlock,
+    );
+    if (removed === existing) return false;
+    const next = removed.replace(/\n{3,}/g, "\n\n");
     await writeFile(
       configPath,
       next.trim() ? `${next.trimEnd()}\n` : "",
@@ -273,11 +298,7 @@ export async function removeAgentTraceHook(
   );
   if (!existsSync(extensionPath)) return false;
   const existing = await readFile(extensionPath, "utf8");
-  const installedSources = [
-    piExtensionSource("review"),
-    piExtensionSource(path.join(homeDir, ".local", "bin", "review")),
-  ];
-  if (!installedSources.some((source) => source.trim() === existing.trim())) {
+  if (!existing.trimStart().startsWith(`// ${PI_EXTENSION_MARKER}`)) {
     return false;
   }
   await rm(extensionPath, { force: true });
@@ -292,7 +313,35 @@ function shellCommand(command: string): string {
 
 function isReviewTraceHookCommand(command: unknown): boolean {
   if (typeof command !== "string") return false;
-  const match = /^(.*) trace hook (SessionStart|SessionEnd)$/.exec(command);
+  const match =
+    /^(.*) trace hook (SessionStart|UserPromptSubmit|SessionEnd)$/.exec(command);
   if (!match) return false;
   return match[1] === "review" || match[1].endsWith("/review'");
+}
+
+function codexTraceHookToml(
+  eventName: "SessionStart" | "UserPromptSubmit" | "SessionEnd",
+  reviewCommand: string,
+): string {
+  const status =
+    eventName === "SessionStart"
+      ? '\nstatusMessage = "Recording agent session id for trace stamping"'
+      : "";
+  return `[[hooks.${eventName}]]
+[[hooks.${eventName}.hooks]]
+type = "command"
+command = "${shellCommand(reviewCommand)} trace hook ${eventName}"${status}`;
+}
+
+function removeCodexTraceHook(content: string, eventName: string): string {
+  const escapedEvent = eventName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `(?:^|\\n)\\[\\[hooks\\.${escapedEvent}\\]\\]\\n` +
+      `\\[\\[hooks\\.${escapedEvent}\\.hooks\\]\\]\\n` +
+      `type = "command"\\n` +
+      `command = "[^"\\n]* trace hook ${escapedEvent}"\\n` +
+      `(?:statusMessage = "[^"\\n]*"\\n)?`,
+    "g",
+  );
+  return content.replace(pattern, "\n");
 }

--- a/packages/progressive-review/src/trace-agent-sessions.ts
+++ b/packages/progressive-review/src/trace-agent-sessions.ts
@@ -1,0 +1,52 @@
+import { readFile, rm, stat, writeFile } from "node:fs/promises";
+
+import { sessionIdSchema } from "@dev-fast/trace-shared";
+
+export const TRACE_SESSION_TTL_MS = 2 * 60 * 60 * 1000;
+
+export async function readActiveTraceSessions(
+  filePath: string,
+  now = Date.now(),
+): Promise<Map<string, number>> {
+  const [content, fileStat] = await Promise.all([
+    readFile(filePath, "utf8").catch(() => ""),
+    stat(filePath).catch(() => null),
+  ]);
+  const legacyTimestamp = Math.floor(fileStat?.mtimeMs ?? now);
+  const sessions = new Map<string, number>();
+
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const fields = line.split("\t");
+    const parsedSessionId = sessionIdSchema.safeParse(fields[0]);
+    if (!parsedSessionId.success) continue;
+    const sessionId = parsedSessionId.data;
+
+    let lastActiveAt = legacyTimestamp;
+    if (fields.length > 1) {
+      if (fields.length !== 2 || !/^\d+$/.test(fields[1] ?? "")) continue;
+      lastActiveAt = Number(fields[1]);
+      if (!Number.isSafeInteger(lastActiveAt) || lastActiveAt <= 0) continue;
+    }
+    if (now - lastActiveAt <= TRACE_SESSION_TTL_MS) {
+      sessions.set(sessionId, lastActiveAt);
+    }
+  }
+
+  return sessions;
+}
+
+export async function writeTraceSessions(
+  filePath: string,
+  sessions: ReadonlyMap<string, number>,
+): Promise<void> {
+  if (sessions.size === 0) {
+    await rm(filePath, { force: true });
+    return;
+  }
+  const content = [...sessions]
+    .map(([sessionId, lastActiveAt]) => `${sessionId}\t${lastActiveAt}`)
+    .join("\n");
+  await writeFile(filePath, `${content}\n`, "utf8");
+}

--- a/packages/progressive-review/src/trace-git-hook-runner.ts
+++ b/packages/progressive-review/src/trace-git-hook-runner.ts
@@ -1,6 +1,3 @@
-import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
-
 import { sessionIdSchema } from "@dev-fast/trace-shared";
 import { git } from "@dev.fast/local-vcs";
 
@@ -9,6 +6,10 @@ import {
   syncReviewTrace,
   writeReviewTraceCommitMapping,
 } from "./review-agent-traces";
+import {
+  readActiveTraceSessions,
+  writeTraceSessions,
+} from "./trace-agent-sessions";
 
 const ZERO_OID = /^0+$/;
 
@@ -72,12 +73,10 @@ async function activeSessions(cwd: string): Promise<string[]> {
   );
   if (!fileResult.ok) return [];
   const filePath = fileResult.stdout.trim();
-  if (!filePath || !existsSync(filePath)) return [];
-  const sessions = (await readFile(filePath, "utf8").catch(() => ""))
-    .split("\n")
-    .map((value) => value.trim())
-    .filter((value) => sessionIdSchema.safeParse(value).success);
-  return [...new Set(sessions)];
+  if (!filePath) return [];
+  const sessions = await readActiveTraceSessions(filePath);
+  await writeTraceSessions(filePath, sessions).catch(() => undefined);
+  return [...sessions.keys()];
 }
 
 async function runPrePush(input: {

--- a/packages/progressive-review/src/trace-hook-runner.test.ts
+++ b/packages/progressive-review/src/trace-hook-runner.test.ts
@@ -6,8 +6,10 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import { promisify } from "node:util";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { TRACE_SESSION_TTL_MS } from "./trace-agent-sessions";
+import { runReviewTraceGitHook } from "./trace-git-hook-runner";
 import { runReviewTraceHook } from "./trace-hook-runner";
 import { configureTraceMachine } from "./trace-machine-setup";
 
@@ -15,6 +17,7 @@ const execFilePromise = promisify(execFile);
 const tempRoots: string[] = [];
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   while (tempRoots.length > 0) {
     const dir = tempRoots.pop();
     if (dir) await rm(dir, { recursive: true, force: true });
@@ -62,6 +65,8 @@ describe("runReviewTraceHook", () => {
   it("records session ID on SessionStart and removes on SessionEnd", async () => {
     const repo = await makeGitRepo();
     const sessionId = "01a015e4-0477-7055-a0fd-21a0f72a4ec6";
+    const now = 1_800_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
 
     // 1. SessionStart via CLI args
     const startCode = await runReviewTraceHook({
@@ -75,7 +80,9 @@ describe("runReviewTraceHook", () => {
 
     const agentSessionFile = path.join(repo, ".git", "agent-session");
     expect(existsSync(agentSessionFile)).toBe(true);
-    expect(await readFile(agentSessionFile, "utf8")).toBe(`${sessionId}\n`);
+    expect(await readFile(agentSessionFile, "utf8")).toBe(
+      `${sessionId}\t${now}\n`,
+    );
 
     // 2. Another session joins
     const secondSessionId = "02b015e4-0477-7055-a0fd-21a0f72a4ec7";
@@ -87,7 +94,7 @@ describe("runReviewTraceHook", () => {
       env: { TRACE_R2_MODE: "mock" },
     });
     expect(await readFile(agentSessionFile, "utf8")).toBe(
-      `${sessionId}\n${secondSessionId}\n`,
+      `${sessionId}\t${now}\n${secondSessionId}\t${now}\n`,
     );
 
     // 3. First session ends
@@ -100,7 +107,7 @@ describe("runReviewTraceHook", () => {
     });
     expect(endCode).toBe(0);
     expect(await readFile(agentSessionFile, "utf8")).toBe(
-      `${secondSessionId}\n`,
+      `${secondSessionId}\t${now}\n`,
     );
 
     // 4. Second session ends (file should be deleted)
@@ -117,6 +124,8 @@ describe("runReviewTraceHook", () => {
   it("parses Claude/Codex hook JSON from stdin", async () => {
     const repo = await makeGitRepo();
     const sessionId = "01a015e4-0477-7055-a0fd-21a0f72a4ec6";
+    const now = 1_800_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
 
     const startPayload = JSON.stringify({
       hook_event_name: "SessionStart",
@@ -136,7 +145,9 @@ describe("runReviewTraceHook", () => {
 
     const agentSessionFile = path.join(repo, ".git", "agent-session");
     expect(existsSync(agentSessionFile)).toBe(true);
-    expect(await readFile(agentSessionFile, "utf8")).toBe(`${sessionId}\n`);
+    expect(await readFile(agentSessionFile, "utf8")).toBe(
+      `${sessionId}\t${now}\n`,
+    );
 
     const endPayload = JSON.stringify({
       hook_event_name: "SessionEnd",
@@ -157,12 +168,101 @@ describe("runReviewTraceHook", () => {
     expect(existsSync(agentSessionFile)).toBe(false);
   });
 
+  it("refreshes timestamps on turn start and drops stale sessions", async () => {
+    const repo = await makeGitRepo();
+    const staleSessionId = "01a015e4-0477-7055-a0fd-21a0f72a4ec6";
+    const activeSessionId = "02b015e4-0477-7055-a0fd-21a0f72a4ec7";
+    const startedAt = 1_800_000_000_000;
+    const heartbeatAt = startedAt + TRACE_SESSION_TTL_MS + 1;
+    const now = vi.spyOn(Date, "now").mockReturnValue(startedAt);
+
+    await runReviewTraceHook({
+      cwd: repo,
+      event: "SessionStart",
+      sessionId: staleSessionId,
+      homeDir: repo,
+      env: { TRACE_R2_MODE: "mock" },
+    });
+    now.mockReturnValue(heartbeatAt);
+    await runReviewTraceHook({
+      cwd: repo,
+      event: "UserPromptSubmit",
+      sessionId: activeSessionId,
+      homeDir: repo,
+      env: { TRACE_R2_MODE: "mock" },
+    });
+
+    const agentSessionFile = path.join(repo, ".git", "agent-session");
+    expect(await readFile(agentSessionFile, "utf8")).toBe(
+      `${activeSessionId}\t${heartbeatAt}\n`,
+    );
+
+    now.mockReturnValue(heartbeatAt + 1_000);
+    await runReviewTraceHook({
+      cwd: repo,
+      event: "turn_start",
+      sessionId: activeSessionId,
+      homeDir: repo,
+      env: { TRACE_R2_MODE: "mock" },
+    });
+    expect(await readFile(agentSessionFile, "utf8")).toBe(
+      `${activeSessionId}\t${heartbeatAt + 1_000}\n`,
+    );
+  });
+
+  it("prunes stale sessions before stamping a Git commit", async () => {
+    const repo = await makeGitRepo();
+    const sessionId = "01a015e4-0477-7055-a0fd-21a0f72a4ec6";
+    const startedAt = 1_800_000_000_000;
+    const now = vi.spyOn(Date, "now").mockReturnValue(startedAt);
+
+    await runReviewTraceHook({
+      cwd: repo,
+      event: "SessionStart",
+      sessionId,
+      homeDir: repo,
+      env: { TRACE_R2_MODE: "mock" },
+    });
+    now.mockReturnValue(startedAt + TRACE_SESSION_TTL_MS + 1);
+    const messagePath = path.join(repo, ".git", "COMMIT_EDITMSG");
+    await writeFile(messagePath, "Test commit\n");
+    await runReviewTraceGitHook({
+      cwd: repo,
+      hook: "prepare-commit-msg",
+      args: [messagePath],
+      stderr: process.stderr,
+    });
+
+    expect(await readFile(messagePath, "utf8")).toBe("Test commit\n");
+    expect(existsSync(path.join(repo, ".git", "agent-session"))).toBe(false);
+
+    await runReviewTraceHook({
+      cwd: repo,
+      event: "UserPromptSubmit",
+      sessionId,
+      homeDir: repo,
+      env: { TRACE_R2_MODE: "mock" },
+    });
+    await writeFile(messagePath, "Fresh commit\n");
+    await runReviewTraceGitHook({
+      cwd: repo,
+      hook: "prepare-commit-msg",
+      args: [messagePath],
+      stderr: process.stderr,
+    });
+    expect(await readFile(messagePath, "utf8")).toContain(
+      `Agent-Session: ${sessionId}`,
+    );
+  });
+
   it("writes valid Jujutsu commit trailer templates", async () => {
     if (!(await commandAvailable("jj"))) return;
     const repo = await makeGitRepo();
     await runJj(repo, ["git", "init", "--colocate", "."]);
     const firstSessionId = "01a015e4-0477-7055-a0fd-21a0f72a4ec6";
     const secondSessionId = "02b015e4-0477-7055-a0fd-21a0f72a4ec7";
+    const startedAt = 1_800_000_000_000;
+    const now = vi.spyOn(Date, "now").mockReturnValue(startedAt);
 
     for (const sessionId of [firstSessionId, secondSessionId]) {
       await runReviewTraceHook({
@@ -185,6 +285,27 @@ describe("runReviewTraceHook", () => {
     ]);
     expect(description).toBe(
       `Trace work\n\nAgent-Session: ${firstSessionId}\nAgent-Session: ${secondSessionId}\n`,
+    );
+
+    now.mockReturnValue(startedAt + TRACE_SESSION_TTL_MS + 1);
+    await runReviewTraceHook({
+      cwd: repo,
+      event: "UserPromptSubmit",
+      sessionId: firstSessionId,
+      homeDir: repo,
+      env: { TRACE_R2_MODE: "mock" },
+    });
+    await runJj(repo, ["describe", "-m", "Fresh trace work"]);
+    const refreshedDescription = await runJj(repo, [
+      "log",
+      "-r",
+      "@",
+      "--no-graph",
+      "-T",
+      "description",
+    ]);
+    expect(refreshedDescription).toBe(
+      `Fresh trace work\n\nAgent-Session: ${firstSessionId}\n`,
     );
   });
 

--- a/packages/progressive-review/src/trace-hook-runner.ts
+++ b/packages/progressive-review/src/trace-hook-runner.ts
@@ -1,12 +1,15 @@
 import { execFile, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
 import { git } from "@dev.fast/local-vcs";
 
+import {
+  readActiveTraceSessions,
+  writeTraceSessions,
+} from "./trace-agent-sessions";
 import { traceMachineEnabled } from "./trace-machine-setup";
 import { enableTraceRepository } from "./trace-repository-hooks";
 
@@ -67,10 +70,13 @@ export async function runReviewTraceHook(
     return 0;
   }
 
-  const isStart = event.toLowerCase().includes("start");
-  const isEnd = event.toLowerCase().includes("end");
+  const normalizedEvent = event.toLowerCase().replaceAll(/[_-]/g, "");
+  const isStart = normalizedEvent === "sessionstart";
+  const isEnd = normalizedEvent === "sessionend";
+  const isHeartbeat =
+    normalizedEvent === "userpromptsubmit" || normalizedEvent === "turnstart";
 
-  if (!isStart && !isEnd) {
+  if (!isStart && !isEnd && !isHeartbeat) {
     return 0;
   }
 
@@ -107,42 +113,27 @@ export async function runReviewTraceHook(
   let remainingSessions: string[] = [];
 
   if (sessionFilePath) {
-    let existingContent = "";
-    if (existsSync(sessionFilePath)) {
-      existingContent = await readFile(sessionFilePath, "utf8").catch(() => "");
-    }
-    const currentSessions = existingContent
-      .split("\n")
-      .map((s) => s.trim())
-      .filter((s) => s && SESSION_ID_REGEX.test(s));
+    const now = Date.now();
+    const currentSessions = await readActiveTraceSessions(sessionFilePath, now);
 
-    if (isStart) {
-      if (!currentSessions.includes(sessionId)) {
-        currentSessions.push(sessionId);
-      }
-      remainingSessions = currentSessions;
-      await writeFile(
-        sessionFilePath,
-        `${currentSessions.join("\n")}\n`,
-        "utf8",
-      ).catch(() => undefined);
+    if (isStart || isHeartbeat) {
+      currentSessions.set(sessionId, now);
+      remainingSessions = [...currentSessions.keys()];
+      await writeTraceSessions(sessionFilePath, currentSessions).catch(
+        () => undefined,
+      );
     } else if (isEnd) {
-      remainingSessions = currentSessions.filter((s) => s !== sessionId);
-      if (remainingSessions.length > 0) {
-        await writeFile(
-          sessionFilePath,
-          `${remainingSessions.join("\n")}\n`,
-          "utf8",
-        ).catch(() => undefined);
-      } else {
-        await rm(sessionFilePath, { force: true }).catch(() => undefined);
-      }
+      currentSessions.delete(sessionId);
+      remainingSessions = [...currentSessions.keys()];
+      await writeTraceSessions(sessionFilePath, currentSessions).catch(
+        () => undefined,
+      );
     }
   }
 
   // 2. Jujutsu (jj) templates.commit_trailers mirror handling
   if (jjRootResult?.stdout.trim()) {
-    if (isStart && remainingSessions.length > 0) {
+    if ((isStart || isHeartbeat) && remainingSessions.length > 0) {
       const templateVal = jjCommitTrailersConfigValue(remainingSessions);
       await execFileAsync(
         "jj",


### PR DESCRIPTION
## What changed

- Store each active agent session as `<session-id>\t<last-active-ms>`.
- Expire sessions after two hours before Git commit stamping and while refreshing jj trailer configuration.
- Refresh activity from Claude Code and Codex `UserPromptSubmit` hooks and pi `turn_start` events.
- Migrate legacy session-id-only files using their file modification time.

## Why

Session end hooks are not guaranteed to run when an agent is left open, so stale sessions could be stamped onto unrelated later commits. Turn-level heartbeats plus a TTL keep attribution precise without losing the ability to commit shortly after an agent response.

## Impact

Existing trace setups upgrade idempotently. Active sessions continue to receive `Agent-Session` trailers; idle sessions age out automatically.

## Validation

- `pnpm --filter @dev.fast/review test` (1,108 tests)
- Targeted trace hook and installer regression tests
- `pnpm --filter @dev.fast/review typecheck`
- `pnpm --filter @dev.fast/review build`
