### PR TITLE
Cache Review Home state in memory

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
@@ -1266,6 +1266,8 @@ export type ReviewThreadsCommandResponse = z.infer<
 export const ReviewOpenResponseSchema = z.strictObject({
   sessionId: requiredString,
   url: loopbackUrlSchema,
+  session: ReviewSessionDescriptorSchema,
+  review: ReviewDescriptorSchema,
 });
 export type ReviewOpenResponse = z.infer<typeof ReviewOpenResponseSchema>;
 
@@ -1277,6 +1279,7 @@ export const ReviewTutorialOpenResponseSchema = z.strictObject({
   sessionId: requiredString,
   url: loopbackUrlSchema,
   review: ReviewDescriptorSchema,
+  session: ReviewSessionDescriptorSchema,
 });
 export type ReviewTutorialOpenResponse = z.infer<
   typeof ReviewTutorialOpenResponseSchema
@@ -1490,6 +1493,9 @@ export const ReviewDesktopGlobalEventSchema = z.discriminatedUnion("event", [
   z.strictObject({
     event: z.literal("session-registered"),
     session: ReviewSessionDescriptorSchema,
+    /* Publish carries the newly authoritative Home row. Ordinary session
+       opens omit it because Home already has the published descriptor. */
+    review: ReviewDescriptorSchema.optional(),
     // True when the session was opened for a non-document surface (the
     // Source tab rooting its file tree): the app must not surface the
     // review document tab for it. Absent means foreground.
@@ -1509,6 +1515,7 @@ export const ReviewDesktopGlobalEventSchema = z.discriminatedUnion("event", [
     uuid: z.uuid({ error: "must be a UUID" }),
     sessionId: requiredString,
     commit: ReviewThreadsCommitSchema,
+    commentCount: nonNegativeInteger,
   }),
   z.strictObject({
     event: z.literal("session-closed"),
@@ -1531,6 +1538,9 @@ export const ReviewDesktopGlobalEventSchema = z.discriminatedUnion("event", [
     event: z.literal("review-attention-changed"),
     uuid: z.uuid({ error: "must be a UUID" }),
     attention: z.enum(["new", "viewed", "dismissed"]),
+    viewedAt: requiredString.nullable(),
+    dismissedAt: requiredString.nullable(),
+    reapsAt: requiredString.nullable(),
   }),
   z.strictObject({
     event: z.literal("preferences-changed"),

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.test.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+	ReviewDescriptor,
+	ReviewSessionDescriptor,
+} from "../common/reviewProtocol.js";
+import { ReviewSessionService } from "./reviewSessionService.js";
+
+const uuid = "11111111-1111-4111-8111-111111111111";
+const review: ReviewDescriptor = {
+	uuid,
+	title: "Cache me",
+	status: "awaiting-review",
+	worktreePath: "/tmp/review",
+	repoKey: "repo",
+	sourceBranch: "feature",
+	presentedDocumentRevision: "a".repeat(40),
+	presentedSoftwareMapRevision: null,
+	lastPublishedAt: "2026-08-25T00:00:00.000Z",
+	available: true,
+	viewedAt: null,
+	dismissedAt: null,
+	reapsAt: null,
+};
+const session: ReviewSessionDescriptor = {
+	sessionId: "session-1",
+	sessionUrl: "http://127.0.0.1:5000/sessions/session-1",
+	reviewUuid: uuid,
+	routePath: "/",
+	startedAt: 1,
+};
+
+function serviceWith(reviews: ReviewDescriptor[] = []): ReviewSessionService {
+	const service = new ReviewSessionService({} as never, {
+		appSessionId: "app-session",
+	} as never);
+	Object.assign(service, {
+		connection: {
+			version: 1,
+			url: "http://127.0.0.1:5000",
+			token: "token",
+			instanceId: "instance",
+		},
+		initializePromise: Promise.resolve(),
+		_reviews: reviews,
+	});
+	return service;
+}
+
+function mockFetch(
+	t: { after(callback: () => void): void },
+	handler: typeof fetch,
+): void {
+	const original = globalThis.fetch;
+	globalThis.fetch = handler;
+	t.after(() => {
+		globalThis.fetch = original;
+	});
+}
+
+test("confirmed dismiss updates the cached review", async (t) => {
+	const service = serviceWith([review]);
+	mockFetch(t, async () =>
+		Response.json({
+			ok: true,
+			uuid,
+			viewedAt: null,
+			dismissedAt: "2026-08-25T01:00:00.000Z",
+			reapsAt: "2026-09-24T01:00:00.000Z",
+		}),
+	);
+
+	await service.dismissReview(uuid);
+
+	assert.equal(service.reviews[0]?.dismissedAt, "2026-08-25T01:00:00.000Z");
+	service.dispose();
+});
+
+test("failed dismiss leaves the cached review unchanged", async (t) => {
+	const service = serviceWith([review]);
+	mockFetch(t, async () => Response.json({ error: "nope" }, { status: 500 }));
+
+	await assert.rejects(service.dismissReview(uuid), /nope/);
+
+	assert.strictEqual(service.reviews[0], review);
+	service.dispose();
+});
+
+test("open uses the returned descriptors without listing reviews", async (t) => {
+	const service = serviceWith([review]);
+	const requests: string[] = [];
+	mockFetch(t, async (input) => {
+		requests.push(String(input));
+		return Response.json({
+			sessionId: session.sessionId,
+			url: session.sessionUrl,
+			session,
+			review: { ...review, viewedAt: "2026-08-25T01:00:00.000Z" },
+		});
+	});
+
+	await service.openReview(uuid);
+
+	assert.deepEqual(requests, [`http://127.0.0.1:5000/reviews/${uuid}/open`]);
+	assert.deepEqual(service.sessions[0], session);
+	assert.equal(service.reviews[0]?.viewedAt, "2026-08-25T01:00:00.000Z");
+	service.dispose();
+});

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
@@ -165,6 +165,7 @@ export class ReviewSessionService
 		return this._reviews;
 	}
 	private _reviewErrors: ReviewListError[] = [];
+	private readonly deletedReviewNotifications = new Set<string>();
 	get reviewErrors(): readonly ReviewListError[] {
 		return this._reviewErrors;
 	}
@@ -176,6 +177,8 @@ export class ReviewSessionService
 	}
 
 	private initializePromise: Promise<void> | null = null;
+	private cliInstallStatus: ReviewCliInstallStatus | undefined;
+	private cliInstallStatusPromise: Promise<ReviewCliInstallStatus> | undefined;
 	private readonly controller = new AbortController();
 	private controlAttached = false;
 	private controlDispatch:
@@ -287,27 +290,23 @@ export class ReviewSessionService
 			);
 		}
 		const payload = parseReviewOpenResponse(await response.json());
-		await this.refreshLists();
-		const descriptor = this._sessionRecords.find(
-			(candidate) => candidate.sessionId === payload.sessionId,
-		);
-		if (!descriptor) {
-			throw new Error(`Review session is unavailable: ${payload.sessionId}`);
-		}
-		return descriptor;
+		this.upsertSession(payload.session);
+		this.upsertReview(payload.review);
+		return payload.session;
 	}
 
 	async closeSession(sessionId: string): Promise<void> {
 		await this.initialize();
-		await fetch(
+		const response = await fetch(
 			`${this.serverUrl}/sessions/${encodeURIComponent(sessionId)}`,
 			{
 				method: "DELETE",
 				headers: this.authHeaders(),
 				signal: AbortSignal.timeout(30_000),
 			},
-		).catch(() => undefined);
-		await this.refreshLists().catch(() => undefined);
+		);
+		await this.requireOk(response, "Review session close");
+		this.removeSession(sessionId);
 	}
 
 	async deleteReview(uuid: string): Promise<void> {
@@ -330,7 +329,7 @@ export class ReviewSessionService
 					: `Review delete returned ${response.status}.`,
 			);
 		}
-		await this.refreshLists();
+		this.removeReview(uuid);
 	}
 
 	/**
@@ -359,7 +358,25 @@ export class ReviewSessionService
 			},
 		);
 		await this.requireOk(response, `Review ${action}`);
-		await this.refreshLists();
+		const payload = (await response.json()) as {
+			uuid?: unknown;
+			viewedAt?: unknown;
+			dismissedAt?: unknown;
+			reapsAt?: unknown;
+		};
+		if (
+			payload.uuid !== uuid ||
+			!isNullableString(payload.viewedAt) ||
+			!isNullableString(payload.dismissedAt) ||
+			!isNullableString(payload.reapsAt)
+		) {
+			throw new Error(`Review ${action} returned an invalid response.`);
+		}
+		this.patchReview(uuid, {
+			viewedAt: payload.viewedAt,
+			dismissedAt: payload.dismissedAt,
+			reapsAt: payload.reapsAt,
+		});
 	}
 
 	/**
@@ -436,9 +453,9 @@ export class ReviewSessionService
 		await this.requireOk(response, "Review tutorial open");
 		const payload = parseReviewTutorialOpenResponse(await response.json());
 		this._tutorialReview = payload.review;
-		// The sessions list must carry the new session before the tab resolves
-		// its model. The reviews list never lists the tutorial.
-		await this.refreshLists();
+		// The reviews list never lists the tutorial, but its confirmed session is
+		// immediately available to the tab that requested it.
+		this.upsertSession(payload.session);
 		return payload;
 	}
 
@@ -450,8 +467,17 @@ export class ReviewSessionService
 			signal: AbortSignal.timeout(30_000),
 		});
 		await this.requireOk(response, "Review tutorial delete");
+		const tutorialUuid = this._tutorialReview?.uuid;
 		this._tutorialReview = undefined;
-		await this.refreshLists();
+		if (tutorialUuid) {
+			const next = this._sessionRecords.filter(
+				(session) => session.reviewUuid !== tutorialUuid,
+			);
+			if (next.length !== this._sessionRecords.length) {
+				this._sessionRecords = next;
+				this._onDidChangeLists.fire();
+			}
+		}
 	}
 
 	/** Raises the server's own error message when it sends one. */
@@ -471,14 +497,22 @@ export class ReviewSessionService
 
 	async getCliInstallStatus(): Promise<ReviewCliInstallStatus> {
 		await this.initialize();
-		const response = await fetch(`${this.serverUrl}/install/status`, {
-			headers: this.authHeaders(),
-			signal: AbortSignal.timeout(30_000),
+		if (this.cliInstallStatus) return this.cliInstallStatus;
+		this.cliInstallStatusPromise ??= (async () => {
+			const response = await fetch(`${this.serverUrl}/install/status`, {
+				headers: this.authHeaders(),
+				signal: AbortSignal.timeout(30_000),
+			});
+			if (!response.ok) {
+				throw new Error(`Review install status returned ${response.status}.`);
+			}
+			const status = parseReviewCliInstallStatus(await response.json());
+			this.cliInstallStatus = status;
+			return status;
+		})().finally(() => {
+			this.cliInstallStatusPromise = undefined;
 		});
-		if (!response.ok) {
-			throw new Error(`Review install status returned ${response.status}.`);
-		}
-		return parseReviewCliInstallStatus(await response.json());
+		return this.cliInstallStatusPromise;
 	}
 
 	async applyCliInstall(request: {
@@ -513,6 +547,7 @@ export class ReviewSessionService
 						: `Review install returned ${response.status}.`,
 			);
 		}
+		this.cliInstallStatus = undefined;
 		return parseReviewCliInstallApplyResponse(payload);
 	}
 
@@ -540,6 +575,7 @@ export class ReviewSessionService
 		if (!response.ok) {
 			throw new Error(`Review install remove returned ${response.status}.`);
 		}
+		this.cliInstallStatus = undefined;
 	}
 
 	async declineCliInstall(): Promise<void> {
@@ -566,6 +602,7 @@ export class ReviewSessionService
 		if (!response.ok) {
 			throw new Error(`Review install ${verb} returned ${response.status}.`);
 		}
+		this.cliInstallStatus = undefined;
 	}
 
 	attachControl(
@@ -596,13 +633,28 @@ export class ReviewSessionService
 	private async initializeGlobalState(): Promise<void> {
 		await this.connect();
 		await this.waitForHealth();
-		await this.refreshLists();
-		void this.maintainGlobalEvents().catch((error) => {
+		let ready = false;
+		let resolveReady!: () => void;
+		let rejectReady!: (error: unknown) => void;
+		const firstSnapshot = new Promise<void>((resolve, reject) => {
+			resolveReady = resolve;
+			rejectReady = reject;
+		});
+		void this.maintainGlobalEvents(() => {
+			if (ready) return;
+			ready = true;
+			resolveReady();
+		}).catch((error) => {
 			if (this.controller.signal.aborted) return;
+			if (!ready) {
+				rejectReady(error);
+				return;
+			}
 			this._onDidFail.fire(
 				error instanceof Error ? error : new Error(String(error)),
 			);
 		});
+		await firstSnapshot;
 	}
 
 	private async initializeAndMaintainControl(
@@ -676,21 +728,6 @@ export class ReviewSessionService
 		this._onDidChangeLists.fire();
 	}
 
-	private async refreshReviews(): Promise<void> {
-		const response = await fetch(`${this.serverUrl}/reviews?limit=100`, {
-			headers: this.authHeaders(),
-			signal: AbortSignal.timeout(REVIEW_LIST_TIMEOUT_MS),
-		});
-		if (!response.ok) {
-			throw await reviewResponseError(
-				response,
-				`Review list returned ${response.status}.`,
-			);
-		}
-		this.applyReviewList(await response.json());
-		this._onDidChangeLists.fire();
-	}
-
 	/**
 	 * The server lists every review, drafts included. A review stays a draft
 	 * until its first publish, so it belongs to no picker or list event yet.
@@ -700,15 +737,19 @@ export class ReviewSessionService
 		this._reviews = parsed.reviews.filter(
 			(review) => review.status !== "draft",
 		);
+		for (const review of this._reviews) {
+			this.deletedReviewNotifications.delete(review.uuid);
+		}
 		this._reviewErrors = parsed.errors;
 	}
 
-	private async maintainGlobalEvents(): Promise<void> {
+	private async maintainGlobalEvents(onConnected: () => void): Promise<void> {
 		let attempt = 0;
 		while (!this.controller.signal.aborted) {
 			try {
 				await this.watchGlobalEvents(() => {
 					attempt = 0;
+					onConnected();
 				});
 				if (this.controller.signal.aborted) return;
 				throw new Error("The embedded Review server event stream ended.");
@@ -749,12 +790,13 @@ export class ReviewSessionService
 					return;
 				}
 				if (event.event === "review-threads-committed") {
+					this.patchReview(event.uuid, { commentCount: event.commentCount });
 					this._onDidCommitReviewThreads.fire(event);
 					return;
 				}
 				if (event.event === "session-registered") {
 					this.upsertSession(event.session);
-					await this.refreshReviews();
+					if (event.review) this.upsertReview(event.review);
 					this._onDidRegisterSession.fire({
 						session: event.session,
 						background: event.background === true,
@@ -763,40 +805,42 @@ export class ReviewSessionService
 				}
 				if (event.event === "session-updated") {
 					this.upsertSession(event.session);
-					await this.refreshReviews();
 					return;
 				}
 				if (event.event === "review-status-changed") {
-					await this.refreshReviews();
+					this.patchReview(event.uuid, { status: event.status });
 					return;
 				}
-				// Dismissal only stamps the review, so the list is re-read rather
-				// than pruned: the row moves to the dismissed group, it does not go.
 				if (event.event === "review-attention-changed") {
-					await this.refreshReviews();
+					this.patchReview(event.uuid, {
+						viewedAt: event.viewedAt,
+						dismissedAt: event.dismissedAt,
+						reapsAt: event.reapsAt,
+					});
 					if (event.attention === "dismissed") {
 						this._onDidDismissReview.fire(event.uuid);
 					}
 					return;
 				}
 				if (event.event === "preferences-changed") {
-					await this.refreshReviews();
+					this._reviews = this._reviews.map((review) => ({
+						...review,
+						reapsAt: reviewReapsAt(
+							review.dismissedAt,
+							event.preferences.dismissedRetentionDays,
+						),
+					}));
+					this._onDidChangeLists.fire();
 					return;
 				}
 				if (event.event === "review-deleted") {
-					this._reviews = this._reviews.filter(
-						(review) => review.uuid !== event.uuid,
-					);
-					this._onDidChangeLists.fire();
-					this._onDidDeleteReview.fire(event.uuid);
+					this.removeReview(event.uuid);
 					return;
 				}
 				const closed = this._sessionRecords.find(
 					(item) => item.sessionId === event.sessionId,
 				);
-				this._sessionRecords = this._sessionRecords.filter(
-					(item) => item.sessionId !== event.sessionId,
-				);
+				this.removeSession(event.sessionId);
 				if (closed) {
 					this._onDidCloseSession.fire({
 						session: closed,
@@ -806,7 +850,6 @@ export class ReviewSessionService
 						reason: event.reason,
 					});
 				}
-				this._onDidChangeLists.fire();
 			},
 			this.controller.signal,
 		);
@@ -890,9 +933,68 @@ export class ReviewSessionService
 		this._onDidChangeLists.fire();
 	}
 
+	private removeSession(sessionId: string): void {
+		const next = this._sessionRecords.filter(
+			(item) => item.sessionId !== sessionId,
+		);
+		if (next.length === this._sessionRecords.length) return;
+		this._sessionRecords = next;
+		this._onDidChangeLists.fire();
+	}
+
+	private upsertReview(review: ReviewDescriptor): void {
+		if (review.status === "draft") return;
+		this.deletedReviewNotifications.delete(review.uuid);
+		this._reviews = [
+			review,
+			...this._reviews.filter((item) => item.uuid !== review.uuid),
+		];
+		this._onDidChangeLists.fire();
+	}
+
+	private patchReview(
+		uuid: string,
+		patch: Partial<ReviewDescriptor>,
+	): void {
+		let changed = false;
+		this._reviews = this._reviews.map((review) => {
+			if (review.uuid !== uuid) return review;
+			changed = Object.entries(patch).some(
+				([key, value]) => review[key as keyof ReviewDescriptor] !== value,
+			);
+			return changed ? { ...review, ...patch } : review;
+		});
+		if (changed) this._onDidChangeLists.fire();
+	}
+
+	private removeReview(uuid: string): void {
+		const next = this._reviews.filter((review) => review.uuid !== uuid);
+		if (next.length !== this._reviews.length) {
+			this._reviews = next;
+			this._onDidChangeLists.fire();
+		}
+		if (this.deletedReviewNotifications.has(uuid)) return;
+		this.deletedReviewNotifications.add(uuid);
+		this._onDidDeleteReview.fire(uuid);
+	}
+
 	private authHeaders(): Record<string, string> {
 		return { "x-review-token": this.token };
 	}
+}
+
+function isNullableString(value: unknown): value is string | null {
+	return value === null || typeof value === "string";
+}
+
+function reviewReapsAt(
+	dismissedAt: string | null | undefined,
+	dismissedRetentionDays: number | null,
+): string | null {
+	if (!dismissedAt || dismissedRetentionDays === null) return null;
+	return new Date(
+		new Date(dismissedAt).getTime() + dismissedRetentionDays * 86_400_000,
+	).toISOString();
 }
 
 async function reviewResponseError(

--- a/packages/progressive-review/src/review-home.ts
+++ b/packages/progressive-review/src/review-home.ts
@@ -375,9 +375,7 @@ export async function reviewDescriptor(
         }).catch(() => [])
       : [],
   ]);
-  const commentCount = documentExists
-    ? safelyCountReviewComments(documentPath)
-    : 0;
+  const commentCount = documentExists ? countReviewComments(documentPath) : 0;
   return {
     uuid: stored.review.uuid,
     title: stored.review.title,
@@ -403,7 +401,7 @@ export async function reviewDescriptor(
   };
 }
 
-function safelyCountReviewComments(reviewMdxPath: string): number {
+export function countReviewComments(reviewMdxPath: string): number {
   try {
     return Object.keys(readReviewComments(reviewMdxPath)).length;
   } catch {

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -35,6 +35,7 @@ import {
 import {
   dismissReview,
   markReviewViewed,
+  reviewReapsAt,
   restoreReview,
   selectReapableReviews,
 } from "../review-attention";
@@ -46,6 +47,7 @@ import {
 import {
   type StoredReview,
   type StoredReviewRecord,
+  countReviewComments,
   findReview,
   listReviews,
   parseStoredReviewRecord,
@@ -105,6 +107,7 @@ import {
 import { createTutorialService } from "./tutorial-service";
 
 const DEFAULT_CAPACITY = 16;
+const REVIEW_REAPER_INTERVAL_MS = 60 * 60 * 1_000;
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -219,6 +222,7 @@ export function createGlobalReviewServer(
     deleteReview: deleteStoredReview,
   });
   let tutorialOpenOperation: Promise<ReviewTutorialOpenResponse> | null = null;
+  let reviewReaper: ReturnType<typeof setInterval> | undefined;
   let closing = false;
   const openNativeAgentTerminal = async (
     reviewSessionId: string,
@@ -376,6 +380,7 @@ export function createGlobalReviewServer(
        stay foreground. */
     const openBody = (await context.req.json().catch(() => null)) as {
       background?: unknown;
+      revision?: unknown;
     } | null;
     const background = openBody?.background === true;
     const review = await findReview(uuid);
@@ -401,13 +406,10 @@ export function createGlobalReviewServer(
         "review_unpublished",
       );
     }
-    const body = (await context.req.json().catch(() => undefined)) as
-      | { revision?: unknown }
-      | undefined;
     if (
-      body?.revision !== undefined &&
-      (typeof body.revision !== "string" ||
-        !/^[0-9a-f]{40}$/.test(body.revision))
+      openBody?.revision !== undefined &&
+      (typeof openBody.revision !== "string" ||
+        !/^[0-9a-f]{40}$/.test(openBody.revision))
     ) {
       throw new ReviewServerError(
         "Review revision must be a 40-character hexadecimal commit ID.",
@@ -416,15 +418,16 @@ export function createGlobalReviewServer(
       );
     }
     const requestedRevision =
-      typeof body?.revision === "string" &&
-      body.revision !== review.review.presentedDocumentRevision
-        ? body.revision
+      typeof openBody?.revision === "string" &&
+      openBody.revision !== review.review.presentedDocumentRevision
+        ? openBody.revision
         : undefined;
     if (requestedRevision) {
       return openHistoricalReviewSession(
         review,
         requestedRevision,
         appSessionId,
+        descriptor,
       );
     }
     const documentRevision = review.review.presentedDocumentRevision;
@@ -434,12 +437,14 @@ export function createGlobalReviewServer(
     const wasDismissed = Boolean(review.review.dismissedAt);
     const viewed = await restoreReview(await markReviewViewed(review));
     if (viewed.review !== review.review) {
-      broadcastGlobal({
-        event: "review-attention-changed",
-        uuid: viewed.review.uuid,
-        attention: "viewed",
-      });
+      await broadcastReviewAttention(viewed, "viewed");
     }
+    const homeReview: ReviewDescriptor = {
+      ...descriptor,
+      viewedAt: viewed.review.viewedAt ?? null,
+      dismissedAt: viewed.review.dismissedAt ?? null,
+      reapsAt: null,
+    };
     if (wasDismissed) {
       await captureSanitizedUiTelemetry(
         telemetry,
@@ -460,6 +465,8 @@ export function createGlobalReviewServer(
       return globalJson(200, {
         sessionId: existing.descriptor.sessionId,
         url: existing.descriptor.sessionUrl,
+        session: existing.descriptor,
+        review: homeReview,
       });
     }
     const documentBuildDir = await publishRuntime.materializePublishRevision({
@@ -489,6 +496,8 @@ export function createGlobalReviewServer(
     return globalJson(201, {
       sessionId: active.descriptor.sessionId,
       url: active.descriptor.sessionUrl,
+      session: active.descriptor,
+      review: homeReview,
     });
   });
 
@@ -496,6 +505,7 @@ export function createGlobalReviewServer(
     review: StoredReview,
     revision: string,
     appSessionId: string | undefined,
+    homeReview: ReviewDescriptor,
   ): Promise<Response> {
     const existing = [...sessions.values()].find(
       (session) =>
@@ -511,6 +521,8 @@ export function createGlobalReviewServer(
       return globalJson(200, {
         sessionId: existing.descriptor.sessionId,
         url: existing.descriptor.sessionUrl,
+        session: existing.descriptor,
+        review: homeReview,
       });
     }
     let documentBuildDir: string;
@@ -554,6 +566,8 @@ export function createGlobalReviewServer(
     return globalJson(201, {
       sessionId: active.descriptor.sessionId,
       url: active.descriptor.sessionUrl,
+      session: active.descriptor,
+      review: homeReview,
     });
   }
   app.post("/reviews/:uuid/dismiss", async (context) => {
@@ -962,6 +976,10 @@ export function createGlobalReviewServer(
         broadcastGlobal({
           event: "session-registered",
           session: successor.descriptor,
+          review: await reviewDescriptor(
+            successor.review,
+            (await readReviewPreferences()).dismissedRetentionDays,
+          ),
         });
         const replaced = [...sessions.values()].filter(
           (session) =>
@@ -1081,6 +1099,10 @@ export function createGlobalReviewServer(
         broadcastGlobal({
           event: "session-registered",
           session: successor.descriptor,
+          review: await reviewDescriptor(
+            successor.review,
+            (await readReviewPreferences()).dismissedRetentionDays,
+          ),
         });
         const replaced = [...sessions.values()].filter(
           (session) =>
@@ -1156,6 +1178,7 @@ export function createGlobalReviewServer(
       sessionId: session.descriptor.sessionId,
       url: session.descriptor.sessionUrl,
       review: await reviewDescriptor(session.review),
+      session: session.descriptor,
     };
   }
 
@@ -1311,6 +1334,9 @@ export function createGlobalReviewServer(
             uuid: registration.review.review.uuid,
             sessionId,
             commit,
+            commentCount: countReviewComments(
+              path.join(registration.review.dir, "review.mdx"),
+            ),
           });
         },
         runReviewThreadMutation: (operation) =>
@@ -1438,11 +1464,7 @@ export function createGlobalReviewServer(
       }
       active.review = await dismissReview(active.review);
       await clearReopenPending(active.review.review.worktreePath);
-      broadcastGlobal({
-        event: "review-attention-changed",
-        uuid: active.review.review.uuid,
-        attention: "dismissed",
-      });
+      await broadcastReviewAttention(active.review, "dismissed");
       broadcastGlobal({
         event: "session-updated",
         session: active.descriptor,
@@ -1459,7 +1481,13 @@ export function createGlobalReviewServer(
   async function setReviewDismissed(
     uuid: string,
     dismissed: boolean,
-  ): Promise<{ ok: true; dismissedAt: string | null }> {
+  ): Promise<{
+    ok: true;
+    uuid: string;
+    viewedAt: string | null;
+    dismissedAt: string | null;
+    reapsAt: string | null;
+  }> {
     if (!UUID_PATTERN.test(uuid)) {
       throw new ReviewServerError("Review not found.", 404);
     }
@@ -1469,19 +1497,47 @@ export function createGlobalReviewServer(
       const next = dismissed
         ? await dismissReview(stored)
         : await restoreReview(stored);
+      const attention = dismissed
+        ? "dismissed"
+        : next.review.viewedAt
+          ? "viewed"
+          : "new";
+      const patch = await reviewAttentionPatch(next);
       broadcastGlobal({
         event: "review-attention-changed",
-        uuid,
-        attention: dismissed
-          ? "dismissed"
-          : next.review.viewedAt
-            ? "viewed"
-            : "new",
+        attention,
+        ...patch,
       });
       return {
         ok: true as const,
-        dismissedAt: next.review.dismissedAt ?? null,
+        ...patch,
       };
+    });
+  }
+
+  async function reviewAttentionPatch(review: StoredReview): Promise<{
+    uuid: string;
+    viewedAt: string | null;
+    dismissedAt: string | null;
+    reapsAt: string | null;
+  }> {
+    const { dismissedRetentionDays } = await readReviewPreferences();
+    return {
+      uuid: review.review.uuid,
+      viewedAt: review.review.viewedAt ?? null,
+      dismissedAt: review.review.dismissedAt ?? null,
+      reapsAt: reviewReapsAt(review.review, dismissedRetentionDays),
+    };
+  }
+
+  async function broadcastReviewAttention(
+    review: StoredReview,
+    attention: "new" | "viewed" | "dismissed",
+  ): Promise<void> {
+    broadcastGlobal({
+      event: "review-attention-changed",
+      attention,
+      ...(await reviewAttentionPatch(review)),
     });
   }
 
@@ -1516,6 +1572,11 @@ export function createGlobalReviewServer(
         console.error(`Could not reap review ${uuid}:`, error);
       }
     }
+  }
+
+  async function runReviewReaper(): Promise<void> {
+    const { dismissedRetentionDays } = await readReviewPreferences();
+    await reapDismissedReviews(dismissedRetentionDays);
   }
 
   async function endSessionTelemetry(
@@ -1714,10 +1775,20 @@ export function createGlobalReviewServer(
       boundPort = await listen(httpServer, input.port);
       discovery.url = urlForBoundPort();
       await writePrivateJsonAtomic(discoveryPath, discovery);
+      void runReviewReaper().catch((error) =>
+        console.error("Could not run Review cleanup:", error),
+      );
+      reviewReaper = setInterval(() => {
+        void runReviewReaper().catch((error) =>
+          console.error("Could not run Review cleanup:", error),
+        );
+      }, REVIEW_REAPER_INTERVAL_MS);
     },
     close: async () => {
       if (closing) return;
       closing = true;
+      if (reviewReaper) clearInterval(reviewReaper);
+      reviewReaper = undefined;
       await removeMatchingDiscovery(discoveryPath, discovery);
       await Promise.all(
         [...sessions.values()].map((session) =>

--- a/packages/review-protocol/src/contracts.test.ts
+++ b/packages/review-protocol/src/contracts.test.ts
@@ -201,6 +201,8 @@ const contracts: Array<[string, ZodType, Record<string, unknown>]> = [
     {
       sessionId: descriptor.sessionId,
       url: descriptor.sessionUrl,
+      session: descriptor,
+      review: reviewDescriptor,
     },
   ],
   [

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1263,6 +1263,8 @@ export type ReviewThreadsCommandResponse = z.infer<
 export const ReviewOpenResponseSchema = z.strictObject({
   sessionId: requiredString,
   url: loopbackUrlSchema,
+  session: ReviewSessionDescriptorSchema,
+  review: ReviewDescriptorSchema,
 });
 export type ReviewOpenResponse = z.infer<typeof ReviewOpenResponseSchema>;
 
@@ -1274,6 +1276,7 @@ export const ReviewTutorialOpenResponseSchema = z.strictObject({
   sessionId: requiredString,
   url: loopbackUrlSchema,
   review: ReviewDescriptorSchema,
+  session: ReviewSessionDescriptorSchema,
 });
 export type ReviewTutorialOpenResponse = z.infer<
   typeof ReviewTutorialOpenResponseSchema
@@ -1487,6 +1490,9 @@ export const ReviewDesktopGlobalEventSchema = z.discriminatedUnion("event", [
   z.strictObject({
     event: z.literal("session-registered"),
     session: ReviewSessionDescriptorSchema,
+    /* Publish carries the newly authoritative Home row. Ordinary session
+       opens omit it because Home already has the published descriptor. */
+    review: ReviewDescriptorSchema.optional(),
     // True when the session was opened for a non-document surface (the
     // Source tab rooting its file tree): the app must not surface the
     // review document tab for it. Absent means foreground.
@@ -1506,6 +1512,7 @@ export const ReviewDesktopGlobalEventSchema = z.discriminatedUnion("event", [
     uuid: z.uuid({ error: "must be a UUID" }),
     sessionId: requiredString,
     commit: ReviewThreadsCommitSchema,
+    commentCount: nonNegativeInteger,
   }),
   z.strictObject({
     event: z.literal("session-closed"),
@@ -1528,6 +1535,9 @@ export const ReviewDesktopGlobalEventSchema = z.discriminatedUnion("event", [
     event: z.literal("review-attention-changed"),
     uuid: z.uuid({ error: "must be a UUID" }),
     attention: z.enum(["new", "viewed", "dismissed"]),
+    viewedAt: requiredString.nullable(),
+    dismissedAt: requiredString.nullable(),
+    reapsAt: requiredString.nullable(),
   }),
   z.strictObject({
     event: z.literal("preferences-changed"),

--- a/packages/review-protocol/src/index.test.ts
+++ b/packages/review-protocol/src/index.test.ts
@@ -71,22 +71,21 @@ describe("review protocol parsers", () => {
       routePath: "/",
       startedAt: 10,
     };
+    const review = {
+      uuid: descriptor.reviewUuid,
+      title: "Protocol rewrite",
+      status: "awaiting-review" as const,
+      worktreePath: "/tmp/repo",
+      repoKey: "repo-1",
+      sourceBranch: "feature/protocol",
+      presentedDocumentRevision: null,
+      presentedSoftwareMapRevision: null,
+      lastPublishedAt: null,
+      available: true,
+    };
     expect(
       parseReviewListResponse({
-        reviews: [
-          {
-            uuid: descriptor.reviewUuid,
-            title: "Protocol rewrite",
-            status: "awaiting-review",
-            worktreePath: "/tmp/repo",
-            repoKey: "repo-1",
-            sourceBranch: "feature/protocol",
-            presentedDocumentRevision: null,
-            presentedSoftwareMapRevision: null,
-            lastPublishedAt: null,
-            available: true,
-          },
-        ],
+        reviews: [review],
         errors: [],
       }),
     ).toMatchObject({ reviews: [{ title: "Protocol rewrite" }] });
@@ -94,10 +93,14 @@ describe("review protocol parsers", () => {
       parseReviewOpenResponse({
         sessionId: descriptor.sessionId,
         url: descriptor.sessionUrl,
+        session: descriptor,
+        review,
       }),
     ).toEqual({
       sessionId: descriptor.sessionId,
       url: descriptor.sessionUrl,
+      session: descriptor,
+      review,
     });
     expect(
       parseReviewSessionLifecycleEvent({


### PR DESCRIPTION
Prompt: Navigating back to Review Home should be instant after the first load. Keep the review list in memory and update it from confirmed events and mutations instead of repeatedly refetching it.

Full transcript at session: b707a871-3df4-4219-a48e-7976fc47926b