### PR TITLE
Hide React Flow attribution in software maps

### DIFF
--- a/packages/progressive-review/app/src/App.test.ts
+++ b/packages/progressive-review/app/src/App.test.ts
@@ -1512,7 +1512,7 @@ describe("review app light theme", () => {
     expect(styles).not.toContain(".review-document h1 + p code");
   });
 
-  it("passes the active review theme through every React Flow surface", () => {
+  it("configures every React Flow surface", () => {
     const diagramsSource = readFileSync(
       new URL("./diagrams.tsx", import.meta.url),
       "utf8",
@@ -1526,10 +1526,14 @@ describe("review app light theme", () => {
       "const { theme } = useReviewDebugSettings()",
     );
     expect(diagramsSource).toContain("colorMode={theme}");
+    expect(diagramsSource).toContain("proOptions={{ hideAttribution: true }}");
     expect(softwareMapSource).toContain(
       "const { theme } = useReviewDebugSettings()",
     );
     expect(softwareMapSource).toContain("colorMode={theme}");
+    expect(softwareMapSource).toContain(
+      "proOptions={{ hideAttribution: true }}",
+    );
   });
 
   it("keeps markdown code blocks on the prose measure and highlights explicit languages", () => {

--- a/packages/progressive-review/app/src/software-map/SoftwareMap.tsx
+++ b/packages/progressive-review/app/src/software-map/SoftwareMap.tsx
@@ -3178,6 +3178,7 @@ function C4MapCanvas({
               <C4HoveredNodeContext.Provider value={hoveredNodeId}>
                 <ReactFlow
                   colorMode={theme}
+                  proOptions={{ hideAttribution: true }}
                   nodes={flow.nodes}
                   edges={flow.edges}
                   nodeTypes={c4NodeTypes}


### PR DESCRIPTION
## Summary

- hide the React Flow attribution on the software-map canvas
- assert that every React Flow surface disables attribution

## Validation

- pnpm --filter @dev.fast/review exec vitest run --config vitest.config.ts app/src/App.test.ts
- pnpm --filter @dev.fast/review exec tsc --noEmit
- pnpm exec oxfmt --check packages/progressive-review/app/src/software-map/SoftwareMap.tsx packages/progressive-review/app/src/App.test.ts
- pnpm exec oxlint packages/progressive-review/app/src/software-map/SoftwareMap.tsx packages/progressive-review/app/src/App.test.ts