### PR TITLE
Use semver tags for Review Desktop releases

### DIFF
--- a/.github/workflows/review-desktop-release.yml
+++ b/.github/workflows/review-desktop-release.yml
@@ -62,7 +62,7 @@ jobs:
           esac
 
           VERSION="${MAJOR}.${MINOR}.${PATCH}"
-          TAG="review-desktop-v${VERSION}"
+          TAG="v${VERSION}"
           echo "Releasing Review Desktop v${VERSION} (tag: $TAG)"
 
           # Both checks below run before anything is written, so a doomed run

--- a/apps/review-desktop/README.md
+++ b/apps/review-desktop/README.md
@@ -119,7 +119,7 @@ Run the **Review Desktop Release** workflow from the Actions tab (or
 patch/minor/major bump. The workflow:
 
 1. bumps `apps/review-desktop/package.json`, commits `[skip ci]`, tags
-   `review-desktop-vX.Y.Z`, and creates a draft GitHub release;
+   `vX.Y.Z`, and creates a draft GitHub release;
 2. compiles the platform-independent Code OSS, Review canvas, Review server,
    workspace packages, and pinned `darwin-arm64` curated extensions on Linux,
    then uploads one `darwin-payload` artifact;


### PR DESCRIPTION
Tag future Review Desktop GitHub releases as vX.Y.Z and update the release guide to match.

Agent-Session: 01a03a0b-a935-7840-89da-6ae09f9e7b47

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>