### PR TITLE
Fix actionable CodeQL findings and vulnerable dependencies

### DIFF
--- a/apps/review-desktop/UPSTREAM
+++ b/apps/review-desktop/UPSTREAM
@@ -95,6 +95,12 @@ one of these entries:
   so the module loads without the package installed.
 - `src/typings/removed-native-modules.d.ts`: ambient declarations replacing
   the typings of removed native dependencies.
+- `extensions/markdown-language-features/src/languageFeatures/copyFiles/snippets.ts`:
+  parse snippet variables linearly instead of using an ambiguous regular
+  expression that can backtrack exponentially on a short workspace setting.
+- `src/vs/platform/terminal/common/terminalEnvironment.ts`: quote complete path
+  arguments with each shell's native rules instead of stripping metacharacters
+  and emitting invalid POSIX quoting for apostrophes.
 - `extensions/package.json` and the extension `package.json`/`package-lock.json`
   files: `@vscode/extension-telemetry` is hoisted to the shared extensions
   install (github keeps its own ^1.0.0 copy; the shared copy is ^0.9.8).

--- a/apps/review-desktop/UPSTREAM
+++ b/apps/review-desktop/UPSTREAM
@@ -88,9 +88,16 @@ one of these entries:
   `@vscode/fs-copyfile`, `native-is-elevated`, `@microsoft/mxc-sdk`,
   `@vscode/l10n-dev`, `@vscode/test-web`, and `@vscode/telemetry-extractor`.
   Their import sites typecheck against `src/typings/removed-native-modules.d.ts`.
+  The lockfile also advances Undici, Hono, its Node adapter, `ip-address`, and
+  `body-parser` within their declared ranges to releases that clear their
+  applicable security advisories.
 - `build/package.json` and `build/package-lock.json`: drop unreferenced
   packaging/publishing tooling (`@azure/*`, `tree-sitter`,
-  `tree-sitter-typescript`, the duplicate `@vscode/ripgrep-universal`).
+  `tree-sitter-typescript`, the duplicate `@vscode/ripgrep-universal`). The
+  lockfile carries patched `brace-expansion`, `js-yaml`, and `linkify-it`
+  releases within the existing manifest ranges.
+- `build/npm/gyp/package-lock.json`: advance patched `brace-expansion` and
+  `ip-address` releases within the existing manifest ranges.
 - `build/lib/i18n.ts`: local l10n types and a lazy `@vscode/l10n-dev` import
   so the module loads without the package installed.
 - `src/typings/removed-native-modules.d.ts`: ambient declarations replacing
@@ -103,7 +110,9 @@ one of these entries:
   and emitting invalid POSIX quoting for apostrophes.
 - `extensions/package.json` and the extension `package.json`/`package-lock.json`
   files: `@vscode/extension-telemetry` is hoisted to the shared extensions
-  install (github keeps its own ^1.0.0 copy; the shared copy is ^0.9.8).
+  install (github keeps its own ^1.0.0 copy; the shared copy is ^0.9.8). The
+  CSS, HTML, JSON, and Markdown extension locks also advance security-patched
+  transitive packages without widening their manifest ranges.
 - `product.json`: also carries `reviewVersion`, Review's own release number.
   `version` stays the Code OSS base version because the curated extensions
   match their `engines.vscode` range against it, so the release number needs a

--- a/apps/review-desktop/code-oss/build/npm/gyp/package-lock.json
+++ b/apps/review-desktop/code-oss/build/npm/gyp/package-lock.json
@@ -138,9 +138,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -439,15 +439,11 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
       "engines": {
         "node": ">= 12"
       }
@@ -487,13 +483,6 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -915,13 +904,13 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -943,13 +932,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
       "version": "12.0.0",

--- a/apps/review-desktop/code-oss/build/package-lock.json
+++ b/apps/review-desktop/code-oss/build/package-lock.json
@@ -1947,16 +1947,16 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@vscode/vsce/node_modules/chalk": {
@@ -2370,9 +2370,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4083,9 +4083,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -4243,9 +4243,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {
@@ -6387,9 +6387,9 @@
       }
     },
     "node_modules/vscode-universal-bundler/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/apps/review-desktop/code-oss/extensions/css-language-features/package-lock.json
+++ b/apps/review-desktop/code-oss/extensions/css-language-features/package-lock.json
@@ -39,15 +39,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/minimatch": {

--- a/apps/review-desktop/code-oss/extensions/html-language-features/package-lock.json
+++ b/apps/review-desktop/code-oss/extensions/html-language-features/package-lock.json
@@ -39,15 +39,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/minimatch": {

--- a/apps/review-desktop/code-oss/extensions/json-language-features/package-lock.json
+++ b/apps/review-desktop/code-oss/extensions/json-language-features/package-lock.json
@@ -39,15 +39,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/minimatch": {

--- a/apps/review-desktop/code-oss/extensions/markdown-language-features/package-lock.json
+++ b/apps/review-desktop/code-oss/extensions/markdown-language-features/package-lock.json
@@ -84,12 +84,12 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.1.tgz",
+      "integrity": "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/types": "~11.1.1"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@types/d3": {
@@ -526,9 +526,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1213,9 +1213,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -1256,6 +1256,15 @@
         "docs",
         "benchmarks"
       ]
+    },
+    "node_modules/fastdom": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.12.tgz",
+      "integrity": "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==",
+      "license": "MIT",
+      "dependencies": {
+        "strictdom": "^1.0.1"
+      }
     },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
@@ -1339,9 +1348,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",
@@ -1426,26 +1435,27 @@
       "license": "MIT"
     },
     "node_modules/mermaid": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "version": "11.17.2",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.17.2.tgz",
+      "integrity": "sha512-V6K3C8EBdEsPFZXSKMJe6ppQOENxuHARr9GvHX4hh47lAbhMRD9qf4oEK7LoaRQxULMa80/qt5gHO73aCleBBg==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
+        "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.1",
+        "@mermaid-js/parser": "^1.2.1",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
+        "cytoscape": "^3.34.0",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
+        "dayjs": "^1.11.21",
+        "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.25",
+        "fastdom": "1.0.12",
+        "katex": "^0.16.47",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -2160,6 +2170,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/strictdom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
+      "integrity": "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==",
+      "license": "MIT"
     },
     "node_modules/stylis": {
       "version": "4.4.0",

--- a/apps/review-desktop/code-oss/extensions/markdown-language-features/src/languageFeatures/copyFiles/snippets.ts
+++ b/apps/review-desktop/code-oss/extensions/markdown-language-features/src/languageFeatures/copyFiles/snippets.ts
@@ -7,26 +7,120 @@
  * Resolves variables in a VS Code snippet style string
  */
 export function resolveSnippet(snippetString: string, vars: ReadonlyMap<string, string>): string {
-	return snippetString.replaceAll(/(?<escape>\\\$)|(?<!\\)\$\{(?<name>\w+)(?:\/(?<pattern>(?:\\\/|[^\}])+?)\/(?<replacement>(?:\\\/|[^\}])+?)\/)?\}/g, (match, _escape, name, pattern, replacement, _offset, _str, groups) => {
-		if (groups?.['escape']) {
-			return '$';
+	let result = '';
+	let cursor = 0;
+	while (cursor < snippetString.length) {
+		if (snippetString[cursor] === '\\' && snippetString[cursor + 1] === '$') {
+			result += '$';
+			cursor += 2;
+			continue;
 		}
 
-		const entry = vars.get(name);
+		const variable = snippetString[cursor] === '$'
+			? parseVariable(snippetString, cursor)
+			: undefined;
+		if (!variable) {
+			result += snippetString[cursor++];
+			continue;
+		}
+
+		const original = snippetString.slice(cursor, variable.end);
+		const entry = vars.get(variable.name);
 		if (typeof entry !== 'string') {
-			return match;
+			result += original;
+		} else if (variable.pattern !== undefined && variable.replacement !== undefined) {
+			result += entry.replace(
+				new RegExp(replaceTransformEscapes(variable.pattern)),
+				replaceTransformEscapes(variable.replacement),
+			);
+		} else {
+			result += entry;
 		}
-
-		if (pattern && replacement) {
-			return entry.replace(new RegExp(replaceTransformEscapes(pattern)), replaceTransformEscapes(replacement));
-		}
-
-		return entry;
-	});
+		cursor = variable.end;
+	}
+	return result;
 }
 
+interface ParsedVariable {
+	readonly end: number;
+	readonly name: string;
+	readonly pattern?: string;
+	readonly replacement?: string;
+}
+
+function parseVariable(source: string, start: number): ParsedVariable | undefined {
+	if (source[start + 1] !== '{') {
+		return undefined;
+	}
+
+	let cursor = start + 2;
+	const nameStart = cursor;
+	while (cursor < source.length && isVariableNameCharacter(source.charCodeAt(cursor))) {
+		cursor++;
+	}
+	if (cursor === nameStart) {
+		return undefined;
+	}
+
+	const name = source.slice(nameStart, cursor);
+	if (source[cursor] === '}') {
+		return { end: cursor + 1, name };
+	}
+	if (source[cursor] !== '/') {
+		return undefined;
+	}
+
+	const patternStart = ++cursor;
+	while (cursor < source.length) {
+		if (source[cursor] === '}') {
+			return undefined;
+		}
+		if (source[cursor] === '\\' && source[cursor + 1] === '/') {
+			cursor += 2;
+			continue;
+		}
+		if (source[cursor] === '/') {
+			break;
+		}
+		cursor++;
+	}
+	if (cursor === patternStart || source[cursor] !== '/') {
+		return undefined;
+	}
+
+	const pattern = source.slice(patternStart, cursor);
+	const replacementStart = ++cursor;
+	while (cursor < source.length) {
+		if (source[cursor] === '}') {
+			return undefined;
+		}
+		if (source[cursor] === '\\' && source[cursor + 1] === '/') {
+			cursor += 2;
+			continue;
+		}
+		if (source[cursor] === '/' && source[cursor + 1] === '}') {
+			if (cursor === replacementStart) {
+				return undefined;
+			}
+			return {
+				end: cursor + 2,
+				name,
+				pattern,
+				replacement: source.slice(replacementStart, cursor),
+			};
+		}
+		cursor++;
+	}
+	return undefined;
+}
+
+function isVariableNameCharacter(code: number): boolean {
+	return code >= 48 && code <= 57
+		|| code >= 65 && code <= 90
+		|| code === 95
+		|| code >= 97 && code <= 122;
+}
 
 function replaceTransformEscapes(str: string): string {
-	return str.replaceAll(/\\\//g, '/');
+	return str.replaceAll('\\/', '/');
 }
-

--- a/apps/review-desktop/code-oss/extensions/markdown-language-features/src/test/copyFile.test.ts
+++ b/apps/review-desktop/code-oss/extensions/markdown-language-features/src/test/copyFile.test.ts
@@ -5,8 +5,10 @@
 
 import * as assert from 'assert';
 import 'mocha';
+import { performance } from 'node:perf_hooks';
 import * as vscode from 'vscode';
 import { resolveCopyDestination } from '../languageFeatures/copyFiles/copyFiles';
+import { resolveSnippet } from '../languageFeatures/copyFiles/snippets';
 
 
 suite('resolveCopyDestination', () => {
@@ -94,5 +96,16 @@ suite('resolveCopyDestination', () => {
 		const dest = resolveCopyDestination(documentUri, 'img.png', '${fileName/(.+)/x\\/y/}.${fileExtName}', () => undefined);
 
 		assert.strictEqual(dest.toString(), 'test://projects/project/sub/x/y.png');
+	});
+
+	test('Snippet parsing should remain linear for incomplete transforms', () => {
+		const variables = new Map([['fileName', 'docs/video.mp4']]);
+		assert.strictEqual(resolveSnippet('src=${fileName}; escaped=\\${fileName}', variables), 'src=docs/video.mp4; escaped=${fileName}');
+		assert.strictEqual(resolveSnippet('${fileName/docs\\/video/cdn\\/video/}', variables), 'cdn/video.mp4');
+
+		const adversarial = '${fileName/' + '\\/'.repeat(26);
+		const startedAt = performance.now();
+		assert.strictEqual(resolveSnippet(adversarial, variables), adversarial);
+		assert.ok(performance.now() - startedAt < 100, 'snippet parsing should remain linear');
 	});
 });

--- a/apps/review-desktop/code-oss/package-lock.json
+++ b/apps/review-desktop/code-oss/package-lock.json
@@ -1137,9 +1137,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4718,22 +4718,36 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -10256,9 +10270,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.4.tgz",
+      "integrity": "sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10576,9 +10590,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -16857,18 +16871,36 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/type-is/node_modules/mime-db": {
@@ -17107,9 +17139,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/apps/review-desktop/code-oss/src/vs/platform/terminal/common/terminalEnvironment.ts
+++ b/apps/review-desktop/code-oss/src/vs/platform/terminal/common/terminalEnvironment.ts
@@ -6,77 +6,51 @@
 import { OperatingSystem, OS } from '../../../base/common/platform.js';
 import { IShellLaunchConfig, TerminalShellType, PosixShellType, WindowsShellType, GeneralShellType } from './terminal.js';
 
-/**
- * Aggressively escape non-windows paths to prepare for being sent to a shell. This will do some
- * escaping inaccurately to be careful about possible script injection via the file path. For
- * example, we're trying to prevent this sort of attack: `/foo/file$(echo evil)`.
- */
+/** Quotes a non-Windows path as one shell word without changing the path. */
 export function escapeNonWindowsPath(path: string, shellType?: TerminalShellType): string {
-	let newPath = path;
-	if (newPath.includes('\\')) {
-		newPath = newPath.replace(/\\/g, '\\\\');
-	}
-
-	// Define shell-specific escaping rules
-	interface ShellEscapeConfig {
-		// How to handle paths with both single and double quotes
-		bothQuotes: (path: string) => string;
-		// How to handle paths with only single quotes
-		singleQuotes: (path: string) => string;
-		// How to handle paths with no single quotes (may have double quotes)
-		noSingleQuotes: (path: string) => string;
-	}
-
-	let escapeConfig: ShellEscapeConfig;
 	switch (shellType) {
 		case PosixShellType.Bash:
 		case PosixShellType.Sh:
 		case PosixShellType.Zsh:
 		case WindowsShellType.GitBash:
-			escapeConfig = {
-				bothQuotes: (path) => `$'${path.replace(/'/g, '\\\'')}'`,
-				singleQuotes: (path) => `'${path.replace(/'/g, '\\\'')}'`,
-				noSingleQuotes: (path) => `'${path}'`
-			};
-			break;
+			return quoteForPosixShell(path);
 		case PosixShellType.Fish:
-			escapeConfig = {
-				bothQuotes: (path) => `"${path.replace(/"/g, '\\"')}"`,
-				singleQuotes: (path) => `'${path.replace(/'/g, '\\\'')}'`,
-				noSingleQuotes: (path) => `'${path}'`
-			};
-			break;
+			return quoteForFishShell(path);
 		case GeneralShellType.PowerShell:
-			// PowerShell should be handled separately in preparePathForShell
-			// but if we get here, use PowerShell escaping
-			escapeConfig = {
-				bothQuotes: (path) => `"${path.replace(/"/g, '`"')}"`,
-				singleQuotes: (path) => `'${path.replace(/'/g, '\'\'')}'`,
-				noSingleQuotes: (path) => `'${path}'`
-			};
-			break;
+			return quoteForPowerShell(path);
 		default:
-			// Default to POSIX shell escaping for unknown shells
-			escapeConfig = {
-				bothQuotes: (path) => `$'${path.replace(/'/g, '\\\'')}'`,
-				singleQuotes: (path) => `'${path.replace(/'/g, '\\\'')}'`,
-				noSingleQuotes: (path) => `'${path}'`
-			};
-			break;
+			return quoteForPosixShell(path);
 	}
+}
 
-	// Remove dangerous characters except single and double quotes, which we'll escape properly
-	const bannedChars = /[\`\$\|\&\>\~\#\!\^\*\;\<]/g;
-	newPath = newPath.replace(bannedChars, '');
+const shellSingleQuote = '\u0027';
 
-	// Apply shell-specific escaping based on quote content
-	if (newPath.includes('\'') && newPath.includes('"')) {
-		return escapeConfig.bothQuotes(newPath);
-	} else if (newPath.includes('\'')) {
-		return escapeConfig.singleQuotes(newPath);
-	} else {
-		return escapeConfig.noSingleQuotes(newPath);
+function quoteForPosixShell(path: string): string {
+	const escapedSingleQuote = `${shellSingleQuote}\\${shellSingleQuote}${shellSingleQuote}`;
+	const result = [shellSingleQuote];
+	for (const character of path) {
+		result.push(character === shellSingleQuote ? escapedSingleQuote : character);
 	}
+	result.push(shellSingleQuote);
+	return result.join('');
+}
+
+function quoteForFishShell(path: string): string {
+	const result = [shellSingleQuote];
+	for (const character of path) {
+		result.push(character === '\\' || character === shellSingleQuote ? `\\${character}` : character);
+	}
+	result.push(shellSingleQuote);
+	return result.join('');
+}
+
+function quoteForPowerShell(path: string): string {
+	const result = [shellSingleQuote];
+	for (const character of path) {
+		result.push(character === shellSingleQuote ? shellSingleQuote.repeat(2) : character);
+	}
+	result.push(shellSingleQuote);
+	return result.join('');
 }
 
 /**

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
@@ -66,7 +66,9 @@ const loopbackOriginSchema = urlSchema("origin", (url) =>
 
 export function normalizeReviewRoutePath(pathname: string): string {
   const pathnameOnly = String(pathname || "/").split(/[?#]/)[0] || "/";
-  const trimmed = pathnameOnly.replace(/\/+$/, "") || "/";
+  let end = pathnameOnly.length;
+  while (end > 1 && pathnameOnly.charCodeAt(end - 1) === 47) end--;
+  const trimmed = pathnameOnly.slice(0, end) || "/";
   return trimmed === "/"
     ? "/"
     : trimmed.startsWith("/")

--- a/apps/review-desktop/code-oss/src/vs/review/common/terminalEnvironmentSecurity.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/terminalEnvironmentSecurity.test.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { escapeNonWindowsPath } from '../../platform/terminal/common/terminalEnvironment.js';
+import { GeneralShellType, PosixShellType } from '../../platform/terminal/common/terminal.js';
+
+test('quotes hostile POSIX paths as one shell word', () => {
+	const hostilePath = "/tmp/a'file\nprintf CODEQL_RELEVANT\n'$HOME\\tail";
+	assert.equal(
+		escapeNonWindowsPath(hostilePath, PosixShellType.Bash),
+		"'/tmp/a'\\''file\nprintf CODEQL_RELEVANT\n'\\''$HOME\\tail'",
+	);
+	assert.equal(
+		escapeNonWindowsPath('/tmp/`$|&;<>#*!^~', PosixShellType.Zsh),
+		"'/tmp/`$|&;<>#*!^~'",
+	);
+});
+
+test('uses the native quoting rules for Fish and PowerShell', () => {
+	assert.equal(escapeNonWindowsPath("a\\b'c", PosixShellType.Fish), "'a\\\\b\\'c'");
+	assert.equal(escapeNonWindowsPath("a'b", GeneralShellType.PowerShell), "'a''b'");
+});

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -63,7 +63,9 @@ const loopbackOriginSchema = urlSchema("origin", (url) =>
 
 export function normalizeReviewRoutePath(pathname: string): string {
   const pathnameOnly = String(pathname || "/").split(/[?#]/)[0] || "/";
-  const trimmed = pathnameOnly.replace(/\/+$/, "") || "/";
+  let end = pathnameOnly.length;
+  while (end > 1 && pathnameOnly.charCodeAt(end - 1) === 47) end--;
+  const trimmed = pathnameOnly.slice(0, end) || "/";
   return trimmed === "/"
     ? "/"
     : trimmed.startsWith("/")

--- a/packages/review-protocol/src/index.test.ts
+++ b/packages/review-protocol/src/index.test.ts
@@ -470,6 +470,15 @@ describe("review protocol parsers", () => {
 
   it("normalizes route paths independently", () => {
     expect(normalizeReviewRoutePath("pr/9/?view=map")).toBe("/pr/9");
+    expect(normalizeReviewRoutePath("/pr/9////")).toBe("/pr/9");
     expect(normalizeReviewRoutePath("/")).toBe("/");
+  });
+
+  it("normalizes adversarial route paths without quadratic scanning", () => {
+    const pathname = `${"/".repeat(32_000)}review`;
+    const startedAt = performance.now();
+
+    expect(normalizeReviewRoutePath(pathname)).toBe(pathname);
+    expect(performance.now() - startedAt).toBeLessThan(100);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,15 +11,15 @@ overrides:
   brace-expansion@2: 2.1.2
   brace-expansion@5: 5.0.8
   esbuild: 0.28.1
-  hono: 4.12.32
+  hono: 4.12.34
   ip-address: 10.2.0
   js-yaml: 4.3.0
   fast-uri: 3.1.4
-  postcss: 8.5.18
+  postcss: 8.5.23
   shell-quote: 1.9.0
   tar: 7.5.22
   qs: 6.15.2
-  undici: 7.28.0
+  undici: 7.29.0
   vite: 8.0.16
 
 importers:
@@ -102,7 +102,7 @@ importers:
         version: link:../local-vcs
       '@hono/node-server':
         specifier: 2.0.12
-        version: 2.0.12(hono@4.12.32)
+        version: 2.0.12(hono@4.12.34)
       '@mdx-js/mdx':
         specifier: 3.1.1
         version: 3.1.1
@@ -137,8 +137,8 @@ importers:
         specifier: 4.0.2
         version: 4.0.2
       hono:
-        specifier: 4.12.32
-        version: 4.12.32
+        specifier: 4.12.34
+        version: 4.12.34
       isomorphic-git:
         specifier: 1.38.10
         version: 1.38.10
@@ -240,8 +240,8 @@ importers:
         specifier: npm:typescript@7.0.1-rc
         version: typescript@7.0.1-rc
       undici:
-        specifier: 7.28.0
-        version: 7.28.0
+        specifier: 7.29.0
+        version: 7.29.0
       vite:
         specifier: 8.0.16
         version: 8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.21.0)
@@ -536,7 +536,7 @@ packages:
     resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: 4.12.32
+      hono: 4.12.34
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -1816,8 +1816,8 @@ packages:
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
-  hono@4.12.32:
-    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.1:
@@ -2257,8 +2257,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   process-warning@5.1.0:
@@ -2589,8 +2589,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -2940,9 +2940,9 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
-  '@hono/node-server@2.0.12(hono@4.12.32)':
+  '@hono/node-server@2.0.12(hono@4.12.34)':
     dependencies:
-      hono: 4.12.32
+      hono: 4.12.34
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -3931,7 +3931,7 @@ snapshots:
 
   help-me@5.0.0: {}
 
-  hono@4.12.32: {}
+  hono@4.12.34: {}
 
   hookable@6.1.1: {}
 
@@ -4011,7 +4011,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -4677,7 +4677,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.18:
+  postcss@8.5.23:
     dependencies:
       nanoid: 3.3.18
       picocolors: 1.1.1
@@ -5112,7 +5112,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -5171,7 +5171,7 @@ snapshots:
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.18
+      postcss: 8.5.23
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,6 @@ minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
 minimumReleaseAgeExclude:
   - "@hono/node-server@2.0.12"
-  - "hono@4.12.32"
   - "@typescript/typescript-*"
   - typescript@7.0.1-rc
   - typescript-7@7.0.1-rc
@@ -28,15 +27,15 @@ overrides:
   "brace-expansion@2": "2.1.2"
   "brace-expansion@5": "5.0.8"
   esbuild: "0.28.1"
-  hono: "4.12.32"
+  hono: "4.12.34"
   ip-address: "10.2.0"
   js-yaml: "4.3.0"
   fast-uri: "3.1.4"
-  postcss: "8.5.18"
+  postcss: "8.5.23"
   shell-quote: "1.9.0"
   tar: "7.5.22"
   qs: "6.15.2"
-  undici: "7.28.0"
+  undici: "7.29.0"
   vite: "8.0.16"
 
 allowBuilds:


### PR DESCRIPTION
## Summary

- replace the vulnerable snippet-transform and route-normalization regular expressions with bounded parsing
- quote terminal paths as one literal shell argument for POSIX, Fish, and PowerShell without dropping path characters
- add regression coverage for adversarial inputs and shell metacharacters
- update Hono, Undici, PostCSS, and low-risk Code OSS lockfile dependencies to security-patched releases
- document intentional Code OSS vendor-lock divergence in `UPSTREAM`

This accompanies the repository-wide CodeQL triage: the three relevant findings were fixed and the remaining 39 alerts were dismissed as false positives. CodeQL remains enabled.

## Dependency audit

- workspace `pnpm audit`: 10 vulnerabilities to 0
- touched nested Code OSS dependency graphs: 0 vulnerabilities
- Code OSS root: 22 vulnerabilities to 17; the remainder require major toolchain upgrades or currently have no fix
- Code OSS build graph: one remaining `extract-zip` advisory with no available fix

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm typecheck`
- focused Hono HTTP tests: 4 passed
- `pnpm --filter @dev-fast/review-desktop test`: 159 passed
- `npm --prefix apps/review-desktop/code-oss run test-review-harness`: 9 passed
- compile-only Review Desktop build

The full workspace test run passed except for the trace-materialization test when the machine-level trace setting was absent. That exact test passed when its required `TRACE_SETTINGS_FILE` setting was supplied.
