### PR TITLE
Refine tutorial guidance and controls

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/browser/media/review.css
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/media/review.css
@@ -1282,6 +1282,52 @@ body
   opacity: 0.72;
 }
 
+/* The comment form's primary button shows its shortcut as a keycap. The
+   button already carries the shortcut in its aria-label; this makes it
+   visible, in the same keycap style the canvas uses. */
+.monaco-workbench.review-workbench
+  .review-widget
+  .form-actions
+  .other-actions
+  > .monaco-text-button:first-child
+  > span::after,
+.monaco-workbench.review-workbench
+  .review-widget
+  .form-actions
+  .other-actions
+  > .monaco-button-dropdown
+  > .monaco-text-button:first-child
+  > span::after {
+  content: "Ctrl↩";
+  display: inline-grid;
+  height: 15px;
+  margin-left: 6px;
+  padding: 0 4px;
+  border: 1px solid color-mix(in srgb, currentColor 34%, transparent);
+  border-radius: 3px;
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  font: 500 9.5px var(--monaco-monospace-font, monospace);
+  line-height: 1;
+  place-items: center;
+  vertical-align: middle;
+}
+
+.monaco-workbench.review-workbench.mac
+  .review-widget
+  .form-actions
+  .other-actions
+  > .monaco-text-button:first-child
+  > span::after,
+.monaco-workbench.review-workbench.mac
+  .review-widget
+  .form-actions
+  .other-actions
+  > .monaco-button-dropdown
+  > .monaco-text-button:first-child
+  > span::after {
+  content: "⌘↩";
+}
+
 .monaco-workbench.review-workbench
   .monaco-editor
   .review-widget.compact-comment-thread

--- a/packages/progressive-review/app/src/App.tsx
+++ b/packages/progressive-review/app/src/App.tsx
@@ -98,10 +98,7 @@ import { diffSoftwareMaps } from "./software-map/topology-diff";
 import { ThreadAnnotations } from "./thread-annotations";
 import { ThreadDraftCard } from "./thread-card";
 import { ThreadTargetModelProvider } from "./thread-target-model";
-import {
-  TutorialExperience,
-  TutorialToolbarAction,
-} from "./tutorial-experience";
+import { TutorialExperienceProvider } from "./tutorial-experience";
 import { captureClientError, captureUiEvent } from "./ui-telemetry";
 import { useReviewTabTelemetry } from "./use-review-tab-telemetry";
 
@@ -472,246 +469,249 @@ function ReviewLayoutContent({
             : "review-document-shell"
         }
       >
-        <header className="review-topbar">
-          <div className="review-topbar-left">
-            <div
-              className="review-segmented"
-              role="group"
-              aria-label="Review views"
-            >
-              {reviewViews.map((view) => (
-                <button
-                  key={view}
-                  type="button"
-                  aria-label={
-                    view === "map"
-                      ? "Map (Experimental)"
-                      : reviewViewLabel(view)
-                  }
-                  aria-pressed={activeView === view}
-                  title={view === "map" ? "Map (Experimental)" : undefined}
-                  className={
-                    activeView === view
-                      ? "review-segment review-segment--active"
-                      : "review-segment"
-                  }
-                  onClick={() => applyReviewView(view)}
-                >
-                  <span>{reviewViewLabel(view)}</span>
-                  {view === "diff" && filesTabFileCount !== null && (
-                    <span className="review-segment-count">
-                      {filesTabFileCount}
-                    </span>
-                  )}
-                  {view === "commits" && (
-                    <span className="review-segment-count">
-                      {commits.length}
-                    </span>
-                  )}
-                </button>
-              ))}
-            </div>
-            <button
-              type="button"
-              className="review-open-source-tree"
-              title="Open the read-only source tree"
-              onClick={() => {
-                captureUiEvent(session, "source_tree_opened", {
-                  via: "topbar",
-                });
-                session.surface.post({ name: "openSourceTree", args: {} });
-              }}
-            >
-              Open source tree ↗
-            </button>
-          </div>
-          <div className="review-topbar-actions">
-            <TutorialToolbarAction />
-            <ReviewHistoryControl />
-            <BugReportControl />
-            <ReviewBatonChip outcome={review.submissionOutcome} />
-            <div
-              className={
-                threadsPanelOpen || askPanelOpen
-                  ? "topbar-threads-split topbar-threads-split--active"
-                  : "topbar-threads-split"
-              }
-              role="group"
-              aria-label="Threads"
-            >
+        <TutorialExperienceProvider
+          shellRef={shellRef}
+          scrollRegionRef={scrollRegionRef}
+        >
+          <header className="review-topbar">
+            <div className="review-topbar-left">
+              <div
+                className="review-segmented"
+                role="group"
+                aria-label="Review views"
+              >
+                {reviewViews.map((view) => (
+                  <button
+                    key={view}
+                    type="button"
+                    aria-label={
+                      view === "map"
+                        ? "Map (Experimental)"
+                        : reviewViewLabel(view)
+                    }
+                    aria-pressed={activeView === view}
+                    title={view === "map" ? "Map (Experimental)" : undefined}
+                    className={
+                      activeView === view
+                        ? "review-segment review-segment--active"
+                        : "review-segment"
+                    }
+                    onClick={() => applyReviewView(view)}
+                  >
+                    <span>{reviewViewLabel(view)}</span>
+                    {view === "diff" && filesTabFileCount !== null && (
+                      <span className="review-segment-count">
+                        {filesTabFileCount}
+                      </span>
+                    )}
+                    {view === "commits" && (
+                      <span className="review-segment-count">
+                        {commits.length}
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </div>
               <button
                 type="button"
-                className={
-                  threadsPanelOpen
-                    ? "topbar-threads-button topbar-threads-button--active"
-                    : "topbar-threads-button"
-                }
+                className="review-open-source-tree"
+                title="Open the read-only source tree"
                 onClick={() => {
-                  captureUiEvent(session, "threads_opened", {
-                    thread_count: threadCount,
+                  captureUiEvent(session, "source_tree_opened", {
+                    via: "topbar",
                   });
-                  session.surface.showThreads();
-                  openThreadsWithDraftCleanup({
-                    draftTarget: review.draftTarget,
-                    closeCommentDraft: review.closeCommentDraft,
-                    openThreads,
-                  });
+                  session.surface.post({ name: "openSourceTree", args: {} });
                 }}
-                aria-pressed={threadsPanelOpen}
               >
-                <ThreadsIcon />
-                <span>Threads</span>
-                {threadCount > 0 && (
-                  <span className="topbar-threads-count">{threadCount}</span>
-                )}
+                Open source tree ↗
               </button>
-              {!review.historicalRevision &&
-                review.submissionOutcome !== "approved" &&
-                review.submissionOutcome !== "dismissed" && (
-                  <button
-                    type="button"
-                    className={
-                      askPanelOpen
-                        ? "topbar-new-ask-button topbar-new-ask-button--active"
-                        : "topbar-new-ask-button"
-                    }
-                    aria-pressed={askPanelOpen}
-                    aria-label={askOrCommentLabel}
-                    title={askOrCommentLabel}
-                    onClick={() => {
-                      captureUiEvent(session, "new_ask_opened", {
-                        via: "topbar",
-                      });
-                      session.surface.showThreads();
-                      openNewAsk();
-                    }}
-                  >
-                    <TerminalIcon />
-                  </button>
-                )}
             </div>
-            {!review.historicalRevision && !review.submissionOutcome && (
-              <div className="topbar-actions-divider" />
-            )}
-            {!review.historicalRevision && !review.submissionOutcome ? (
-              <ReviewCornerAction />
-            ) : null}
-          </div>
-        </header>
-        {review.historicalRevision ? (
-          <div className="review-history-banner" role="status">
-            <span>You are viewing an older version of this review.</span>
-            <button
-              type="button"
-              onClick={() =>
-                void session.surface.post({
-                  name: "openReviewRevision",
-                  args: {},
-                })
-              }
-            >
-              Back to latest
-            </button>
-          </div>
-        ) : null}
-        <section
-          ref={scrollRegionRef}
-          className={`review-view-region review-view-region--${activeView}`}
-          data-review-scroll-owner={
-            activeView === "review" ? "document" : undefined
-          }
-        >
-          <div
-            className="review-document-view"
-            hidden={activeView !== "review"}
-          >
-            <>
-              <ReviewToc />
-              <ReviewDocumentSelectionSurface articleRef={articleRef}>
-                <ReviewDocumentBoundary
-                  key={documentRevision}
-                  session={session}
-                  revision={documentRevision}
-                  onError={(_revision, error) =>
-                    reportReviewDocumentRenderError(session, error)
+            <div className="review-topbar-actions">
+              <ReviewHistoryControl />
+              <BugReportControl />
+              <ReviewBatonChip outcome={review.submissionOutcome} />
+              <div
+                className={
+                  threadsPanelOpen || askPanelOpen
+                    ? "topbar-threads-split topbar-threads-split--active"
+                    : "topbar-threads-split"
+                }
+                role="group"
+                aria-label="Threads"
+              >
+                <button
+                  type="button"
+                  className={
+                    threadsPanelOpen
+                      ? "topbar-threads-button topbar-threads-button--active"
+                      : "topbar-threads-button"
                   }
-                >
-                  <ReviewViewStateProvider
-                    tourRestore={viewStateSync.tourRestore}
-                    persistOverlayTour={viewStateSync.persistOverlayTour}
-                  >
-                    <ReviewDocumentContent ReviewDocument={ReviewDocument} />
-                  </ReviewViewStateProvider>
-                </ReviewDocumentBoundary>
-                <ThreadAnnotations
-                  articleRef={articleRef}
-                  onOpenInPanel={(thread) => {
+                  onClick={() => {
+                    captureUiEvent(session, "threads_opened", {
+                      thread_count: threadCount,
+                    });
                     session.surface.showThreads();
-                    openCommentThread(thread.threadId);
+                    openThreadsWithDraftCleanup({
+                      draftTarget: review.draftTarget,
+                      closeCommentDraft: review.closeCommentDraft,
+                      openThreads,
+                    });
                   }}
-                />
-              </ReviewDocumentSelectionSurface>
-            </>
-          </div>
-          {softwareMapEnabled && activeView === "map" && (
-            <div className="review-map-view">
-              <div className="review-map-canvas-shell">
-                <SoftwareMapTopologyUnavailable
-                  repoSoftwareMap={repoSoftwareMap}
-                  baseSoftwareMap={baseSoftwareMap}
-                  baseRef={review.resolvedBaseRef ?? undefined}
-                  headRef={review.resolvedHeadRef ?? undefined}
-                />
-                <SoftwareMap
-                  model={activeSoftwareMap ?? undefined}
-                  focusRequest={review.softwareMapFocusRequest}
-                  height="100%"
-                  showChrome={false}
-                  showFloatingActions={!activePanel}
-                  registerTargets={false}
-                />
-                <MapSettingsControl />
+                  aria-pressed={threadsPanelOpen}
+                >
+                  <ThreadsIcon />
+                  <span>Threads</span>
+                  {threadCount > 0 && (
+                    <span className="topbar-threads-count">{threadCount}</span>
+                  )}
+                </button>
+                {!review.historicalRevision &&
+                  review.submissionOutcome !== "approved" &&
+                  review.submissionOutcome !== "dismissed" && (
+                    <button
+                      type="button"
+                      className={
+                        askPanelOpen
+                          ? "topbar-new-ask-button topbar-new-ask-button--active"
+                          : "topbar-new-ask-button"
+                      }
+                      aria-pressed={askPanelOpen}
+                      aria-label={askOrCommentLabel}
+                      title={askOrCommentLabel}
+                      onClick={() => {
+                        captureUiEvent(session, "new_ask_opened", {
+                          via: "topbar",
+                        });
+                        session.surface.showThreads();
+                        openNewAsk();
+                      }}
+                    >
+                      <TerminalIcon />
+                    </button>
+                  )}
               </div>
+              {!review.historicalRevision && !review.submissionOutcome && (
+                <div className="topbar-actions-divider" />
+              )}
+              {!review.historicalRevision && !review.submissionOutcome ? (
+                <ReviewCornerAction />
+              ) : null}
             </div>
-          )}
-          {activeView === "commits" && (
-            <ReviewCommitsView
-              commits={commits}
-              range={range}
-              onOpenDiff={(commit, via) => {
-                setDiffScope(commit);
-                captureUiEvent(session, "commit_diff_opened", { via });
-                applyReviewView("diff");
-              }}
-            />
-          )}
-          <div
-            aria-hidden={activeView !== "diff" || diffScope !== null}
-            className={
-              activeView === "diff" && diffScope === null
-                ? "review-diff-view"
-                : "review-diff-view review-diff-view--preloaded"
+          </header>
+          {review.historicalRevision ? (
+            <div className="review-history-banner" role="status">
+              <span>You are viewing an older version of this review.</span>
+              <button
+                type="button"
+                onClick={() =>
+                  void session.surface.post({
+                    name: "openReviewRevision",
+                    args: {},
+                  })
+                }
+              >
+                Back to latest
+              </button>
+            </div>
+          ) : null}
+          <section
+            ref={scrollRegionRef}
+            className={`review-view-region review-view-region--${activeView}`}
+            data-review-scroll-owner={
+              activeView === "review" ? "document" : undefined
             }
           >
-            <ReviewDiffView />
-          </div>
-          {activeView === "diff" && diffScope !== null && (
-            <div className="review-diff-view review-diff-view--scoped">
-              <CommitDiffScopeBar
-                commit={diffScope}
-                onBack={() => {
-                  setDiffScope(null);
-                  applyReviewView("commits");
+            <div
+              className="review-document-view"
+              hidden={activeView !== "review"}
+            >
+              <>
+                <ReviewToc />
+                <ReviewDocumentSelectionSurface articleRef={articleRef}>
+                  <ReviewDocumentBoundary
+                    key={documentRevision}
+                    session={session}
+                    revision={documentRevision}
+                    onError={(_revision, error) =>
+                      reportReviewDocumentRenderError(session, error)
+                    }
+                  >
+                    <ReviewViewStateProvider
+                      tourRestore={viewStateSync.tourRestore}
+                      persistOverlayTour={viewStateSync.persistOverlayTour}
+                    >
+                      <ReviewDocumentContent ReviewDocument={ReviewDocument} />
+                    </ReviewViewStateProvider>
+                  </ReviewDocumentBoundary>
+                  <ThreadAnnotations
+                    articleRef={articleRef}
+                    onOpenInPanel={(thread) => {
+                      session.surface.showThreads();
+                      openCommentThread(thread.threadId);
+                    }}
+                  />
+                </ReviewDocumentSelectionSurface>
+              </>
+            </div>
+            {softwareMapEnabled && activeView === "map" && (
+              <div className="review-map-view">
+                <div className="review-map-canvas-shell">
+                  <SoftwareMapTopologyUnavailable
+                    repoSoftwareMap={repoSoftwareMap}
+                    baseSoftwareMap={baseSoftwareMap}
+                    baseRef={review.resolvedBaseRef ?? undefined}
+                    headRef={review.resolvedHeadRef ?? undefined}
+                  />
+                  <SoftwareMap
+                    model={activeSoftwareMap ?? undefined}
+                    focusRequest={review.softwareMapFocusRequest}
+                    height="100%"
+                    showChrome={false}
+                    showFloatingActions={!activePanel}
+                    registerTargets={false}
+                  />
+                  <MapSettingsControl />
+                </div>
+              </div>
+            )}
+            {activeView === "commits" && (
+              <ReviewCommitsView
+                commits={commits}
+                range={range}
+                onOpenDiff={(commit, via) => {
+                  setDiffScope(commit);
+                  captureUiEvent(session, "commit_diff_opened", { via });
+                  applyReviewView("diff");
                 }}
               />
-              <ReviewDiffView scope={{ commit: diffScope.commit }} />
+            )}
+            <div
+              aria-hidden={activeView !== "diff" || diffScope !== null}
+              className={
+                activeView === "diff" && diffScope === null
+                  ? "review-diff-view"
+                  : "review-diff-view review-diff-view--preloaded"
+              }
+            >
+              <ReviewDiffView />
             </div>
-          )}
-          {activeView === "trace" && (
-            <ReviewTraceView initialSelection={traceSelection} />
-          )}
-        </section>
-        <TutorialExperience />
+            {activeView === "diff" && diffScope !== null && (
+              <div className="review-diff-view review-diff-view--scoped">
+                <CommitDiffScopeBar
+                  commit={diffScope}
+                  onBack={() => {
+                    setDiffScope(null);
+                    applyReviewView("commits");
+                  }}
+                />
+                <ReviewDiffView scope={{ commit: diffScope.commit }} />
+              </div>
+            )}
+            {activeView === "trace" && (
+              <ReviewTraceView initialSelection={traceSelection} />
+            )}
+          </section>
+        </TutorialExperienceProvider>
       </main>
       {rightPanelOpen && (
         <div

--- a/packages/progressive-review/app/src/icons.tsx
+++ b/packages/progressive-review/app/src/icons.tsx
@@ -184,6 +184,20 @@ export function ContentsIcon(): ReactElement {
   );
 }
 
+export function TutorialIcon(): ReactElement {
+  return (
+    <svg
+      aria-hidden="true"
+      className="ui-icon ui-icon--tutorial"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path d="M4.5 5.5h4.75A2.75 2.75 0 0 1 12 8.25V19a2.75 2.75 0 0 0-2.75-2.75H4.5V5.5Z" />
+      <path d="M19.5 5.5h-4.75A2.75 2.75 0 0 0 12 8.25V19a2.75 2.75 0 0 1 2.75-2.75h4.75V5.5Z" />
+    </svg>
+  );
+}
+
 export function PlusIcon(): ReactElement {
   return (
     <svg

--- a/packages/progressive-review/app/src/review-components.tsx
+++ b/packages/progressive-review/app/src/review-components.tsx
@@ -69,6 +69,7 @@ import {
   buildTraceTurns,
   extractEventText,
 } from "./trace-document";
+import { useTutorialSection } from "./tutorial-section-context";
 import { captureUiEvent } from "./ui-telemetry";
 import { useAgentTrace } from "./use-agent-trace";
 
@@ -225,6 +226,14 @@ export function ReviewSection(props: ReviewSectionProps) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const [summary, setSummary] = useState<ReviewSectionSummary | null>(null);
   const { heading, body } = reviewSectionContent(title, children);
+  const tutorialSection = useTutorialSection(title);
+
+  // The active tutorial chapter opens itself. Other chapters keep the
+  // reader's own collapse state, so a thread or answer created during a
+  // completed chapter stays visible.
+  useEffect(() => {
+    if (tutorialSection.state === "active") setCollapsed(false);
+  }, [setCollapsed, tutorialSection.state]);
 
   const toggleCollapsed = () => setCollapsed((current) => !current);
 
@@ -263,6 +272,7 @@ export function ReviewSection(props: ReviewSectionProps) {
           : "review-section"
       }
       data-review-section={title}
+      data-tutorial-chapter-state={tutorialSection.state ?? undefined}
     >
       <div className="review-section-header">
         <button

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -381,12 +381,6 @@
   background: var(--surface-raised);
   color: var(--ink);
   font-size: 10px;
-  opacity: 0;
-}
-
-.review-commit-card:hover .review-commit-open,
-.review-commit-open:focus-visible {
-  opacity: 1;
 }
 
 .review-commit-files {
@@ -671,10 +665,10 @@
   box-sizing: border-box;
 }
 
-/* Scrollbars: deliberately unstyled. Any custom ::-webkit-scrollbar rule
-   makes Chromium abandon the platform overlay scrollbars; leaving them
-   native gives auto-hiding bars that appear only while scrolling (per the
-   user's OS setting). Monaco still renders its own slider elements. */
+/* Scrollbars use the platform treatment unless a surface opts into a scoped
+   treatment. The Review document below uses a transparent track so its thumb
+   communicates position without drawing a persistent gutter. Monaco still
+   renders its own slider elements. */
 
 .review-canvas-root {
   margin: 0;
@@ -707,7 +701,6 @@ button {
   color: var(--ink);
   background: var(--bg);
   color-scheme: dark;
-  --tutorial-scrim: rgba(2, 5, 10, 0.42);
   --tutorial-ring: color-mix(in srgb, var(--accent) 82%, white);
   --tutorial-ring-glow: color-mix(in srgb, var(--accent) 44%, transparent);
   --tutorial-guide-bg: color-mix(
@@ -1622,72 +1615,94 @@ button {
   margin-top: 0;
 }
 
+/* The same segmented control as the view switcher in the top bar: same
+   tokens for the group, the resting and hover text, and the raised active
+   segment. Inline-flex so the tutorial ring hugs the group. */
 .tutorial-keymap-picker {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin: 14px 0;
+  display: inline-flex;
+  gap: 2px;
+  margin: 6px 0 12px;
+  padding: 2px;
+  border-radius: calc(var(--chrome-control-radius) + 2px);
+  background: var(--chrome-hover-bg);
+}
+
+/* Prose sits larger than chrome, so the buttons grow a step: 28px tall,
+   13px type, wider padding. */
+.tutorial-keymap-picker button {
+  height: 28px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: var(--chrome-control-radius);
+  color: var(--chrome-fg-muted);
+  background: var(--transparent);
+  cursor: pointer;
+  font: var(--chrome-font-weight) 13px var(--chrome-font);
+  white-space: nowrap;
+}
+
+.tutorial-keymap-picker button:hover:not(:disabled):not([aria-pressed="true"]) {
+  color: var(--chrome-fg);
+  background: var(--surface);
+}
+
+.tutorial-keymap-picker button:disabled {
+  cursor: default;
+  opacity: 0.6;
 }
 
 .tutorial-keymap-picker button[aria-pressed="true"] {
-  border-color: var(--selection);
-  color: var(--selection);
-  background: var(--rpc-wash);
+  color: var(--chrome-fg);
+  background: var(--surface-raised);
+  box-shadow: 0 0 0 1px var(--rule-soft);
 }
 
+/* One look for every tutorial action: the view buttons in the prose, the
+   keybinding picker, and the card's primary action. Prose rules would
+   otherwise restyle the MDX paragraph the button label arrives in. */
 .tutorial-view-button {
   display: inline-flex;
   align-items: center;
   gap: 8px;
   margin: 6px 0 12px;
   padding: 6px 11px;
-  border: 1px solid var(--selection);
+  border: 1px solid var(--tutorial-ring);
   border-radius: 6px;
-  color: var(--selection);
+  color: var(--tutorial-ring);
   background: var(--rpc-wash);
   cursor: pointer;
   font: 12px var(--font-mono);
+}
+
+.review-document .tutorial-view-button p {
+  margin: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
 }
 
 .tutorial-view-button:hover {
   background: var(--accent-stripe);
 }
 
+/* The tutorial lives in the bottom right corner of the shell, one layer
+   above the sticky toolbar, in every view. It never measures its target: the
+   target carries data-tutorial-target and draws its own outline. */
 .tutorial-experience {
   position: absolute;
-  /* The sticky review toolbar lives on the shared debug layer. The tutorial
-     must paint one layer above it or a toolbar target hides the spotlight and
-     leaves only the border that spills below the toolbar visible. */
   z-index: calc(var(--review-debug-layer) + 1);
   inset: 0;
   pointer-events: none;
 }
 
-.tutorial-spotlight {
-  position: absolute;
-  z-index: 2;
-  border: 2px solid var(--tutorial-ring);
-  border-radius: 9px;
-  box-shadow: 0 0 0 3px var(--tutorial-ring-glow);
-  pointer-events: none;
-}
-
-.tutorial-scrim {
-  position: absolute;
-  z-index: 1;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-}
-
+/* The workbench keeps a 10px strip under the canvas, so 8px here reads as
+   the same 18px gap from the window edge as the right side. */
 .tutorial-guide {
   position: absolute;
-  z-index: 3;
-  top: var(--tutorial-guide-top, 64px);
-  left: var(--tutorial-guide-left, calc(100% - 308px));
+  right: 18px;
+  bottom: 8px;
   display: flex;
-  width: min(292px, calc(100% - 32px));
+  width: min(292px, calc(100% - 36px));
   overflow: hidden;
   flex-direction: column;
   border: 1px solid var(--tutorial-guide-border);
@@ -1697,6 +1712,144 @@ button {
   box-shadow: 0 10px 32px var(--shadow-color-strong);
   pointer-events: auto;
   backdrop-filter: blur(16px);
+}
+
+/* While a comment composer has focus, only the chapter line stays. The
+   doubled class outranks the later `.tutorial-guide footer` rule. */
+.tutorial-guide.tutorial-guide--folded .tutorial-guide-progress,
+.tutorial-guide.tutorial-guide--folded .tutorial-guide-copy,
+.tutorial-guide.tutorial-guide--folded footer {
+  display: none;
+}
+
+/* The hidden tutorial: a small floating button in the same corner. */
+.tutorial-guide-pill {
+  position: absolute;
+  right: 28px;
+  bottom: 18px;
+  display: grid;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  place-items: center;
+  border: 1px solid var(--tutorial-guide-border);
+  border-radius: 50%;
+  color: var(--tutorial-ring);
+  background: var(--tutorial-guide-bg);
+  box-shadow: 0 6px 20px var(--shadow-color-strong);
+  cursor: pointer;
+  pointer-events: auto;
+  backdrop-filter: blur(16px);
+}
+
+.tutorial-guide-pill:hover {
+  color: var(--ink);
+}
+
+.tutorial-guide-pill:focus-visible {
+  outline: 2px solid var(--tutorial-ring);
+  outline-offset: 2px;
+}
+
+.tutorial-guide-pill .ui-icon {
+  width: 22px;
+  height: 22px;
+  pointer-events: none;
+  stroke-width: 1.6px;
+}
+
+/* Target rings are their own elements, drawn in a layer nothing clips:
+   inside the scroll region for document content (so they travel with it),
+   in the shell overlay for toolbar controls. Each ring follows its target's
+   corner radius and breathes a little. */
+.tutorial-target-layer {
+  position: absolute;
+  z-index: calc(var(--review-debug-layer) + 1);
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.tutorial-target-ring {
+  position: absolute;
+  border: 2px solid var(--tutorial-ring);
+  box-shadow: 0 0 0 4px var(--tutorial-ring-glow);
+  pointer-events: none;
+  animation: tutorial-target-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes tutorial-target-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 4px var(--tutorial-ring-glow);
+  }
+  50% {
+    box-shadow: 0 0 0 8px
+      color-mix(in srgb, var(--tutorial-ring-glow) 45%, transparent);
+  }
+}
+
+/* An inline link reads as marked text: one wash box per line. */
+.tutorial-target-ring--inline {
+  border: 0;
+  border-radius: 5px;
+  background: var(--tutorial-ring-glow);
+  box-shadow: none;
+  animation: tutorial-link-pulse 1.6s ease-in-out infinite;
+}
+
+/* The comment step marks one code line and shows its gutter "+" control
+   without a hover, so the reader knows where to start. The glyph rule
+   mirrors the workbench hover rule for .comment-diff-added. */
+.view-line[data-tutorial-line] {
+  background: var(--tutorial-ring-glow);
+  animation: tutorial-link-pulse 1.6s ease-in-out infinite;
+}
+
+[data-tutorial-target]
+  .margin-view-overlays
+  > div[data-tutorial-line]
+  > .comment-range-glyph.comment-diff-added::before {
+  position: absolute;
+  z-index: 10;
+  left: -6px;
+  display: flex;
+  width: 18px !important;
+  height: 100%;
+  margin-left: -5px;
+  padding-left: 1px;
+  border-radius: 50%;
+  color: #fff;
+  background: var(--review-comment-accent, var(--tutorial-ring));
+  box-shadow: 0 0 0 0 var(--tutorial-ring-glow);
+  align-items: center;
+  justify-content: center;
+  animation: tutorial-glyph-pulse 1.6s ease-in-out infinite;
+  content: var(--vscode-icon-plus-content, "+");
+  font-family: codicon;
+}
+
+@keyframes tutorial-glyph-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 var(--tutorial-ring-glow);
+  }
+  50% {
+    box-shadow: 0 0 0 6px var(--tutorial-ring-glow);
+  }
+}
+
+@keyframes tutorial-link-pulse {
+  0%,
+  100% {
+    background: var(--tutorial-ring-glow);
+  }
+  50% {
+    background: color-mix(in srgb, var(--tutorial-ring) 22%, transparent);
+  }
 }
 
 .tutorial-guide header {
@@ -1754,33 +1907,31 @@ button {
   padding: 13px 14px 15px;
 }
 
-.tutorial-guide-copy > p:first-child {
+/* Doubled selectors outrank the document prose rules (.review-document h2,
+   .review-document p) that would otherwise size, justify, and center the
+   card copy. */
+.tutorial-guide .tutorial-guide-copy > p:first-child {
+  width: auto;
   margin: 0;
+  text-align: left;
   color: var(--tutorial-ring);
   font: 11px/16px var(--font-mono);
 }
 
-.tutorial-guide-copy h2 {
+.tutorial-guide .tutorial-guide-copy h2 {
+  width: auto;
   margin: 0;
+  text-align: left;
   color: var(--ink);
   font: 500 17px/22px var(--font-serif);
 }
 
-.tutorial-guide-copy > p:last-of-type {
+.tutorial-guide .tutorial-guide-copy > p:last-of-type {
+  width: auto;
   margin: 0;
+  text-align: left;
   color: var(--ink-soft);
   font: 12px/18px var(--font-mono);
-}
-
-.tutorial-guide-primary {
-  align-self: flex-start;
-  margin-top: 4px;
-  padding: 6px 10px;
-  border: 1px solid var(--tutorial-ring);
-  border-radius: 6px;
-  color: var(--tutorial-ring);
-  background: var(--rpc-wash);
-  font: 12px var(--font-mono);
 }
 
 .tutorial-guide footer {
@@ -1824,6 +1975,15 @@ button {
 @media (prefers-reduced-motion: reduce) {
   .tutorial-guide-progress span {
     transition: none;
+  }
+
+  .tutorial-target-ring,
+  .view-line[data-tutorial-line],
+  [data-tutorial-target]
+    .margin-view-overlays
+    > div[data-tutorial-line]
+    > .comment-range-glyph.comment-diff-added::before {
+    animation: none;
   }
 }
 
@@ -1956,7 +2116,6 @@ button {
   --rule-soft: var(--vscode-editorWidget-border, #cccccc);
   --selection: var(--accent);
   --selection-shadow: color-mix(in srgb, var(--accent) 40%, transparent);
-  --tutorial-scrim: rgba(24, 28, 36, 0.24);
   --tutorial-ring: color-mix(in srgb, var(--accent) 86%, #14213d);
   --tutorial-ring-glow: color-mix(in srgb, var(--accent) 34%, transparent);
   --tutorial-guide-bg: color-mix(in srgb, var(--surface-raised) 98%, white);
@@ -5313,6 +5472,22 @@ button {
   white-space: nowrap;
 }
 
+/* Shortcut keycap inside the accent button: drawn from currentColor so it
+   reads on the button in both themes. */
+.thread-compose-kbd {
+  display: inline-grid;
+  height: 15px;
+  margin-left: 1px;
+  padding: 0 4px;
+  border: 1px solid color-mix(in srgb, currentColor 34%, var(--transparent));
+  border-radius: 3px;
+  background: color-mix(in srgb, currentColor 12%, var(--transparent));
+  color: inherit;
+  font: 500 9.5px var(--font-mono);
+  line-height: 1;
+  place-items: center;
+}
+
 .thread-compose-verb-primary:disabled {
   cursor: default;
   opacity: 0.46;
@@ -7102,8 +7277,38 @@ button {
   min-width: 0;
   overflow-x: hidden;
   overflow-y: auto;
+  scrollbar-color: var(--review-scrollbar-thumb) transparent;
+  scrollbar-width: thin;
   padding: var(--review-page-top) calc(52px + var(--review-thread-gutter)) 120px
     52px;
+}
+
+.review-view-region--review::-webkit-scrollbar {
+  width: var(--review-scrollbar-size);
+  background: transparent;
+}
+
+.review-view-region--review::-webkit-scrollbar-track,
+.review-view-region--review::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.review-view-region--review::-webkit-scrollbar-thumb {
+  min-height: 32px;
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background: var(--review-scrollbar-thumb);
+  background-clip: padding-box;
+}
+
+.review-view-region--review::-webkit-scrollbar-thumb:hover {
+  background: var(--review-scrollbar-thumb-hover);
+  background-clip: padding-box;
+}
+
+.review-view-region--review::-webkit-scrollbar-thumb:active {
+  background: var(--review-scrollbar-thumb-active);
+  background-clip: padding-box;
 }
 
 .review-view-region--review.review-view-region--document-warning {

--- a/packages/progressive-review/app/src/thread-card.test.tsx
+++ b/packages/progressive-review/app/src/thread-card.test.tsx
@@ -67,17 +67,17 @@ describe("ThreadComposer", () => {
     expect(onAddToReview).not.toHaveBeenCalled();
 
     await setTextarea(container, "Queue this finding");
-    const commandEnter = new KeyboardEvent("keydown", {
+    const shiftEnter = new KeyboardEvent("keydown", {
       key: "Enter",
-      metaKey: true,
+      shiftKey: true,
       bubbles: true,
       cancelable: true,
     });
     await act(async () => {
-      textarea(container).dispatchEvent(commandEnter);
+      textarea(container).dispatchEvent(shiftEnter);
     });
 
-    expect(commandEnter.defaultPrevented).toBe(false);
+    expect(shiftEnter.defaultPrevented).toBe(false);
     expect(textarea(container).value).toBe("Queue this finding");
 
     await act(async () => {
@@ -90,6 +90,10 @@ describe("ThreadComposer", () => {
     // sends the other one.
     expect(onAskNow).toHaveBeenNthCalledWith(2, "Queue this finding");
     expect(onAddToReview).not.toHaveBeenCalled();
+    expect(
+      primaryButton(container).querySelector(".thread-compose-kbd")
+        ?.textContent,
+    ).toMatch(/↩$/);
   });
 
   it("clears a submitted ask while the answer is still running", async () => {
@@ -121,30 +125,34 @@ describe("ThreadComposer", () => {
     await act(async () => finishAsk());
   });
 
-  it("submits a message with Enter and keeps Command-Enter for a newline", async () => {
+  it("submits a message with Enter or Command-Enter and keeps Shift-Enter for a newline", async () => {
     const onSubmit = vi.fn<(body: string) => void>();
     const { container } = await renderMessageComposer({
       initialDraft: "Please change this",
       onSubmit,
     });
 
-    const commandEnter = new KeyboardEvent("keydown", {
+    const shiftEnter = new KeyboardEvent("keydown", {
       key: "Enter",
-      metaKey: true,
+      shiftKey: true,
       bubbles: true,
       cancelable: true,
     });
     await act(async () => {
-      textarea(container).dispatchEvent(commandEnter);
+      textarea(container).dispatchEvent(shiftEnter);
     });
 
-    expect(commandEnter.defaultPrevented).toBe(false);
+    expect(shiftEnter.defaultPrevented).toBe(false);
     expect(onSubmit).not.toHaveBeenCalled();
     expect(textarea(container).value).toBe("Please change this");
 
     await act(async () => {
       textarea(container).dispatchEvent(
-        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          metaKey: true,
+          bubbles: true,
+        }),
       );
     });
 

--- a/packages/progressive-review/app/src/thread-card.tsx
+++ b/packages/progressive-review/app/src/thread-card.tsx
@@ -638,6 +638,13 @@ export function composeVerbMenuPlacement(input: {
     : "below";
 }
 
+/* The same shortcut the workbench comment form uses (⌘Enter on macOS,
+   Ctrl+Enter elsewhere). */
+const SUBMIT_SHORTCUT_LABEL =
+  typeof navigator !== "undefined" && /Mac|iP/.test(navigator.platform)
+    ? "⌘↩"
+    : "Ctrl↩";
+
 const COMPOSE_VERB_DETAILS: Record<
   ComposeVerb,
   { label: string; description: string }
@@ -875,8 +882,9 @@ export function ThreadComposer(props: ThreadComposerProps): ReactElement {
         return;
       }
       if (event.key !== "Enter") return;
-      const shouldSubmit =
-        !event.metaKey && !event.shiftKey && !event.altKey && !event.ctrlKey;
+      // Enter submits, as does Cmd/Ctrl+Enter (the workbench composer's
+      // shortcut, shown on the button). Shift/Alt+Enter insert a newline.
+      const shouldSubmit = !event.shiftKey && !event.altKey;
       if (!shouldSubmit) return;
       event.preventDefault();
       event.currentTarget.form?.requestSubmit();
@@ -920,8 +928,10 @@ export function ThreadComposer(props: ThreadComposerProps): ReactElement {
               disabled={!draft.trim()}
               onMouseDown={(event) => event.preventDefault()}
             >
-              <ComposeVerbIcon verb={verb} />
               <span>{COMPOSE_VERB_DETAILS[verb].label}</span>
+              <kbd className="thread-compose-kbd" aria-hidden="true">
+                {SUBMIT_SHORTCUT_LABEL}
+              </kbd>
             </button>
             <div
               id={tooltipId}

--- a/packages/progressive-review/app/src/tutorial-experience.test.tsx
+++ b/packages/progressive-review/app/src/tutorial-experience.test.tsx
@@ -3,15 +3,15 @@
 import { readFileSync } from "node:fs";
 
 import type { ReviewCanvasTutorialBridge } from "@dev.fast/review-protocol";
-import { act } from "react";
+import { type ReactElement, act, useRef } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ReviewSessionProvider } from "./host/review-session";
+import { ReviewSection } from "./review-components";
+import { testReviewSession } from "./review-session-test-utils";
 import { TutorialProvider } from "./tutorial-context";
-import {
-  TutorialExperience,
-  TutorialToolbarAction,
-} from "./tutorial-experience";
+import { TutorialExperienceProvider } from "./tutorial-experience";
 
 const reviewState = vi.hoisted(() => ({
   softwareMapEnabled: false,
@@ -24,13 +24,17 @@ vi.mock("./review-context", () => ({
   }),
 }));
 
-class FakeResizeObserver {
-  observe() {}
-  disconnect() {}
-  unobserve() {}
-}
+const CHAPTER_TITLES = [
+  "Welcome",
+  "Commits and diffs",
+  "Comments are threads",
+  "Interactive Diagrams",
+  "Get help",
+];
 
+const session = testReviewSession();
 let root: ReturnType<typeof createRoot> | null = null;
+let canvasRoot: HTMLElement;
 
 beforeEach(() => {
   (
@@ -40,16 +44,14 @@ beforeEach(() => {
   ).IS_REACT_ACT_ENVIRONMENT = true;
   reviewState.softwareMapEnabled = false;
   reviewState.threads = [];
-  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
-  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
-    callback(0);
-    return 1;
-  });
-  vi.stubGlobal("cancelAnimationFrame", () => {});
+  window.localStorage.clear();
   Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
     configurable: true,
     value: vi.fn<() => void>(),
   });
+  canvasRoot = document.createElement("div");
+  canvasRoot.className = "review-canvas-root";
+  document.body.append(canvasRoot);
 });
 
 afterEach(async () => {
@@ -58,85 +60,294 @@ afterEach(async () => {
   document.body.replaceChildren();
   delete (HTMLElement.prototype as { scrollIntoView?: unknown }).scrollIntoView;
   vi.restoreAllMocks();
-  vi.unstubAllGlobals();
 });
 
-describe("TutorialExperience", () => {
-  it("shows one active instruction and progressively discloses chapters", () => {
-    const { app, mount, sections } = tutorialSurface();
-    const tutorial = tutorialBridge([]);
-    root = createRoot(mount);
-    act(() => {
-      root?.render(
-        <TutorialProvider tutorial={tutorial}>
-          <TutorialExperience />
-        </TutorialProvider>,
-      );
-    });
+function Shell({
+  activeView = "review",
+}: {
+  activeView?: "review" | "commits";
+}): ReactElement {
+  const shellRef = useRef<HTMLElement | null>(null);
+  const regionRef = useRef<HTMLElement | null>(null);
+  return (
+    <main ref={shellRef} className="review-document-shell">
+      <TutorialExperienceProvider
+        shellRef={shellRef}
+        scrollRegionRef={regionRef}
+      >
+        <button type="button" className="review-segment" aria-label="Commits">
+          Commits
+        </button>
+        <button
+          type="button"
+          className="tutorial-view-button"
+          data-tutorial-view="commits"
+        >
+          Explore the sample commits
+        </button>
+        <section ref={regionRef} className="review-view-region">
+          <div
+            className="review-document-view"
+            hidden={activeView !== "review"}
+          >
+            {CHAPTER_TITLES.map((title) => (
+              <ReviewSection key={title} title={title}>
+                <h2>{title}</h2>
+                {title === "Welcome" ? (
+                  <div className="tutorial-keymap-picker" />
+                ) : (
+                  <p>{title} body</p>
+                )}
+              </ReviewSection>
+            ))}
+          </div>
+          {activeView === "commits" ? (
+            <button type="button" className="review-commit-open">
+              Open diff
+            </button>
+          ) : null}
+        </section>
+      </TutorialExperienceProvider>
+    </main>
+  );
+}
 
-    expect(app.querySelector(".tutorial-guide")?.textContent).toContain(
-      "Choose your keybindings",
-    );
-    expect(app.querySelectorAll(".tutorial-guide-copy h2")).toHaveLength(1);
-    expect(
-      app
-        .querySelector(".tutorial-scrim mask rect:nth-of-type(2)")
-        ?.getAttribute("width"),
-    ).toBe("666");
-    expect(app.querySelector(".tutorial-spotlight")).not.toBeNull();
-    expect(sections.get("Welcome")?.toggle.ariaExpanded).toBe("true");
-    expect(sections.get("Commits and diffs")?.toggle.ariaExpanded).toBe(
-      "false",
-    );
-    expect(sections.get("Comments are threads")?.toggle.ariaExpanded).toBe(
-      "false",
-    );
-    expect(sections.get("Interactive Diagrams")?.toggle.ariaExpanded).toBe(
-      "false",
+function render(
+  tutorial: ReviewCanvasTutorialBridge,
+  props: { activeView?: "review" | "commits" } = {},
+) {
+  root = createRoot(canvasRoot);
+  act(() => {
+    root?.render(
+      <ReviewSessionProvider session={session}>
+        <TutorialProvider tutorial={tutorial}>
+          <Shell {...props} />
+        </TutorialProvider>
+      </ReviewSessionProvider>,
     );
   });
+}
 
-  it("completes a button step from the real target click", () => {
-    const { mount, commits } = tutorialSurface();
+function section(title: string): HTMLElement {
+  const element = canvasRoot.querySelector<HTMLElement>(
+    `[data-review-section="${title}"]`,
+  );
+  if (!element) throw new Error(`Missing section ${title}`);
+  return element;
+}
+
+function card(): HTMLElement | null {
+  return canvasRoot.querySelector(".tutorial-guide");
+}
+
+describe("TutorialExperience", () => {
+  it("shows one guide card in the shell corner and marks the target", () => {
+    const tutorial = tutorialBridge([]);
+    render(tutorial);
+
+    expect(card()?.textContent).toContain("Choose your keybindings");
+    expect(canvasRoot.querySelectorAll(".tutorial-guide")).toHaveLength(1);
+    expect(card()?.parentElement?.className).toBe("tutorial-experience");
+    expect(card()?.parentElement?.parentElement?.className).toBe(
+      "review-document-shell",
+    );
+    expect(section("Welcome").dataset.tutorialChapterState).toBe("active");
+    expect(section("Commits and diffs").dataset.tutorialChapterState).toBe(
+      "upcoming",
+    );
+    expect(
+      canvasRoot
+        .querySelector(".tutorial-keymap-picker")
+        ?.getAttribute("data-tutorial-target"),
+    ).toBe("chooseKeymap");
+    expect(canvasRoot.querySelector(".tutorial-scrim")).toBeNull();
+    expect(canvasRoot.querySelector(".tutorial-spotlight")).toBeNull();
+  });
+
+  it("draws target rings in a layer inside the scroll region", () => {
+    const tutorial = tutorialBridge([]);
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    try {
+      render(tutorial);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    const layer = canvasRoot.querySelector(
+      ".review-view-region > .tutorial-target-layer",
+    );
+    expect(layer?.querySelectorAll(".tutorial-target-ring")).toHaveLength(1);
+    expect(
+      canvasRoot.querySelectorAll(".tutorial-experience .tutorial-target-ring"),
+    ).toHaveLength(0);
+  });
+
+  it("draws a toolbar target's ring in the shell overlay", () => {
     const tutorial = tutorialBridge([
       "chooseKeymap",
       "showHover",
       "gotoDefinition",
       "openPeek",
     ]);
-    root = createRoot(mount);
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    try {
+      render(tutorial);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    // The Commits tab sits outside the region; the prose button inside it.
+    expect(
+      canvasRoot.querySelectorAll(".tutorial-experience .tutorial-target-ring"),
+    ).toHaveLength(2);
+    expect(
+      canvasRoot.querySelector(".review-view-region > .tutorial-target-layer"),
+    ).toBeNull();
+  });
+
+  it("expands the active chapter without collapsing the others", () => {
+    const tutorial = tutorialBridge([]);
+    render(tutorial);
+    const toggle = (title: string) =>
+      section(title).querySelector<HTMLButtonElement>(
+        ".review-section-toggle",
+      )!;
+    act(() => toggle("Comments are threads").click());
+    expect(toggle("Comments are threads").getAttribute("aria-expanded")).toBe(
+      "false",
+    );
+    act(() => toggle("Welcome").click());
+    expect(toggle("Welcome").getAttribute("aria-expanded")).toBe("false");
+
     act(() => {
       root?.render(
-        <TutorialProvider tutorial={tutorial}>
-          <TutorialExperience />
-        </TutorialProvider>,
+        <ReviewSessionProvider session={session}>
+          <TutorialProvider
+            tutorial={tutorialBridge([
+              "chooseKeymap",
+              "showHover",
+              "gotoDefinition",
+              "openPeek",
+              "openCommits",
+              "openDiff",
+            ])}
+          >
+            <Shell />
+          </TutorialProvider>
+        </ReviewSessionProvider>,
       );
     });
 
+    expect(toggle("Comments are threads").getAttribute("aria-expanded")).toBe(
+      "true",
+    );
+    expect(toggle("Welcome").getAttribute("aria-expanded")).toBe("false");
+    expect(section("Welcome").dataset.tutorialChapterState).toBe("complete");
+    expect(card()?.textContent).toContain("Start a thread");
+  });
+
+  it("completes a button step from the real target click", () => {
+    const tutorial = tutorialBridge([
+      "chooseKeymap",
+      "showHover",
+      "gotoDefinition",
+      "openPeek",
+    ]);
+    render(tutorial);
+
+    const commits = canvasRoot.querySelector<HTMLButtonElement>(
+      '.review-segment[aria-label="Commits"]',
+    )!;
+    expect(card()?.textContent).toContain("Inspect the commits");
+    expect(commits.dataset.tutorialTarget).toBe("openCommits");
     expect(
-      mount.parentElement?.querySelector(".tutorial-guide")?.textContent,
-    ).toContain("Inspect the commits");
-    expect(
-      mount.parentElement
-        ?.querySelector<HTMLElement>(".tutorial-experience")
-        ?.style.getPropertyValue("--tutorial-guide-top"),
-    ).toBe("80px");
+      canvasRoot.querySelector<HTMLElement>(".tutorial-view-button")?.dataset
+        .tutorialTarget,
+    ).toBe("openCommits");
     act(() => commits.click());
     expect(tutorial.setStep).toHaveBeenCalledWith("openCommits", true);
   });
 
-  it("uses no animated target ring", () => {
+  it("keeps the guide in a non-document view and marks its target", () => {
+    const tutorial = tutorialBridge([
+      "chooseKeymap",
+      "showHover",
+      "gotoDefinition",
+      "openPeek",
+      "openCommits",
+    ]);
+    render(tutorial, { activeView: "commits" });
+
+    expect(card()?.textContent).toContain("Open a focused diff");
+    expect(
+      canvasRoot.querySelector<HTMLElement>(".review-commit-open")?.dataset
+        .tutorialTarget,
+    ).toBe("openDiff");
+  });
+
+  it("places the guide without a scrim, spotlight, or measured position", () => {
     const css = readFileSync("app/src/styles.css", "utf8");
 
-    expect(css).not.toContain(".tutorial-spotlight::after");
-    expect(css).not.toContain("tutorial-target-pulse");
-    expect(css).toMatch(
-      /\.tutorial-experience\s*{[^}]*z-index:\s*calc\(var\(--review-debug-layer\) \+ 1\);/s,
+    expect(css).not.toContain(".tutorial-scrim");
+    expect(css).not.toContain(".tutorial-spotlight");
+    expect(css).not.toContain("--tutorial-guide-top");
+    expect(css).toContain("[data-tutorial-target]");
+    expect(css).toContain(`.view-line[data-tutorial-line],
+  [data-tutorial-target]
+    .margin-view-overlays
+    > div[data-tutorial-line]
+    > .comment-range-glyph.comment-diff-added::before {
+    animation: none;
+  }`);
+  });
+
+  it("coalesces target discovery after several DOM mutations", async () => {
+    const frames: FrameRequestCallback[] = [];
+    const requestFrame = vi.fn<(callback: FrameRequestCallback) => number>(
+      (callback) => {
+        frames.push(callback);
+        return frames.length;
+      },
     );
+    vi.stubGlobal("requestAnimationFrame", requestFrame);
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    try {
+      render(tutorialBridge([]));
+      frames.length = 0;
+      requestFrame.mockClear();
+
+      const firstTarget = document.createElement("div");
+      firstTarget.className = "tutorial-keymap-picker";
+      await act(async () => {
+        section("Welcome").append(firstTarget);
+        await Promise.resolve();
+      });
+
+      const secondTarget = document.createElement("div");
+      secondTarget.className = "tutorial-keymap-picker";
+      await act(async () => {
+        section("Welcome").append(secondTarget);
+        await Promise.resolve();
+      });
+
+      expect(requestFrame).toHaveBeenCalledOnce();
+      act(() => frames[0]?.(0));
+      expect(firstTarget.dataset.tutorialTarget).toBe("chooseKeymap");
+      expect(secondTarget.dataset.tutorialTarget).toBe("chooseKeymap");
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("gets out of the way and completes the sequence step when its real tour opens", async () => {
-    const { canvasRoot, mount } = tutorialSurface();
     const tutorial = tutorialBridge([
       "chooseKeymap",
       "showHover",
@@ -146,18 +357,9 @@ describe("TutorialExperience", () => {
       "openDiff",
       "leaveComment",
     ]);
-    root = createRoot(mount);
-    act(() => {
-      root?.render(
-        <TutorialProvider tutorial={tutorial}>
-          <TutorialExperience />
-        </TutorialProvider>,
-      );
-    });
+    render(tutorial);
 
-    expect(canvasRoot.querySelector(".tutorial-guide")?.textContent).toContain(
-      "Walk the sequence",
-    );
+    expect(card()?.textContent).toContain("Walk the sequence");
     const diagramTour = document.createElement("div");
     diagramTour.className = "diagram-tour-overlay";
     const sequence = document.createElement("div");
@@ -168,12 +370,11 @@ describe("TutorialExperience", () => {
       await Promise.resolve();
     });
 
-    expect(canvasRoot.querySelector(".tutorial-guide")).toBeNull();
+    expect(card()).toBeNull();
     expect(tutorial.setStep).toHaveBeenCalledWith("openSequence", true);
   });
 
   it("completes the database stop from the real database Tour", async () => {
-    const { canvasRoot, mount } = tutorialSurface();
     const tutorial = tutorialBridge([
       "chooseKeymap",
       "showHover",
@@ -184,18 +385,9 @@ describe("TutorialExperience", () => {
       "leaveComment",
       "openSequence",
     ]);
-    root = createRoot(mount);
-    act(() => {
-      root?.render(
-        <TutorialProvider tutorial={tutorial}>
-          <TutorialExperience />
-        </TutorialProvider>,
-      );
-    });
+    render(tutorial);
 
-    expect(canvasRoot.querySelector(".tutorial-guide")?.textContent).toContain(
-      "Inspect the database flow",
-    );
+    expect(card()?.textContent).toContain("Inspect the database flow");
     const diagramTour = document.createElement("div");
     diagramTour.className = "diagram-tour-overlay";
     const database = document.createElement("div");
@@ -206,12 +398,161 @@ describe("TutorialExperience", () => {
       await Promise.resolve();
     });
 
-    expect(canvasRoot.querySelector(".tutorial-guide")).toBeNull();
+    expect(card()).toBeNull();
     expect(tutorial.setStep).toHaveBeenCalledWith("openDatabase", true);
   });
 
+  it("completes the comment step once a thread exists", () => {
+    const tutorial = tutorialBridge([
+      "chooseKeymap",
+      "showHover",
+      "gotoDefinition",
+      "openPeek",
+      "openCommits",
+      "openDiff",
+    ]);
+    reviewState.threads = [{}];
+    render(tutorial);
+
+    expect(tutorial.setStep).toHaveBeenCalledWith("leaveComment", true);
+  });
+
+  it("forces the tour forward with Next", () => {
+    const tutorial = tutorialBridge([]);
+    render(tutorial);
+
+    const next = [...canvasRoot.querySelectorAll("button")].find(
+      (button) => button.textContent === "Next",
+    );
+    expect(next).toBeDefined();
+    act(() => next?.click());
+    expect(tutorial.setStep).toHaveBeenCalledWith("chooseKeymap", true);
+    expect(tutorial.dismiss).not.toHaveBeenCalled();
+  });
+
+  it("folds to its header while a comment composer has focus", () => {
+    const tutorial = tutorialBridge([]);
+    render(tutorial);
+    const composer = document.createElement("form");
+    composer.className = "thread-compose";
+    const input = document.createElement("textarea");
+    composer.append(input);
+    section("Welcome").append(composer);
+
+    act(() => input.focus());
+    expect(card()?.classList.contains("tutorial-guide--folded")).toBe(true);
+    act(() => input.blur());
+    expect(card()?.classList.contains("tutorial-guide--folded")).toBe(false);
+  });
+
+  it("steps back to the previous chapter's last step and numbers sub-steps", () => {
+    const tutorial = tutorialBridge([
+      "chooseKeymap",
+      "showHover",
+      "gotoDefinition",
+      "openPeek",
+    ]);
+    render(tutorial);
+
+    expect(card()?.querySelector("header span")?.textContent).toBe(
+      "Chapter 2.1 of 5",
+    );
+    const back = [...canvasRoot.querySelectorAll("button")].find(
+      (button) => button.textContent === "Back",
+    );
+    act(() => back?.click());
+    expect(tutorial.setStep).toHaveBeenCalledTimes(1);
+    expect(tutorial.setStep).toHaveBeenCalledWith("openPeek", false);
+  });
+
+  it("scrolls an off-screen step target into view once", () => {
+    const tutorial = tutorialBridge([]);
+    const scrolled = vi.fn<() => void>();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrolled,
+    });
+    const offScreen = { top: 2000, bottom: 2040 } as DOMRect;
+    const viewRect = { top: 0, bottom: 800 } as DOMRect;
+    const original = HTMLElement.prototype.getBoundingClientRect;
+    HTMLElement.prototype.getBoundingClientRect = function () {
+      return this.classList.contains("tutorial-keymap-picker")
+        ? offScreen
+        : viewRect;
+    };
+    try {
+      render(tutorial);
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = original;
+    }
+
+    const targetScrolls = scrolled.mock.contexts.filter((element) =>
+      (element as HTMLElement).classList.contains("tutorial-keymap-picker"),
+    );
+    expect(targetScrolls).toHaveLength(1);
+  });
+
+  it("marks the first declaration line and its gutter row on the comment step", async () => {
+    const tutorial = tutorialBridge([
+      "chooseKeymap",
+      "showHover",
+      "gotoDefinition",
+      "openPeek",
+      "openCommits",
+      "openDiff",
+    ]);
+    render(tutorial);
+    const editor = document.createElement("div");
+    editor.className = "review-inline-editor";
+    const lines = document.createElement("div");
+    lines.className = "view-lines";
+    const margins = document.createElement("div");
+    margins.className = "margin-view-overlays";
+    const rows = [
+      'import\u00a0type\u00a0{\u00a0CheckoutItem\u00a0}\u00a0from\u00a0"../orders/order.js";',
+      "",
+      "export\u00a0class\u00a0InventoryService\u00a0{",
+      "\u00a0\u00a0reserve(_items:\u00a0readonly\u00a0CheckoutItem[]):\u00a0void\u00a0{}",
+      "\u00a0\u00a0reserve(items:\u00a0readonly\u00a0CheckoutItem[]):\u00a0void\u00a0{",
+      "\u00a0\u00a0\u00a0\u00a0const\u00a0unavailable\u00a0=\u00a0items.find((item)\u00a0=>\u00a0item.quantity\u00a0<\u00a01);",
+    ];
+    // Reverse DOM order: Monaco does not keep rows in line order.
+    for (const [index, text] of [...rows.entries()].reverse()) {
+      const line = document.createElement("div");
+      line.className = "view-line";
+      line.style.top = `${index * 18}px`;
+      line.textContent = text;
+      lines.append(line);
+      const margin = document.createElement("div");
+      margin.style.top = `${index * 18}px`;
+      margins.append(margin);
+    }
+    editor.append(margins, lines);
+    await act(async () => {
+      section("Comments are threads")
+        .querySelector(".review-section-body")
+        ?.append(editor);
+      await Promise.resolve();
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      });
+    });
+
+    const marked = [
+      ...editor.querySelectorAll<HTMLElement>("[data-tutorial-line]"),
+    ];
+    expect(marked).toHaveLength(2);
+    expect(marked.map((element) => element.style.top)).toEqual([
+      "72px",
+      "72px",
+    ]);
+    expect(
+      marked.find((element) => element.classList.contains("view-line"))
+        ?.textContent,
+    ).toContain("reserve(items");
+  });
+
   it("finishes from the final Get help stop", () => {
-    const { canvasRoot, mount } = tutorialSurface();
     const tutorial = tutorialBridge([
       "chooseKeymap",
       "showHover",
@@ -223,18 +564,9 @@ describe("TutorialExperience", () => {
       "openSequence",
       "openDatabase",
     ]);
-    root = createRoot(mount);
-    act(() => {
-      root?.render(
-        <TutorialProvider tutorial={tutorial}>
-          <TutorialExperience />
-        </TutorialProvider>,
-      );
-    });
+    render(tutorial);
 
-    expect(canvasRoot.querySelector(".tutorial-guide")?.textContent).toContain(
-      "Know where to get help",
-    );
+    expect(card()?.textContent).toContain("Know where to get help");
     const finish = [...canvasRoot.querySelectorAll("button")].find(
       (button) => button.textContent === "Finish tour",
     );
@@ -244,22 +576,26 @@ describe("TutorialExperience", () => {
     expect(tutorial.close).toHaveBeenCalledOnce();
   });
 
-  it("renders the dismissed affordance as the primary Resume Tutorial action", () => {
-    const mount = document.createElement("div");
-    document.body.append(mount);
-    const tutorial = tutorialBridge([], true);
-    root = createRoot(mount);
-    act(() => {
-      root?.render(
-        <TutorialProvider tutorial={tutorial}>
-          <TutorialToolbarAction />
-        </TutorialProvider>,
-      );
-    });
+  it("renders no card or chapter state when dismissed", () => {
+    render(tutorialBridge([], true));
 
-    const button = mount.querySelector("button");
-    expect(button?.textContent).toBe("Resume Tutorial");
-    expect(button?.classList.contains("review-corner-submit")).toBe(true);
+    expect(card()).toBeNull();
+    expect(section("Welcome").dataset.tutorialChapterState).toBeUndefined();
+    expect(canvasRoot.querySelector("[data-tutorial-target]")).toBeNull();
+  });
+
+  it("shrinks to a floating Tutorial button when hidden", () => {
+    const tutorial = tutorialBridge([], true);
+    render(tutorial);
+
+    const pill = canvasRoot.querySelector<HTMLButtonElement>(
+      ".tutorial-experience > .tutorial-guide-pill",
+    );
+    expect(pill?.getAttribute("aria-label")).toBe("Show tutorial");
+    expect(pill?.querySelector(".ui-icon--tutorial")).not.toBeNull();
+    expect(card()).toBeNull();
+    act(() => pill?.click());
+    expect(tutorial.reopen).toHaveBeenCalledOnce();
   });
 });
 
@@ -282,86 +618,4 @@ function tutorialBridge(
     ),
     close: vi.fn<ReviewCanvasTutorialBridge["close"]>(),
   } satisfies ReviewCanvasTutorialBridge;
-}
-
-function tutorialSurface(): {
-  canvasRoot: HTMLElement;
-  app: HTMLElement;
-  mount: HTMLElement;
-  commits: HTMLButtonElement;
-  sections: Map<string, { section: HTMLElement; toggle: HTMLButtonElement }>;
-} {
-  const canvasRoot = document.createElement("div");
-  canvasRoot.className = "review-canvas-root";
-  const app = document.createElement("div");
-  app.className = "review-app review-document-shell";
-  app.getBoundingClientRect = () => rect(0, 0, 1200, 800);
-  const commits = document.createElement("button");
-  commits.className = "review-segment";
-  commits.setAttribute("aria-label", "Commits");
-  commits.getBoundingClientRect = () => rect(60, 12, 74, 28);
-  app.append(commits);
-  const viewRegion = document.createElement("section");
-  viewRegion.className = "review-view-region";
-  viewRegion.getBoundingClientRect = () => rect(0, 64, 1200, 736);
-  app.append(viewRegion);
-  const sections = new Map<
-    string,
-    { section: HTMLElement; toggle: HTMLButtonElement }
-  >();
-  for (const [index, title] of [
-    "Welcome",
-    "Commits and diffs",
-    "Comments are threads",
-    "Interactive Diagrams",
-    "Get help",
-  ].entries()) {
-    const section = document.createElement("section");
-    section.className = "review-section";
-    section.dataset.reviewSection = title;
-    section.getBoundingClientRect = () => rect(300, 96 + index * 120, 650, 104);
-    const toggle = document.createElement("button");
-    toggle.className = "review-section-toggle";
-    toggle.ariaExpanded = "true";
-    toggle.addEventListener("click", () => {
-      toggle.ariaExpanded = toggle.ariaExpanded === "true" ? "false" : "true";
-    });
-    section.append(toggle);
-    const body = document.createElement("div");
-    body.className = "review-section-body";
-    body.getBoundingClientRect = () => rect(320, 130 + index * 120, 610, 56);
-    section.append(body);
-    if (title === "Welcome") {
-      const picker = document.createElement("div");
-      picker.className = "tutorial-keymap-picker";
-      picker.getBoundingClientRect = () => rect(320, 160, 280, 42);
-      body.append(picker);
-    }
-    viewRegion.append(section);
-    sections.set(title, { section, toggle });
-  }
-  const mount = document.createElement("div");
-  viewRegion.append(mount);
-  canvasRoot.append(app);
-  document.body.append(canvasRoot);
-  return { canvasRoot, app, mount, commits, sections };
-}
-
-function rect(
-  left: number,
-  top: number,
-  width: number,
-  height: number,
-): DOMRect {
-  return {
-    x: left,
-    y: top,
-    left,
-    top,
-    right: left + width,
-    bottom: top + height,
-    width,
-    height,
-    toJSON: () => ({}),
-  };
 }

--- a/packages/progressive-review/app/src/tutorial-experience.tsx
+++ b/packages/progressive-review/app/src/tutorial-experience.tsx
@@ -1,7 +1,7 @@
-import type { TutorialStepId } from "@dev.fast/review-protocol";
 import {
-  type CSSProperties,
   type ReactElement,
+  type ReactNode,
+  type RefObject,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -9,7 +9,9 @@ import {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 
+import { TutorialIcon } from "./icons";
 import { useReview } from "./review-context";
 import {
   REVIEW_INTERACTION_EVENT,
@@ -23,36 +25,62 @@ import {
   availableTutorialSteps,
   tutorialChapter,
 } from "./tutorial-plan";
-
-interface TutorialTargetLayout {
-  stepId: TutorialStepId;
-  left: number;
-  top: number;
-  width: number;
-  height: number;
-  chapterLeft: number;
-  chapterTop: number;
-  chapterWidth: number;
-  chapterHeight: number;
-  guideLeft: number;
-  guideTop: number;
-}
+import {
+  type TutorialChapterState,
+  TutorialSectionProvider,
+} from "./tutorial-section-context";
 
 type DiagramTourKind = "sequence" | "database" | "other";
 
-const GUIDE_WIDTH = 292;
-const GUIDE_HEIGHT_ESTIMATE = 224;
-const GUIDE_GAP = 14;
-const EDGE_GAP = 16;
+interface TutorialExperienceState {
+  activeStep: TutorialStepDefinition | null;
+  activeIndex: number;
+  steps: readonly TutorialStepDefinition[];
+  totalSteps: number;
+  hidden: boolean;
+  /** A comment composer has focus: the guide folds to its header. */
+  composing: boolean;
+  onBack(): void;
+  onNext(): void;
+  onDismiss(): void;
+  onFinish(): void;
+  onClose(): void;
+}
 
-export function TutorialExperience(): ReactElement | null {
+const COMPOSER_SELECTOR =
+  ".comment-form-container, .review-widget.compact-comment-thread, .thread-compose";
+
+/**
+ * Drives the tutorial for the document shell it wraps. The guide card sits in
+ * the bottom right corner of the shell in every view; hidden, it shrinks to a
+ * small floating button there. The step's target carries
+ * `data-tutorial-target` for its highlight. Nothing measures the target, so
+ * typing and scrolling never move the card.
+ */
+export function TutorialExperienceProvider({
+  shellRef,
+  scrollRegionRef,
+  children,
+}: {
+  shellRef: RefObject<HTMLElement | null>;
+  /** The scrolling view region; target rings for its content live inside
+      it so they scroll with the content. */
+  scrollRegionRef?: RefObject<HTMLElement | null>;
+  children: ReactNode;
+}): ReactElement {
   const tutorial = useTutorial();
   const review = useReview();
-  const hostRef = useRef<HTMLDivElement | null>(null);
   const revealedChapterRef = useRef<TutorialChapterId | null>(null);
-  const [targetLayout, setTargetLayout] = useState<TutorialTargetLayout | null>(
-    null,
-  );
+  // The shell ref belongs to an ancestor, so it attaches after this
+  // provider's layout effects. Read it once mounted and key effects on it.
+  const [shell, setShell] = useState<HTMLElement | null>(null);
+  const [region, setRegion] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setShell(shellRef.current);
+    setRegion(scrollRegionRef?.current ?? null);
+  }, [scrollRegionRef, shellRef]);
+  const [targets, setTargets] = useState<readonly HTMLElement[]>([]);
+  const [composing, setComposing] = useState(false);
   const [diagramTourKind, setDiagramTourKind] =
     useState<DiagramTourKind | null>(null);
   const steps = useMemo(
@@ -72,7 +100,7 @@ export function TutorialExperience(): ReactElement | null {
     ? steps.findIndex((step) => step.id === activeStep.id)
     : steps.length;
   const threadCount = review.allCommentThreads().length;
-  const guideHidden = dismissed || diagramTourKind !== null;
+  const hidden = !tutorial || dismissed || diagramTourKind !== null;
 
   const completeStep = useCallback(
     (step: TutorialStepDefinition) => {
@@ -95,9 +123,7 @@ export function TutorialExperience(): ReactElement | null {
   }, [activeStep, completeStep, dismissed, threadCount]);
 
   useLayoutEffect(() => {
-    const root = hostRef.current?.closest<HTMLElement>(
-      ".review-document-shell",
-    );
+    const root = shell;
     const canvasRoot =
       root?.closest<HTMLElement>(".review-canvas-root") ?? root?.parentElement;
     if (!canvasRoot) return;
@@ -117,7 +143,7 @@ export function TutorialExperience(): ReactElement | null {
     const observer = new MutationObserver(update);
     observer.observe(canvasRoot, { childList: true, subtree: true });
     return () => observer.disconnect();
-  }, []);
+  }, [shell]);
 
   useEffect(() => {
     if (dismissed || !activeStep) {
@@ -133,9 +159,7 @@ export function TutorialExperience(): ReactElement | null {
   }, [activeStep, completeStep, diagramTourKind, dismissed]);
 
   useEffect(() => {
-    const root = hostRef.current?.closest<HTMLElement>(
-      ".review-document-shell",
-    );
+    const root = shell;
     if (!root || dismissed || !activeStep) return;
     const onClick = (event: Event) => {
       if (activeStep.completion !== "click") return;
@@ -161,209 +185,136 @@ export function TutorialExperience(): ReactElement | null {
       root.removeEventListener("click", onClick, true);
       root.removeEventListener(REVIEW_INTERACTION_EVENT, onReviewInteraction);
     };
-  }, [activeStep, completeStep, dismissed]);
+  }, [activeStep, completeStep, dismissed, shell]);
 
+  // Fold the guide while a comment composer has focus, so it never covers
+  // the text the reader is writing.
+  useEffect(() => {
+    const root = shell;
+    if (!root || hidden) return;
+    const update = () => {
+      const active = document.activeElement;
+      setComposing(
+        active instanceof Element && active.closest(COMPOSER_SELECTOR) !== null,
+      );
+    };
+    root.addEventListener("focusin", update);
+    root.addEventListener("focusout", update);
+    update();
+    return () => {
+      root.removeEventListener("focusin", update);
+      root.removeEventListener("focusout", update);
+    };
+  }, [hidden, shell]);
+
+  // Bring a newly active chapter into view once. The section itself expands
+  // through the section context; nothing collapses the other chapters.
   useLayoutEffect(() => {
-    const root = hostRef.current?.closest<HTMLElement>(
-      ".review-document-shell",
-    );
-    if (!root || dismissed) {
+    const root = shell;
+    if (!root || hidden) {
       revealedChapterRef.current = null;
       return;
     }
+    if (revealedChapterRef.current === activeChapterId) return;
+    revealedChapterRef.current = activeChapterId;
     const activeTitle = tutorialChapter(activeChapterId).title;
-    const availableByChapter = new Map<TutorialChapterId, TutorialStepId[]>();
-    for (const step of steps) {
-      const values = availableByChapter.get(step.chapter) ?? [];
-      values.push(step.id);
-      availableByChapter.set(step.chapter, values);
-    }
-    const sections = [
-      ...root.querySelectorAll<HTMLElement>("[data-review-section]"),
-    ];
-    for (const section of sections) {
-      const title = section.dataset.reviewSection;
-      const chapter = TUTORIAL_CHAPTERS.find(
-        (candidate) => candidate.title === title,
-      );
-      if (!chapter) continue;
-      const chapterSteps = availableByChapter.get(chapter.id) ?? [];
-      const chapterComplete =
-        chapter.id === "finish"
-          ? completed
-          : chapterSteps.every((id) => checked.has(id));
-      section.dataset.tutorialChapterState =
-        chapter.id === activeChapterId
-          ? "active"
-          : chapterComplete
-            ? "complete"
-            : "upcoming";
-      const toggle = section.querySelector<HTMLButtonElement>(
-        ".review-section-toggle",
-      );
-      const shouldExpand = title === activeTitle;
-      const expanded = toggle?.getAttribute("aria-expanded") === "true";
-      if (toggle && shouldExpand !== expanded) toggle.click();
-    }
-    if (revealedChapterRef.current !== activeChapterId) {
-      const activeSection = sections.find(
-        (section) => section.dataset.reviewSection === activeTitle,
-      );
-      activeSection?.scrollIntoView({ block: "start", behavior: "smooth" });
-      revealedChapterRef.current = activeChapterId;
-    }
-    return () => {
-      for (const section of sections) {
-        delete section.dataset.tutorialChapterState;
-      }
-    };
-  }, [activeChapterId, checked, completed, dismissed, steps]);
+    [...root.querySelectorAll<HTMLElement>("[data-review-section]")]
+      .find((section) => section.dataset.reviewSection === activeTitle)
+      ?.scrollIntoView({ block: "start", behavior: "smooth" });
+  }, [activeChapterId, hidden, shell]);
 
+  // Mark the active step's target. DOM changes coalesce into one query per
+  // frame; no geometry is measured and state changes only when the answer does.
   useLayoutEffect(() => {
-    const root = hostRef.current?.closest<HTMLElement>(
-      ".review-document-shell",
-    );
-    if (!root || guideHidden || !activeStep) {
-      setTargetLayout(null);
+    const root = shell;
+    if (!root || hidden || !activeStep) {
+      setTargets([]);
       return;
     }
-    let target: HTMLElement | null = null;
-    let targetResizeObserver: ResizeObserver | null = null;
-    let frame = 0;
-    let revealedTarget = false;
-    const update = () => {
-      cancelAnimationFrame(frame);
-      frame = requestAnimationFrame(() => {
-        const nextTarget = root.querySelector<HTMLElement>(
-          activeStep.targetSelector,
+    // A step can name several targets (a toolbar tab and a prose button that
+    // open the same view); every match is marked.
+    let targets: HTMLElement[] = [];
+    let revealed = false;
+    let scheduledFrame: number | null = null;
+    const apply = () => {
+      let next = [
+        ...root.querySelectorAll<HTMLElement>(activeStep.targetSelector),
+      ];
+      // A line-marking step points at one code block: the first visible match.
+      if (activeStep.lineMatcher) {
+        const first = next.find(
+          (candidate) => candidate.closest("[hidden]") === null,
         );
-        if (nextTarget !== target) {
-          targetResizeObserver?.disconnect();
-          target = nextTarget;
-          if (target && typeof ResizeObserver !== "undefined") {
-            targetResizeObserver = new ResizeObserver(update);
-            targetResizeObserver.observe(target);
-          }
+        next = first ? [first] : [];
+      }
+      for (const target of targets) {
+        if (!next.includes(target)) delete target.dataset.tutorialTarget;
+      }
+      for (const target of next) target.dataset.tutorialTarget = activeStep.id;
+      targets = next;
+      const visible = targets.filter(
+        (target) => target.closest("[hidden]") === null,
+      );
+      setTargets((current) =>
+        current.length === visible.length &&
+        current.every((target, index) => target === visible[index])
+          ? current
+          : visible,
+      );
+      if (activeStep.lineMatcher && visible[0]) {
+        markTutorialLine(root, visible[0], activeStep.lineMatcher);
+      }
+      // Bring an off-screen target into view once per step. This is the only
+      // measurement the tutorial makes, and it happens on a step change, not
+      // on scroll.
+      const first = visible[0];
+      if (first && !revealed) {
+        revealed = true;
+        const view = (
+          root.querySelector(".review-view-region") ?? root
+        ).getBoundingClientRect();
+        const rect = first.getBoundingClientRect();
+        if (rect.bottom > view.bottom || rect.top < view.top) {
+          first.scrollIntoView({ block: "center", behavior: "smooth" });
         }
-        if (!target) {
-          setTargetLayout(null);
-          return;
-        }
-        const rootRect = root.getBoundingClientRect();
-        const targetRect = target.getBoundingClientRect();
-        const viewRect = root
-          .querySelector<HTMLElement>(".review-view-region")
-          ?.getBoundingClientRect();
-        const guideHeight =
-          hostRef.current
-            ?.querySelector<HTMLElement>(".tutorial-guide")
-            ?.getBoundingClientRect().height || GUIDE_HEIGHT_ESTIMATE;
-        const chapterRect = root
-          .querySelector<HTMLElement>('[data-tutorial-chapter-state="active"]')
-          ?.getBoundingClientRect();
-        if (
-          targetRect.width <= 0 ||
-          targetRect.height <= 0 ||
-          targetRect.bottom <= rootRect.top ||
-          targetRect.top >= rootRect.bottom
-        ) {
-          if (
-            !revealedTarget &&
-            targetRect.width > 0 &&
-            targetRect.height > 0
-          ) {
-            revealedTarget = true;
-            target.scrollIntoView({ block: "center", behavior: "smooth" });
-          }
-          setTargetLayout(null);
-          return;
-        }
-        const left = targetRect.left - rootRect.left;
-        const top = targetRect.top - rootRect.top;
-        const width = targetRect.width;
-        const height = targetRect.height;
-        const rightSpace = rootRect.width - (left + width);
-        const belowSpace = rootRect.height - (top + height);
-        const guideMinTop = clamp(
-          (viewRect?.top ?? rootRect.top) - rootRect.top + EDGE_GAP,
-          EDGE_GAP,
-          Math.max(EDGE_GAP, rootRect.height - EDGE_GAP),
-        );
-        const guideBottom = clamp(
-          (viewRect?.bottom ?? rootRect.bottom) - rootRect.top - EDGE_GAP,
-          guideMinTop,
-          Math.max(guideMinTop, rootRect.height - EDGE_GAP),
-        );
-        const guideMaxTop = Math.max(guideMinTop, guideBottom - guideHeight);
-        let guideLeft: number;
-        let guideTop: number;
-        if (rightSpace >= GUIDE_WIDTH + GUIDE_GAP + EDGE_GAP) {
-          guideLeft = left + width + GUIDE_GAP;
-          guideTop = clamp(top, guideMinTop, guideMaxTop);
-        } else if (belowSpace >= GUIDE_HEIGHT_ESTIMATE + GUIDE_GAP) {
-          guideLeft = clamp(
-            left,
-            EDGE_GAP,
-            rootRect.width - GUIDE_WIDTH - EDGE_GAP,
-          );
-          guideTop = clamp(top + height + GUIDE_GAP, guideMinTop, guideMaxTop);
-        } else {
-          guideLeft = rootRect.width - GUIDE_WIDTH - EDGE_GAP;
-          guideTop = guideMinTop;
-        }
-        setTargetLayout({
-          stepId: activeStep.id,
-          left,
-          top,
-          width,
-          height,
-          chapterLeft: chapterRect ? chapterRect.left - rootRect.left : 0,
-          chapterTop: chapterRect ? chapterRect.top - rootRect.top : 0,
-          chapterWidth: chapterRect?.width ?? 0,
-          chapterHeight: chapterRect?.height ?? 0,
-          guideLeft,
-          guideTop,
-        });
+      }
+    };
+    const scheduleApply = () => {
+      if (scheduledFrame !== null) return;
+      scheduledFrame = requestAnimationFrame(() => {
+        scheduledFrame = null;
+        apply();
       });
     };
-    const mutationObserver = new MutationObserver(update);
-    mutationObserver.observe(root, {
+    const observer = new MutationObserver(scheduleApply);
+    observer.observe(root, {
       attributes: true,
-      attributeFilter: ["aria-expanded", "aria-pressed", "class", "hidden"],
+      attributeFilter: ["hidden"],
       childList: true,
       subtree: true,
     });
-    const rootResizeObserver =
-      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(update);
-    rootResizeObserver?.observe(root);
-    root.addEventListener("scroll", update, true);
-    window.addEventListener("resize", update);
-    update();
+    apply();
     return () => {
-      cancelAnimationFrame(frame);
-      mutationObserver.disconnect();
-      rootResizeObserver?.disconnect();
-      targetResizeObserver?.disconnect();
-      root.removeEventListener("scroll", update, true);
-      window.removeEventListener("resize", update);
+      observer.disconnect();
+      if (scheduledFrame !== null) cancelAnimationFrame(scheduledFrame);
+      for (const target of targets) delete target.dataset.tutorialTarget;
+      clearTutorialLine(root);
     };
-  }, [activeStep, guideHidden]);
+  }, [activeStep, hidden, shell]);
 
+  const rings = useTargetRings(targets, shell, region);
+
+  // Back reopens the previous step only, so crossing a chapter boundary
+  // lands on that chapter's last step rather than its first.
   const goBack = useCallback(() => {
     if (!tutorial || activeIndex <= 0) return;
-    const previous = steps[activeIndex - 1]!;
-    if (activeStep?.chapter === "finish") {
-      tutorial.setStep(previous.id, false);
-      return;
-    }
-    if (activeStep && previous.chapter !== activeStep.chapter) {
-      for (const step of steps) {
-        if (step.chapter === previous.chapter) tutorial.setStep(step.id, false);
-      }
-      return;
-    }
-    tutorial.setStep(previous.id, false);
-  }, [activeIndex, activeStep, steps, tutorial]);
+    tutorial.setStep(steps[activeIndex - 1]!.id, false);
+  }, [activeIndex, steps, tutorial]);
+
+  const goNext = useCallback(() => {
+    if (!tutorial || !activeStep || activeStep.completion === "finish") return;
+    tutorial.setStep(activeStep.id, true);
+  }, [activeStep, tutorial]);
 
   const finishTour = useCallback(() => {
     if (!tutorial || activeStep?.completion !== "finish") return;
@@ -371,118 +322,124 @@ export function TutorialExperience(): ReactElement | null {
     tutorial.close();
   }, [activeStep, completeStep, tutorial]);
 
-  if (!tutorial) return null;
-  const activeTargetLayout =
-    targetLayout?.stepId === activeStep?.id ? targetLayout : null;
-  const guideStyle = activeTargetLayout
-    ? ({
-        "--tutorial-guide-left": `${activeTargetLayout.guideLeft}px`,
-        "--tutorial-guide-top": `${activeTargetLayout.guideTop}px`,
-      } as CSSProperties)
-    : undefined;
-  const spotlightStyle = activeTargetLayout
-    ? ({
-        left: activeTargetLayout.left - 5,
-        top: activeTargetLayout.top - 5,
-        width: activeTargetLayout.width + 10,
-        height: activeTargetLayout.height + 10,
-      } as CSSProperties)
-    : undefined;
+  const experience: TutorialExperienceState | null = tutorial
+    ? {
+        activeStep,
+        activeIndex,
+        steps,
+        totalSteps: steps.length,
+        hidden,
+        composing,
+        onBack: goBack,
+        onNext: goNext,
+        onDismiss: tutorial.dismiss,
+        onFinish: finishTour,
+        onClose: tutorial.close,
+      }
+    : null;
+
+  const sectionValue = useMemo(() => {
+    const chapterStates = new Map<string, TutorialChapterState>();
+    if (!tutorial || dismissed) return { chapterStates };
+    for (const chapter of TUTORIAL_CHAPTERS) {
+      const chapterSteps = steps.filter((step) => step.chapter === chapter.id);
+      const chapterComplete =
+        chapter.id === "finish"
+          ? completed
+          : chapterSteps.every((step) => checked.has(step.id));
+      chapterStates.set(
+        chapter.title,
+        chapter.id === activeChapterId
+          ? "active"
+          : chapterComplete
+            ? "complete"
+            : "upcoming",
+      );
+    }
+    return { chapterStates };
+  }, [activeChapterId, checked, completed, dismissed, steps, tutorial]);
 
   return (
-    <div
-      ref={hostRef}
-      className="tutorial-experience"
-      data-tutorial-active-step={activeStep?.id ?? "complete"}
-      style={guideStyle}
-    >
-      {!guideHidden && activeTargetLayout ? (
-        <>
-          <svg className="tutorial-scrim" aria-hidden="true">
-            <defs>
-              <mask id="tutorial-scrim-mask" maskUnits="userSpaceOnUse">
-                <rect width="100%" height="100%" fill="white" />
-                <rect
-                  x={activeTargetLayout.chapterLeft - 8}
-                  y={activeTargetLayout.chapterTop - 8}
-                  width={activeTargetLayout.chapterWidth + 16}
-                  height={activeTargetLayout.chapterHeight + 16}
-                  rx="10"
-                  fill="black"
-                />
-                <rect
-                  x={activeTargetLayout.left - 5}
-                  y={activeTargetLayout.top - 5}
-                  width={activeTargetLayout.width + 10}
-                  height={activeTargetLayout.height + 10}
-                  rx="9"
-                  fill="black"
-                />
-              </mask>
-            </defs>
-            <rect
-              width="100%"
-              height="100%"
-              fill="var(--tutorial-scrim)"
-              mask="url(#tutorial-scrim-mask)"
-            />
-          </svg>
-          <div
-            className="tutorial-spotlight"
-            style={spotlightStyle}
-            aria-hidden="true"
-          />
-        </>
+    <TutorialSectionProvider value={sectionValue}>
+      {children}
+      {region && rings.some((ring) => ring.host === "region")
+        ? createPortal(
+            <div className="tutorial-target-layer" aria-hidden="true">
+              {rings
+                .filter((ring) => ring.host === "region")
+                .map((ring) => (
+                  <TutorialTargetRing key={ring.key} ring={ring} />
+                ))}
+            </div>,
+            region,
+          )
+        : null}
+      {tutorial && diagramTourKind === null ? (
+        <div className="tutorial-experience">
+          {rings
+            .filter((ring) => ring.host === "shell")
+            .map((ring) => (
+              <TutorialTargetRing key={ring.key} ring={ring} />
+            ))}
+          {dismissed ? (
+            <button
+              type="button"
+              className="tutorial-guide-pill"
+              aria-label="Show tutorial"
+              title="Show tutorial"
+              onClick={tutorial.reopen}
+            >
+              <TutorialIcon />
+            </button>
+          ) : (
+            <TutorialGuide experience={experience} />
+          )}
+        </div>
       ) : null}
-      {!guideHidden ? (
-        <TutorialGuide
-          activeStep={activeStep}
-          activeIndex={activeIndex}
-          totalSteps={steps.length}
-          targetFound={activeTargetLayout !== null}
-          onBack={goBack}
-          onDismiss={tutorial.dismiss}
-          onFinish={finishTour}
-          onClose={tutorial.close}
-        />
-      ) : null}
-    </div>
+    </TutorialSectionProvider>
   );
 }
 
+/** The guide card: chapter, step, instruction, and tour controls. */
 function TutorialGuide({
-  activeStep,
-  activeIndex,
-  totalSteps,
-  targetFound,
-  onBack,
-  onDismiss,
-  onFinish,
-  onClose,
+  experience,
 }: {
-  activeStep: TutorialStepDefinition | null;
-  activeIndex: number;
-  totalSteps: number;
-  targetFound: boolean;
-  onBack(): void;
-  onDismiss(): void;
-  onFinish(): void;
-  onClose(): void;
-}): ReactElement {
+  experience: TutorialExperienceState | null;
+}): ReactElement | null {
+  if (!experience || experience.hidden) return null;
+  const { activeStep, activeIndex, totalSteps } = experience;
   const chapter = tutorialChapter(activeStep?.chapter ?? "finish");
   const chapterIndex = TUTORIAL_CHAPTERS.findIndex(
     (candidate) => candidate.id === chapter.id,
   );
-  const fallback = activeStep
-    ? tutorialFallbackAction(activeStep, targetFound)
-    : tutorialViewAction("review", "Return to the tour");
+  // "3.2" reads as chapter 3, step 2 within that chapter.
+  const stepInChapter = activeStep
+    ? experience.steps
+        .filter((step) => step.chapter === activeStep.chapter)
+        .findIndex((step) => step.id === activeStep.id) + 1
+    : 0;
+  const chapterLabel = stepInChapter
+    ? `${chapterIndex + 1}.${stepInChapter}`
+    : `${chapterIndex + 1}`;
   return (
-    <aside className="tutorial-guide" aria-label="Tutorial guide">
+    <aside
+      className={
+        experience.composing
+          ? "tutorial-guide tutorial-guide--folded"
+          : "tutorial-guide"
+      }
+      aria-label="Tutorial guide"
+      data-tutorial-step={activeStep?.id ?? "complete"}
+    >
       <header>
         <span>
-          Chapter {chapterIndex + 1} of {TUTORIAL_CHAPTERS.length}
+          Chapter {chapterLabel} of {TUTORIAL_CHAPTERS.length}
         </span>
-        <button type="button" onClick={onDismiss} aria-label="Hide tutorial">
+        <button
+          type="button"
+          onClick={experience.onDismiss}
+          aria-label="Hide tutorial"
+        >
           ×
         </button>
       </header>
@@ -493,37 +450,32 @@ function TutorialGuide({
           }}
         />
       </div>
-      <div className="tutorial-guide-copy" aria-live="polite">
+      <div className="tutorial-guide-copy">
         <p>{chapter.title}</p>
         <h2>{activeStep?.title ?? "Tour complete"}</h2>
         <p>
           {activeStep?.instruction ??
             "You have walked through the core Review experience."}
         </p>
-        {fallback ? (
-          <button
-            type="button"
-            className="tutorial-guide-primary"
-            onClick={fallback.run}
-          >
-            {fallback.label}
-          </button>
-        ) : null}
       </div>
       <footer>
-        <button type="button" onClick={onBack} disabled={activeIndex <= 0}>
+        <button
+          type="button"
+          onClick={experience.onBack}
+          disabled={activeIndex <= 0}
+        >
           Back
         </button>
         {activeStep?.completion === "finish" ? (
-          <button type="button" onClick={onFinish}>
+          <button type="button" onClick={experience.onFinish}>
             Finish tour
           </button>
         ) : activeStep ? (
-          <button type="button" onClick={onDismiss}>
-            Skip tour
+          <button type="button" onClick={experience.onNext}>
+            Next
           </button>
         ) : (
-          <button type="button" onClick={onClose}>
+          <button type="button" onClick={experience.onClose}>
             Close tutorial
           </button>
         )}
@@ -532,56 +484,173 @@ function TutorialGuide({
   );
 }
 
-function tutorialFallbackAction(
-  step: TutorialStepDefinition,
-  targetFound: boolean,
-): { label: string; run(): void } | null {
-  if (targetFound) return null;
-  if (step.id === "openDiff") {
-    return tutorialViewAction("commits", "Open Commits");
-  }
-  if (
-    step.chapter === "welcome" ||
-    step.chapter === "comments" ||
-    step.chapter === "diagrams" ||
-    step.chapter === "finish"
-  ) {
-    return tutorialViewAction("review", "Return to the tour");
-  }
-  return null;
+interface TutorialRingBox {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
 }
 
-function tutorialViewAction(
-  view: "review" | "commits",
-  label: string,
-): { label: string; run(): void } {
-  return {
-    label,
-    run: () => {
-      const ariaLabel = view === "review" ? "Review" : "Commits";
-      document
-        .querySelector<HTMLButtonElement>(
-          `.review-segment[aria-label="${ariaLabel}"]`,
-        )
-        ?.click();
-    },
-  };
+interface TutorialRing {
+  key: string;
+  /** Where the ring is drawn: inside the scroll region (moves with the
+      content) or in the shell overlay (toolbar targets). */
+  host: "region" | "shell";
+  /** Inline targets (links) get one wash box per line, no outline. */
+  inline: boolean;
+  radius: number;
+  boxes: TutorialRingBox[];
 }
 
-function clamp(value: number, minimum: number, maximum: number): number {
-  return Math.min(Math.max(value, minimum), Math.max(minimum, maximum));
+const RING_GAP = 4;
+
+/**
+ * Measures the marked targets and describes a ring for each. Measurement
+ * happens on a target change, on a target or content resize, and on a
+ * window resize — never on scroll. Rings for content inside the scroll
+ * region are placed in the region's own coordinate space, so they travel
+ * with the content and never lag.
+ */
+function useTargetRings(
+  targets: readonly HTMLElement[],
+  shell: HTMLElement | null,
+  region: HTMLElement | null,
+): TutorialRing[] {
+  const [rings, setRings] = useState<TutorialRing[]>([]);
+  useLayoutEffect(() => {
+    if (!shell || targets.length === 0) {
+      setRings([]);
+      return;
+    }
+    let frame = 0;
+    const measure = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        const shellRect = shell.getBoundingClientRect();
+        const regionRect = region?.getBoundingClientRect();
+        setRings(
+          targets.map((target, index) => {
+            const inRegion = region !== null && region.contains(target);
+            const originLeft =
+              inRegion && regionRect
+                ? regionRect.left - region.scrollLeft
+                : shellRect.left;
+            const originTop =
+              inRegion && regionRect
+                ? regionRect.top - region.scrollTop
+                : shellRect.top;
+            const inline = target instanceof HTMLAnchorElement;
+            const rects = inline
+              ? [...target.getClientRects()]
+              : [target.getBoundingClientRect()];
+            const radius = parseFloat(getComputedStyle(target).borderRadius);
+            return {
+              key: `${index}:${target.dataset.tutorialTarget ?? ""}`,
+              host: inRegion ? "region" : "shell",
+              inline,
+              radius: (Number.isFinite(radius) ? radius : 4) + RING_GAP,
+              boxes: (rects.length ? rects : [target.getBoundingClientRect()])
+                // A wrapped link reports an empty rect at the break.
+                .filter((rect, _, all) => all.length === 1 || rect.width > 0)
+                .map((rect) => ({
+                  left: rect.left - originLeft,
+                  top: rect.top - originTop,
+                  width: rect.width,
+                  height: rect.height,
+                })),
+            };
+          }),
+        );
+      });
+    };
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(measure);
+    for (const target of targets) resizeObserver?.observe(target);
+    // Content above a target can grow (an editor mounts, a composer opens)
+    // without the target itself resizing, so watch the region's content too.
+    if (region) {
+      for (const child of region.querySelectorAll(
+        ":scope > *, :scope > .review-document-view > *",
+      )) {
+        resizeObserver?.observe(child);
+      }
+    }
+    window.addEventListener("resize", measure);
+    measure();
+    return () => {
+      cancelAnimationFrame(frame);
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [region, shell, targets]);
+  return rings;
 }
 
-export function TutorialToolbarAction(): ReactElement | null {
-  const tutorial = useTutorial();
-  if (!tutorial || !tutorial.content.progress.dismissed) return null;
+function TutorialTargetRing({ ring }: { ring: TutorialRing }): ReactElement {
   return (
-    <button
-      type="button"
-      className="tutorial-toolbar-action review-corner-submit"
-      onClick={tutorial.reopen}
-    >
-      Resume Tutorial
-    </button>
+    <>
+      {ring.boxes.map((box, index) => (
+        <div
+          key={index}
+          className={
+            ring.inline
+              ? "tutorial-target-ring tutorial-target-ring--inline"
+              : "tutorial-target-ring"
+          }
+          style={
+            ring.inline
+              ? {
+                  left: box.left - 4,
+                  top: box.top - 1,
+                  width: box.width + 8,
+                  height: box.height + 2,
+                }
+              : {
+                  left: box.left - RING_GAP,
+                  top: box.top - RING_GAP,
+                  width: box.width + RING_GAP * 2,
+                  height: box.height + RING_GAP * 2,
+                  borderRadius: ring.radius,
+                }
+          }
+        />
+      ))}
+    </>
   );
+}
+
+/**
+ * Marks the first rendered code line whose text matches, plus the gutter
+ * row at the same offset so its comment control can show. Monaco keeps rows
+ * in visual order by their `top` style, not by DOM order.
+ */
+function markTutorialLine(
+  root: HTMLElement,
+  editor: HTMLElement,
+  matcher: RegExp,
+): void {
+  clearTutorialLine(root);
+  const rows = [...editor.querySelectorAll<HTMLElement>(".view-line")].sort(
+    (left, right) => parseFloat(left.style.top) - parseFloat(right.style.top),
+  );
+  const row = rows.find((candidate) =>
+    matcher.test(candidate.textContent ?? ""),
+  );
+  if (!row) return;
+  row.dataset.tutorialLine = "";
+  for (const margin of editor.querySelectorAll<HTMLElement>(
+    ".margin-view-overlays > div",
+  )) {
+    if (margin.style.top === row.style.top) margin.dataset.tutorialLine = "";
+  }
+}
+
+function clearTutorialLine(root: HTMLElement): void {
+  for (const marked of root.querySelectorAll<HTMLElement>(
+    "[data-tutorial-line]",
+  )) {
+    delete marked.dataset.tutorialLine;
+  }
 }

--- a/packages/progressive-review/app/src/tutorial-keymap-picker.tsx
+++ b/packages/progressive-review/app/src/tutorial-keymap-picker.tsx
@@ -33,11 +33,7 @@ export function TutorialKeymapPicker(_props: TutorialKeymapPickerProps) {
               .finally(() => setPending(null));
           }}
         >
-          {pending === choice.value
-            ? "Applying…"
-            : tutorial?.content.keymap === choice.value
-              ? `${choice.label} ✓`
-              : choice.label}
+          {pending === choice.value ? "Applying…" : choice.label}
         </button>
       ))}
     </div>

--- a/packages/progressive-review/app/src/tutorial-plan.ts
+++ b/packages/progressive-review/app/src/tutorial-plan.ts
@@ -27,8 +27,16 @@ export interface TutorialStepDefinition {
   instruction: string;
   completion: TutorialStepCompletion;
   targetSelector: string;
+  /** Marks the first code line in the target that matches, with its gutter
+      comment control shown, so the reader sees where to start. */
+  lineMatcher?: RegExp;
   requiresSoftwareMap?: boolean;
 }
+
+/* A function or method signature that opens a body, or a const/let/var
+   declaration. `\s` also covers the non-breaking spaces Monaco renders. */
+const DECLARATION_LINE =
+  /^\s*(?:export\s+)?(?:async\s+)?(?:function\b|const\b|let\b|var\b)|^\s*(?:(?:public|private|protected|static|async|readonly)\s+)*[A-Za-z_$][\w$]*\s*\([^)]*\)\s*(?::\s*[^{]+)?\{\s*$/;
 
 export const TUTORIAL_CHAPTERS: readonly TutorialChapterDefinition[] = [
   { id: "welcome", title: "Welcome" },
@@ -101,8 +109,14 @@ const tutorialSteps: readonly TutorialStepDefinition[] = [
     instruction:
       "Move over the code, use the comment control in the left gutter, and write a note.",
     completion: "comment",
-    targetSelector:
+    // The reader arrives here from the commit diff, so the open Diff view's
+    // editors count as well as the document's code block. Only the visible
+    // one is marked.
+    targetSelector: [
       '[data-review-section="Comments are threads"] .review-inline-editor',
+      ".review-diff-view:not(.review-diff-view--preloaded) .monaco-diff-editor .editor.modified",
+    ].join(", "),
+    lineMatcher: DECLARATION_LINE,
   },
   {
     id: "openSequence",

--- a/packages/progressive-review/app/src/tutorial-section-context.tsx
+++ b/packages/progressive-review/app/src/tutorial-section-context.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext } from "react";
+
+export type TutorialChapterState = "active" | "complete" | "upcoming";
+
+export interface TutorialSectionContextValue {
+  /** Chapter state keyed by the document section title. */
+  chapterStates: ReadonlyMap<string, TutorialChapterState>;
+}
+
+const TutorialSectionContext =
+  createContext<TutorialSectionContextValue | null>(null);
+
+export const TutorialSectionProvider = TutorialSectionContext.Provider;
+
+/**
+ * The tutorial chapter state of a document section. Outside the tutorial (no
+ * provider) every section gets null.
+ */
+export function useTutorialSection(title: string): {
+  state: TutorialChapterState | null;
+} {
+  const value = useContext(TutorialSectionContext);
+  return { state: value?.chapterStates.get(title) ?? null };
+}


### PR DESCRIPTION
## Summary
- move the tutorial guide into a persistent corner card with a compact icon-only reopen control
- highlight live tutorial targets across Review views without continuous scroll tracking
- progressively reveal chapter state, improve comment shortcuts, and use a transparent Review scrollbar track
- coalesce dynamic DOM target discovery and respect reduced-motion preferences

## Verification
- running macOS Review smoke passed: guide positioning, hide/reopen icon, Tour mount/unmount, progress updates, target refresh, and scrollbar treatment
- exact-head `pnpm run ci` passed, including Code OSS compile, desktop tests, native Review harness, and tutorial asset validation
- exact-head TypeScript check passed
- progressive-review full suite passed 1,121/1,122 in the clean PR worktree; the single unrelated Git/jj fixture passed 23/23 on focused rerun (and the original worktree full suite passed 1,122/1,122)