### PR TITLE
Upgrade Review workflow caches to v6

### DIFF
--- a/.github/workflows/review-desktop-ci.yml
+++ b/.github/workflows/review-desktop-ci.yml
@@ -70,7 +70,7 @@ jobs:
       # tree and install only the delta.
       - name: Restore Code OSS dependencies
         id: code-oss-deps
-        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             apps/review-desktop/code-oss/node_modules
@@ -100,7 +100,7 @@ jobs:
 
       - name: Save Code OSS dependencies
         if: steps.code-oss-deps.outputs.cache-hit != 'true'
-        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             apps/review-desktop/code-oss/node_modules

--- a/.github/workflows/review-desktop-release.yml
+++ b/.github/workflows/review-desktop-release.yml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Restore Code OSS dependencies
         id: code-oss-deps
-        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             apps/review-desktop/code-oss/node_modules
@@ -212,7 +212,7 @@ jobs:
       - name: Check for existing Code OSS dependency cache
         if: steps.code-oss-deps.outputs.cache-hit != 'true'
         id: code-oss-deps-lookup
-        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             apps/review-desktop/code-oss/node_modules
@@ -221,7 +221,7 @@ jobs:
 
       - name: Save Code OSS dependencies
         if: steps.code-oss-deps.outputs.cache-hit != 'true' && steps.code-oss-deps-lookup.outputs.cache-hit != 'true'
-        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             apps/review-desktop/code-oss/node_modules
@@ -271,7 +271,7 @@ jobs:
 
       - name: Restore Code OSS dependencies
         id: code-oss-deps
-        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             apps/review-desktop/code-oss/node_modules
@@ -357,7 +357,7 @@ jobs:
       - name: Check for existing Code OSS dependency cache
         if: steps.code-oss-deps.outputs.cache-hit != 'true'
         id: code-oss-deps-lookup
-        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             apps/review-desktop/code-oss/node_modules
@@ -366,7 +366,7 @@ jobs:
 
       - name: Save Code OSS dependencies
         if: steps.code-oss-deps.outputs.cache-hit != 'true' && steps.code-oss-deps-lookup.outputs.cache-hit != 'true'
-        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             apps/review-desktop/code-oss/node_modules


### PR DESCRIPTION
## Summary

- port the remaining Review Desktop workflow update from Fix-Fast/dev#624
- pin all Review CI and release cache restore/save steps to the actions/cache v6 commit

## Checks

- `pnpm install --frozen-lockfile`
- `actionlint -shellcheck= .github/workflows/review-desktop-ci.yml .github/workflows/review-desktop-release.yml`
- `git diff --check`

Full `actionlint` reports the same three shell warnings as `origin/main`. Full `pnpm format:check` reports the unchanged `packages/progressive-review/app/src/CodePeek.tsx` formatting issue.