### PR TITLE
Revise dev-review landing-section guidance

### DIFF
--- a/packages/progressive-review/skills/dev-review/references/document-authoring.md
+++ b/packages/progressive-review/skills/dev-review/references/document-authoring.md
@@ -10,13 +10,16 @@ Assume raw prose will confuse the reader. Spend substantial reasoning effort dec
 
 Remember that the reader can ONLY see the 'user' prompts _before_ coding started and the document you write to explain what changed. This means jargon in the middle - references to specific parts of code, especially any and all abstractions, changes, and code referenced _during_ the editing process - is confusing and not helpful. More words do not help. Progressive disclosure of complexity is key.
 
-Open the document with a landing section. The landing section should be brief, and include both of the following, on separate lines:
+Open the document with a landing section after the H1 and before the first H2. Be concise.
 
-**Problem**: [What problem does this change solve? (What problem(s) is this change not trying to solve?) For a bugfix, this can be what was wrong before; for a new feature, this can be what this adds.]
-**Summary**: [A short description of the change, two to three sentences at most.]
+**Summary** 
+- short bullet points that summarize the change, for example:
+- comment peeks now open in the real diff editor, not a stitched-together fake buffer
+- both diff sides are actual files on disk, so imports and go-to-definition just work
+- comments stick to real lines — deleted ones included
 
-- Answer the 'why' behind the change completely (in the developer's own words, if we have agent traces,) capturing the intent behind the pr. Answer the 'what' briefly. The detail belongs in the later sections.
-- Define each domain term at its first mention.
+**Why**
+A couple short sentences about: What problem does this change solve? (What problem(s) is this change not trying to solve?) For a bugfix, this can be what was wrong before; for a new feature, this can be what this adds. Capture the intent behind the pr using the developer's own prompts, if those are available to you (either through associated agent trace sessions, or your own context window, if you have the implementation session in context.)
 
 After the landing section, use fewer than five further sections when practical. Choose the sections that fit this change. Good section choices are:
 

--- a/packages/progressive-review/skills/dev-review/references/trace-quoting.md
+++ b/packages/progressive-review/skills/dev-review/references/trace-quoting.md
@@ -76,7 +76,7 @@ Use `trace_quote_props` from the response without reconstructing it. Every `Trac
 
 ## Quote density by section
 
-- Landing section: This section should almost entirely be composed from user (or, maybe, agent-written, but user-approved later on) quotes, save for some glue words connecting the quotes. The two-to-four-sentence cap holds; short quotes beat long ones here. the most important thing is to capture the user's intent, in their words, which led to the code change in the pinned diff.
+- Landing section: The 'why' of this section should almost entirely be composed from quotes of user prompts (or agent messages that were later approved by the user), save for some glue words connecting the quotes. Keep it concise; short quotes beat long ones here. The most important thing is to capture the user's intent, in their words, which led to the code change in the pinned diff.
 - Requirements: at least one quote per bullet.
 - Design: a quote states each decision. An `AnchorLink` shows the decision in code.
 - Implementation: authored prose with `AnchorLink` evidence. Quotes are optional.


### PR DESCRIPTION
## Summary
- lead review documents with a concise bullet summary after the H1
- separate the motivation into a short Why section grounded in the original user prompts
- align the trace-quoting guidance with the revised landing-section structure

## Why
The existing guidance prescribes Problem and Summary lines but does not produce the most skimmable opening for a progressive review. This revision makes the landing section easier to scan while preserving the original intent and quote-grounding requirements.

## Verification
- Documentation-only change; no automated tests run.