### PR TITLE
Resolve language features from unified CodePeeks

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewCodeResources.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewCodeResources.ts
@@ -17,6 +17,7 @@ export const REVIEW_UNIFIED_SCHEME = "devfast-review-unified";
 export interface ReviewResourceSession {
   readonly session: {
     readonly rootPath: string;
+    readonly baseRootPath?: string;
     readonly headRootPath?: string;
   };
 }
@@ -66,6 +67,15 @@ export function reviewHeadFileUri(
   return reviewFileUri({ session: { rootPath: headRootPath } }, filePath);
 }
 
+export function reviewBaseFileUri(
+  session: ReviewResourceSession,
+  filePath: string,
+): URI | undefined {
+  const baseRootPath = session.session.baseRootPath;
+  if (!baseRootPath) return undefined;
+  return reviewFileUri({ session: { rootPath: baseRootPath } }, filePath);
+}
+
 export function reviewResourceIdentity(
   session: ReviewResourceIdentitySession,
   resource: URI,
@@ -81,7 +91,11 @@ export function reviewResourceIdentity(
   }
   if (resource.scheme !== "file") return null;
 
-  const roots = [session.session.headRootPath, session.session.rootPath];
+  const roots = [
+    session.session.headRootPath,
+    session.session.baseRootPath,
+    session.session.rootPath,
+  ];
   for (const rootPath of roots) {
     if (!rootPath) continue;
     const relative = extUri.relativePath(URI.file(rootPath), resource);

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
@@ -1546,6 +1546,7 @@ export type ReviewDesktopGlobalEvent = z.infer<
 export const ReviewSessionSchema = z.strictObject({
   sessionId: requiredString.optional(),
   rootPath: requiredString,
+  baseRootPath: requiredString.optional(),
   headRootPath: requiredString.optional(),
   baseRef: requiredString,
   headRef: requiredString.optional(),

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewCodeResourceService.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewCodeResourceService.test.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Event } from "../../base/common/event.js";
+import { URI } from "../../base/common/uri.js";
+import { ReviewCodeResourceService } from "./reviewCodeResourceService.js";
+
+test("diff targets use the pinned base and head checkouts", async () => {
+  const session = {
+    sessionId: "session-1",
+    rootPath: "/tmp/review-worktree",
+    baseRootPath: "/tmp/review-base",
+    headRootPath: "/tmp/review-head",
+    baseRef: "base",
+    resolvedBaseRef: "base",
+    headRef: "head",
+    routePath: "/",
+  };
+  const service = new ReviewCodeResourceService(
+    {
+      registerTextModelContentProvider: () => ({ dispose() {} }),
+    } as never,
+    {} as never,
+    {} as never,
+    {
+      activeModel: {
+        session: {
+          session,
+          sessionUrl: "http://127.0.0.1:5570/sessions/session-1",
+          token: "token",
+        },
+        request: async () =>
+          new Response(
+            JSON.stringify({
+              ok: true,
+              files: [
+                {
+                  path: "src/new.ts",
+                  previousPath: "src/old.ts",
+                  status: "renamed",
+                  additions: 2,
+                  deletions: 2,
+                },
+              ],
+            }),
+            { status: 200 },
+          ),
+      },
+      onDidChangeActiveModel: Event.None,
+    } as never,
+  );
+
+  const base = await service.target("src/new.ts", "base");
+  const head = await service.target("src/new.ts", "head");
+
+  assert.equal(
+    base.resource.toString(),
+    URI.file("/tmp/review-base/src/old.ts").toString(),
+  );
+  assert.equal(
+    head.resource.toString(),
+    URI.file("/tmp/review-head/src/new.ts").toString(),
+  );
+  assert.equal(base.workingTreeFallback, false);
+  assert.equal(head.workingTreeFallback, false);
+  service.dispose();
+});

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewCodeResourceService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewCodeResourceService.ts
@@ -18,6 +18,7 @@ import {
   REVIEW_BASE_SCHEME,
   REVIEW_HEAD_SCHEME,
   REVIEW_UNIFIED_SCHEME,
+  reviewBaseFileUri,
   reviewFileUri,
   reviewHeadFileUri,
   reviewVirtualUri,
@@ -38,6 +39,7 @@ import {
 export {
   REVIEW_BASE_SCHEME,
   REVIEW_HEAD_SCHEME,
+  reviewBaseFileUri,
   reviewFileUri,
   reviewHeadFileUri,
   reviewResourceIdentity,
@@ -289,35 +291,37 @@ export class ReviewCodeResourceService
     }
     const diffFile = reviewDiffFileForReveal(files, path, side);
     if (!diffFile) {
-      const headResource =
-        side === "head" && !scope ? reviewHeadFileUri(session, path) : undefined;
+      const pinnedResource = !scope
+        ? side === "base"
+          ? reviewBaseFileUri(session, path)
+          : reviewHeadFileUri(session, path)
+        : undefined;
       return {
-        resource: headResource ?? reviewFileUri(session, path),
-        workingTreeFallback: !headResource,
+        resource: pinnedResource ?? reviewFileUri(session, path),
+        workingTreeFallback: !pinnedResource,
       };
     }
     const displayPath =
       side === "base"
         ? (diffFile.previousPath ?? diffFile.path)
         : diffFile.path;
+    const pinnedResource = !scope
+      ? side === "base" && diffFile.status !== "added"
+        ? reviewBaseFileUri(session, displayPath)
+        : side === "head" && diffFile.status !== "deleted"
+          ? reviewHeadFileUri(session, displayPath)
+          : undefined
+      : undefined;
     return {
       resource:
-        side === "head" && diffFile.status !== "deleted"
-          ? ((!scope ? reviewHeadFileUri(session, displayPath) : undefined) ??
-            reviewVirtualUri(
-              side,
-              displayPath,
-              diffFile.path,
-              session.session.sessionId,
-              scope?.commit,
-            ))
-          : reviewVirtualUri(
-              side,
-              displayPath,
-              diffFile.path,
-              session.session.sessionId,
-              scope?.commit,
-            ),
+        pinnedResource ??
+        reviewVirtualUri(
+          side,
+          displayPath,
+          diffFile.path,
+          session.session.sessionId,
+          scope?.commit,
+        ),
       diffFile,
       workingTreeFallback: false,
     };
@@ -582,11 +586,16 @@ export class ReviewCodeResourceService
       };
     }
     if (resource.scheme !== "file") return null;
-    const rootPath = session.session.headRootPath;
-    if (!rootPath) return null;
-    const path = extUri.relativePath(URI.file(rootPath), resource);
-    if (!path || path.startsWith("../")) return null;
-    return { path, side: "head" };
+    const roots: readonly [string | undefined, ReviewDiffSide][] = [
+      [session.session.headRootPath, "head"],
+      [session.session.baseRootPath, "base"],
+    ];
+    for (const [rootPath, side] of roots) {
+      if (!rootPath) continue;
+      const path = extUri.relativePath(URI.file(rootPath), resource);
+      if (path && !path.startsWith("../")) return { path, side };
+    }
+    return null;
   }
 
   reset(): void {
@@ -709,6 +718,7 @@ export class ReviewCodeResourceService
       session.headRef,
       session.routePath ?? "",
       session.rootPath,
+      session.baseRootPath ?? "",
       session.headRootPath ?? "",
     ].join("\n");
   }

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewInlineEditorService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewInlineEditorService.ts
@@ -33,7 +33,10 @@ import type {
   ICompositeCodeEditor,
   IEditorDecorationsCollection,
 } from "../../editor/common/editorCommon.js";
+import { getDefinitionsAtPosition } from "../../editor/contrib/gotoSymbol/browser/goToSymbol.js";
+import { getHoversPromise } from "../../editor/contrib/hover/browser/getHover.js";
 import type { ITextModel } from "../../editor/common/model.js";
+import { ILanguageFeaturesService } from "../../editor/common/services/languageFeatures.js";
 import { ITextModelService } from "../../editor/common/services/resolverService.js";
 import { ITextResourceConfigurationService } from "../../editor/common/services/textResourceConfiguration.js";
 import { IInstantiationService } from "../../platform/instantiation/common/instantiation.js";
@@ -70,12 +73,17 @@ import {
 } from "./reviewMultiDiff.js";
 import { markReviewEmbeddedEditor } from "./reviewEmbeddedNavigation.js";
 import {
+  provideReviewUnifiedDefinition,
+  provideReviewUnifiedHover,
+} from "./reviewUnifiedDefinition.js";
+import {
   computeMultiDiffEditorOptions,
   MultiDiffEditorInput,
 } from "../../workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.js";
 import { MultiDiffEditorItem } from "../../workbench/contrib/multiDiffEditor/browser/multiDiffSourceResolverService.js";
 import { ID as COMMENT_EDITOR_CONTRIBUTION_ID } from "../../workbench/contrib/comments/browser/commentsController.js";
 import { ContentHoverController } from "../../editor/contrib/hover/browser/contentHoverController.js";
+import { IExtensionService } from "../../workbench/services/extensions/common/extensions.js";
 
 const INLINE_HEADER_HEIGHT = MULTI_DIFF_RESOURCE_HEADER_HEIGHT;
 const CONTENT_HEIGHT_EPSILON = 0.5;
@@ -129,14 +137,54 @@ export class ReviewInlineEditorService
     private readonly textResourceConfigurationService: ITextResourceConfigurationService,
     @ICodeEditorService
     private readonly codeEditorService: ICodeEditorService,
+    @ILanguageFeaturesService
+    private readonly languageFeaturesService: ILanguageFeaturesService,
     @ITextModelService
     private readonly textModelService: ITextModelService,
+    @IExtensionService
+    private readonly extensionService: IExtensionService,
   ) {
     super();
     this._register(
       this.codeEditorService.registerCodeEditorOpenHandler(
         (input, source, sideBySide) =>
           this.openUnifiedNavigation(input, source, sideBySide),
+      ),
+    );
+    this._register(
+      this.languageFeaturesService.definitionProvider.register(
+        { scheme: REVIEW_UNIFIED_SCHEME, exclusive: true },
+        {
+          provideDefinition: (model, position, token) =>
+            provideReviewUnifiedDefinition(
+              this.resources,
+              this.textModelService,
+              this.extensionService,
+              this.languageFeaturesService.definitionProvider,
+              model,
+              position,
+              token,
+              getDefinitionsAtPosition,
+            ),
+        },
+      ),
+    );
+    this._register(
+      this.languageFeaturesService.hoverProvider.register(
+        { scheme: REVIEW_UNIFIED_SCHEME, exclusive: true },
+        {
+          provideHover: (model, position, token) =>
+            provideReviewUnifiedHover(
+              this.resources,
+              this.textModelService,
+              this.extensionService,
+              this.languageFeaturesService.hoverProvider,
+              model,
+              position,
+              token,
+              getHoversPromise,
+            ),
+        },
       ),
     );
   }

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewUnifiedDefinition.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewUnifiedDefinition.test.ts
@@ -1,0 +1,318 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CancellationToken } from "../../base/common/cancellation.js";
+import { URI } from "../../base/common/uri.js";
+import { Position } from "../../editor/common/core/position.js";
+import { Range } from "../../editor/common/core/range.js";
+import {
+  reviewBaseFileUri,
+  reviewHeadFileUri,
+} from "../common/reviewCodeResources.js";
+
+test("unified definitions delegate base and head rows to their pinned models", async () => {
+  Object.assign(globalThis, {
+    window: globalThis,
+    location: { href: "http://localhost/" },
+  });
+  const { provideReviewUnifiedDefinition } = await import(
+    "./reviewUnifiedDefinition.js"
+  );
+  const session = {
+    session: {
+      rootPath: "/tmp/review-worktree",
+      baseRootPath: "/tmp/review-base",
+      headRootPath: "/tmp/review-head",
+    },
+  };
+  const unifiedResource = URI.from({
+    scheme: "devfast-review-unified",
+    path: "/src/example.ts",
+  });
+
+  for (const sample of [
+    { side: "base" as const, sourceLine: 17, unifiedLine: 4 },
+    { side: "head" as const, sourceLine: 23, unifiedLine: 9 },
+  ]) {
+    const expectedResource =
+      sample.side === "base"
+        ? reviewBaseFileUri(session, "src/example.ts")
+        : reviewHeadFileUri(session, "src/example.ts");
+    assert.ok(expectedResource);
+    let disposed = false;
+    const sourceModel = {
+      uri: expectedResource,
+      getLanguageId: () => "typescript",
+      validatePosition: (position: Position) => position,
+    };
+    const resources = {
+      unifiedResource: (resource: URI) =>
+        resource.toString() === unifiedResource.toString()
+          ? {
+              targetForRange: (startLine: number, endLine: number) => {
+                assert.equal(startLine, sample.unifiedLine);
+                assert.equal(endLine, sample.unifiedLine);
+                return {
+                  path: "src/example.ts",
+                  side: sample.side,
+                  startLine: sample.sourceLine,
+                  endLine: sample.sourceLine,
+                };
+              },
+            }
+          : undefined,
+      target: async (path: string, side: string) => {
+        assert.equal(path, "src/example.ts");
+        assert.equal(side, sample.side);
+        return {
+          resource: expectedResource,
+          workingTreeFallback: false,
+        };
+      },
+    };
+    const textModelService = {
+      createModelReference: async (resource: URI) => {
+        assert.equal(resource.toString(), expectedResource.toString());
+        return {
+          object: { textEditorModel: sourceModel },
+          dispose: () => {
+            disposed = true;
+          },
+        };
+      },
+    };
+    const unifiedModel = {
+      uri: unifiedResource,
+      validateRange: (range: Range) => range,
+    };
+    let activated = false;
+    const definitionCalls: Position[] = [];
+    const definitions = await provideReviewUnifiedDefinition(
+      resources as never,
+      textModelService as never,
+      {
+        activateByEvent: async (event: string) => {
+          assert.equal(event, "onLanguage:typescript");
+          activated = true;
+        },
+      } as never,
+      {} as never,
+      unifiedModel as never,
+      new Position(sample.unifiedLine, 8),
+      CancellationToken.None,
+      async (_providers, model, position, recursive, token) => {
+        assert.equal(activated, true);
+        assert.strictEqual(model, sourceModel);
+        assert.equal(recursive, false);
+        assert.strictEqual(token, CancellationToken.None);
+        definitionCalls.push(position);
+        if (definitionCalls.length === 1) {
+          assert.deepEqual(position, new Position(sample.sourceLine, 8));
+          return [
+            {
+              uri: expectedResource,
+              range: new Range(2, 10, 2, 24),
+              targetSelectionRange: new Range(2, 10, 2, 24),
+              originSelectionRange: new Range(
+                sample.sourceLine,
+                7,
+                sample.sourceLine,
+                15,
+              ),
+            },
+          ];
+        }
+        assert.deepEqual(position, new Position(2, 10));
+        return [
+          {
+            uri: URI.file("/tmp/definition.ts"),
+            range: new Range(2, 1, 2, 12),
+            originSelectionRange: new Range(
+              sample.sourceLine,
+              7,
+              sample.sourceLine,
+              15,
+            ),
+          },
+        ];
+      },
+    );
+
+    assert.equal(definitions.length, 1);
+    assert.equal(
+      definitions[0]?.uri.toString(),
+      URI.file("/tmp/definition.ts").toString(),
+    );
+    assert.deepEqual(
+      definitions[0]?.originSelectionRange,
+      new Range(sample.unifiedLine, 7, sample.unifiedLine, 15),
+    );
+    assert.equal(disposed, true);
+  }
+});
+
+test("unified hovers delegate base and head rows to their pinned models", async () => {
+  Object.assign(globalThis, {
+    window: globalThis,
+    location: { href: "http://localhost/" },
+  });
+  const { provideReviewUnifiedHover } = await import(
+    "./reviewUnifiedDefinition.js"
+  );
+  const unifiedResource = URI.from({
+    scheme: "devfast-review-unified",
+    path: "/src/example.ts",
+  });
+
+  for (const sample of [
+    {
+      side: "base" as const,
+      sourceLine: 17,
+      unifiedLine: 4,
+      resource: URI.file("/tmp/review-base/src/example.ts"),
+    },
+    {
+      side: "head" as const,
+      sourceLine: 23,
+      unifiedLine: 9,
+      resource: URI.file("/tmp/review-head/src/example.ts"),
+    },
+  ]) {
+    let activated = false;
+    let disposed = false;
+    const sourceModel = {
+      uri: sample.resource,
+      getLanguageId: () => "typescript",
+      validatePosition: (position: Position) => position,
+    };
+    const hover = await provideReviewUnifiedHover(
+      {
+        unifiedResource: () => ({
+          targetForRange: () => ({
+            path: "src/example.ts",
+            side: sample.side,
+            startLine: sample.sourceLine,
+            endLine: sample.sourceLine,
+          }),
+        }),
+        target: async (_path: string, side: string) => {
+          assert.equal(side, sample.side);
+          return { resource: sample.resource, workingTreeFallback: false };
+        },
+      } as never,
+      {
+        createModelReference: async (resource: URI) => {
+          assert.equal(resource.toString(), sample.resource.toString());
+          return {
+            object: { textEditorModel: sourceModel },
+            dispose: () => {
+              disposed = true;
+            },
+          };
+        },
+      } as never,
+      {
+        activateByEvent: async (event: string) => {
+          assert.equal(event, "onLanguage:typescript");
+          activated = true;
+        },
+      } as never,
+      {} as never,
+      {
+        uri: unifiedResource,
+        validateRange: (range: Range) => range,
+      } as never,
+      new Position(sample.unifiedLine, 8),
+      CancellationToken.None,
+      async (_providers, model, position, token, recursive) => {
+        assert.equal(activated, true);
+        assert.strictEqual(model, sourceModel);
+        assert.deepEqual(position, new Position(sample.sourceLine, 8));
+        assert.strictEqual(token, CancellationToken.None);
+        assert.equal(recursive, false);
+        return [
+          {
+            contents: [{ value: "function signature" }],
+            range: new Range(sample.sourceLine, 7, sample.sourceLine, 15),
+          },
+          { contents: [{ value: "documentation" }] },
+        ];
+      },
+    );
+
+    assert.deepEqual(
+      hover?.contents.map((content) => content.value),
+      ["function signature", "documentation"],
+    );
+    assert.deepEqual(
+      hover?.range,
+      new Range(sample.unifiedLine, 7, sample.unifiedLine, 15),
+    );
+    assert.equal(disposed, true);
+  }
+});
+
+test("unified definition model references are disposed when delegation fails", async () => {
+  Object.assign(globalThis, {
+    window: globalThis,
+    location: { href: "http://localhost/" },
+  });
+  const { provideReviewUnifiedDefinition } = await import(
+    "./reviewUnifiedDefinition.js"
+  );
+  const unifiedResource = URI.from({
+    scheme: "devfast-review-unified",
+    path: "/src/example.ts",
+  });
+  let disposed = false;
+
+  await assert.rejects(
+    provideReviewUnifiedDefinition(
+      {
+        unifiedResource: () => ({
+          targetForRange: () => ({
+            path: "src/example.ts",
+            side: "base",
+            startLine: 17,
+            endLine: 17,
+          }),
+        }),
+        target: async () => ({
+          resource: URI.file("/tmp/review-base/src/example.ts"),
+          workingTreeFallback: false,
+        }),
+      } as never,
+      {
+        createModelReference: async () => ({
+          object: {
+            textEditorModel: {
+              getLanguageId: () => "typescript",
+              validatePosition: (position: Position) => position,
+            },
+          },
+          dispose: () => {
+            disposed = true;
+          },
+        }),
+      } as never,
+      { activateByEvent: async () => undefined } as never,
+      {} as never,
+      {
+        uri: unifiedResource,
+        validateRange: (range: Range) => range,
+      } as never,
+      new Position(4, 8),
+      CancellationToken.None,
+      async () => {
+        throw new Error("definition provider failed");
+      },
+    ),
+    /definition provider failed/,
+  );
+  assert.equal(disposed, true);
+});

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewUnifiedDefinition.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewUnifiedDefinition.ts
@@ -1,0 +1,226 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { CancellationToken } from "../../base/common/cancellation.js";
+import { Position } from "../../editor/common/core/position.js";
+import { Range } from "../../editor/common/core/range.js";
+import type { LanguageFeatureRegistry } from "../../editor/common/languageFeatureRegistry.js";
+import type {
+  DefinitionProvider,
+  Hover,
+  HoverProvider,
+  LocationLink,
+} from "../../editor/common/languages.js";
+import type { ITextModel } from "../../editor/common/model.js";
+import type { ITextModelService } from "../../editor/common/services/resolverService.js";
+import type { IExtensionService } from "../../workbench/services/extensions/common/extensions.js";
+import type { IReviewCodeResourceService } from "./reviewCodeResourceService.js";
+
+type UnifiedLanguageFeatureResources = Pick<
+  IReviewCodeResourceService,
+  "target" | "unifiedResource"
+>;
+type UnifiedLanguageFeatureModelService = Pick<
+  ITextModelService,
+  "createModelReference"
+>;
+type UnifiedLanguageFeatureExtensionService = Pick<
+  IExtensionService,
+  "activateByEvent"
+>;
+type DefinitionResolver = (
+  providers: LanguageFeatureRegistry<DefinitionProvider>,
+  model: ITextModel,
+  position: Position,
+  recursive: boolean,
+  token: CancellationToken,
+) => Promise<LocationLink[]>;
+type HoverResolver = (
+  providers: LanguageFeatureRegistry<HoverProvider>,
+  model: ITextModel,
+  position: Position,
+  token: CancellationToken,
+  recursive: boolean,
+) => Promise<Hover[]>;
+
+interface UnifiedSourcePosition {
+  readonly sourceModel: ITextModel;
+  readonly sourcePosition: Position;
+  readonly unifiedLine: number;
+}
+
+export async function provideReviewUnifiedDefinition(
+  resources: UnifiedLanguageFeatureResources,
+  textModelService: UnifiedLanguageFeatureModelService,
+  extensionService: UnifiedLanguageFeatureExtensionService,
+  definitionProviders: LanguageFeatureRegistry<DefinitionProvider>,
+  model: ITextModel,
+  position: Position,
+  token: CancellationToken,
+  resolveDefinitions: DefinitionResolver,
+): Promise<LocationLink[]> {
+  return withReviewUnifiedSourcePosition(
+    resources,
+    textModelService,
+    extensionService,
+    model,
+    position,
+    [],
+    async ({ sourceModel, sourcePosition, unifiedLine }) => {
+      const definitions = await resolveDefinitions(
+        definitionProviders,
+        sourceModel,
+        sourcePosition,
+        false,
+        token,
+      );
+      const resolvedDefinitions = (
+        await Promise.all(
+          definitions.map(async (definition) => {
+            const targets = await followSameFileDefinition(
+              definitionProviders,
+              sourceModel,
+              definition,
+              token,
+              resolveDefinitions,
+            );
+            return targets.map((targetDefinition) => ({
+              ...targetDefinition,
+              originSelectionRange: definition.originSelectionRange,
+            }));
+          }),
+        )
+      ).flat();
+      return resolvedDefinitions.map((definition) => ({
+        ...definition,
+        originSelectionRange: definition.originSelectionRange
+          ? model.validateRange(
+              new Range(
+                unifiedLine,
+                definition.originSelectionRange.startColumn,
+                unifiedLine,
+                definition.originSelectionRange.endColumn,
+              ),
+            )
+          : undefined,
+      }));
+    },
+  );
+}
+
+export async function provideReviewUnifiedHover(
+  resources: UnifiedLanguageFeatureResources,
+  textModelService: UnifiedLanguageFeatureModelService,
+  extensionService: UnifiedLanguageFeatureExtensionService,
+  hoverProviders: LanguageFeatureRegistry<HoverProvider>,
+  model: ITextModel,
+  position: Position,
+  token: CancellationToken,
+  resolveHovers: HoverResolver,
+): Promise<Hover | undefined> {
+  return withReviewUnifiedSourcePosition(
+    resources,
+    textModelService,
+    extensionService,
+    model,
+    position,
+    undefined,
+    async ({ sourceModel, sourcePosition, unifiedLine }) => {
+      const hovers = await resolveHovers(
+        hoverProviders,
+        sourceModel,
+        sourcePosition,
+        token,
+        false,
+      );
+      const first = hovers[0];
+      if (!first) return undefined;
+      return {
+        ...first,
+        contents: hovers.flatMap((hover) => hover.contents),
+        range: first.range
+          ? model.validateRange(
+              new Range(
+                unifiedLine,
+                first.range.startColumn,
+                unifiedLine,
+                first.range.endColumn,
+              ),
+            )
+          : undefined,
+      };
+    },
+  );
+}
+
+async function withReviewUnifiedSourcePosition<T>(
+  resources: UnifiedLanguageFeatureResources,
+  textModelService: UnifiedLanguageFeatureModelService,
+  extensionService: UnifiedLanguageFeatureExtensionService,
+  model: ITextModel,
+  position: Position,
+  fallback: T,
+  provide: (position: UnifiedSourcePosition) => Promise<T>,
+): Promise<T> {
+  const unified = resources.unifiedResource(model.uri);
+  const mapped = unified?.targetForRange(
+    position.lineNumber,
+    position.lineNumber,
+  );
+  if (!mapped) return fallback;
+
+  const target = await resources.target(mapped.path, mapped.side);
+  const sourceReference = await textModelService.createModelReference(
+    target.resource,
+  );
+  try {
+    const sourceModel = sourceReference.object.textEditorModel;
+    if (!sourceModel) return fallback;
+    const sourcePosition = sourceModel.validatePosition(
+      new Position(mapped.startLine, position.column),
+    );
+    await extensionService.activateByEvent(
+      `onLanguage:${sourceModel.getLanguageId()}`,
+    );
+    return provide({
+      sourceModel,
+      sourcePosition,
+      unifiedLine: position.lineNumber,
+    });
+  } finally {
+    sourceReference.dispose();
+  }
+}
+
+async function followSameFileDefinition(
+  definitionProviders: LanguageFeatureRegistry<DefinitionProvider>,
+  sourceModel: ITextModel,
+  definition: LocationLink,
+  token: CancellationToken,
+  resolveDefinitions: DefinitionResolver,
+): Promise<LocationLink[]> {
+  if (definition.uri.toString() !== sourceModel.uri.toString()) {
+    return [definition];
+  }
+  const targetRange = Range.lift(
+    definition.targetSelectionRange ?? definition.range,
+  );
+  const definitions = await resolveDefinitions(
+    definitionProviders,
+    sourceModel,
+    targetRange.getStartPosition(),
+    false,
+    token,
+  );
+  const forwarded = definitions.filter(
+    (candidate) =>
+      candidate.uri.toString() !== definition.uri.toString() ||
+      !Range.equalsRange(
+        candidate.targetSelectionRange ?? candidate.range,
+        targetRange,
+      ),
+  );
+  return forwarded.length > 0 ? forwarded : [definition];
+}

--- a/apps/review-desktop/scripts/inline-diff-editor-contract.test.mjs
+++ b/apps/review-desktop/scripts/inline-diff-editor-contract.test.mjs
@@ -72,6 +72,13 @@ const resourceSource = readFileSync(
   ),
   "utf8",
 );
+const unifiedDefinitionSource = readFileSync(
+  new URL(
+    "../code-oss/src/vs/review/services/reviewUnifiedDefinition.ts",
+    import.meta.url,
+  ),
+  "utf8",
+);
 const reviewConfiguration = readFileSync(
   new URL(
     "../code-oss/src/vs/review/common/reviewConfigurationDefaults.ts",
@@ -271,6 +278,49 @@ test("unified CodePeek navigation opens the mapped review resource", () => {
     /resolverReference = await this\.textModelService\.createModelReference/,
   );
   assert.match(resourceSource, /resolverReference\.dispose\(\)/);
+});
+
+test("unified CodePeek definitions delegate to the mapped source model", () => {
+  assert.match(
+    source,
+    /definitionProvider\.register\(\s*\{ scheme: REVIEW_UNIFIED_SCHEME, exclusive: true \}/,
+  );
+  assert.match(
+    unifiedDefinitionSource,
+    /unified\?\.targetForRange\(\s*position\.lineNumber,\s*position\.lineNumber/,
+  );
+  assert.match(
+    unifiedDefinitionSource,
+    /createModelReference\(\s*target\.resource,\s*\)/,
+  );
+  assert.match(
+    unifiedDefinitionSource,
+    /resolveDefinitions\(\s*definitionProviders,\s*sourceModel,\s*sourcePosition/,
+  );
+  assert.match(
+    unifiedDefinitionSource,
+    /activateByEvent\(\s*`onLanguage:\$\{sourceModel\.getLanguageId\(\)\}`/,
+  );
+  assert.match(
+    unifiedDefinitionSource,
+    /followSameFileDefinition\(\s*definitionProviders,\s*sourceModel,\s*definition/,
+  );
+  assert.match(unifiedDefinitionSource, /sourceReference\.dispose\(\)/);
+});
+
+test("unified CodePeek hovers delegate to the mapped source model", () => {
+  assert.match(
+    source,
+    /hoverProvider\.register\(\s*\{ scheme: REVIEW_UNIFIED_SCHEME, exclusive: true \}/,
+  );
+  assert.match(
+    unifiedDefinitionSource,
+    /resolveHovers\(\s*hoverProviders,\s*sourceModel,\s*sourcePosition/,
+  );
+  assert.match(
+    unifiedDefinitionSource,
+    /contents: hovers\.flatMap\(\(hover\) => hover\.contents\)/,
+  );
 });
 
 test("the multi-diff scroller releases the wheel at real content bounds", () => {

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -1247,13 +1247,19 @@ export function createGlobalReviewServer(
         "review_unbound",
       );
     }
+    const baseRootPath = await ensureReviewPinnedCheckout({
+      rootPath: registration.review.review.worktreePath,
+      ref: registration.review.review.baseCommit,
+      reviewUuid: registration.review.review.uuid,
+      role: "base",
+    });
     const headRootPath = await ensureReviewPinnedCheckout({
       rootPath: registration.review.review.worktreePath,
       ref: sourceCommit,
       reviewUuid: registration.review.review.uuid,
       role: "head",
     });
-    if (!headRootPath) {
+    if (!baseRootPath || !headRootPath) {
       throw new ReviewServerError(
         `Review ${registration.review.review.uuid} cannot create its managed checkout.`,
         409,
@@ -1266,6 +1272,7 @@ export function createGlobalReviewServer(
       boundPort,
       registration.documentPath,
       registration.source,
+      baseRootPath,
       headRootPath,
     );
     let active!: ActiveReviewSession;
@@ -1869,6 +1876,7 @@ function sessionWireFor(
   port: number,
   documentPath: string,
   source?: ActiveReviewSession["source"],
+  baseRootPath?: string,
   headRootPath?: string,
 ): ReviewSessionWire {
   const headRef = source?.sourceCommit ?? review.review.sourceCommit;
@@ -1883,6 +1891,7 @@ function sessionWireFor(
   return {
     sessionId: descriptor.sessionId,
     rootPath: review.review.worktreePath,
+    baseRootPath,
     headRootPath,
     baseRef: review.review.baseCommit,
     headRef,

--- a/packages/review-protocol/src/contracts.test.ts
+++ b/packages/review-protocol/src/contracts.test.ts
@@ -103,6 +103,8 @@ const reviewDescriptor = {
 const session = {
   sessionId: "session-1",
   rootPath: "/tmp/repo",
+  baseRootPath: "/tmp/review-base",
+  headRootPath: "/tmp/review-head",
   baseRef: "main",
   routePath: "/",
   appUrl: "http://127.0.0.1:5570/",

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1543,6 +1543,7 @@ export type ReviewDesktopGlobalEvent = z.infer<
 export const ReviewSessionSchema = z.strictObject({
   sessionId: requiredString.optional(),
   rootPath: requiredString,
+  baseRootPath: requiredString.optional(),
   headRootPath: requiredString.optional(),
   baseRef: requiredString,
   headRef: requiredString.optional(),


### PR DESCRIPTION
Keeps synthetic unified CodePeeks so deleted lines retain line numbers and comment interactions, while making Hover and Go to Definition resolve through the real pinned source models.

The original PR 14 failed for two independent reasons: language extension activation was asynchronous on a cold Review, and TypeScript first resolves an imported symbol to its local binding. This version explicitly awaits the language activation event, follows one same-file definition hop, and routes both base and head positions through pinned checkouts. Hover uses the same mapping and activation lifecycle, then maps its range back to the visible unified row.

Tests cover base/head mapping, cold activation ordering, hover content and range projection, import-alias forwarding, resource disposal, protocol plumbing, and the full desktop/server suites.