### PR TITLE
Use native diffs for commentable CodePeeks

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewCodeResources.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewCodeResources.ts
@@ -17,6 +17,7 @@ export const REVIEW_UNIFIED_SCHEME = "devfast-review-unified";
 export interface ReviewResourceSession {
   readonly session: {
     readonly rootPath: string;
+    readonly baseRootPath?: string;
     readonly headRootPath?: string;
   };
 }
@@ -66,6 +67,15 @@ export function reviewHeadFileUri(
   return reviewFileUri({ session: { rootPath: headRootPath } }, filePath);
 }
 
+export function reviewBaseFileUri(
+  session: ReviewResourceSession,
+  filePath: string,
+): URI | undefined {
+  const baseRootPath = session.session.baseRootPath;
+  if (!baseRootPath) return undefined;
+  return reviewFileUri({ session: { rootPath: baseRootPath } }, filePath);
+}
+
 export function reviewResourceIdentity(
   session: ReviewResourceIdentitySession,
   resource: URI,
@@ -81,7 +91,11 @@ export function reviewResourceIdentity(
   }
   if (resource.scheme !== "file") return null;
 
-  const roots = [session.session.headRootPath, session.session.rootPath];
+  const roots = [
+    session.session.headRootPath,
+    session.session.baseRootPath,
+    session.session.rootPath,
+  ];
   for (const rootPath of roots) {
     if (!rootPath) continue;
     const relative = extUri.relativePath(URI.file(rootPath), resource);

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
@@ -1546,6 +1546,7 @@ export type ReviewDesktopGlobalEvent = z.infer<
 export const ReviewSessionSchema = z.strictObject({
   sessionId: requiredString.optional(),
   rootPath: requiredString,
+  baseRootPath: requiredString.optional(),
   headRootPath: requiredString.optional(),
   baseRef: requiredString,
   headRef: requiredString.optional(),

--- a/apps/review-desktop/code-oss/src/vs/review/contrib/comments/reviewComments.contribution.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/comments/reviewComments.contribution.ts
@@ -65,6 +65,7 @@ import {
   type ReviewCommentStoreSnapshot,
   type ReviewCommentThreadRecord,
   type ReviewDiffFileWire,
+  type ReviewDiffSide,
 } from "../../common/reviewProtocol.js";
 import {
   IReviewCodeResourceService,
@@ -930,11 +931,16 @@ export class ReviewCommentController
       };
     }
     if (resource.scheme !== "file") return null;
-    const rootPath = model.session.session.headRootPath;
-    if (!rootPath) return null;
-    const path = extUri.relativePath(URI.file(rootPath), resource);
-    if (!path || path.startsWith("../")) return null;
-    return { path, side: "head" };
+    const roots: readonly [string | undefined, ReviewDiffSide][] = [
+      [model.session.session.headRootPath, "head"],
+      [model.session.session.baseRootPath, "base"],
+    ];
+    for (const [rootPath, side] of roots) {
+      if (!rootPath) continue;
+      const path = extUri.relativePath(URI.file(rootPath), resource);
+      if (path && !path.startsWith("../")) return { path, side };
+    }
+    return null;
   }
 
   private projectThread(

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewCodeResourceService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewCodeResourceService.ts
@@ -18,6 +18,7 @@ import {
   REVIEW_BASE_SCHEME,
   REVIEW_HEAD_SCHEME,
   REVIEW_UNIFIED_SCHEME,
+  reviewBaseFileUri,
   reviewFileUri,
   reviewHeadFileUri,
   reviewVirtualUri,
@@ -38,6 +39,7 @@ import {
 export {
   REVIEW_BASE_SCHEME,
   REVIEW_HEAD_SCHEME,
+  reviewBaseFileUri,
   reviewFileUri,
   reviewHeadFileUri,
   reviewResourceIdentity,
@@ -289,35 +291,37 @@ export class ReviewCodeResourceService
     }
     const diffFile = reviewDiffFileForReveal(files, path, side);
     if (!diffFile) {
-      const headResource =
-        side === "head" && !scope ? reviewHeadFileUri(session, path) : undefined;
+      const pinnedResource = !scope
+        ? side === "base"
+          ? reviewBaseFileUri(session, path)
+          : reviewHeadFileUri(session, path)
+        : undefined;
       return {
-        resource: headResource ?? reviewFileUri(session, path),
-        workingTreeFallback: !headResource,
+        resource: pinnedResource ?? reviewFileUri(session, path),
+        workingTreeFallback: !pinnedResource,
       };
     }
     const displayPath =
       side === "base"
         ? (diffFile.previousPath ?? diffFile.path)
         : diffFile.path;
+    const pinnedResource = !scope
+      ? side === "base" && diffFile.status !== "added"
+        ? reviewBaseFileUri(session, displayPath)
+        : side === "head" && diffFile.status !== "deleted"
+          ? reviewHeadFileUri(session, displayPath)
+          : undefined
+      : undefined;
     return {
       resource:
-        side === "head" && diffFile.status !== "deleted"
-          ? ((!scope ? reviewHeadFileUri(session, displayPath) : undefined) ??
-            reviewVirtualUri(
-              side,
-              displayPath,
-              diffFile.path,
-              session.session.sessionId,
-              scope?.commit,
-            ))
-          : reviewVirtualUri(
-              side,
-              displayPath,
-              diffFile.path,
-              session.session.sessionId,
-              scope?.commit,
-            ),
+        pinnedResource ??
+        reviewVirtualUri(
+          side,
+          displayPath,
+          diffFile.path,
+          session.session.sessionId,
+          scope?.commit,
+        ),
       diffFile,
       workingTreeFallback: false,
     };
@@ -582,11 +586,16 @@ export class ReviewCodeResourceService
       };
     }
     if (resource.scheme !== "file") return null;
-    const rootPath = session.session.headRootPath;
-    if (!rootPath) return null;
-    const path = extUri.relativePath(URI.file(rootPath), resource);
-    if (!path || path.startsWith("../")) return null;
-    return { path, side: "head" };
+    const roots: readonly [string | undefined, ReviewDiffSide][] = [
+      [session.session.headRootPath, "head"],
+      [session.session.baseRootPath, "base"],
+    ];
+    for (const [rootPath, side] of roots) {
+      if (!rootPath) continue;
+      const path = extUri.relativePath(URI.file(rootPath), resource);
+      if (path && !path.startsWith("../")) return { path, side };
+    }
+    return null;
   }
 
   reset(): void {
@@ -709,6 +718,7 @@ export class ReviewCodeResourceService
       session.headRef,
       session.routePath ?? "",
       session.rootPath,
+      session.baseRootPath ?? "",
       session.headRootPath ?? "",
     ].join("\n");
   }

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewComments.contribution.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewComments.contribution.test.ts
@@ -11,10 +11,7 @@ import { Emitter, Event } from "../../base/common/event.js";
 import { URI } from "../../base/common/uri.js";
 import { Range } from "../../editor/common/core/range.js";
 import {
-  REVIEW_BASE_SCHEME,
-  REVIEW_HEAD_SCHEME,
   REVIEW_UNIFIED_SCHEME,
-  reviewVirtualUri,
 } from "../common/reviewCodeResources.js";
 import {
   createGitLabTextDiffPosition,
@@ -116,6 +113,7 @@ test("keeps one stable comment projection per diff resource", async () => {
         sessionId,
         resolvedBaseRef: baseSha,
         headRef: headSha,
+        baseRootPath: "/tmp/review-base",
         headRootPath: "/tmp/review-head",
       },
     },
@@ -152,13 +150,13 @@ test("keeps one stable comment projection per diff resource", async () => {
       if (resource.toString() === unifiedResource.toString()) {
         return { startLine: 3, endLine: 9 };
       }
-      if (resource.scheme === REVIEW_BASE_SCHEME) {
-        return resource.path === `/${path}`
+      if (resource.path === `/tmp/review-base/${path}`) {
+        return resource.scheme === "file"
           ? { startLine: 267, endLine: 270 }
           : undefined;
       }
-      if (resource.scheme === REVIEW_HEAD_SCHEME) {
-        return resource.path === `/${path}`
+      if (resource.path === `/tmp/review-head/${path}`) {
+        return resource.scheme === "file"
           ? { startLine: 320, endLine: 322 }
           : undefined;
       }
@@ -169,18 +167,26 @@ test("keeps one stable comment projection per diff resource", async () => {
       startLine: number,
       endLine: number,
     ) {
-      if (
-        resource.toString() !== unifiedResource.toString() ||
-        startLine !== 3 ||
-        endLine !== 9
-      ) {
-        return null;
+      if (resource.toString() === unifiedResource.toString()) {
+        if (startLine !== 3 || endLine !== 9) return null;
+        return {
+          diffFile,
+          start: { old_line: 267, new_line: null },
+          end: { old_line: null, new_line: 322 },
+        };
       }
-      return {
-        diffFile,
-        start: { old_line: 267, new_line: null },
-        end: { old_line: null, new_line: 322 },
-      };
+      if (
+        resource.path === `/tmp/review-base/${path}` &&
+        startLine === 267 &&
+        endLine === 270
+      ) {
+        return {
+          diffFile,
+          start: { old_line: 267, new_line: null },
+          end: { old_line: 270, new_line: null },
+        };
+      }
+      return null;
     },
   };
   const controller = new ReviewCommentController(
@@ -197,21 +203,11 @@ test("keeps one stable comment projection per diff resource", async () => {
     } as never,
   );
   assert.equal(commentingRangeUpdates, 1);
-  const baseResource = reviewVirtualUri(
-    "base",
-    path,
-    path,
-    sessionId,
-  );
-  const headResource = reviewVirtualUri(
-    "head",
-    path,
-    path,
-    sessionId,
-  );
+  const baseResource = URI.file(`/tmp/review-base/${path}`);
+  const headResource = URI.file(`/tmp/review-head/${path}`);
 
-  assert.equal(baseResource.scheme, REVIEW_BASE_SCHEME);
-  assert.equal(headResource.scheme, REVIEW_HEAD_SCHEME);
+  assert.equal(baseResource.scheme, "file");
+  assert.equal(headResource.scheme, "file");
   const unified = await controller.getDocumentComments(
     unifiedResource,
     CancellationToken.None,
@@ -229,7 +225,7 @@ test("keeps one stable comment projection per diff resource", async () => {
     CancellationToken.None,
   );
   const unrelated = await controller.getDocumentComments(
-    reviewVirtualUri("head", "src/other.ts", "src/other.ts", sessionId),
+    URI.file("/tmp/review-head/src/other.ts"),
     CancellationToken.None,
   );
 
@@ -278,10 +274,39 @@ test("keeps one stable comment projection per diff resource", async () => {
   );
   const eventCount = commentEvents.length;
   await controller.createCommentThreadTemplate(
+    baseResource,
+    new Range(267, 1, 270, 1),
+  );
+  const baseTemplateEvent = commentEvents[eventCount] as {
+    readonly added: Array<{
+      readonly isTemplate: boolean;
+      readonly threadId: string;
+      readonly resource: string;
+      readonly range: unknown;
+    }>;
+  };
+  const baseTemplate = baseTemplateEvent.added[0]!;
+  assert.equal(baseTemplate.isTemplate, true);
+  await controller.addToReview({
+    thread: baseTemplate as never,
+    text: "Deleted-line comment",
+  });
+  const baseSaved = savedComments[0] as {
+    readonly target: typeof target;
+  };
+  const baseLineRange = baseSaved.target.position.line_range;
+  assert.ok(baseLineRange);
+  assert.equal(baseLineRange.start.old_line, 267);
+  assert.equal(baseLineRange.start.new_line, null);
+  assert.equal(baseLineRange.end.old_line, 270);
+  assert.equal(baseLineRange.end.new_line, null);
+
+  const unifiedEventCount = commentEvents.length;
+  await controller.createCommentThreadTemplate(
     unifiedResource,
     new Range(3, 1, 9, 1),
   );
-  const templateEvent = commentEvents[eventCount] as {
+  const templateEvent = commentEvents[unifiedEventCount] as {
     readonly added: Array<{
       readonly isTemplate: boolean;
       readonly threadId: string;
@@ -295,7 +320,7 @@ test("keeps one stable comment projection per diff resource", async () => {
     thread: template as never,
     text: "New comment",
   });
-  const saved = savedComments[0] as {
+  const saved = savedComments[1] as {
     readonly target: typeof target;
   };
   assert.deepEqual(saved.target.position.line_range, position.line_range);

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewInlineEditorService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewInlineEditorService.ts
@@ -61,7 +61,6 @@ import {
   IReviewCodeResourceService,
   type ReviewCodeDiffTarget,
   type ReviewCodeModelReference,
-  type ReviewUnifiedCodeModelReference,
 } from "./reviewCodeResourceService.js";
 import {
   ReviewMultiDiffUIElementFactory,
@@ -244,26 +243,6 @@ export class ReviewInlineEditorService
     query: ReviewFindQuery,
   ): Promise<ReviewInlineFindResult> {
     if (!query.text) return { matchCount: 0 };
-    if (spec.commentsEnabled) {
-      const unified = await this.resources.acquireUnifiedDiff(
-        spec.path,
-        spec.side,
-        spec.ranges,
-      );
-      if (unified) {
-        try {
-          return {
-            matchCount: findModelRanges(
-              unified.model,
-              unified.windows,
-              query,
-            ).length,
-          };
-        } finally {
-          unified.dispose();
-        }
-      }
-    }
     const diff = await this.resources.resolveDiff(
       spec.path,
       spec.side,
@@ -370,14 +349,12 @@ class InlineEditorHandle extends Disposable implements ReviewInlineEditorHandle 
   private editor: CodeEditorWidget | undefined;
   private multiDiffEditor: MultiDiffEditorWidget | undefined;
   private modelReference: ReviewCodeModelReference | undefined;
-  private unifiedModelReference: ReviewUnifiedCodeModelReference | undefined;
   private diffModel: InlineDiffModel | undefined;
   private decoration: IEditorDecorationsCollection | undefined;
   private readonly diffRangeDecorations = new Map<
     ICodeEditor,
     IEditorDecorationsCollection
   >();
-  private diffDecoration: IEditorDecorationsCollection | undefined;
   private readonly findDecorations = new Map<
     ICodeEditor,
     IEditorDecorationsCollection
@@ -412,11 +389,7 @@ class InlineEditorHandle extends Disposable implements ReviewInlineEditorHandle 
   }
 
   get hasModel(): boolean {
-    return (
-      this.modelReference !== undefined ||
-      this.unifiedModelReference !== undefined ||
-      this.diffModel !== undefined
-    );
+    return this.modelReference !== undefined || this.diffModel !== undefined;
   }
 
   constructor(
@@ -519,7 +492,7 @@ class InlineEditorHandle extends Disposable implements ReviewInlineEditorHandle 
     }
     const matches: InlineFindMatch[] = [];
     const codeEditor = this.editor;
-    const modelReference = this.unifiedModelReference ?? this.modelReference;
+    const modelReference = this.modelReference;
     if (codeEditor && modelReference) {
       matches.push(
         ...this.findModelMatches(
@@ -582,34 +555,15 @@ class InlineEditorHandle extends Disposable implements ReviewInlineEditorHandle 
       collection.clear();
     }
     this.diffRangeDecorations.clear();
-    this.diffDecoration?.clear();
     this.editorStore.dispose();
     this.spec.container.replaceChildren();
-    this.spec.container.classList.remove(
-      "review-inline-code-editor",
-      "review-inline-unified-diff",
-    );
+    this.spec.container.classList.remove("review-inline-code-editor");
     super.dispose();
     this.onDispose();
   }
 
   private async initialize(): Promise<void> {
     try {
-      if (this.spec.commentsEnabled) {
-        const unifiedReference = await this.resources.acquireUnifiedDiff(
-          this.spec.path,
-          this.spec.side,
-          this.spec.ranges,
-        );
-        if (unifiedReference) {
-          if (this.disposed) {
-            unifiedReference.dispose();
-            return;
-          }
-          this.initializeUnifiedEditor(unifiedReference);
-          return;
-        }
-      }
       const diffTarget = await this.resources.resolveDiff(
         this.spec.path,
         this.spec.side,
@@ -660,75 +614,6 @@ class InlineEditorHandle extends Disposable implements ReviewInlineEditorHandle 
     } catch (error) {
       if (!this.disposed) this.emitError(error);
     }
-  }
-
-  private initializeUnifiedEditor(
-    reference: ReviewUnifiedCodeModelReference,
-  ): void {
-    const labelUris = reviewMultiDiffLabelUris(reference.target.diffFile);
-    this.setHeader(
-      reference.target.original,
-      reference.target.modified,
-      labelUris.original,
-      labelUris.modified,
-    );
-    this.unifiedModelReference = reference;
-    this.editorStore.add(reference);
-    const editor = this.instantiationService.createInstance(
-      CodeEditorWidget,
-      this.body,
-      {
-        ...inlineEditorOptions(this.overflowWidgetsDomNode),
-        lineNumbers: (lineNumber) =>
-          String(reference.rows[lineNumber - 1]?.authorLine ?? lineNumber),
-      },
-      {
-        telemetryData: { source: "reviewInlineUnifiedCodeEditor" },
-        contributions: reviewInlineEditorContributions(true),
-      },
-    );
-    this.editor = editor;
-    reviewInlineEditors.add(editor);
-    this.spec.container.dataset["reviewInlineEditorKind"] = "unified";
-    this.spec.container.classList.add("review-inline-unified-diff");
-    this.editorStore.add(editor);
-    editor.setModel(reference.model);
-    this.diffDecoration = editor.createDecorationsCollection();
-    this.diffDecoration.set(
-      reference.rows.flatMap((row) => {
-        if (row.kind === "unchanged") return [];
-        const added = row.kind === "added";
-        return [
-          {
-            range: new Range(
-              row.lineNumber,
-              1,
-              row.lineNumber,
-              Number.MAX_SAFE_INTEGER,
-            ),
-            options: {
-              description: `Review unified ${row.kind} line`,
-              isWholeLine: true,
-              className: added ? "line-insert" : "line-delete",
-              marginClassName: added ? "gutter-insert" : "gutter-delete",
-              lineNumberClassName: added
-                ? "review-unified-line-number-added"
-                : "review-unified-line-number-deleted",
-            },
-          },
-        ];
-      }),
-    );
-    this.bindFocus(editor);
-    this.trackScroll(
-      () => editor.getScrollTop(),
-      (listener) => editor.onDidScrollChange(listener),
-    );
-    this.editorStore.add(
-      editor.onDidContentSizeChange(() => this.layoutCodeEditorToContent()),
-    );
-    this.applyRange();
-    this.markCreated();
   }
 
   private async initializeMultiDiffEditor(
@@ -909,7 +794,7 @@ class InlineEditorHandle extends Disposable implements ReviewInlineEditorHandle 
       return;
     }
     const codeEditor = this.editor;
-    const modelReference = this.unifiedModelReference ?? this.modelReference;
+    const modelReference = this.modelReference;
     if (!codeEditor || !modelReference) return;
     this.applyWindows(codeEditor, modelReference.windows);
     this.layoutCodeEditorToContent();
@@ -919,7 +804,7 @@ class InlineEditorHandle extends Disposable implements ReviewInlineEditorHandle 
 
   private layoutCodeEditorToContent(): void {
     const codeEditor = this.editor;
-    const modelReference = this.unifiedModelReference ?? this.modelReference;
+    const modelReference = this.modelReference;
     if (!codeEditor || !modelReference) return;
     const windows = modelReference.windows;
     const lineCount = reviewPeekWindowsLineCount(windows);
@@ -1282,17 +1167,6 @@ class InlineEditorHandle extends Disposable implements ReviewInlineEditorHandle 
   }
 
   private ranges(): Range[] {
-    if (this.unifiedModelReference) {
-      return this.unifiedModelReference.ranges.map(
-        (range) =>
-          new Range(
-            range.startLine,
-            1,
-            range.endLine,
-            Number.MAX_SAFE_INTEGER,
-          ),
-      );
-    }
     return this.spec.ranges.map(
       (range) =>
         new Range(

--- a/apps/review-desktop/scripts/inline-diff-editor-contract.test.mjs
+++ b/apps/review-desktop/scripts/inline-diff-editor-contract.test.mjs
@@ -138,19 +138,17 @@ test("internal changed CodePeeks keep the native multi-diff used by Files", () =
   assert.doesNotMatch(source, /createInstance\(\s*DiffEditorWidget/);
 });
 
-test("authored CodePeeks use one unified native comment editor", () => {
+test("authored CodePeeks comment on the native pinned base/head diff", () => {
+  assert.doesNotMatch(source, /acquireUnifiedDiff\(/);
+  assert.doesNotMatch(source, /initializeUnifiedEditor\(/);
   assert.match(
     source,
-    /if \(this\.spec\.commentsEnabled\) \{[\s\S]*?acquireUnifiedDiff\(/,
+    /reviewInlineDiffEditorContributions\(\s*this\.spec\.commentsEnabled === true,?\s*\)/,
   );
-  assert.match(source, /initializeUnifiedEditor\(/);
-  assert.match(source, /reviewInlineEditorContributions\(true\)/);
-  assert.match(source, /lineNumbers:\s*\(lineNumber\) =>/);
-  assert.match(source, /className:\s*added \? "line-insert" : "line-delete"/);
-  assert.match(resourceSource, /REVIEW_UNIFIED_SCHEME/);
-  assert.match(resourceSource, /version:\s*session\.session\.sessionId/);
-  assert.match(resourceSource, /side,/);
-  assert.doesNotMatch(resourceSource, /instance:\s*generateUuid/);
+  assert.match(source, /diffEditor\.getOriginalEditor\(\)/);
+  assert.match(source, /diffEditor\.getModifiedEditor\(\)/);
+  assert.match(resourceSource, /reviewBaseFileUri\(session, displayPath\)/);
+  assert.match(resourceSource, /reviewHeadFileUri\(session, displayPath\)/);
 });
 
 test("light-theme comments use light surfaces and preserve the diff tint", () => {
@@ -170,10 +168,7 @@ test("light-theme comments use light surfaces and preserve the diff tint", () =>
     reviewStyles,
     /\.monaco-workbench\.review-workbench\.vs\s*{[^}]*--review-comment-surface:\s*var\(--vscode-editorWidget-background, #ffffff\);[^}]*--review-comment-footer:[^}]*--review-comment-shadow:\s*rgb\(0 0 0 \/ 12%\);/s,
   );
-  assert.match(
-    reviewStyles,
-    /color:\s*var\(--review-comment-chip-ink\);/,
-  );
+  assert.match(reviewStyles, /color:\s*var\(--review-comment-chip-ink\);/);
   assert.match(
     reviewStyles,
     /box-shadow:\s*0 10px 28px var\(--review-comment-shadow\);/,
@@ -221,10 +216,7 @@ test("peek scrolling is confined to the window's rendered range", () => {
 
 test("peek code intelligence widgets escape the canvas clip", () => {
   assert.match(source, /fixedOverflowWidgets:\s*true/);
-  assert.match(
-    source,
-    /inlineEditorOptions\(this\.overflowWidgetsDomNode\)/,
-  );
+  assert.match(source, /inlineEditorOptions\(this\.overflowWidgetsDomNode\)/);
   // Multi-diff inner editors get the node through the UI-element factory,
   // not a widget constructor param — keeps upstream call sites untouched.
   assert.match(

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -1247,13 +1247,19 @@ export function createGlobalReviewServer(
         "review_unbound",
       );
     }
+    const baseRootPath = await ensureReviewPinnedCheckout({
+      rootPath: registration.review.review.worktreePath,
+      ref: registration.review.review.baseCommit,
+      reviewUuid: registration.review.review.uuid,
+      role: "base",
+    });
     const headRootPath = await ensureReviewPinnedCheckout({
       rootPath: registration.review.review.worktreePath,
       ref: sourceCommit,
       reviewUuid: registration.review.review.uuid,
       role: "head",
     });
-    if (!headRootPath) {
+    if (!baseRootPath || !headRootPath) {
       throw new ReviewServerError(
         `Review ${registration.review.review.uuid} cannot create its managed checkout.`,
         409,
@@ -1266,6 +1272,7 @@ export function createGlobalReviewServer(
       boundPort,
       registration.documentPath,
       registration.source,
+      baseRootPath,
       headRootPath,
     );
     let active!: ActiveReviewSession;
@@ -1869,6 +1876,7 @@ function sessionWireFor(
   port: number,
   documentPath: string,
   source?: ActiveReviewSession["source"],
+  baseRootPath?: string,
   headRootPath?: string,
 ): ReviewSessionWire {
   const headRef = source?.sourceCommit ?? review.review.sourceCommit;
@@ -1883,6 +1891,7 @@ function sessionWireFor(
   return {
     sessionId: descriptor.sessionId,
     rootPath: review.review.worktreePath,
+    baseRootPath,
     headRootPath,
     baseRef: review.review.baseCommit,
     headRef,

--- a/packages/review-protocol/src/contracts.test.ts
+++ b/packages/review-protocol/src/contracts.test.ts
@@ -103,6 +103,8 @@ const reviewDescriptor = {
 const session = {
   sessionId: "session-1",
   rootPath: "/tmp/repo",
+  baseRootPath: "/tmp/review-base",
+  headRootPath: "/tmp/review-head",
   baseRef: "main",
   routePath: "/",
   appUrl: "http://127.0.0.1:5570/",

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1543,6 +1543,7 @@ export type ReviewDesktopGlobalEvent = z.infer<
 export const ReviewSessionSchema = z.strictObject({
   sessionId: requiredString.optional(),
   rootPath: requiredString,
+  baseRootPath: requiredString.optional(),
   headRootPath: requiredString.optional(),
   baseRef: requiredString,
   headRef: requiredString.optional(),


### PR DESCRIPTION
## Summary
- render authored CodePeeks with the existing native two-sided diff editor instead of a synthetic unified text model
- materialize and expose a pinned base checkout alongside the pinned head checkout so both editor models are real files
- project comments onto each real diff side, including deleted base-side lines

## Why
Synthetic `devfast-review-unified:` models do not participate in normal TypeScript project resolution, so imports and definitions fail inside authored peeks. Real pinned file models restore the normal language-provider path without proxying every provider.

## Verification
- `pnpm --filter @dev-fast/review-desktop test`
- `pnpm --filter @dev.fast/review test` (1,109 tests)
- `pnpm --filter @dev.fast/review-protocol test`
- `pnpm --filter @dev.fast/review-protocol typecheck`
- `pnpm --filter @dev.fast/review typecheck`
- `pnpm dev` build + launch