### PR TITLE
Make trace storage experimental and opt-in

### DIFF
--- a/apps/review-desktop/README.md
+++ b/apps/review-desktop/README.md
@@ -264,11 +264,17 @@ like Home and Agent Setup, not the stock VS Code settings editor. It holds:
 | Privacy | Share anonymous usage data — see [docs/telemetry.md](../../docs/telemetry.md) |
 | Editor | Theme, Keymap |
 | Tools | Extensions |
-| Experimental Features | Software Map |
+| Experimental Features | Software Map, Trace capture |
 
 Software Map defaults to off. Enable it to add the Map tab to reviews.
 Disable it to remove Map entry points. This preference persists in the
 application profile. The change does not require a reload.
+
+Trace capture defaults to off and is not part of onboarding. Enabling it
+takes R2 credentials, installs the agent session hooks and the
+`trace-archaeology` skill for every installed agent, and lets reviews quote
+agent sessions. Disabling removes the hooks and skill again. The state lives
+in the review server's machine trace settings, not the application profile.
 
 The application menu is macOS only. On Windows and Linux the same surfaces are
 available from the command palette (`review.openSettings`).

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewConfiguration.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewConfiguration.ts
@@ -43,7 +43,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[REVIEW_SOFTWARE_MAP_SETTING]: {
 			type: 'boolean',
-			default: true,
+			default: false,
 			description: localize('review.experimental.softwareMap.enabled', "Show the experimental Software Map view in reviews."),
 		},
 	},

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewConfigurationDefaults.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewConfigurationDefaults.ts
@@ -29,7 +29,7 @@ export const REVIEW_KEYMAPS = ['none', 'vim', 'emacs'] as const;
 export type ReviewKeymap = typeof REVIEW_KEYMAPS[number];
 
 export const reviewConfigurationDefaults = {
-	[REVIEW_SOFTWARE_MAP_SETTING]: true,
+	[REVIEW_SOFTWARE_MAP_SETTING]: false,
 	[REVIEW_TELEMETRY_SETTING]: true,
 	'telemetry.telemetryLevel': 'off',
 	'telemetry.enableTelemetry': false,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -22,6 +22,11 @@ different CLI and Desktop versions.
 The `review map` command group is experimental. Its verbs, Git-notes storage
 model, and JSON events may change without a migration period before 1.0.
 
+The `review trace` command group and trace capture are experimental and off
+by default. `review install` configures capture only when `--trace-*`
+credentials are given; Review Desktop exposes it under Settings ▸
+Experimental Features.
+
 ## Common workflow
 
 ```sh

--- a/packages/progressive-review/README.md
+++ b/packages/progressive-review/README.md
@@ -86,13 +86,14 @@ writes a `review` shim to `~/.local/bin` that always resolves to the app's
 bundled CLI. `review install` remains for headless environments; a standalone
 CLI defers to the app's bundled copy whenever Review Desktop is running.
 
-Explicit agent setup installs FFF. It registers the standard `fff` MCP server
-for Claude and Codex, and installs `npm:@ff-labs/pi-fff` for Pi. The MCP
-registration points FFF at `~/.dev/trace-search`. Review accepts existing FFF
-integrations without changes. Silent app-update synchronization never runs an
-FFF installer.
+Agent setup installs only the Review CLI and skills. Enabling Trace capture in
+Settings ▸ Experimental Features also installs FFF: it registers the standard
+`fff` MCP server for Claude and Codex, and installs `npm:@ff-labs/pi-fff` for
+Pi. The MCP registration points FFF at `~/.dev/trace-search`. Review accepts
+existing FFF integrations without changes. Silent app-update synchronization
+never runs an FFF installer.
 
-The same setup page configures R2 and enables trace capture for the machine.
+The experimental setup configures R2 and enables trace capture for the machine.
 Each agent session activates its current repository. Git receives a managed
 hook dispatcher that chains the repository's prior hooks. Jujutsu receives a
 repository commit-trailer template. A target repository needs no Review files.

--- a/packages/progressive-review/app/src/agent-setup-card.test.tsx
+++ b/packages/progressive-review/app/src/agent-setup-card.test.tsx
@@ -129,45 +129,6 @@ describe("AgentSetupCard", () => {
     });
     expect(onStatusChange).toHaveBeenCalledExactlyOnceWith(grantedStatus);
   });
-
-  it("enables trace capture through the shared install action", async () => {
-    const traceStatus: ReviewCliInstallStatus = {
-      ...grantedStatus,
-      trace: {
-        ...grantedStatus.trace,
-        configured: true,
-        endpoint: "https://account.r2.cloudflarestorage.com",
-        bucket: "review-traces",
-        accessKeyIdPrefix: "key-id",
-      },
-    };
-    const apply = vi.fn<ReviewCanvasInstallContent["apply"]>(
-      async () => traceStatus,
-    );
-    const install: ReviewCanvasInstallContent = {
-      status: traceStatus,
-      apply,
-      remove: vi.fn<ReviewCanvasInstallContent["remove"]>(),
-      decline: vi.fn<ReviewCanvasInstallContent["decline"]>(),
-      skip: vi.fn<ReviewCanvasInstallContent["skip"]>(),
-      enablePrompts: vi.fn<ReviewCanvasInstallContent["enablePrompts"]>(),
-    };
-
-    await act(async () => root.render(<AgentSetupCard install={install} />));
-    await act(async () => {
-      [...container.querySelectorAll<HTMLButtonElement>("button")]
-        .find((button) => button.textContent === "Enable")
-        ?.click();
-    });
-
-    expect(apply).toHaveBeenCalledExactlyOnceWith({
-      targets: [],
-      trace: {
-        endpoint: "https://account.r2.cloudflarestorage.com",
-        bucket: "review-traces",
-      },
-    });
-  });
 });
 
 const status: ReviewCliInstallStatus = {

--- a/packages/progressive-review/app/src/agent-setup-card.test.tsx
+++ b/packages/progressive-review/app/src/agent-setup-card.test.tsx
@@ -125,7 +125,6 @@ describe("AgentSetupCard", () => {
 
     expect(apply).toHaveBeenCalledExactlyOnceWith({
       targets: ["codex"],
-      fff: true,
     });
     expect(onStatusChange).toHaveBeenCalledExactlyOnceWith(grantedStatus);
   });

--- a/packages/progressive-review/app/src/agent-setup-card.tsx
+++ b/packages/progressive-review/app/src/agent-setup-card.tsx
@@ -146,7 +146,6 @@ export function AgentSetupCard({
                     targets: presentTargets,
                     shim: true,
                     fff: fffTargets.length > 0,
-                    ...(status.trace.configured ? { trace: true } : {}),
                   }),
                 )
               }
@@ -382,8 +381,10 @@ export function AgentSetupCard({
             void run(
               "trace",
               () =>
+                // Hooks and the trace skill are installed per agent alongside
+                // capture, so enabling covers every agent already set up.
                 install.apply({
-                  targets: [],
+                  targets: staleTargets,
                   trace: {
                     ...(traceEndpoint ? { endpoint: traceEndpoint } : {}),
                     ...(traceBucket ? { bucket: traceBucket } : {}),

--- a/packages/progressive-review/app/src/agent-setup-card.tsx
+++ b/packages/progressive-review/app/src/agent-setup-card.tsx
@@ -3,7 +3,7 @@ import type {
   ReviewCliInstallStatus,
   ReviewCliInstallTarget,
 } from "@dev.fast/review-protocol";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { AGENT_LOGOS } from "./agent-logos";
 
@@ -45,6 +45,8 @@ export function AgentSetupCard({
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  useEffect(() => setStatus(install.status), [install.status]);
+
   const run = async (
     key: string,
     action: () => Promise<ReviewCliInstallStatus>,
@@ -85,14 +87,6 @@ export function AgentSetupCard({
           )),
     )
     .map((agent) => agent.target);
-  const fffReady =
-    fffTargets.length > 0 &&
-    fffTargets.every((target) =>
-      status.fff.registrations.some(
-        (registration) =>
-          registration.target === target && registration.present,
-      ),
-    );
   const firstRun = !status.stamp || status.stamp.consent === "skipped";
 
   return (
@@ -120,7 +114,7 @@ export function AgentSetupCard({
               : "No coding agents were detected on this machine. You can still install the "}
             <code>review</code> terminal command.
           </p>
-          {fffTargets.length > 0 ? (
+          {status.trace.enabled && fffTargets.length > 0 ? (
             <p>
               This action also installs FFF when needed. It registers the
               standard <code>fff</code> server for Claude and Codex, and
@@ -137,7 +131,9 @@ export function AgentSetupCard({
                   install.apply({
                     targets: presentTargets,
                     shim: true,
-                    fff: fffTargets.length > 0,
+                    ...(status.trace.enabled && fffTargets.length > 0
+                      ? { fff: true }
+                      : {}),
                   }),
                 )
               }
@@ -223,7 +219,9 @@ export function AgentSetupCard({
                     void run(`remove-${agent.target}`, () =>
                       install.remove({
                         targets: [agent.target],
-                        ...(supportsFff(agent.target) ? { fff: true } : {}),
+                        ...(status.trace.enabled && supportsFff(agent.target)
+                          ? { fff: true }
+                          : {}),
                       }),
                     )
                   }
@@ -240,7 +238,9 @@ export function AgentSetupCard({
                   void run(agent.target, () =>
                     install.apply({
                       targets: [agent.target],
-                      ...(supportsFff(agent.target) ? { fff: true } : {}),
+                      ...(status.trace.enabled && supportsFff(agent.target)
+                        ? { fff: true }
+                        : {}),
                     }),
                   )
                 }
@@ -255,47 +255,6 @@ export function AgentSetupCard({
           );
         })}
       </ul>
-      <div className="review-agent-setup-terminal">
-        <div className="review-agent-setup-terminal-info">
-          <span className="review-agent-setup-name">Trace search</span>
-          <span
-            className="review-agent-setup-state"
-            data-installed={fffReady}
-            title={`${status.fff.binary.path} · ${status.fff.corpusRoot}`}
-          >
-            {fffReady
-              ? "ready"
-              : status.fff.binary.installed
-                ? "registration needed"
-                : "not installed"}
-          </span>
-          <span className="review-agent-setup-cli">
-            FFF MCP binary:{" "}
-            {status.fff.binary.installed ? "installed" : "not managed here"} ·{" "}
-            {status.fff.registrations
-              .map(
-                (registration) =>
-                  `${TARGET_LABELS[registration.target]}: ${registration.present ? (registration.target === "pi" ? "installed" : "registered") : "missing"}`,
-              )
-              .join(" · ")}
-          </span>
-          <span className="review-agent-setup-cli">
-            Existing FFF integrations stay unchanged. Open a new agent session
-            after setup.
-          </span>
-        </div>
-        <button
-          type="button"
-          disabled={busy !== null || fffTargets.length === 0}
-          onClick={() =>
-            void run("fff", () =>
-              install.apply({ targets: fffTargets, fff: true }),
-            )
-          }
-        >
-          {busy === "fff" ? "Installing…" : fffReady ? "Repair" : "Install"}
-        </button>
-      </div>
       {status.cli ? (
         <div className="review-agent-setup-terminal">
           <div className="review-agent-setup-terminal-info">
@@ -362,6 +321,6 @@ export function AgentSetupCard({
   );
 }
 
-function supportsFff(target: ReviewCliInstallTarget): boolean {
+export function supportsFff(target: ReviewCliInstallTarget): boolean {
   return target === "claude" || target === "codex" || target === "pi";
 }

--- a/packages/progressive-review/app/src/agent-setup-card.tsx
+++ b/packages/progressive-review/app/src/agent-setup-card.tsx
@@ -44,14 +44,6 @@ export function AgentSetupCard({
   const [status, setStatus] = useState<ReviewCliInstallStatus>(install.status);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [traceEndpoint, setTraceEndpoint] = useState(
-    install.status.trace.endpoint ?? "",
-  );
-  const [traceBucket, setTraceBucket] = useState(
-    install.status.trace.bucket ?? "",
-  );
-  const [traceKey, setTraceKey] = useState("");
-  const [traceSecret, setTraceSecret] = useState("");
 
   const run = async (
     key: string,
@@ -302,108 +294,6 @@ export function AgentSetupCard({
           }
         >
           {busy === "fff" ? "Installing…" : fffReady ? "Repair" : "Install"}
-        </button>
-      </div>
-      <div className="review-agent-setup-terminal review-agent-setup-trace">
-        <div className="review-agent-setup-terminal-info">
-          <span className="review-agent-setup-name">Trace capture</span>
-          <span
-            className="review-agent-setup-state"
-            data-installed={status.trace.enabled}
-            title={status.trace.envPath}
-          >
-            {status.trace.enabled
-              ? status.trace.error
-                ? "enabled, storage check failed"
-                : "enabled"
-              : status.trace.configured
-                ? "ready to enable"
-                : "not configured"}
-          </span>
-          <span className="review-agent-setup-cli">
-            Session hooks activate each Git or Jujutsu repository when an agent
-            session starts.
-          </span>
-        </div>
-        <div className="review-agent-setup-trace-fields">
-          <input
-            aria-label="R2 endpoint URL"
-            placeholder="R2 endpoint URL"
-            value={traceEndpoint}
-            onChange={(event) => setTraceEndpoint(event.currentTarget.value)}
-          />
-          <input
-            aria-label="R2 bucket"
-            placeholder="R2 bucket"
-            value={traceBucket}
-            onChange={(event) => setTraceBucket(event.currentTarget.value)}
-          />
-          <input
-            aria-label="R2 access key ID"
-            placeholder={
-              status.trace.accessKeyIdPrefix
-                ? `Access key (${status.trace.accessKeyIdPrefix}…)`
-                : "R2 access key ID"
-            }
-            value={traceKey}
-            onChange={(event) => setTraceKey(event.currentTarget.value)}
-          />
-          <input
-            aria-label="R2 secret access key"
-            type="password"
-            placeholder={
-              status.trace.configured
-                ? "Secret key (unchanged)"
-                : "R2 secret access key"
-            }
-            value={traceSecret}
-            onChange={(event) => setTraceSecret(event.currentTarget.value)}
-          />
-        </div>
-        {status.trace.enabled ? (
-          <button
-            type="button"
-            className="review-agent-setup-subtle"
-            disabled={busy !== null}
-            onClick={() =>
-              void run("trace-remove", () =>
-                install.remove({ targets: [], trace: true }),
-              )
-            }
-          >
-            {busy === "trace-remove" ? "Disabling…" : "Disable"}
-          </button>
-        ) : null}
-        <button
-          type="button"
-          disabled={busy !== null}
-          onClick={() =>
-            void run(
-              "trace",
-              () =>
-                // Hooks and the trace skill are installed per agent alongside
-                // capture, so enabling covers every agent already set up.
-                install.apply({
-                  targets: staleTargets,
-                  trace: {
-                    ...(traceEndpoint ? { endpoint: traceEndpoint } : {}),
-                    ...(traceBucket ? { bucket: traceBucket } : {}),
-                    ...(traceKey ? { key: traceKey } : {}),
-                    ...(traceSecret ? { secret: traceSecret } : {}),
-                  },
-                }),
-              () => {
-                setTraceKey("");
-                setTraceSecret("");
-              },
-            )
-          }
-        >
-          {busy === "trace"
-            ? "Checking…"
-            : status.trace.enabled
-              ? "Repair"
-              : "Enable"}
         </button>
       </div>
       {status.cli ? (

--- a/packages/progressive-review/app/src/review-home-view.tsx
+++ b/packages/progressive-review/app/src/review-home-view.tsx
@@ -310,26 +310,7 @@ export function setupBannerMessage(
       .map((agent) => TARGET_LABELS[agent.target])
       .join(", ")}.`;
   }
-  const traceAgents = status.agents.filter(
-    (agent) =>
-      agent.present &&
-      (agent.target === "claude" ||
-        agent.target === "codex" ||
-        agent.target === "pi"),
-  );
-  const missingFff = traceAgents.filter(
-    (agent) =>
-      !status.fff.registrations.some(
-        (registration) =>
-          registration.target === agent.target && registration.present,
-      ),
-  );
-  if (traceAgents.length > 0 && missingFff.length > 0) {
-    return "FFF trace search needs setup for your coding agents.";
-  }
-  if (!status.trace.enabled) {
-    return "Trace capture needs setup.";
-  }
+  // Trace capture is experimental and opt-in, so Home never nags about it.
   return null;
 }
 

--- a/packages/progressive-review/app/src/settings-page.tsx
+++ b/packages/progressive-review/app/src/settings-page.tsx
@@ -6,6 +6,7 @@ import type {
 import { type ReactNode, useState } from "react";
 
 import { AgentSetupCard } from "./agent-setup-card";
+import { TraceCaptureSection } from "./trace-capture-section";
 
 const THEME_LABELS: Record<ReviewThemeChoice, string> = {
   light: "Light",
@@ -221,6 +222,9 @@ export function SettingsPage({
                 <span>{softwareMapEnabled ? "On" : "Off"}</span>
               </label>
             </Row>
+            {settings.install ? (
+              <TraceCaptureSection install={settings.install} />
+            ) : null}
           </Section>
 
           {error ? <p className="review-settings-error">{error}</p> : null}

--- a/packages/progressive-review/app/src/settings-page.tsx
+++ b/packages/progressive-review/app/src/settings-page.tsx
@@ -1,9 +1,10 @@
 import type {
   ReviewCanvasSettingsContent,
+  ReviewCliInstallStatus,
   ReviewKeymapChoice,
   ReviewThemeChoice,
 } from "@dev.fast/review-protocol";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 
 import { AgentSetupCard } from "./agent-setup-card";
 import { TraceCaptureSection } from "./trace-capture-section";
@@ -67,8 +68,21 @@ export function SettingsPage({
   const [softwareMapEnabled, setSoftwareMapEnabled] = useState(
     settings.softwareMapEnabled,
   );
+  const [installStatus, setInstallStatus] = useState<
+    ReviewCliInstallStatus | undefined
+  >(settings.install?.status);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(
+    () => setInstallStatus(settings.install?.status),
+    [settings.install?.status],
+  );
+
+  const install =
+    settings.install && installStatus
+      ? { ...settings.install, status: installStatus }
+      : settings.install;
 
   const run = async <T,>(
     key: string,
@@ -97,9 +111,14 @@ export function SettingsPage({
             Settings apply to Review Desktop on this machine.
           </p>
 
-          {settings.install ? (
+          {install ? (
             <Section label="Agents">
-              <AgentSetupCard install={settings.install} embedded manageOnly />
+              <AgentSetupCard
+                install={install}
+                embedded
+                manageOnly
+                onStatusChange={setInstallStatus}
+              />
             </Section>
           ) : null}
 
@@ -222,8 +241,11 @@ export function SettingsPage({
                 <span>{softwareMapEnabled ? "On" : "Off"}</span>
               </label>
             </Row>
-            {settings.install ? (
-              <TraceCaptureSection install={settings.install} />
+            {install ? (
+              <TraceCaptureSection
+                install={install}
+                onStatusChange={setInstallStatus}
+              />
             ) : null}
           </Section>
 

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -8997,6 +8997,15 @@ a.review-doc-meta-pr:hover {
   background: var(--control-bg);
 }
 
+.review-agent-setup-trace-search {
+  flex-basis: 100%;
+  width: 100%;
+}
+
+.review-agent-setup-trace-search .review-agent-setup-terminal-info {
+  flex-basis: auto;
+}
+
 .review-agent-setup button.review-agent-setup-subtle {
   border-color: var(--transparent);
   color: var(--review-home-meta);

--- a/packages/progressive-review/app/src/trace-capture-section.test.tsx
+++ b/packages/progressive-review/app/src/trace-capture-section.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import type {
+  ReviewCanvasInstallContent,
+  ReviewCliInstallStatus,
+} from "@dev.fast/review-protocol";
+import { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TraceCaptureSection } from "./trace-capture-section";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("TraceCaptureSection", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("enables capture for every installed agent through the install action", async () => {
+    const apply = vi.fn<ReviewCanvasInstallContent["apply"]>(
+      async () => traceStatus,
+    );
+    const install: ReviewCanvasInstallContent = {
+      status: traceStatus,
+      apply,
+      remove: vi.fn<ReviewCanvasInstallContent["remove"]>(),
+      decline: vi.fn<ReviewCanvasInstallContent["decline"]>(),
+      skip: vi.fn<ReviewCanvasInstallContent["skip"]>(),
+      enablePrompts: vi.fn<ReviewCanvasInstallContent["enablePrompts"]>(),
+    };
+
+    await act(async () =>
+      root.render(<TraceCaptureSection install={install} />),
+    );
+    await act(async () => {
+      [...container.querySelectorAll<HTMLButtonElement>("button")]
+        .find((button) => button.textContent === "Enable")
+        ?.click();
+    });
+
+    expect(apply).toHaveBeenCalledExactlyOnceWith({
+      targets: ["codex"],
+      trace: {
+        endpoint: "https://account.r2.cloudflarestorage.com",
+        bucket: "review-traces",
+      },
+    });
+  });
+
+  it("disables capture through the shared remove action", async () => {
+    const enabledStatus: ReviewCliInstallStatus = {
+      ...traceStatus,
+      trace: { ...traceStatus.trace, enabled: true },
+    };
+    const remove = vi.fn<ReviewCanvasInstallContent["remove"]>(
+      async () => traceStatus,
+    );
+    const install: ReviewCanvasInstallContent = {
+      status: enabledStatus,
+      apply: vi.fn<ReviewCanvasInstallContent["apply"]>(),
+      remove,
+      decline: vi.fn<ReviewCanvasInstallContent["decline"]>(),
+      skip: vi.fn<ReviewCanvasInstallContent["skip"]>(),
+      enablePrompts: vi.fn<ReviewCanvasInstallContent["enablePrompts"]>(),
+    };
+
+    await act(async () =>
+      root.render(<TraceCaptureSection install={install} />),
+    );
+    await act(async () => {
+      [...container.querySelectorAll<HTMLButtonElement>("button")]
+        .find((button) => button.textContent === "Disable")
+        ?.click();
+    });
+
+    expect(remove).toHaveBeenCalledExactlyOnceWith({
+      targets: [],
+      trace: true,
+    });
+  });
+});
+
+const traceStatus: ReviewCliInstallStatus = {
+  agents: [{ target: "codex", present: true, installed: true }],
+  fingerprint: "fingerprint",
+  stamp: {
+    consent: "granted",
+    updatedAt: "2026-08-09T00:00:00.000Z",
+    targets: ["codex"],
+  },
+  stale: false,
+  shim: { path: "/tmp/review", onPath: false },
+  fff: {
+    serverName: "fff",
+    corpusRoot: "/tmp/trace-search",
+    binary: { path: "/tmp/fff-mcp", installed: false },
+    registrations: [{ target: "codex", present: false, managed: false }],
+  },
+  trace: {
+    enabled: false,
+    configured: true,
+    autoActivateRepositories: false,
+    envPath: "/tmp/trace-env",
+    settingsPath: "/tmp/trace-settings.json",
+    endpoint: "https://account.r2.cloudflarestorage.com",
+    bucket: "review-traces",
+    accessKeyIdPrefix: "key-id",
+  },
+  cli: { path: "/tmp/cli.js", version: "0.0.1" },
+};

--- a/packages/progressive-review/app/src/trace-capture-section.test.tsx
+++ b/packages/progressive-review/app/src/trace-capture-section.test.tsx
@@ -54,6 +54,7 @@ describe("TraceCaptureSection", () => {
 
     expect(apply).toHaveBeenCalledExactlyOnceWith({
       targets: ["codex"],
+      fff: true,
       trace: {
         endpoint: "https://account.r2.cloudflarestorage.com",
         bucket: "review-traces",

--- a/packages/progressive-review/app/src/trace-capture-section.tsx
+++ b/packages/progressive-review/app/src/trace-capture-section.tsx
@@ -1,0 +1,160 @@
+import type {
+  ReviewCanvasInstallContent,
+  ReviewCliInstallStatus,
+} from "@dev.fast/review-protocol";
+import { useState } from "react";
+
+/**
+ * Experimental trace capture controls. Lives under Settings ▸ Experimental
+ * Features only: onboarding never mentions it, and nothing else in the app
+ * depends on it being enabled.
+ *
+ * The on/off state is the machine-level trace setting the review server owns,
+ * read back through the install status. Enabling installs the agent hooks and
+ * trace skill for every agent already set up; disabling removes them again.
+ */
+export function TraceCaptureSection({
+  install,
+}: {
+  install: ReviewCanvasInstallContent;
+}) {
+  const [status, setStatus] = useState<ReviewCliInstallStatus>(install.status);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [traceEndpoint, setTraceEndpoint] = useState(
+    install.status.trace.endpoint ?? "",
+  );
+  const [traceBucket, setTraceBucket] = useState(
+    install.status.trace.bucket ?? "",
+  );
+  const [traceKey, setTraceKey] = useState("");
+  const [traceSecret, setTraceSecret] = useState("");
+
+  const run = async (
+    key: string,
+    action: () => Promise<ReviewCliInstallStatus>,
+    onSuccess?: () => void,
+  ) => {
+    setBusy(key);
+    setError(null);
+    try {
+      setStatus(await action());
+      onSuccess?.();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const installedTargets = status.stamp?.targets?.length
+    ? status.stamp.targets
+    : status.agents
+        .filter((agent) => agent.installed)
+        .map((agent) => agent.target);
+
+  return (
+    <div className="review-agent-setup-terminal review-agent-setup-trace">
+      <div className="review-agent-setup-terminal-info">
+        <span className="review-agent-setup-name">Trace capture</span>
+        <span
+          className="review-agent-setup-state"
+          data-installed={status.trace.enabled}
+          title={status.trace.envPath}
+        >
+          {status.trace.enabled
+            ? status.trace.error
+              ? "enabled, storage check failed"
+              : "enabled"
+            : status.trace.configured
+              ? "ready to enable"
+              : "off"}
+        </span>
+        <span className="review-agent-setup-cli">
+          Records agent sessions to your own R2 bucket so reviews can quote
+          them. Session hooks activate each Git or Jujutsu repository when an
+          agent session starts.
+        </span>
+      </div>
+      <div className="review-agent-setup-trace-fields">
+        <input
+          aria-label="R2 endpoint URL"
+          placeholder="R2 endpoint URL"
+          value={traceEndpoint}
+          onChange={(event) => setTraceEndpoint(event.currentTarget.value)}
+        />
+        <input
+          aria-label="R2 bucket"
+          placeholder="R2 bucket"
+          value={traceBucket}
+          onChange={(event) => setTraceBucket(event.currentTarget.value)}
+        />
+        <input
+          aria-label="R2 access key ID"
+          placeholder={
+            status.trace.accessKeyIdPrefix
+              ? `Access key (${status.trace.accessKeyIdPrefix}…)`
+              : "R2 access key ID"
+          }
+          value={traceKey}
+          onChange={(event) => setTraceKey(event.currentTarget.value)}
+        />
+        <input
+          aria-label="R2 secret access key"
+          type="password"
+          placeholder={
+            status.trace.configured
+              ? "Secret key (unchanged)"
+              : "R2 secret access key"
+          }
+          value={traceSecret}
+          onChange={(event) => setTraceSecret(event.currentTarget.value)}
+        />
+      </div>
+      {status.trace.enabled ? (
+        <button
+          type="button"
+          className="review-agent-setup-subtle"
+          disabled={busy !== null}
+          onClick={() =>
+            void run("trace-remove", () =>
+              install.remove({ targets: [], trace: true }),
+            )
+          }
+        >
+          {busy === "trace-remove" ? "Disabling…" : "Disable"}
+        </button>
+      ) : null}
+      <button
+        type="button"
+        disabled={busy !== null}
+        onClick={() =>
+          void run(
+            "trace",
+            () =>
+              install.apply({
+                targets: installedTargets,
+                trace: {
+                  ...(traceEndpoint ? { endpoint: traceEndpoint } : {}),
+                  ...(traceBucket ? { bucket: traceBucket } : {}),
+                  ...(traceKey ? { key: traceKey } : {}),
+                  ...(traceSecret ? { secret: traceSecret } : {}),
+                },
+              }),
+            () => {
+              setTraceKey("");
+              setTraceSecret("");
+            },
+          )
+        }
+      >
+        {busy === "trace"
+          ? "Checking…"
+          : status.trace.enabled
+            ? "Repair"
+            : "Enable"}
+      </button>
+      {error ? <p className="review-agent-setup-error">{error}</p> : null}
+    </div>
+  );
+}

--- a/packages/progressive-review/app/src/trace-capture-section.tsx
+++ b/packages/progressive-review/app/src/trace-capture-section.tsx
@@ -2,7 +2,9 @@ import type {
   ReviewCanvasInstallContent,
   ReviewCliInstallStatus,
 } from "@dev.fast/review-protocol";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
+import { supportsFff, TARGET_LABELS } from "./agent-setup-card";
 
 /**
  * Experimental trace capture controls. Lives under Settings ▸ Experimental
@@ -15,8 +17,10 @@ import { useState } from "react";
  */
 export function TraceCaptureSection({
   install,
+  onStatusChange,
 }: {
   install: ReviewCanvasInstallContent;
+  onStatusChange?: (status: ReviewCliInstallStatus) => void;
 }) {
   const [status, setStatus] = useState<ReviewCliInstallStatus>(install.status);
   const [busy, setBusy] = useState<string | null>(null);
@@ -30,6 +34,8 @@ export function TraceCaptureSection({
   const [traceKey, setTraceKey] = useState("");
   const [traceSecret, setTraceSecret] = useState("");
 
+  useEffect(() => setStatus(install.status), [install.status]);
+
   const run = async (
     key: string,
     action: () => Promise<ReviewCliInstallStatus>,
@@ -38,7 +44,9 @@ export function TraceCaptureSection({
     setBusy(key);
     setError(null);
     try {
-      setStatus(await action());
+      const next = await action();
+      setStatus(next);
+      onStatusChange?.(next);
       onSuccess?.();
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
@@ -52,6 +60,26 @@ export function TraceCaptureSection({
     : status.agents
         .filter((agent) => agent.installed)
         .map((agent) => agent.target);
+  const fffTargets = status.agents
+    .filter(
+      (agent) =>
+        supportsFff(agent.target) &&
+        (agent.present ||
+          agent.installed ||
+          status.fff.registrations.some(
+            (registration) =>
+              registration.target === agent.target && registration.present,
+          )),
+    )
+    .map((agent) => agent.target);
+  const fffReady =
+    fffTargets.length > 0 &&
+    fffTargets.every((target) =>
+      status.fff.registrations.some(
+        (registration) =>
+          registration.target === target && registration.present,
+      ),
+    );
 
   return (
     <div className="review-agent-setup-terminal review-agent-setup-trace">
@@ -134,6 +162,7 @@ export function TraceCaptureSection({
             () =>
               install.apply({
                 targets: installedTargets,
+                ...(fffTargets.length > 0 ? { fff: true } : {}),
                 trace: {
                   ...(traceEndpoint ? { endpoint: traceEndpoint } : {}),
                   ...(traceBucket ? { bucket: traceBucket } : {}),
@@ -154,6 +183,53 @@ export function TraceCaptureSection({
             ? "Repair"
             : "Enable"}
       </button>
+      {status.trace.enabled && fffTargets.length > 0 ? (
+        <div className="review-agent-setup-terminal review-agent-setup-trace-search">
+          <div className="review-agent-setup-terminal-info">
+            <span className="review-agent-setup-name">Trace search</span>
+            <span
+              className="review-agent-setup-state"
+              data-installed={fffReady}
+              title={`${status.fff.binary.path} · ${status.fff.corpusRoot}`}
+            >
+              {fffReady
+                ? "ready"
+                : status.fff.binary.installed
+                  ? "registration needed"
+                  : "not installed"}
+            </span>
+            <span className="review-agent-setup-cli">
+              FFF MCP binary:{" "}
+              {status.fff.binary.installed ? "installed" : "not managed here"}
+              {" · "}
+              {status.fff.registrations
+                .filter((registration) =>
+                  fffTargets.includes(registration.target),
+                )
+                .map(
+                  (registration) =>
+                    `${TARGET_LABELS[registration.target]}: ${registration.present ? (registration.target === "pi" ? "installed" : "registered") : "missing"}`,
+                )
+                .join(" · ")}
+            </span>
+            <span className="review-agent-setup-cli">
+              Existing FFF integrations stay unchanged. Open a new agent session
+              after setup.
+            </span>
+          </div>
+          <button
+            type="button"
+            disabled={busy !== null}
+            onClick={() =>
+              void run("fff", () =>
+                install.apply({ targets: fffTargets, fff: true }),
+              )
+            }
+          >
+            {busy === "fff" ? "Installing…" : fffReady ? "Repair" : "Install"}
+          </button>
+        </div>
+      ) : null}
       {error ? <p className="review-agent-setup-error">{error}</p> : null}
     </div>
   );

--- a/packages/progressive-review/app/src/trace-capture-section.tsx
+++ b/packages/progressive-review/app/src/trace-capture-section.tsx
@@ -4,7 +4,7 @@ import type {
 } from "@dev.fast/review-protocol";
 import { useEffect, useState } from "react";
 
-import { supportsFff, TARGET_LABELS } from "./agent-setup-card";
+import { TARGET_LABELS, supportsFff } from "./agent-setup-card";
 
 /**
  * Experimental trace capture controls. Lives under Settings ▸ Experimental

--- a/packages/progressive-review/app/src/welcome-page.tsx
+++ b/packages/progressive-review/app/src/welcome-page.tsx
@@ -181,15 +181,16 @@ function onboardingSetupComplete(status: ReviewCliInstallStatus): boolean {
   const fffAgents = installedAgents.filter(
     (agent) => agent.target === "claude" || agent.target === "codex",
   );
+  // Trace capture is experimental and lives in Settings; onboarding does
+  // not depend on it.
   return (
-    status.trace.enabled &&
-    (fffAgents.length === 0 ||
-      fffAgents.every((agent) =>
-        status.fff.registrations.some(
-          (registration) =>
-            registration.target === agent.target && registration.present,
-        ),
-      ))
+    fffAgents.length === 0 ||
+    fffAgents.every((agent) =>
+      status.fff.registrations.some(
+        (registration) =>
+          registration.target === agent.target && registration.present,
+      ),
+    )
   );
 }
 

--- a/packages/progressive-review/src/agent-trace-hooks.ts
+++ b/packages/progressive-review/src/agent-trace-hooks.ts
@@ -160,8 +160,7 @@ export async function installCodexTraceHook(
     "SessionEnd",
   ] as const;
   const missingEvents = hookEvents.filter(
-    (eventName) =>
-      !existing.includes(` trace hook ${eventName}`),
+    (eventName) => !existing.includes(` trace hook ${eventName}`),
   );
   if (missingEvents.length === 0) {
     return { agent: "codex", path: configPath, modified: false };
@@ -314,7 +313,9 @@ function shellCommand(command: string): string {
 function isReviewTraceHookCommand(command: unknown): boolean {
   if (typeof command !== "string") return false;
   const match =
-    /^(.*) trace hook (SessionStart|UserPromptSubmit|SessionEnd)$/.exec(command);
+    /^(.*) trace hook (SessionStart|UserPromptSubmit|SessionEnd)$/.exec(
+      command,
+    );
   if (!match) return false;
   return match[1] === "review" || match[1].endsWith("/review'");
 }

--- a/packages/progressive-review/src/cli-runner.ts
+++ b/packages/progressive-review/src/cli-runner.ts
@@ -542,11 +542,26 @@ export async function runProgressiveReviewCli(
           "all",
         ]),
       )
-      .option("--trace-endpoint <url>", "R2 endpoint URL")
-      .option("--trace-bucket <name>", "R2 bucket name")
-      .option("--trace-key <id>", "R2 access key ID")
-      .option("--trace-secret <key>", "R2 secret access key")
-      .option("--without-traces", "Do not configure trace capture")
+      .option(
+        "--trace-endpoint <url>",
+        "R2 endpoint URL (experimental trace capture)",
+      )
+      .option(
+        "--trace-bucket <name>",
+        "R2 bucket name (experimental trace capture)",
+      )
+      .option(
+        "--trace-key <id>",
+        "R2 access key ID (experimental trace capture)",
+      )
+      .option(
+        "--trace-secret <key>",
+        "R2 secret access key (experimental trace capture)",
+      )
+      .option(
+        "--without-traces",
+        "Deprecated: trace capture is off unless --trace-* options are given",
+      )
       .addHelpText("after", progressiveReviewInstallHelp()),
     "plain",
   );
@@ -566,9 +581,11 @@ export async function runProgressiveReviewCli(
         targets: installTargets(targets),
         env,
         fff: true,
-        ...(options.traces === false
-          ? {}
-          : {
+        // Trace capture is experimental and opt-in: only a request that names
+        // R2 credentials configures it. --without-traces stays accepted so
+        // existing scripts keep working.
+        ...(traceCredentialsRequested(options) && options.traces !== false
+          ? {
               trace: {
                 credentials: {
                   endpoint: options.traceEndpoint,
@@ -577,7 +594,8 @@ export async function runProgressiveReviewCli(
                   secret: options.traceSecret,
                 },
               },
-            }),
+            }
+          : {}),
         json: options.json,
         stdout: input.stdout,
         stderr: input.stderr,
@@ -1219,6 +1237,20 @@ function progressiveReviewTopLevelHelp(): string {
   ].join("\n");
 }
 
+function traceCredentialsRequested(options: {
+  traceEndpoint?: string;
+  traceBucket?: string;
+  traceKey?: string;
+  traceSecret?: string;
+}): boolean {
+  return Boolean(
+    options.traceEndpoint ||
+    options.traceBucket ||
+    options.traceKey ||
+    options.traceSecret,
+  );
+}
+
 function progressiveReviewInstallHelp(): string {
   return [
     "",
@@ -1239,8 +1271,9 @@ function progressiveReviewInstallHelp(): string {
     "  review install codex",
     "  review install claude cursor",
     "  review install all",
+    "",
+    "Trace capture (experimental) is off unless R2 credentials are given:",
     "  review install codex --trace-endpoint <url> --trace-bucket <name> --trace-key <id> --trace-secret <key>",
-    "  review install codex --without-traces",
   ].join("\n");
 }
 

--- a/packages/progressive-review/src/install.test.ts
+++ b/packages/progressive-review/src/install.test.ts
@@ -7,6 +7,9 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { runInstall } from "./install";
 
+const REQUIRED_SKILLS = ["dev-review", "dev-review-map"] as const;
+const ALL_SKILLS = [...REQUIRED_SKILLS, "trace-archaeology"] as const;
+
 const tempRoots: string[] = [];
 
 afterEach(async () => {
@@ -34,7 +37,7 @@ async function writeSkill(
 
 async function makePackageRoot(): Promise<string> {
   const packageRoot = await makeTempDir();
-  for (const name of ["dev-review", "dev-review-map", "trace-archaeology"]) {
+  for (const name of ALL_SKILLS) {
     await writeSkill(packageRoot, name);
   }
   return packageRoot;
@@ -66,7 +69,7 @@ describe("runInstall", () => {
     });
 
     expect(code).toBe(0);
-    for (const name of ["dev-review", "dev-review-map", "trace-archaeology"]) {
+    for (const name of REQUIRED_SKILLS) {
       expect(
         await readFile(
           path.join(homeDir, ".claude", "skills", name, "SKILL.md"),
@@ -86,11 +89,14 @@ describe("runInstall", () => {
         ),
       ).toContain(`# ${name}`);
     }
-    // Verify trace hooks are installed
+    // Trace capture is off by default: no agent hooks, no trace skill.
     expect(existsSync(path.join(homeDir, ".claude", "settings.json"))).toBe(
-      true,
+      false,
     );
-    expect(existsSync(path.join(homeDir, ".codex", "config.toml"))).toBe(true);
+    expect(existsSync(path.join(homeDir, ".codex", "config.toml"))).toBe(false);
+    expect(
+      existsSync(path.join(homeDir, ".claude", "skills", "trace-archaeology")),
+    ).toBe(false);
 
     // Legacy prompt/command locations should stay empty.
     await expect(
@@ -162,7 +168,7 @@ describe("runInstall", () => {
         "utf8",
       ),
     ).rejects.toThrow(/ENOENT/);
-    for (const name of ["dev-review", "dev-review-map", "trace-archaeology"]) {
+    for (const name of REQUIRED_SKILLS) {
       expect(
         await readFile(
           path.join(homeDir, ".agents", "skills", name, "SKILL.md"),
@@ -252,7 +258,7 @@ describe("runInstall", () => {
     });
 
     expect(code).toBe(0);
-    for (const name of ["dev-review", "dev-review-map", "trace-archaeology"]) {
+    for (const name of REQUIRED_SKILLS) {
       expect(
         await readFile(
           path.join(homeDir, ".cursor", "skills", name, "SKILL.md"),
@@ -289,7 +295,7 @@ describe("runInstall", () => {
     });
 
     expect(code).toBe(0);
-    for (const name of ["dev-review", "dev-review-map", "trace-archaeology"]) {
+    for (const name of REQUIRED_SKILLS) {
       expect(
         await readFile(
           path.join(homeDir, ".agents", "skills", name, "SKILL.md"),
@@ -297,6 +303,49 @@ describe("runInstall", () => {
         ),
       ).toContain(`# ${name}`);
     }
+    expect(
+      existsSync(
+        path.join(homeDir, ".pi", "agent", "extensions", "review-trace.ts"),
+      ),
+    ).toBe(false);
+  });
+
+  it("installs trace hooks and the trace skill once capture is enabled", async () => {
+    const packageRoot = await makePackageRoot();
+    const homeDir = await makeTempDir();
+    const streams = silentStreams();
+    const settingsPath = path.join(homeDir, "trace-settings.json");
+    await writeFile(
+      settingsPath,
+      JSON.stringify({
+        version: 1,
+        enabled: true,
+        autoActivateRepositories: true,
+      }),
+    );
+
+    const code = await runInstall({
+      targets: ["claude", "codex", "pi"],
+      homeDir,
+      packageRoot,
+      env: { TRACE_SETTINGS_FILE: settingsPath },
+      stdout: streams.stdout,
+      stderr: streams.stderr,
+    });
+
+    expect(code).toBe(0);
+    for (const root of [".claude", ".agents"]) {
+      expect(
+        await readFile(
+          path.join(homeDir, root, "skills", "trace-archaeology", "SKILL.md"),
+          "utf8",
+        ),
+      ).toContain("# trace-archaeology");
+    }
+    expect(existsSync(path.join(homeDir, ".claude", "settings.json"))).toBe(
+      true,
+    );
+    expect(existsSync(path.join(homeDir, ".codex", "config.toml"))).toBe(true);
     expect(
       existsSync(
         path.join(homeDir, ".pi", "agent", "extensions", "review-trace.ts"),

--- a/packages/progressive-review/src/install.ts
+++ b/packages/progressive-review/src/install.ts
@@ -28,11 +28,10 @@ import {
 
 export type InstallTarget = "claude" | "codex" | "cursor" | "pi";
 
-const REQUIRED_SKILL_NAMES = [
-  "dev-review",
-  "dev-review-map",
-  "trace-archaeology",
-] as const;
+const REQUIRED_SKILL_NAMES = ["dev-review", "dev-review-map"] as const;
+// Installed only on machines that capture traces; removed when capture is
+// disabled so agents are not steered toward an unconfigured feature.
+const TRACE_SKILL_NAMES = ["trace-archaeology"] as const;
 const STALE_SKILL_NAMES = [
   "review",
   "review-map",
@@ -78,7 +77,7 @@ export async function runInstall(input: {
   const skillsDir = path.join(packageRoot, "skills");
   const skillDirs = await listSkillDirs(skillsDir);
   const skillNames = new Set(skillDirs.map((skill) => skill.name));
-  const missingSkills = REQUIRED_SKILL_NAMES.filter(
+  const missingSkills = [...REQUIRED_SKILL_NAMES, ...TRACE_SKILL_NAMES].filter(
     (name) => !skillNames.has(name),
   );
   if (missingSkills.length > 0) {
@@ -126,6 +125,10 @@ export async function runInstall(input: {
     await removeStaleSkills(destRoot);
     for (const skillDir of skillDirs) {
       const skillDest = path.join(destRoot, skillDir.name);
+      if (isTraceSkill(skillDir.name) && !installTraceHooks) {
+        await rm(skillDest, { recursive: true, force: true });
+        continue;
+      }
       await installDirectory(skillDir.src, skillDest);
       installed.push({ kind: "skill", dest: skillDest });
     }
@@ -210,15 +213,37 @@ export async function removeInstalledSkills(
   homeDir = os.homedir(),
 ): Promise<void> {
   const destRoot = skillsDestRoot(homeDir, target);
-  for (const name of [...REQUIRED_SKILL_NAMES, ...STALE_SKILL_NAMES]) {
+  for (const name of [
+    ...REQUIRED_SKILL_NAMES,
+    ...TRACE_SKILL_NAMES,
+    ...STALE_SKILL_NAMES,
+  ]) {
     await rm(path.join(destRoot, name), { recursive: true, force: true });
   }
+}
+
+export async function removeTraceSkills(
+  target: InstallTarget,
+  homeDir = os.homedir(),
+): Promise<void> {
+  const destRoot = skillsDestRoot(homeDir, target);
+  for (const name of TRACE_SKILL_NAMES) {
+    await rm(path.join(destRoot, name), { recursive: true, force: true });
+  }
+}
+
+function isTraceSkill(name: string): boolean {
+  return (TRACE_SKILL_NAMES as readonly string[]).includes(name);
 }
 
 export async function detectInstalledTargets(
   homeDir = os.homedir(),
 ): Promise<InstallTarget[]> {
-  const knownSkillNames = [...REQUIRED_SKILL_NAMES, ...STALE_SKILL_NAMES];
+  const knownSkillNames = [
+    ...REQUIRED_SKILL_NAMES,
+    ...TRACE_SKILL_NAMES,
+    ...STALE_SKILL_NAMES,
+  ];
   const installed: InstallTarget[] = [];
   for (const target of ALL_INSTALL_TARGETS) {
     const destRoot = skillsDestRoot(homeDir, target);

--- a/packages/progressive-review/src/install.ts
+++ b/packages/progressive-review/src/install.ts
@@ -23,6 +23,7 @@ import { emitJsonEvent, failWithJsonError, humanStream } from "./cli-output";
 import {
   type TraceCredentialsInput,
   configureTraceMachine,
+  traceMachineEnabled,
 } from "./trace-machine-setup";
 
 export type InstallTarget = "claude" | "codex" | "cursor" | "pi";
@@ -113,6 +114,12 @@ export async function runInstall(input: {
     }
   }
 
+  // Agent hooks only make sense when this machine captures traces. A
+  // previous install may already have enabled it without credentials in
+  // this request.
+  const installTraceHooks =
+    traceEnabled || (await traceMachineEnabled({ homeDir, env }));
+
   const installed: InstalledItem[] = [];
   for (const target of input.targets) {
     const destRoot = skillsDestRoot(homeDir, target);
@@ -122,6 +129,7 @@ export async function runInstall(input: {
       await installDirectory(skillDir.src, skillDest);
       installed.push({ kind: "skill", dest: skillDest });
     }
+    if (!installTraceHooks) continue;
     if (target === "claude") {
       await installClaudeTraceHook(homeDir, input.reviewCommand);
     } else if (target === "codex") {

--- a/packages/progressive-review/src/review-scaffold.ts
+++ b/packages/progressive-review/src/review-scaffold.ts
@@ -45,6 +45,7 @@ import { ensurePinnedReviewWorktreeAtCommit } from "./review-worktree-target";
 import { resolveReviewRoot, resolveReviewSource } from "./runtime";
 import { compileReviewDocumentBundle } from "./server/doc-bundler";
 import { reviewInfoEvent } from "./server/review-info";
+import { traceMachineEnabled } from "./trace-machine-setup";
 
 export interface RunReviewScaffoldInput {
   cwd: string;
@@ -364,6 +365,12 @@ async function discoverAndPullScaffoldTraces(input: {
   headCommit: string;
   progress?: (message: string) => void;
 }): Promise<{ traces: ReviewScaffoldTraces; warnings: string[] }> {
+  // Trace storage is opt-in. Without it there is nothing to discover, and
+  // probing R2 on every scaffold would only produce noise.
+  if (!(await traceMachineEnabled())) {
+    return { traces: emptyScaffoldTraces([]), warnings: [] };
+  }
+
   let resolvedSessions: ReviewAgentTraceSession[];
   try {
     resolvedSessions = await listReviewTraceSessions(input);

--- a/packages/progressive-review/src/server/cli-install.ts
+++ b/packages/progressive-review/src/server/cli-install.ts
@@ -38,6 +38,7 @@ import {
   type InstallTarget,
   detectInstalledTargets,
   removeInstalledSkills,
+  removeTraceSkills,
   runInstall,
 } from "../install";
 import { readProgressiveReviewPackageVersion } from "../package-paths";
@@ -317,6 +318,14 @@ export async function removeCliInstall(input: {
   if (input.trace) {
     await disableAllTraceRepositories(homeDir);
     await disableTraceMachine({ homeDir, env });
+    // Disabling capture also retires the per-agent pieces that exist only
+    // for it, regardless of which targets this request named.
+    for (const target of await detectInstalledTargets(homeDir)) {
+      await removeTraceSkills(target, homeDir);
+      if (target === "claude" || target === "codex" || target === "pi") {
+        await removeAgentTraceHook(target, homeDir);
+      }
+    }
     chunks.push("[ok] disabled Review trace capture\n");
   }
 

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 
 import {
   REVIEW_DESKTOP_DISCOVERY_VERSION,
+  type ReviewDescriptor,
   type ReviewDesktopDiscovery,
   type ReviewDesktopGlobalEvent,
   type ReviewRecord,
@@ -35,8 +36,8 @@ import {
 import {
   dismissReview,
   markReviewViewed,
-  reviewReapsAt,
   restoreReview,
+  reviewReapsAt,
   selectReapableReviews,
 } from "../review-attention";
 import { listReviewDocumentVersions } from "../review-document-versions";


### PR DESCRIPTION
## Summary

Trace capture (agent session hooks + R2 storage) was wired into the default install and onboarding even though it needs credentials most users never configure. This stack makes it an explicit, experimental opt-in, following the Software Map precedent, and fixes Software Map's own default while at it.

Each commit stands on its own and is bisectable:

1. **Default Software Map to off** — code said `true`, README said off.
2. **Scaffold skips trace discovery** when the machine hasn't enabled capture (no R2 probe per scaffold).
3. **Agent trace hooks install only with capture enabled** (`install.ts`) — previously every Claude/Codex/pi skills install wrote `review trace hook` hooks.
4. **`trace-archaeology` skill ships only with capture** and is removed when capture is disabled.
5. **`review install` no longer tries to configure trace** unless `--trace-*` options are given; `--without-traces` stays as a no-op.
6. **First-run install no longer re-applies trace.** The Enable control now installs hooks + skill for every installed agent (they're gated on capture now).
7. **Onboarding completes without trace; Home stops nagging.**
8. **Trace capture moves to Settings ▸ Experimental Features** as `TraceCaptureSection`, next to Software Map. No new workbench setting or protocol field: the on/off state stays the server-owned `~/.config/dev-trace/settings.json`, which every hook already gates on.
9. **Docs** (`docs/cli-reference.md`, desktop README).
10. **Tests** for the new defaults.

## Behavior change for existing users

Machines that already enabled capture keep working unchanged. Machines that never configured it stop receiving hook entries and the `trace-archaeology` skill on the next install.

## Test plan

- `pnpm lint`, `pnpm format:check` clean
- `tsc --noEmit` in `packages/progressive-review` clean
- `vitest run` in `packages/progressive-review`: 138 files / 1114 tests pass
- `node --test scripts/*.test.mjs` passes