### PR TITLE
Ship Review documentation with the agent skill

### DIFF
--- a/apps/review-desktop/scripts/package-linux.sh
+++ b/apps/review-desktop/scripts/package-linux.sh
@@ -45,6 +45,7 @@ for artifact in \
   "$PACKAGED_ROOT/resources/app/review-runtime/dist/server/desktop-host.js" \
   "$PACKAGED_ROOT/resources/app/review-runtime/dist/cli.js" \
   "$PACKAGED_ROOT/resources/app/review-runtime/skills/dev-review/SKILL.md" \
+  "$PACKAGED_ROOT/resources/app/review-runtime/skills/dev-review/docs/README.md" \
   "$PACKAGED_ROOT/resources/app/review-runtime/skills/dev-review-map/SKILL.md" \
   "$PACKAGED_ROOT/resources/app/review-runtime/skills/trace-archaeology/SKILL.md" \
   "$PACKAGED_ROOT/resources/app/review-runtime/tutorial/review.mdx" \

--- a/apps/review-desktop/scripts/package-macos.sh
+++ b/apps/review-desktop/scripts/package-macos.sh
@@ -93,6 +93,7 @@ for artifact in \
   "$PACKAGED_APP/Contents/Resources/app/review-runtime/dist/server/desktop-host.js" \
   "$PACKAGED_APP/Contents/Resources/app/review-runtime/dist/cli.js" \
   "$PACKAGED_APP/Contents/Resources/app/review-runtime/skills/dev-review/SKILL.md" \
+  "$PACKAGED_APP/Contents/Resources/app/review-runtime/skills/dev-review/docs/README.md" \
   "$PACKAGED_APP/Contents/Resources/app/review-runtime/skills/dev-review-map/SKILL.md" \
   "$PACKAGED_APP/Contents/Resources/app/review-runtime/skills/trace-archaeology/SKILL.md" \
   "$PACKAGED_APP/Contents/Resources/app/review-runtime/tutorial/review.mdx" \

--- a/apps/review-desktop/scripts/stage-review-runtime-docs.test.mjs
+++ b/apps/review-desktop/scripts/stage-review-runtime-docs.test.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { after, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { stageReviewDocs } from "./stage-review-runtime.mjs";
+
+const temporaryRoots = [];
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+
+after(async () => {
+  await Promise.all(
+    temporaryRoots.map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function temporaryRoot(prefix) {
+  const root = await mkdtemp(path.join(os.tmpdir(), prefix));
+  temporaryRoots.push(root);
+  return root;
+}
+
+test("stages the complete Review documentation tree inside dev-review", async () => {
+  const root = await temporaryRoot("review-runtime-docs-");
+  const runtimeRoot = path.join(root, "review-runtime");
+  const skillRoot = path.join(runtimeRoot, "skills", "dev-review");
+  const docsRoot = path.join(root, "source-docs");
+  await mkdir(path.join(skillRoot, "docs"), { recursive: true });
+  await mkdir(path.join(docsRoot, "assets"), { recursive: true });
+  await writeFile(path.join(skillRoot, "SKILL.md"), "# dev-review\n");
+  await writeFile(path.join(skillRoot, "docs", "stale.md"), "stale\n");
+  await writeFile(path.join(docsRoot, "README.md"), "# Review docs\n");
+  await writeFile(path.join(docsRoot, "guide.md"), "# Guide\n");
+  await writeFile(
+    path.join(docsRoot, "assets", "image.png"),
+    Buffer.from([0, 1, 2, 3]),
+  );
+
+  const destination = await stageReviewDocs(runtimeRoot, docsRoot);
+
+  assert.equal(
+    await readFile(path.join(destination, "README.md"), "utf8"),
+    "# Review docs\n",
+  );
+  assert.equal(
+    await readFile(path.join(destination, "guide.md"), "utf8"),
+    "# Guide\n",
+  );
+  assert.deepEqual(
+    await readFile(path.join(destination, "assets", "image.png")),
+    Buffer.from([0, 1, 2, 3]),
+  );
+  await assert.rejects(readFile(path.join(destination, "stale.md")), /ENOENT/);
+});
+
+test("bundled Review documentation has no escaping or broken relative links", async () => {
+  const docsRoot = path.join(repositoryRoot, "docs");
+  const markdownFiles = await listMarkdownFiles(docsRoot);
+  const missing = [];
+
+  for (const file of markdownFiles) {
+    const source = await readFile(file, "utf8");
+    const links = source.matchAll(/!?\[[^\]]*\]\(([^)]+)\)/g);
+    for (const match of links) {
+      const target = match[1].trim();
+      if (target.startsWith("#") || /^[a-z][a-z0-9+.-]*:/i.test(target)) {
+        continue;
+      }
+
+      const relativeTarget = target.split("#", 1)[0];
+      const resolved = path.resolve(path.dirname(file), relativeTarget);
+      if (
+        resolved !== docsRoot &&
+        !resolved.startsWith(`${docsRoot}${path.sep}`)
+      ) {
+        missing.push(`${path.relative(docsRoot, file)} -> ${target} (escapes)`);
+        continue;
+      }
+      try {
+        await access(resolved);
+      } catch {
+        missing.push(`${path.relative(docsRoot, file)} -> ${target}`);
+      }
+    }
+  }
+
+  assert.deepEqual(missing, []);
+});
+
+async function listMarkdownFiles(root) {
+  const files = [];
+  const walk = async (directory) => {
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) await walk(absolute);
+      else if (entry.isFile() && entry.name.endsWith(".md"))
+        files.push(absolute);
+    }
+  };
+  await walk(root);
+  return files;
+}

--- a/apps/review-desktop/scripts/stage-review-runtime.mjs
+++ b/apps/review-desktop/scripts/stage-review-runtime.mjs
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import {
   access,
   chmod,
+  cp,
   readFile,
   readdir,
   realpath,
@@ -57,6 +58,7 @@ const REQUIRED_ENTRIES = [
   RUNTIME_CLI_ENTRY,
   "app/src",
   "skills/dev-review/SKILL.md",
+  "skills/dev-review/docs/README.md",
   "skills/dev-review-map/SKILL.md",
   "skills/trace-archaeology/SKILL.md",
   "tutorial/review.mdx",
@@ -115,9 +117,79 @@ export async function stageReviewRuntime(packagedRoot) {
     { cwd: monorepoRoot, maxBuffer: 64 * 1024 * 1024 },
   );
 
+  await stageReviewDocs(runtimeRoot);
   await makeTreeOwnerWritable(path.join(runtimeRoot, "tutorial", "git-stub"));
   await assertRuntimeClosure(runtimeRoot);
   return runtimeRoot;
+}
+
+export async function stageReviewDocs(
+  runtimeRoot,
+  sourceDocsRoot = path.join(monorepoRoot, "docs"),
+) {
+  const skillRoot = path.join(runtimeRoot, "skills", "dev-review");
+  if (!(await isDirectory(skillRoot))) {
+    throw new Error(
+      `Cannot stage Review documentation without the dev-review skill: ${skillRoot}`,
+    );
+  }
+  if (!(await isDirectory(sourceDocsRoot))) {
+    throw new Error(
+      `Review documentation source is missing: ${sourceDocsRoot}`,
+    );
+  }
+
+  const destination = path.join(skillRoot, "docs");
+  await rm(destination, { recursive: true, force: true });
+  await cp(sourceDocsRoot, destination, { recursive: true });
+  await assertMatchingFileTrees(sourceDocsRoot, destination);
+  return destination;
+}
+
+async function assertMatchingFileTrees(sourceRoot, destinationRoot) {
+  const [sourceFiles, destinationFiles] = await Promise.all([
+    listRelativeFiles(sourceRoot),
+    listRelativeFiles(destinationRoot),
+  ]);
+  if (sourceFiles.join("\n") !== destinationFiles.join("\n")) {
+    throw new Error(
+      "The staged Review documentation file list does not match.",
+    );
+  }
+
+  for (const relative of sourceFiles) {
+    const [source, destination] = await Promise.all([
+      readFile(path.join(sourceRoot, relative)),
+      readFile(path.join(destinationRoot, relative)),
+    ]);
+    if (!source.equals(destination)) {
+      throw new Error(
+        `The staged Review documentation differs at ${relative}.`,
+      );
+    }
+  }
+}
+
+async function listRelativeFiles(root) {
+  const files = [];
+  const walk = async (directory) => {
+    const entries = await readdir(directory, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await walk(absolute);
+      } else if (entry.isFile()) {
+        files.push(path.relative(root, absolute));
+      } else {
+        throw new Error(
+          `Review documentation contains an unsupported entry: ${absolute}`,
+        );
+      }
+    }
+  };
+  await walk(root);
+  return files;
 }
 
 async function makeTreeOwnerWritable(directory) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ directory as a reference.
 - [GitHub Issues](https://github.com/devdotfast/review/issues) — bugs and feature
   requests.
 - [Discord](https://discord.gg/FmrJraNvN) — setup questions and community help.
-- [Contributing](../CONTRIBUTING.md)
-- [Security policy](../SECURITY.md)
-- [Desktop build and release guide](../apps/review-desktop/README.md)
-- [Code - OSS provenance](../apps/review-desktop/UPSTREAM)
+- [Contributing](https://github.com/devdotfast/review/blob/main/CONTRIBUTING.md)
+- [Security policy](https://github.com/devdotfast/review/blob/main/SECURITY.md)
+- [Desktop build and release guide](https://github.com/devdotfast/review/blob/main/apps/review-desktop/README.md)
+- [Code - OSS provenance](https://github.com/devdotfast/review/blob/main/apps/review-desktop/UPSTREAM)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -159,7 +159,8 @@ attachment controls for Review source, map source, and diffs before it sends
 anything. Read [Privacy](privacy.md#user-initiated-bug-reports) for the exact
 boundary.
 
-For a suspected vulnerability, follow the [security policy](../SECURITY.md) and
+For a suspected vulnerability, follow the
+[security policy](https://github.com/devdotfast/review/blob/main/SECURITY.md) and
 use a private GitHub security advisory. Do not open a public issue with secrets
 or exploit details.
 

--- a/packages/progressive-review/skills/dev-review/SKILL.md
+++ b/packages/progressive-review/skills/dev-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-review
-description: Author and publish a progressive Review for a branch, jj change, or pull request. Use when a user asks to explain or review a code change in Review Desktop.
+description: Answer product questions about Review Desktop, or author and publish a progressive Review for a branch, jj change, or pull request. Use for Review capabilities, setup, CLI, privacy, telemetry, troubleshooting, and code-change or architecture reviews.
 ---
 
 # dev.fast Review
@@ -13,6 +13,12 @@ The Review has two independent artifacts:
 - The software map describes the repository structure at the base and head commits.
 
 Document publication must not wait for map authoring.
+
+## Product questions
+
+When the user asks what Review Desktop can do or how to install, use, configure, or troubleshoot it, read the bundled [Review documentation](docs/README.md). Read only the index and the pages relevant to the question. When the bundled index is unavailable because this skill is loaded directly from a source checkout, use the [source documentation](../../../../docs/README.md) instead.
+
+Answer the question without launching Review Desktop, scaffolding a Review, or publishing. Enter the authoring workflow only when the user also asks you to create, update, or open a Review.
 
 ## Before authoring
 

--- a/packages/progressive-review/src/install.test.ts
+++ b/packages/progressive-review/src/install.test.ts
@@ -238,6 +238,45 @@ describe("runInstall", () => {
     ).rejects.toThrow(/ENOENT/);
   });
 
+  it("installs bundled Review documentation with the dev-review skill", async () => {
+    const packageRoot = await makePackageRoot();
+    const sourceDocs = path.join(packageRoot, "skills", "dev-review", "docs");
+    await mkdir(path.join(sourceDocs, "assets"), { recursive: true });
+    await writeFile(path.join(sourceDocs, "README.md"), "# Review docs\n");
+    await writeFile(path.join(sourceDocs, "assets", "image.png"), "image\n");
+
+    const homeDir = await makeTempDir();
+    const destination = path.join(
+      homeDir,
+      ".agents",
+      "skills",
+      "dev-review",
+      "docs",
+    );
+    await mkdir(destination, { recursive: true });
+    await writeFile(path.join(destination, "stale.md"), "stale\n");
+    const streams = silentStreams();
+
+    const code = await runInstall({
+      targets: ["codex"],
+      homeDir,
+      packageRoot,
+      stdout: streams.stdout,
+      stderr: streams.stderr,
+    });
+
+    expect(code).toBe(0);
+    expect(await readFile(path.join(destination, "README.md"), "utf8")).toBe(
+      "# Review docs\n",
+    );
+    expect(
+      await readFile(path.join(destination, "assets", "image.png"), "utf8"),
+    ).toBe("image\n");
+    await expect(
+      readFile(path.join(destination, "stale.md"), "utf8"),
+    ).rejects.toThrow(/ENOENT/);
+  });
+
   it("installs only Cursor when requested", async () => {
     const packageRoot = await makePackageRoot();
     const homeDir = await makeTempDir();


### PR DESCRIPTION
## Summary

- bundle the public Review docs inside the shipped dev-review skill during runtime packaging
- route Review product questions to the relevant bundled docs on demand
- validate recursive staging, links, and installed skill replacement

## Testing

- `pnpm run ci`
- `SKIP_NOTARIZE=1 pnpm --filter @dev-fast/review-desktop app:package:macos`
- skill quick validator
- fresh `node:24-bookworm-slim` Docker build, stage, and install; all 12 documentation files matched exactly