### PR TITLE
Resolve definitions from unified CodePeeks

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewInlineEditorService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewInlineEditorService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Dimension } from "../../base/browser/dom.js";
+import type { CancellationToken } from "../../base/common/cancellation.js";
 import { Emitter } from "../../base/common/event.js";
 import {
   Disposable,
@@ -27,13 +28,17 @@ import {
   MultiDiffEditorResourceHeader,
 } from "../../editor/browser/widget/multiDiffEditor/multiDiffEditorResourceHeader.js";
 import type { IDiffEditorOptions } from "../../editor/common/config/editorOptions.js";
+import { Position } from "../../editor/common/core/position.js";
 import { Range } from "../../editor/common/core/range.js";
 import { USUAL_WORD_SEPARATORS } from "../../editor/common/core/wordHelper.js";
 import type {
   ICompositeCodeEditor,
   IEditorDecorationsCollection,
 } from "../../editor/common/editorCommon.js";
+import { getDefinitionsAtPosition } from "../../editor/contrib/gotoSymbol/browser/goToSymbol.js";
+import type { LocationLink } from "../../editor/common/languages.js";
 import type { ITextModel } from "../../editor/common/model.js";
+import { ILanguageFeaturesService } from "../../editor/common/services/languageFeatures.js";
 import { ITextModelService } from "../../editor/common/services/resolverService.js";
 import { ITextResourceConfigurationService } from "../../editor/common/services/textResourceConfiguration.js";
 import { IInstantiationService } from "../../platform/instantiation/common/instantiation.js";
@@ -129,6 +134,8 @@ export class ReviewInlineEditorService
     private readonly textResourceConfigurationService: ITextResourceConfigurationService,
     @ICodeEditorService
     private readonly codeEditorService: ICodeEditorService,
+    @ILanguageFeaturesService
+    private readonly languageFeaturesService: ILanguageFeaturesService,
     @ITextModelService
     private readonly textModelService: ITextModelService,
   ) {
@@ -139,6 +146,62 @@ export class ReviewInlineEditorService
           this.openUnifiedNavigation(input, source, sideBySide),
       ),
     );
+    this._register(
+      this.languageFeaturesService.definitionProvider.register(
+        { scheme: REVIEW_UNIFIED_SCHEME, exclusive: true },
+        {
+          provideDefinition: (model, position, token) =>
+            this.provideUnifiedDefinition(model, position, token),
+        },
+      ),
+    );
+  }
+
+  private async provideUnifiedDefinition(
+    model: ITextModel,
+    position: Position,
+    token: CancellationToken,
+  ): Promise<LocationLink[]> {
+    const unified = this.resources.unifiedResource(model.uri);
+    const mapped = unified?.targetForRange(
+      position.lineNumber,
+      position.lineNumber,
+    );
+    if (!mapped) return [];
+
+    const target = await this.resources.target(mapped.path, mapped.side);
+    const sourceReference = await this.textModelService.createModelReference(
+      target.resource,
+    );
+    try {
+      const sourceModel = sourceReference.object.textEditorModel;
+      if (!sourceModel) return [];
+      const sourcePosition = sourceModel.validatePosition(
+        new Position(mapped.startLine, position.column),
+      );
+      const definitions = await getDefinitionsAtPosition(
+        this.languageFeaturesService.definitionProvider,
+        sourceModel,
+        sourcePosition,
+        false,
+        token,
+      );
+      return definitions.map((definition) => ({
+        ...definition,
+        originSelectionRange: definition.originSelectionRange
+          ? model.validateRange(
+              new Range(
+                position.lineNumber,
+                definition.originSelectionRange.startColumn,
+                position.lineNumber,
+                definition.originSelectionRange.endColumn,
+              ),
+            )
+          : undefined,
+      }));
+    } finally {
+      sourceReference.dispose();
+    }
   }
 
   private async openUnifiedNavigation(

--- a/apps/review-desktop/scripts/inline-diff-editor-contract.test.mjs
+++ b/apps/review-desktop/scripts/inline-diff-editor-contract.test.mjs
@@ -273,6 +273,26 @@ test("unified CodePeek navigation opens the mapped review resource", () => {
   assert.match(resourceSource, /resolverReference\.dispose\(\)/);
 });
 
+test("unified CodePeek definitions delegate to the mapped source model", () => {
+  assert.match(
+    source,
+    /definitionProvider\.register\(\s*\{ scheme: REVIEW_UNIFIED_SCHEME, exclusive: true \}/,
+  );
+  assert.match(
+    source,
+    /unified\?\.targetForRange\(\s*position\.lineNumber,\s*position\.lineNumber/,
+  );
+  assert.match(
+    source,
+    /createModelReference\(\s*target\.resource,\s*\)/,
+  );
+  assert.match(
+    source,
+    /getDefinitionsAtPosition\(\s*this\.languageFeaturesService\.definitionProvider,\s*sourceModel,\s*sourcePosition/,
+  );
+  assert.match(source, /sourceReference\.dispose\(\)/);
+});
+
 test("the multi-diff scroller releases the wheel at real content bounds", () => {
   // With the scroll range in place the widget's own wheel handling is
   // honest: handleMouseWheel and alwaysConsumeMouseWheel stay at their


### PR DESCRIPTION
## Summary

- Route definition lookups from synthetic unified CodePeek rows through their corresponding pinned source model.
- Preserve the origin range in the unified buffer so navigation stays anchored to the clicked token.
- Add contract coverage for the adapter.

## Scope

This is deliberately surgical: it fixes head, added, and unchanged rows. Base-only or deleted rows keep the existing base-resource behavior.

## Verification

- Desktop test suite: 136 passed
- Client typecheck: passed
- Production desktop build: passed
- Diff check: passed
- Layer checker: unchanged pre-existing violations in reviewTitlebarPart.ts