### PR TITLE
Cache and prefetch parsed Review diffs by revision

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
@@ -102,6 +102,7 @@ import {
 import { IReviewVerbsService } from "../../../contrib/verbs/reviewVerbs.js";
 import { ReviewInlineEditorService } from "../../../services/reviewInlineEditorService.js";
 import { ReviewDiffViewService } from "../../../services/reviewDiffViewService.js";
+import { IReviewDiffService } from "../../../services/reviewDiffService.js";
 import {
 	ReviewEmbeddedEditorSelection,
 	reviewEmbeddedSelectionFromOptions,
@@ -239,6 +240,7 @@ export class ReviewCanvasEditorPane extends EditorPane {
 		private readonly sessionService: IReviewSessionService,
 		@IReviewSessionModelService
 		private readonly sessionModelService: IReviewSessionModelService,
+		@IReviewDiffService private readonly diffService: IReviewDiffService,
 		@IReviewVerbsService private readonly verbs: IReviewVerbsService,
 		@IReviewCanvasEditorTabsService
 		private readonly tabsService: IReviewCanvasEditorTabsService,
@@ -1178,6 +1180,9 @@ export class ReviewCanvasEditorPane extends EditorPane {
 			};
 		});
 		try {
+			void this.diffService.prefetch().catch((error) => {
+				this.logService.debug(`[review] diff prefetch failed: ${error}`);
+			});
 			const assets = await this.loadAssets();
 			if (generation !== this.loadGeneration) {
 				return new Error("Review canvas load was superseded.");

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
@@ -760,6 +760,8 @@ export interface ReviewDiffViewHandle extends ReviewDisposable {
  */
 export interface ReviewDiffViewFactory {
   create(spec: ReviewDiffViewSpec): ReviewDiffViewHandle;
+  /** Returns the parsed full diff that backs the native diff view. */
+  files?(scope?: ReviewCommitScope): Promise<readonly ReviewDiffFileWire[]>;
 }
 
 export interface ReviewCommitScope {

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffService.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffService.test.ts
@@ -8,21 +8,18 @@ import test from "node:test";
 
 import { ReviewDiffService } from "./reviewDiffService.js";
 
-test("loads parsed file metadata and patches through one service", async () => {
+test("caches one parsed full-diff corpus per revision and scope", async () => {
   const requests: Array<{ url: string; body: unknown }> = [];
   const session = {
     session: { sessionId: "session-1", routePath: "/docs/review.mdx" },
     sessionUrl: "http://127.0.0.1:5570/sessions/session-1",
     token: "token",
   };
-  const service = new ReviewDiffService({
+  const sessionModel = {
     activeModel: {
       session,
       request: async (url: string, init: RequestInit) => {
         requests.push({ url, body: JSON.parse(String(init.body)) });
-        const body = JSON.parse(String(init.body)) as {
-          includePatch: boolean;
-        };
         return Response.json({
           ok: true,
           files: [
@@ -32,32 +29,64 @@ test("loads parsed file metadata and patches through one service", async () => {
               status: "renamed",
               additions: 2,
               deletions: 1,
-              ...(body.includePatch ? { patch: "diff --git a b" } : {}),
+              patch: "diff --git a b",
             },
           ],
         });
       },
     },
-  } as never);
+  };
+  const service = new ReviewDiffService(sessionModel as never);
 
-  assert.deepEqual(await service.files({ commit: "abc123" }), [
+  const [first, concurrent] = await Promise.all([
+    service.files(),
+    service.files(),
+  ]);
+  assert.strictEqual(first, concurrent);
+  assert.deepEqual(first, [
     {
       path: "src/new.ts",
       previousPath: "src/old.ts",
       status: "renamed",
       additions: 2,
       deletions: 1,
+      patch: "diff --git a b",
     },
   ]);
   assert.equal(await service.patch("src/new.ts"), "diff --git a b");
+  await service.prefetch();
+  await service.files({ commit: "abc123" });
   assert.deepEqual(requests, [
     {
       url: "http://127.0.0.1:5570/sessions/session-1/__progressive-review/diff-files?document=%2Fdocs%2Freview.mdx",
-      body: { includePatch: false, commit: "abc123" },
+      body: { includePatch: true },
     },
     {
       url: "http://127.0.0.1:5570/sessions/session-1/__progressive-review/diff-files?document=%2Fdocs%2Freview.mdx",
-      body: { includePatch: true, paths: ["src/new.ts"] },
+      body: { includePatch: true, commit: "abc123" },
     },
   ]);
+});
+
+test("does not cache failed diff requests", async () => {
+  let attempts = 0;
+  const session = {
+    session: { sessionId: "session-1", routePath: "/" },
+    sessionUrl: "http://127.0.0.1:5570/sessions/session-1",
+    token: "token",
+  };
+  const service = new ReviewDiffService({
+    activeModel: {
+      session,
+      request: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("temporary failure");
+        return Response.json({ ok: true, files: [] });
+      },
+    },
+  } as never);
+
+  await assert.rejects(service.files(), /temporary failure/);
+  assert.deepEqual(await service.files(), []);
+  assert.equal(attempts, 2);
 });

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { LRUCache } from "../../base/common/map.js";
 import { createDecorator } from "../../platform/instantiation/common/instantiation.js";
 import type {
   ReviewCommitScope,
@@ -23,45 +24,53 @@ export interface IReviewDiffService {
   readonly _serviceBrand: undefined;
   files(scope?: ReviewCommitScope): Promise<readonly ReviewDiffFileWire[]>;
   patch(path: string): Promise<string | undefined>;
+  prefetch(scope?: ReviewCommitScope): Promise<void>;
 }
 
 export class ReviewDiffService implements IReviewDiffService {
   declare readonly _serviceBrand: undefined;
+  private readonly corpora = new LRUCache<
+    string,
+    Promise<readonly ReviewDiffFileWire[]>
+  >(8);
 
   constructor(
     @IReviewSessionModelService
     private readonly sessionModelService: IReviewSessionModelService,
   ) {}
 
-  async files(
-    scope?: ReviewCommitScope,
-  ): Promise<readonly ReviewDiffFileWire[]> {
-    const result = await this.request({
-      includePatch: false,
-      commit: scope?.commit,
+  files(scope?: ReviewCommitScope): Promise<readonly ReviewDiffFileWire[]> {
+    const model = this.sessionModelService.activeModel;
+    if (!model) return Promise.reject(new Error("Review session is unavailable."));
+    const key = this.cacheKey(model.session, scope);
+    const cached = this.corpora.get(key);
+    if (cached) return cached;
+
+    let pending: Promise<readonly ReviewDiffFileWire[]>;
+    pending = this.loadCorpus(model.session, scope).catch((error) => {
+      if (this.corpora.get(key) === pending) this.corpora.delete(key);
+      throw error;
     });
-    return result.files.map((file) => ({
-      path: file.path,
-      previousPath: file.previousPath,
-      status: file.status,
-      additions: file.additions,
-      deletions: file.deletions,
-    }));
+    this.corpora.set(key, pending);
+    return pending;
   }
 
   async patch(path: string): Promise<string | undefined> {
-    const result = await this.request({ includePatch: true, paths: [path] });
-    return result.files.find((file) => file.path === path)?.patch;
+    return (await this.files()).find((file) => file.path === path)?.patch;
   }
 
-  private async request(body: {
-    includePatch: boolean;
-    commit?: string;
-    paths?: string[];
-  }) {
+  async prefetch(scope?: ReviewCommitScope): Promise<void> {
+    await this.files(scope);
+  }
+
+  private async loadCorpus(
+    session: ReviewDesktopSession,
+    scope?: ReviewCommitScope,
+  ): Promise<readonly ReviewDiffFileWire[]> {
     const model = this.sessionModelService.activeModel;
-    if (!model) throw new Error("Review session is unavailable.");
-    const session = model.session;
+    if (model?.session.session.sessionId !== session.session.sessionId) {
+      throw new Error("Review diff request belongs to a stale session.");
+    }
     const routePath = session.session.routePath ?? "/";
     const response = await model.request(
       String(reviewDiffFilesUrl(session.sessionUrl, routePath)),
@@ -71,8 +80,11 @@ export class ReviewDiffService implements IReviewDiffService {
           "x-review-token": session.token,
           "content-type": "application/json",
         },
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(body.includePatch ? 5_000 : 2_000),
+        body: JSON.stringify({
+          includePatch: true,
+          commit: scope?.commit,
+        }),
+        signal: AbortSignal.timeout(30_000),
       },
     );
     const result = parseReviewDiffFilesResponse(await response.json());
@@ -82,7 +94,25 @@ export class ReviewDiffService implements IReviewDiffService {
       );
     }
     this.requireCurrentSession(session);
-    return result;
+    return result.files;
+  }
+
+  private cacheKey(
+    session: ReviewDesktopSession,
+    scope?: ReviewCommitScope,
+  ): string {
+    const wire = session.session;
+    return [
+      wire.sessionId,
+      wire.resolvedBaseRef,
+      wire.baseRef,
+      wire.headRef ?? "",
+      wire.routePath ?? "/",
+      wire.rootPath,
+      wire.baseRootPath ?? "",
+      wire.headRootPath ?? "",
+      scope?.commit ?? "full",
+    ].join("\n");
   }
 
   private requireCurrentSession(session: ReviewDesktopSession): void {

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffViewService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffViewService.ts
@@ -12,6 +12,8 @@ import type { ICodeEditor } from "../../editor/browser/editorBrowser.js";
 import type { IMultiDiffEditorViewState } from "../../editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.js";
 import { IInstantiationService } from "../../platform/instantiation/common/instantiation.js";
 import type {
+  ReviewCommitScope,
+  ReviewDiffFileWire,
   ReviewDiffViewFactory,
   ReviewDiffViewHandle,
   ReviewDiffViewSpec,
@@ -74,6 +76,12 @@ export class ReviewDiffViewService
     );
     this.handles.add(handle);
     return handle;
+  }
+
+  files(
+    scope?: ReviewCommitScope,
+  ): Promise<readonly ReviewDiffFileWire[]> {
+    return this.codeResources.files(scope);
   }
 
   reset(): void {

--- a/packages/progressive-review/app/src/App.test.ts
+++ b/packages/progressive-review/app/src/App.test.ts
@@ -1773,9 +1773,11 @@ describe("review app light theme", () => {
     // The canvas never renders diff text itself: the workbench mounts its own
     // widgets into the container this component hands it.
     expect(appSource).toContain("<ReviewDiffView");
+    expect(appSource).toContain("review-diff-view--preloaded");
     expect(appSource).toContain(
-      "scope={diffScope ? { commit: diffScope.commit } : undefined}",
+      'aria-hidden={activeView !== "diff" || diffScope !== null}',
     );
+    expect(appSource).toContain("scope={{ commit: diffScope.commit }}");
     expect(diffViewSource).toContain("session.bridge.diffView");
     expect(contextSource).not.toContain("includePatch: true");
   });

--- a/packages/progressive-review/app/src/App.tsx
+++ b/packages/progressive-review/app/src/App.tsx
@@ -691,26 +691,26 @@ function ReviewLayoutContent({
               }}
             />
           )}
-          {activeView === "diff" && (
-            <div
-              className={
-                diffScope
-                  ? "review-diff-view review-diff-view--scoped"
-                  : "review-diff-view"
-              }
-            >
-              {diffScope ? (
-                <CommitDiffScopeBar
-                  commit={diffScope}
-                  onBack={() => {
-                    setDiffScope(null);
-                    applyReviewView("commits");
-                  }}
-                />
-              ) : null}
-              <ReviewDiffView
-                scope={diffScope ? { commit: diffScope.commit } : undefined}
+          <div
+            aria-hidden={activeView !== "diff" || diffScope !== null}
+            className={
+              activeView === "diff" && diffScope === null
+                ? "review-diff-view"
+                : "review-diff-view review-diff-view--preloaded"
+            }
+          >
+            <ReviewDiffView />
+          </div>
+          {activeView === "diff" && diffScope !== null && (
+            <div className="review-diff-view review-diff-view--scoped">
+              <CommitDiffScopeBar
+                commit={diffScope}
+                onBack={() => {
+                  setDiffScope(null);
+                  applyReviewView("commits");
+                }}
               />
+              <ReviewDiffView scope={{ commit: diffScope.commit }} />
             </div>
           )}
           {activeView === "trace" && (

--- a/packages/progressive-review/app/src/ReviewCommitsView.tsx
+++ b/packages/progressive-review/app/src/ReviewCommitsView.tsx
@@ -93,21 +93,29 @@ function CommitRow({
     captureUiEvent(session, "commit_expanded", { expanded: next });
     if (!next || filesState) return;
     setFilesState({ status: "loading" });
-    session
-      .fetch("/diff-files", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ includePatch: true, commit: commit.commit }),
-      })
-      .then(async (response) => {
-        const result = parseReviewDiffFilesResponse(await response.json());
-        if (!response.ok || !result.ok) {
-          throw new Error(
-            result.ok ? "Unable to load commit files." : result.error,
-          );
-        }
-        setFilesState({ status: "loaded", files: result.files });
-      })
+    const diffView = session.bridge.diffView;
+    const request = diffView.files
+      ? diffView.files({ commit: commit.commit }).then((files) => [...files])
+      : session
+          .fetch("/diff-files", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              includePatch: true,
+              commit: commit.commit,
+            }),
+          })
+          .then(async (response) => {
+            const result = parseReviewDiffFilesResponse(await response.json());
+            if (!response.ok || !result.ok) {
+              throw new Error(
+                result.ok ? "Unable to load commit files." : result.error,
+              );
+            }
+            return result.files;
+          });
+    request
+      .then((files) => setFilesState({ status: "loaded", files }))
       .catch((error: unknown) => {
         setFilesState({
           status: "error",

--- a/packages/progressive-review/app/src/review-diff-files-context.test.tsx
+++ b/packages/progressive-review/app/src/review-diff-files-context.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import type { ReviewDiffFileWire } from "@dev.fast/review-protocol";
 import { act, useLayoutEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -23,6 +24,57 @@ afterEach(async () => {
 });
 
 describe("ReviewDiffFilesProvider", () => {
+  it("reads the desktop's prefetched diff without a network request", async () => {
+    const files = vi.fn<() => Promise<ReviewDiffFileWire[]>>(async () => [
+      {
+        path: "src/prefetched.ts",
+        status: "modified" as const,
+        additions: 4,
+        deletions: 2,
+        patch: "diff --git a/src/prefetched.ts b/src/prefetched.ts",
+      },
+    ]);
+    const nativeSession = testReviewSession(
+      {},
+      {
+        diffView: {
+          create: () => {
+            throw new Error("unused test diff view");
+          },
+          files,
+        },
+      },
+    );
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+    const container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+
+    function Probe() {
+      const state = useReviewDiffFiles();
+      return (
+        <span>
+          {state.status === "loaded" ? state.files[0]?.path : state.status}
+        </span>
+      );
+    }
+
+    await act(async () => {
+      root!.render(
+        <ReviewSessionProvider session={nativeSession}>
+          <ReviewDiffFilesProvider documentKey="review-one">
+            <Probe />
+          </ReviewDiffFilesProvider>
+        </ReviewSessionProvider>,
+      );
+    });
+
+    expect(container.textContent).toBe("src/prefetched.ts");
+    expect(files).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("starts one patch-free request after commit and shares it with every consumer", async () => {
     let committed = false;
     let resolveRequest!: (response: Response) => void;

--- a/packages/progressive-review/app/src/review-diff-files-context.tsx
+++ b/packages/progressive-review/app/src/review-diff-files-context.tsx
@@ -39,6 +39,7 @@ export function ReviewDiffFilesProvider({
 }) {
   const session = useReviewSession();
   const reviewFetch = session.fetch;
+  const diffView = session.bridge.diffView;
   const container = useReviewContainer();
   const [snapshot, setSnapshot] = useState<ReviewDiffFilesSnapshot>(() => ({
     documentKey,
@@ -60,23 +61,28 @@ export function ReviewDiffFilesProvider({
           },
     );
     recordDiffSummaryRequest(container);
-    reviewFetch("/diff-files", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ includePatch: false }),
-      signal: controller.signal,
-    })
-      .then(async (response) => {
-        const result = parseReviewDiffFilesResponse(await response.json());
-        if (!response.ok || !result.ok) {
-          throw new Error(
-            result.ok ? "Unable to load diff files." : result.error,
-          );
-        }
+    const request = diffView.files
+      ? diffView.files().then((files) => [...files])
+      : reviewFetch("/diff-files", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ includePatch: false }),
+          signal: controller.signal,
+        }).then(async (response) => {
+          const result = parseReviewDiffFilesResponse(await response.json());
+          if (!response.ok || !result.ok) {
+            throw new Error(
+              result.ok ? "Unable to load diff files." : result.error,
+            );
+          }
+          return result.files;
+        });
+    request
+      .then((files) => {
         if (controller.signal.aborted) return;
         setSnapshot({
           documentKey,
-          state: { status: "loaded", files: result.files },
+          state: { status: "loaded", files },
         });
         recordDiffSummaryReady(container);
       })
@@ -91,7 +97,7 @@ export function ReviewDiffFilesProvider({
         });
       });
     return () => controller.abort();
-  }, [container, documentKey, reviewFetch]);
+  }, [container, diffView, documentKey, reviewFetch]);
 
   const value = useMemo(() => state, [state]);
   return (

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -2426,6 +2426,17 @@ button {
   overflow: hidden;
 }
 
+/* Keep the full diff alive while another view is selected. It initializes in
+ * the review page's loading window, then the first Diff click and every return
+ * reuse the same file tree, editor models, selection, and scroll state. */
+.review-diff-view--preloaded {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .review-diff-view--scoped {
   grid-template-rows: 30px minmax(0, 1fr);
 }

--- a/packages/progressive-review/src/review-diff-files.test.ts
+++ b/packages/progressive-review/src/review-diff-files.test.ts
@@ -297,6 +297,29 @@ describe("resolveReviewDiffFiles", () => {
     }
   });
 
+  test("reuses a precomputed comparison when reading file content", async () => {
+    const fixture = await createFileContentFixture();
+    try {
+      const comparison = await resolveReviewDiffFiles({
+        rootPath: fixture.rootPath,
+        baseRef: fixture.baseRef,
+        headRef: fixture.headRef,
+      });
+      await expect(
+        resolveReviewFileContent({
+          rootPath: fixture.rootPath,
+          baseRef: "missing-base",
+          headRef: "missing-head",
+          path: "src/modified.ts",
+          side: "head",
+          comparison,
+        }),
+      ).resolves.toEqual({ content: "export const modified = 'head';\n" });
+    } finally {
+      await rm(fixture.rootPath, { recursive: true, force: true });
+    }
+  });
+
   test("reads the live working-tree head while keeping the base pinned", async () => {
     const fixture = await createFileContentFixture();
     try {

--- a/packages/progressive-review/src/review-diff-files.ts
+++ b/packages/progressive-review/src/review-diff-files.ts
@@ -79,15 +79,18 @@ export async function resolveReviewFileContent(input: {
   path: string;
   side: "base" | "head";
   maxBytes?: number;
+  comparison?: ReviewDiffFilesResult;
 }): Promise<ReviewFileContentResult> {
   const requestedPath = input.path.trim();
   if (!requestedPath) throw new Error("A changed file path is required.");
-  const comparison = await resolveReviewDiffFiles({
-    rootPath: input.rootPath,
-    baseRef: input.baseRef,
-    headRef: input.headRef,
-    includePatch: false,
-  });
+  const comparison =
+    input.comparison ??
+    (await resolveReviewDiffFiles({
+      rootPath: input.rootPath,
+      baseRef: input.baseRef,
+      headRef: input.headRef,
+      includePatch: false,
+    }));
   const file = comparison.files.find((entry) => entry.path === requestedPath);
   if (!file) {
     throw new Error(

--- a/packages/progressive-review/src/server/review-api.ts
+++ b/packages/progressive-review/src/server/review-api.ts
@@ -37,7 +37,10 @@ import {
 } from "../review-agent-traces";
 import { reviewCommentPrompt } from "../review-comment-agent";
 import { resolveReviewCommitScope } from "../review-commits";
-import type { ReviewDiffFile } from "../review-diff-files";
+import type {
+  ReviewDiffFile,
+  ReviewDiffFilesResult,
+} from "../review-diff-files";
 import {
   resolveReviewDiffFiles,
   resolveReviewFileContent,
@@ -253,6 +256,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   const threadServices = new Map<string, ReviewThreadsService>();
   const agentMirrors = new Map<string, NativeMessageMirror>();
   const launchedAgentMessageIds = new Set<string>();
+  const diffCorpora = new Map<string, Promise<ReviewDiffFilesResult>>();
   const startMirror = (
     writableReviewPath: string,
     service: ReviewThreadsService,
@@ -954,13 +958,20 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     const url = new URL(context.req.url);
     const body = parseReviewDiffFilesInput(await readJson(context.req.raw));
     const diffTarget = await resolveScopedDiffTarget(url, body.commit);
-    const result = await resolveReviewDiffFiles({
-      rootPath: diffTarget.rootPath,
-      baseRef: diffTarget.baseRef,
-      headRef: diffTarget.headRef,
-      includePatch: body.includePatch,
-      paths: body.paths,
-    });
+    const corpus = await diffCorpus(diffTarget);
+    const requestedPaths = new Set(body.paths ?? []);
+    const files = corpus.files
+      .filter(
+        (file) =>
+          requestedPaths.size === 0 ||
+          requestedPaths.has(file.path) ||
+          (file.previousPath !== undefined &&
+            requestedPaths.has(file.previousPath)),
+      )
+      .map(({ patch, ...file }) =>
+        body.includePatch ? { ...file, patch } : file,
+      );
+    const result = { ...corpus, files };
     return reviewApiJsonResponse(200, { ok: true, ...result });
   }
 
@@ -977,11 +988,41 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       url,
       contentRequest.commit,
     );
+    const comparison = await diffCorpus(diffTarget);
     const result = await resolveReviewFileContent({
       ...diffTarget,
       ...contentRequest,
+      comparison,
     });
     return reviewApiJsonResponse(200, { ok: true, ...result });
+  }
+
+  function diffCorpus(diffTarget: {
+    rootPath: string;
+    baseRef?: string;
+    headRef?: string;
+  }): Promise<ReviewDiffFilesResult> {
+    const key = JSON.stringify([
+      diffTarget.rootPath,
+      diffTarget.baseRef ?? "",
+      diffTarget.headRef ?? "",
+    ]);
+    const cached = diffCorpora.get(key);
+    if (cached) return cached;
+    let pending: Promise<ReviewDiffFilesResult>;
+    pending = resolveReviewDiffFiles({
+      ...diffTarget,
+      includePatch: true,
+    }).catch((error) => {
+      if (diffCorpora.get(key) === pending) diffCorpora.delete(key);
+      throw error;
+    });
+    diffCorpora.set(key, pending);
+    if (diffCorpora.size > 32) {
+      const oldest = diffCorpora.keys().next().value;
+      if (oldest !== undefined) diffCorpora.delete(oldest);
+    }
+    return pending;
   }
 
   async function reviewCommits(

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -757,6 +757,8 @@ export interface ReviewDiffViewHandle extends ReviewDisposable {
  */
 export interface ReviewDiffViewFactory {
   create(spec: ReviewDiffViewSpec): ReviewDiffViewHandle;
+  /** Returns the parsed full diff that backs the native diff view. */
+  files?(scope?: ReviewCommitScope): Promise<readonly ReviewDiffFileWire[]>;
 }
 
 export interface ReviewCommitScope {


### PR DESCRIPTION
Prompt: Fetch the entire unified diff in one batch, parse and cache it in memory, and prefetch it while the review loads. The first click into Diffs and returning from another tab should feel instant, with no visible preload.

Full transcript at sessions: 01a037c9-f06c-7692-8b48-18b8cb4fef0c, a3048527-ef89-4dc0-9d84-9be5445f6738, 01a037e0-5b94-7c81-a471-edd7bdd07b30