### PR TITLE
Fix fast-uri CVE in vendored lockfiles and pin Actions to SHAs

### DIFF
--- a/.github/workflows/review-desktop-ci.yml
+++ b/.github/workflows/review-desktop-ci.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
       - name: Setup monorepo Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -54,7 +54,7 @@ jobs:
             libx11-dev libxkbfile-dev libkrb5-dev libsecret-1-dev
 
       - name: Setup Code OSS Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: apps/review-desktop/code-oss/.nvmrc
           cache: npm
@@ -70,7 +70,7 @@ jobs:
       # tree and install only the delta.
       - name: Restore Code OSS dependencies
         id: code-oss-deps
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             apps/review-desktop/code-oss/node_modules
@@ -100,7 +100,7 @@ jobs:
 
       - name: Save Code OSS dependencies
         if: steps.code-oss-deps.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             apps/review-desktop/code-oss/node_modules

--- a/.github/workflows/review-desktop-release.yml
+++ b/.github/workflows/review-desktop-release.yml
@@ -42,7 +42,7 @@ jobs:
       # out over SSH with the release deploy key is therefore the one way this
       # job can land the version bump on main directly.
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
@@ -140,15 +140,15 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.tag.outputs.tag || github.sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
       - name: Setup monorepo Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -167,7 +167,7 @@ jobs:
             libx11-dev libxkbfile-dev libkrb5-dev libsecret-1-dev
 
       - name: Setup Code OSS Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: apps/review-desktop/code-oss/.nvmrc
           cache: npm
@@ -175,7 +175,7 @@ jobs:
 
       - name: Restore Code OSS dependencies
         id: code-oss-deps
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             apps/review-desktop/code-oss/node_modules
@@ -202,7 +202,7 @@ jobs:
         run: bash apps/review-desktop/scripts/compile-darwin-payload.sh
 
       - name: Upload darwin payload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: darwin-payload
           path: apps/review-desktop/dist/darwin-payload.tar.zst
@@ -212,7 +212,7 @@ jobs:
       - name: Check for existing Code OSS dependency cache
         if: steps.code-oss-deps.outputs.cache-hit != 'true'
         id: code-oss-deps-lookup
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             apps/review-desktop/code-oss/node_modules
@@ -221,7 +221,7 @@ jobs:
 
       - name: Save Code OSS dependencies
         if: steps.code-oss-deps.outputs.cache-hit != 'true' && steps.code-oss-deps-lookup.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             apps/review-desktop/code-oss/node_modules
@@ -246,15 +246,15 @@ jobs:
       RELEASE_TAG: ${{ needs.tag.outputs.tag }}
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.tag.outputs.tag || github.sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
       - name: Setup monorepo Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -263,7 +263,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup Code OSS Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: apps/review-desktop/code-oss/.nvmrc
           cache: npm
@@ -271,7 +271,7 @@ jobs:
 
       - name: Restore Code OSS dependencies
         id: code-oss-deps
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             apps/review-desktop/code-oss/node_modules
@@ -289,7 +289,7 @@ jobs:
             ${{ runner.os }}-code-oss-deps-v2-
 
       - name: Download darwin payload
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: darwin-payload
           path: ${{ runner.temp }}/darwin-payload
@@ -357,7 +357,7 @@ jobs:
       - name: Check for existing Code OSS dependency cache
         if: steps.code-oss-deps.outputs.cache-hit != 'true'
         id: code-oss-deps-lookup
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             apps/review-desktop/code-oss/node_modules
@@ -366,7 +366,7 @@ jobs:
 
       - name: Save Code OSS dependencies
         if: steps.code-oss-deps.outputs.cache-hit != 'true' && steps.code-oss-deps-lookup.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             apps/review-desktop/code-oss/node_modules

--- a/apps/review-desktop/code-oss/build/agent-sdk/agents/claude/package-lock.json
+++ b/apps/review-desktop/code-oss/build/agent-sdk/agents/claude/package-lock.json
@@ -645,9 +645,9 @@
 			"peer": true
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"funding": [
 				{
 					"type": "github",

--- a/apps/review-desktop/code-oss/build/package-lock.json
+++ b/apps/review-desktop/code-oss/build/package-lock.json
@@ -3278,9 +3278,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {

--- a/apps/review-desktop/code-oss/build/rspack/package-lock.json
+++ b/apps/review-desktop/code-oss/build/rspack/package-lock.json
@@ -871,7 +871,7 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
+      "version": "3.1.5",
       "dev": true,
       "funding": [
         {

--- a/apps/review-desktop/code-oss/test/mcp/package-lock.json
+++ b/apps/review-desktop/code-oss/test/mcp/package-lock.json
@@ -513,9 +513,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/apps/review-desktop/code-oss/test/monaco/package-lock.json
+++ b/apps/review-desktop/code-oss/test/monaco/package-lock.json
@@ -883,9 +883,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Two supply-chain fixes surfaced by a security pass after the repo went public.

## 1. `fast-uri` 3.1.2 → 3.1.5 in five vendored Code - OSS lockfiles

[GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) / CVE-2026-13676 — host confusion via failed IDN canonicalization, fixed in 3.1.3. This raises five **high**-severity Dependabot alerts.

**The shipping app was never affected.** `pnpm-workspace.yaml` already overrides `fast-uri` to 3.1.4, and `code-oss/package-lock.json` resolves 3.1.5. The five stragglers are build and test tooling:

| lockfile | scope |
| --- | --- |
| `build/package-lock.json` | dev |
| `build/rspack/package-lock.json` | dev |
| `build/agent-sdk/agents/claude/package-lock.json` | runtime (private, build tarball only) |
| `test/monaco/package-lock.json` | dev |
| `test/mcp/package-lock.json` | runtime (test fixtures) |

Bumped to 3.1.5 for consistency with what `code-oss/package-lock.json` already resolves. The integrity hash was verified by downloading the published tarball and recomputing SHA-512. Only `version`/`resolved`/`integrity` values changed — the rspack entry is a peer-only marker and keeps its deliberate lack of `resolved`/`integrity`.

## 2. Pin all 23 Actions references to commit SHAs

Every `uses:` resolved a mutable tag. `review-desktop-release.yml` runs with the Apple signing certificate, keychain password, and R2 credentials in scope, so a retagged release would execute alongside them. `pnpm/action-setup` is the only third-party action and the sharpest edge; its `v6` is an annotated tag, dereferenced here to the underlying commit.

Each SHA is the current tip of the tag it replaces, with the tag preserved in a trailing comment so the version stays readable and Dependabot can still propose updates.

## Verification

- fast-uri integrity hash recomputed from the real tarball — matches
- All five lockfiles still parse as valid JSON; diff is 13 insertions / 13 deletions, values only
- Workflow diff is 23/23 lines, **zero** non-`uses:` lines changed
- `actionlint` reports the same three pre-existing shellcheck findings before and after

## Not addressed here

The `review_release` self-hosted runner group has `allows_public_repositories=true`. Not currently exploitable — the only workflow using `review_big_boy` is dispatch-only and fork-reachable CI runs on `ubuntu-latest` — but it's worth closing separately, since adding a `pull_request` trigger to a self-hosted job would turn it into remote code execution on the build host.