### PR TITLE
Centralize Review diff loading in ReviewDiffService

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/review.common.main.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/review.common.main.ts
@@ -362,6 +362,10 @@ import {
   IReviewDiffTabsService,
   ReviewDiffTabsService,
 } from "./services/reviewDiffTabs.js";
+import {
+  IReviewDiffService,
+  ReviewDiffService,
+} from "./services/reviewDiffService.js";
 
 registerSingleton(
   IReviewSessionService,
@@ -386,6 +390,11 @@ registerSingleton(
 registerSingleton(
   IReviewDiffTabsService,
   ReviewDiffTabsService,
+  InstantiationType.Delayed,
+);
+registerSingleton(
+  IReviewDiffService,
+  ReviewDiffService,
   InstantiationType.Delayed,
 );
 registerSingleton(

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewCodeResourceService.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewCodeResourceService.test.ts
@@ -53,6 +53,17 @@ test("diff targets use the pinned base and head checkouts", async () => {
       },
       onDidChangeActiveModel: Event.None,
     } as never,
+    {
+      files: async () => [
+        {
+          path: "src/new.ts",
+          previousPath: "src/old.ts",
+          status: "renamed",
+          additions: 2,
+          deletions: 2,
+        },
+      ],
+    } as never,
   );
 
   const base = await service.target("src/new.ts", "base");

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewCodeResourceService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewCodeResourceService.ts
@@ -63,13 +63,12 @@ import type {
 } from "../common/reviewProtocol.js";
 import {
   gitLabDiffPositionRows,
-  parseReviewDiffFilesResponse,
   parseReviewFileContentResponse,
 } from "../common/reviewProtocol.js";
 import {
   reviewDiffFileForReveal,
-  reviewDiffFilesUrl,
 } from "../common/reviewReveal.js";
+import { IReviewDiffService } from "./reviewDiffService.js";
 import {
   IReviewSessionModelService,
   type ReviewDesktopSession,
@@ -219,6 +218,7 @@ export class ReviewCodeResourceService
     @ILanguageService private readonly languageService: ILanguageService,
     @IReviewSessionModelService
     private readonly sessionModelService: IReviewSessionModelService,
+    @IReviewDiffService private readonly diffService: IReviewDiffService,
   ) {
     super();
     this.codeRevision = this.currentCodeRevision();
@@ -267,10 +267,7 @@ export class ReviewCodeResourceService
     side: ReviewDiffSide,
     scope?: ReviewCommitScope,
   ): Promise<ReviewCodeResourceTarget> {
-    const files = await this.diffFilesForSession(session, scope);
-    if (!files) {
-      throw new Error("Review diff metadata is unavailable.");
-    }
+    const files = await this.diffService.files(scope);
     const diffFile = reviewDiffFileForReveal(files, path, side);
     if (!diffFile) {
       const pinnedResource = !scope
@@ -310,11 +307,8 @@ export class ReviewCodeResourceService
   }
 
   async files(scope?: ReviewCommitScope): Promise<readonly ReviewDiffFileWire[]> {
-    const files = await this.diffFilesForSession(this.requireSession(), scope);
-    if (!files) {
-      throw new Error("Review diff metadata is unavailable.");
-    }
-    return files;
+    this.requireSession();
+    return this.diffService.files(scope);
   }
 
   async acquireSnippet(
@@ -367,7 +361,7 @@ export class ReviewCodeResourceService
     ]);
     const patch =
       diffFile.patch ??
-      (await this.diffPatchForSession(session, diffFile.path));
+      (await this.diffService.patch(diffFile.path));
     if (!patch) return undefined;
 
     const mappings = reviewPeekLineMappings(patch);
@@ -699,66 +693,6 @@ export class ReviewCodeResourceService
       session.baseRootPath ?? "",
       session.headRootPath ?? "",
     ].join("\n");
-  }
-
-  private async diffFilesForSession(
-    session: ReviewDesktopSession,
-    scope?: ReviewCommitScope,
-  ): Promise<ReviewDiffFileWire[] | undefined> {
-    const routePath = session.session.routePath ?? "/";
-    try {
-      const response = await this.request(
-        session,
-        reviewDiffFilesUrl(session.sessionUrl, routePath),
-        {
-          method: "POST",
-          headers: {
-            "x-review-token": session.token,
-            "content-type": "application/json",
-          },
-          body: JSON.stringify({ includePatch: false, commit: scope?.commit }),
-          signal: AbortSignal.timeout(2_000),
-        },
-      );
-      const result = parseReviewDiffFilesResponse(await response.json());
-      if (!response.ok || !result.ok) return undefined;
-      return result.files.map((file) => ({
-        path: file.path,
-        previousPath: file.previousPath,
-        status: file.status,
-        additions: file.additions,
-        deletions: file.deletions,
-      }));
-    } catch {
-      return undefined;
-    }
-  }
-
-  private async diffPatchForSession(
-    session: ReviewDesktopSession,
-    path: string,
-  ): Promise<string | undefined> {
-    const routePath = session.session.routePath ?? "/";
-    try {
-      const response = await this.request(
-        session,
-        reviewDiffFilesUrl(session.sessionUrl, routePath),
-        {
-          method: "POST",
-          headers: {
-            "x-review-token": session.token,
-            "content-type": "application/json",
-          },
-          body: JSON.stringify({ includePatch: true, paths: [path] }),
-          signal: AbortSignal.timeout(5_000),
-        },
-      );
-      const result = parseReviewDiffFilesResponse(await response.json());
-      if (!response.ok || !result.ok) return undefined;
-      return result.files.find((file) => file.path === path)?.patch;
-    } catch {
-      return undefined;
-    }
   }
 
   private async provideDiffContent(

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffService.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffService.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ReviewDiffService } from "./reviewDiffService.js";
+
+test("loads parsed file metadata and patches through one service", async () => {
+  const requests: Array<{ url: string; body: unknown }> = [];
+  const session = {
+    session: { sessionId: "session-1", routePath: "/docs/review.mdx" },
+    sessionUrl: "http://127.0.0.1:5570/sessions/session-1",
+    token: "token",
+  };
+  const service = new ReviewDiffService({
+    activeModel: {
+      session,
+      request: async (url: string, init: RequestInit) => {
+        requests.push({ url, body: JSON.parse(String(init.body)) });
+        const body = JSON.parse(String(init.body)) as {
+          includePatch: boolean;
+        };
+        return Response.json({
+          ok: true,
+          files: [
+            {
+              path: "src/new.ts",
+              previousPath: "src/old.ts",
+              status: "renamed",
+              additions: 2,
+              deletions: 1,
+              ...(body.includePatch ? { patch: "diff --git a b" } : {}),
+            },
+          ],
+        });
+      },
+    },
+  } as never);
+
+  assert.deepEqual(await service.files({ commit: "abc123" }), [
+    {
+      path: "src/new.ts",
+      previousPath: "src/old.ts",
+      status: "renamed",
+      additions: 2,
+      deletions: 1,
+    },
+  ]);
+  assert.equal(await service.patch("src/new.ts"), "diff --git a b");
+  assert.deepEqual(requests, [
+    {
+      url: "http://127.0.0.1:5570/sessions/session-1/__progressive-review/diff-files?document=%2Fdocs%2Freview.mdx",
+      body: { includePatch: false, commit: "abc123" },
+    },
+    {
+      url: "http://127.0.0.1:5570/sessions/session-1/__progressive-review/diff-files?document=%2Fdocs%2Freview.mdx",
+      body: { includePatch: true, paths: ["src/new.ts"] },
+    },
+  ]);
+});

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffService.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from "../../platform/instantiation/common/instantiation.js";
+import type {
+  ReviewCommitScope,
+  ReviewDiffFileWire,
+} from "../common/reviewProtocol.js";
+import { parseReviewDiffFilesResponse } from "../common/reviewProtocol.js";
+import { reviewDiffFilesUrl } from "../common/reviewReveal.js";
+import {
+  IReviewSessionModelService,
+  type ReviewDesktopSession,
+} from "./reviewSessionModelService.js";
+
+export const IReviewDiffService =
+  createDecorator<IReviewDiffService>("reviewDiffService");
+
+/** Owns loading and parsing diff data for the active Review session. */
+export interface IReviewDiffService {
+  readonly _serviceBrand: undefined;
+  files(scope?: ReviewCommitScope): Promise<readonly ReviewDiffFileWire[]>;
+  patch(path: string): Promise<string | undefined>;
+}
+
+export class ReviewDiffService implements IReviewDiffService {
+  declare readonly _serviceBrand: undefined;
+
+  constructor(
+    @IReviewSessionModelService
+    private readonly sessionModelService: IReviewSessionModelService,
+  ) {}
+
+  async files(
+    scope?: ReviewCommitScope,
+  ): Promise<readonly ReviewDiffFileWire[]> {
+    const result = await this.request({
+      includePatch: false,
+      commit: scope?.commit,
+    });
+    return result.files.map((file) => ({
+      path: file.path,
+      previousPath: file.previousPath,
+      status: file.status,
+      additions: file.additions,
+      deletions: file.deletions,
+    }));
+  }
+
+  async patch(path: string): Promise<string | undefined> {
+    const result = await this.request({ includePatch: true, paths: [path] });
+    return result.files.find((file) => file.path === path)?.patch;
+  }
+
+  private async request(body: {
+    includePatch: boolean;
+    commit?: string;
+    paths?: string[];
+  }) {
+    const model = this.sessionModelService.activeModel;
+    if (!model) throw new Error("Review session is unavailable.");
+    const session = model.session;
+    const routePath = session.session.routePath ?? "/";
+    const response = await model.request(
+      String(reviewDiffFilesUrl(session.sessionUrl, routePath)),
+      {
+        method: "POST",
+        headers: {
+          "x-review-token": session.token,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(body.includePatch ? 5_000 : 2_000),
+      },
+    );
+    const result = parseReviewDiffFilesResponse(await response.json());
+    if (!response.ok || !result.ok) {
+      throw new Error(
+        result.ok ? `Review diff returned ${response.status}.` : result.error,
+      );
+    }
+    this.requireCurrentSession(session);
+    return result;
+  }
+
+  private requireCurrentSession(session: ReviewDesktopSession): void {
+    if (
+      this.sessionModelService.activeModel?.session.session.sessionId !==
+      session.session.sessionId
+    ) {
+      throw new Error("Review diff request belongs to a stale session.");
+    }
+  }
+}


### PR DESCRIPTION
Prompt: Add one idiomatic service that owns fetching Review diffs, then add caching separately on top of that service.

Full transcript at sessions: 01a037c9-f06c-7692-8b48-18b8cb4fef0c, a3048527-ef89-4dc0-9d84-9be5445f6738, 01a037e0-5b94-7c81-a471-edd7bdd07b30