### PR TITLE
Restore scrolling in the Review Commits view

### DIFF
--- a/packages/progressive-review/app/src/App.test.ts
+++ b/packages/progressive-review/app/src/App.test.ts
@@ -1137,6 +1137,16 @@ describe("review app light theme", () => {
     );
   });
 
+  it("lets the Commits view scroll within the shared view region", () => {
+    const styles = readFileSync(new URL("./styles.css", import.meta.url), {
+      encoding: "utf8",
+    });
+
+    expect(styles).toMatch(
+      /\.review-view-region\s*{[^}]*overflow:\s*hidden;[^}]*}[\s\S]*\.review-view-region--commits\s*{[^}]*overflow:\s*auto;/s,
+    );
+  });
+
   it("aligns the Review page surface while letting Map fill its view", () => {
     const styles = readFileSync(new URL("./styles.css", import.meta.url), {
       encoding: "utf8",

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -176,10 +176,6 @@
 }
 
 /* Commit range view */
-.review-view-region--commits {
-  overflow: auto;
-}
-
 .review-commits-view {
   min-height: 100%;
   padding: 32px 24px;
@@ -2251,6 +2247,10 @@ button {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+}
+
+.review-view-region--commits {
+  overflow: auto;
 }
 
 .review-document-view {


### PR DESCRIPTION
Prompt: The Commits tab does not scroll. Fix it as one extra PR on top of the stack.

Full transcript at sessions: 01a037c9-f06c-7692-8b48-18b8cb4fef0c, a3048527-ef89-4dc0-9d84-9be5445f6738, 01a037e0-5b94-7c81-a471-edd7bdd07b30