### PR TITLE
Expand README with limitations and FAQs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ not explain whether the system is right. See the
 ## Known limitations
 * Review was engineered with reviewing changes to one repo, your coding agent can obviously pull context from other repos on your machine, but we haven't engineered it to map architectural changes across repos. If you need this let us know!
 * Review doesnt properly handle stacked prs right now, but this is coming soon.
+* It's currently a pain to share reviews between machines, self-hostable collaboration tools are also on our roadmap.
+
+*If there are any other features you need, feel free to ask on discord or open an issue/discussion!*
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ not explain whether the system is right. See the
 [Privacy](docs/privacy.md) ·
 [Troubleshooting](docs/troubleshooting.md)
 
+## Known limitations
+* Review was engineered with reviewing changes to one repo, your coding agent can obviously pull context from other repos on your machine, but we haven't engineered it to map architectural changes across repos. If you need this let us know!
+* Review doesnt properly handle stacked prs right now, but this is coming soon.
+
 ## Development
 
 Review requires Node.js 24 and pnpm 11. See the

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ not explain whether the system is right. See the
 
 ## Known limitations
 
-- Review was designed to review changes in a single repository. Your coding
-  agent can pull context from other repositories on your machine, but Review
-  does not yet map architectural changes across repositories. If you need this,
-  let us know.
-- Review does not properly handle stacked PRs yet, but support is coming soon.
-- Sharing reviews between machines is currently difficult. Self-hostable
+- Review was engineered with reviewing changes to one repo. Your coding agent
+  can obviously pull context from other repos on your machine, but we haven't
+  engineered it to map architectural changes across repos. If you need this, let
+  us know!
+- Review doesn't properly handle stacked PRs right now, but this is coming soon.
+- It's currently a pain to share reviews between machines; self-hostable
   collaboration tools are also on our roadmap.
 
 _If there are any other features you need, feel free to ask on Discord or open
@@ -66,42 +66,42 @@ an issue or discussion!_
 ## FAQs
 
 <details>
-<summary><strong>Who is Review for?</strong></summary>
+<summary><strong>Who is the Review app for?</strong></summary>
 
-- If you want the productivity gains of generating code with AI while still
-  understanding how your codebase works and maintaining quality, Review is for
-  you.
-- If you do not use AI to write much code and are comfortable reviewing diffs
-  line by line, Review probably is not for you.
+- If you still want the gains of generating code with AI but also want to
+  understand how your codebase works and maintain quality, Review is for you.
+- If you don't use AI to write a lot of code and are content reading diffs line
+  by line, Review probably isn't for you.
 
 </details>
 
 <details>
 <summary>
-<strong>How is Review different from Greptile, Bugbot, and CodeRabbit?</strong>
+<strong>How is this different from Greptile, Bugbot, CodeRabbit, etc.?</strong>
 </summary>
 
-Those tools review LLM-generated code with another LLM. Review is complementary:
-it does not review your code for you, but helps you understand the change and
-spot regressions quickly.
+These tools review your LLM-generated code with another LLM. Review is a
+complementary tool. Review doesn't review your code for you, but helps you
+understand it and spot regressions quickly.
 
 </details>
 
 <details>
-<summary><strong>How is Review different from Plannotator?</strong></summary>
+<summary><strong>How is this different from Plannotator?</strong></summary>
 
-Plannotator is an alternative to using the terminal for reviewing plans and
-simple code diffs. Review draws inspiration from Plannotator's lifecycle, but is
-designed as an opinionated framework for reviewing AI-generated code changes.
+Plannotator is meant as an alternative to using the terminal for reviewing plans
+and simple code diffs. Review takes some inspiration from Plannotator in its
+lifecycle but is engineered as an opinionated framework for reviewing
+AI-generated code diffs.
 
 </details>
 
 <details>
-<summary><strong>How will Review make money?</strong></summary>
+<summary><strong>How are you guys gonna make money on this?</strong></summary>
 
 Eventually, we'll charge companies for a hosted Review product that manages
-review creation alongside features such as trajectory storage and review
-sharing. Everything will remain easy to self-host.
+review creation alongside features like trajectory storage, review sharing,
+etc., but everything will remain easily self-hostable.
 
 </details>
 
@@ -148,12 +148,13 @@ fork retains Microsoft's MIT license and third-party notices; see
 
 ## Influences
 
-- [Geoffrey Litt on understanding as the new bottleneck](https://www.geoffreylitt.com/2026/07/02/understanding-is-the-new-bottleneck)
-  offers a great overview of the constraints of modern software engineering.
-- [Maggie Appleton on vibe coding and legacy code](https://maggieappleton.com/2025-08-vibe-legacy-code/)
-  and [Val Town on vibe code](https://blog.val.town/vibe-code) do a great job
-  describing how AI-generated code fits into our pre-2025 notion of software
-  engineering.
-- We're big fans of Karpathy, so here are two posts we love discussing:
-  - [On LLM agents](https://x.com/karpathy/status/1979644538185752935)
-  - [On agents as "junior engineer savants"](https://x.com/karpathy/status/1915581920022585597)
+- <https://www.geoffreylitt.com/2026/07/02/understanding-is-the-new-bottleneck>
+  — a great overview of the constraints of modern software engineering.
+- <https://maggieappleton.com/2025-08-vibe-legacy-code/> and
+  <https://blog.val.town/vibe-code> — do a great job describing how AI-generated
+  code fits into our pre-2025 notion of software engineering.
+- We're big fans of Karpathy, so here are some of his banger tweets we love
+  discussing:
+  - On LLM agents: <https://x.com/karpathy/status/1979644538185752935>
+  - On agents as "junior engineer savants":
+    <https://x.com/karpathy/status/1915581920022585597>

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Review is an open-source desktop app for understanding and reviewing
 agent-written code. Coding agents turn a branch or pull request into a guided,
 interactive Review connected to the exact code behind it.
 
-Explore architecture and data flow, inspect diffs, ask questions,
-and explore coding traces from one interface.
+Explore architecture and data flow, inspect diffs, ask questions, and explore
+coding traces from one interface.
 
 <p align="center">
   <img
@@ -29,6 +29,7 @@ and explore coding traces from one interface.
   />
 </p>
 
+<!-- prettier-ignore -->
 > [!NOTE]
 > Review is in beta and currently ships for macOS on Apple silicon.
 
@@ -36,8 +37,8 @@ and explore coding traces from one interface.
 
 1. [Download Review](https://install.dev.fast) and open the app.
 2. Connect Claude Code, Codex, and other coding agents from the welcome screen.
-3. Ask your agent to review your current branch against up-to-date main and
-   open the result in Review.
+3. Ask your agent to review your current branch against up-to-date main and open
+   the result in Review.
 
 Review works especially well for large changes where a file-by-file diff does
 not explain whether the system is right. See the
@@ -45,43 +46,64 @@ not explain whether the system is right. See the
 
 ## Documentation
 
-[How Review works](docs/how-review-works.md) ·
-[Coding agents](docs/agents.md) ·
-[CLI](docs/cli-reference.md) ·
-[Privacy](docs/privacy.md) ·
+[How Review works](docs/how-review-works.md) · [Coding agents](docs/agents.md) ·
+[CLI](docs/cli-reference.md) · [Privacy](docs/privacy.md) ·
 [Troubleshooting](docs/troubleshooting.md)
 
 ## Known limitations
-* Review was engineered with reviewing changes to one repo, your coding agent can obviously pull context from other repos on your machine, but we haven't engineered it to map architectural changes across repos. If you need this let us know!
-* Review doesnt properly handle stacked prs right now, but this is coming soon.
-* It's currently a pain to share reviews between machines, self-hostable collaboration tools are also on our roadmap.
 
-*If there are any other features you need, feel free to ask on discord or open an issue/discussion!*
+- Review was designed to review changes in a single repository. Your coding
+  agent can pull context from other repositories on your machine, but Review
+  does not yet map architectural changes across repositories. If you need this,
+  let us know.
+- Review does not properly handle stacked PRs yet, but support is coming soon.
+- Sharing reviews between machines is currently difficult. Self-hostable
+  collaboration tools are also on our roadmap.
+
+_If there are any other features you need, feel free to ask on Discord or open
+an issue or discussion!_
 
 ## FAQs
-<details>
-<summary><b>Who is the Review app for?</b></summary>
 
-* If you still want the gains of generating code with AI but also want to understand how your codebase works and maintain quality, Review is for you.
-* If you don't use AI to write a lot of code and are content reading diffs line by line, Review probably isn't for you.
-</details>
 <details>
-<summary><b>How is this different from Greptile/Bugbot/CodeRabbit/etc...</b></summary>
+<summary><strong>Who is Review for?</strong></summary>
 
-These tools review your llm generated code with another llm. Review is a complementary tool. Review doesn't review your code for you but helps you understand it and spot regressions quickly.
-</details>
-<details>
-<summary><b>How is this different from Plannotator</b></summary>
+- If you want the productivity gains of generating code with AI while still
+  understanding how your codebase works and maintaining quality, Review is for
+  you.
+- If you do not use AI to write much code and are comfortable reviewing diffs
+  line by line, Review probably is not for you.
 
-Plannotator is meant as an alternative to using the terminal for reviewing plans and simple code diffs. Review takes some inspiration from Plannotator in lifecycle but is engineered as an opinionated framework for reviewing AI generated code diffs.
 </details>
 
 <details>
-<summary><b>How are you guys gunna make money on this?</b></summary>
+<summary>
+<strong>How is Review different from Greptile, Bugbot, and CodeRabbit?</strong>
+</summary>
 
-Eventually we’ll charge companies for a hosted review product that manages review creation alongside features like trajectory storage, review sharing, etc, but everything will remain easily self-hostable.
+Those tools review LLM-generated code with another LLM. Review is complementary:
+it does not review your code for you, but helps you understand the change and
+spot regressions quickly.
+
 </details>
 
+<details>
+<summary><strong>How is Review different from Plannotator?</strong></summary>
+
+Plannotator is an alternative to using the terminal for reviewing plans and
+simple code diffs. Review draws inspiration from Plannotator's lifecycle, but is
+designed as an opinionated framework for reviewing AI-generated code changes.
+
+</details>
+
+<details>
+<summary><strong>How will Review make money?</strong></summary>
+
+Eventually, we'll charge companies for a hosted Review product that manages
+review creation alongside features such as trajectory storage and review
+sharing. Everything will remain easy to self-host.
+
+</details>
 
 ## Development
 
@@ -98,11 +120,17 @@ Run `pnpm run ci` before submitting a pull request. See
 
 ### A note on vendoring Code OSS
 
-With everyone using dedicated agent TUIs and desktop apps, we only use our text editors for reviewing line-by-line diffs now, so we figured why not have a text editor meant for reviewing code. In that case, might as well start off with the most successful open source editor out there as a baseline.
+With everyone using dedicated agent TUIs and desktop apps, we only use our text
+editors for reviewing line-by-line diffs now, so we figured why not have a text
+editor meant for reviewing code. In that case, might as well start off with the
+most successful open source editor out there as a baseline.
 
-We vendor Code OSS unlike other forks that maintain patches because coding agents have a hard time with patches and theres a lot of stuff from stock vscode (ie. ~45% of the codebase is copilot these days 😬) that we dont need. 
+We vendor Code OSS unlike other forks that maintain patches because coding
+agents have a hard time with patches and there's a lot of stuff from stock VS
+Code (i.e., ~45% of the codebase is Copilot these days 😬) that we don't need.
 
-We regularly monitor upstream code oss and merge in security/feature patches as they come in.
+We regularly monitor upstream Code OSS and merge in security/feature patches as
+they come in.
 
 ## Privacy
 
@@ -118,10 +146,14 @@ fork retains Microsoft's MIT license and third-party notices; see
 [`apps/review-desktop/LICENSE`](apps/review-desktop/LICENSE) and
 [`apps/review-desktop/UPSTREAM`](apps/review-desktop/UPSTREAM).
 
-
 ## Influences
-* https://www.geoffreylitt.com/2026/07/02/understanding-is-the-new-bottleneck -- a great overview of the constraints of modern software engineering.
-* https://maggieappleton.com/2025-08-vibe-legacy-code/ and https://blog.val.town/vibe-code -- do a great job describing how ai generated code fits into our pre-2025 notion of software engineering.
-* we're big fans of Karpathy, so here are some of his banger tweets we love discussing
-  * on llm agents: https://x.com/karpathy/status/1979644538185752935
-  * on agents as "junior engineer savants": https://x.com/karpathy/status/1915581920022585597
+
+- [Geoffrey Litt on understanding as the new bottleneck](https://www.geoffreylitt.com/2026/07/02/understanding-is-the-new-bottleneck)
+  offers a great overview of the constraints of modern software engineering.
+- [Maggie Appleton on vibe coding and legacy code](https://maggieappleton.com/2025-08-vibe-legacy-code/)
+  and [Val Town on vibe code](https://blog.val.town/vibe-code) do a great job
+  describing how AI-generated code fits into our pre-2025 notion of software
+  engineering.
+- We're big fans of Karpathy, so here are two posts we love discussing:
+  - [On LLM agents](https://x.com/karpathy/status/1979644538185752935)
+  - [On agents as "junior engineer savants"](https://x.com/karpathy/status/1915581920022585597)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,31 @@ not explain whether the system is right. See the
 
 *If there are any other features you need, feel free to ask on discord or open an issue/discussion!*
 
+## FAQs
+<details>
+<summary><b>Who is the Review app for?</b></summary>
+
+* If you still want the gains of generating code with AI but also want to understand how your codebase works and maintain quality, Review is for you.
+* If you don't use AI to write a lot of code and are content reading diffs line by line, Review probably isn't for you.
+</details>
+<details>
+<summary><b>How is this different from Greptile/Bugbot/CodeRabbit/etc...</b></summary>
+
+These tools review your llm generated code with another llm. Review is a complementary tool. Review doesn't review your code for you but helps you understand it and spot regressions quickly.
+</details>
+<details>
+<summary><b>How is this different from Plannotator</b></summary>
+
+Plannotator is meant as an alternative to using the terminal for reviewing plans and simple code diffs. Review takes some inspiration from Plannotator in lifecycle but is engineered as an opinionated framework for reviewing AI generated code diffs.
+</details>
+
+<details>
+<summary><b>How are you guys gunna make money on this?</b></summary>
+
+Eventually we’ll charge companies for a hosted review product that manages review creation alongside features like trajectory storage, review sharing, etc, but everything will remain easily self-hostable.
+</details>
+
+
 ## Development
 
 Review requires Node.js 24 and pnpm 11. See the
@@ -92,3 +117,11 @@ Review is available under the [MIT License](LICENSE). The vendored Code - OSS
 fork retains Microsoft's MIT license and third-party notices; see
 [`apps/review-desktop/LICENSE`](apps/review-desktop/LICENSE) and
 [`apps/review-desktop/UPSTREAM`](apps/review-desktop/UPSTREAM).
+
+
+## Influences
+* https://www.geoffreylitt.com/2026/07/02/understanding-is-the-new-bottleneck -- a great overview of the constraints of modern software engineering.
+* https://maggieappleton.com/2025-08-vibe-legacy-code/ and https://blog.val.town/vibe-code -- do a great job describing how ai generated code fits into our pre-2025 notion of software engineering.
+* we're big fans of Karpathy, so here are some of his banger tweets we love discussing
+  * on llm agents: https://x.com/karpathy/status/1979644538185752935
+  * on agents as "junior engineer savants": https://x.com/karpathy/status/1915581920022585597


### PR DESCRIPTION
## Summary

- document current architecture, stacked-PR, and cross-machine sharing limitations
- add FAQs about the intended audience, adjacent tools, and business model
- add links to articles and posts that influenced Review
- normalize Markdown spacing, lists, line wrapping, capitalization, grammar, and punctuation while preserving the original wording

## Verification

- all four FAQ summaries end with question marks
- Prettier check with prose wrapping
- markdownlint-cli2: 0 issues, excluding intentional inline HTML and HTML-first-heading rules
- GitHub-flavored Markdown render check
- git diff --check
- verified all local README link targets exist