### PR TITLE
Fix review paragraph spacing

### DIFF
--- a/packages/progressive-review/app/src/App.test.ts
+++ b/packages/progressive-review/app/src/App.test.ts
@@ -1506,7 +1506,7 @@ describe("review app light theme", () => {
       /\.sequence-diagram,\s*\.database-lens\s*{[^}]*background:\s*var\(--diagram-surface\);/s,
     );
     expect(styles).toMatch(
-      /\.review-document p,\s*\.review-document li\s*{[^}]*font-size:\s*15px;[^}]*line-height:\s*1\.72;/s,
+      /\.review-document p,\s*\.review-document li\s*{[^}]*font-size:\s*15px;[^}]*line-height:\s*1\.72;[^}]*text-align:\s*left;/s,
     );
     expect(styles).not.toContain(".review-document h1 + p");
     expect(styles).not.toContain(".review-document h1 + p code");

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -7651,7 +7651,7 @@ a.review-doc-meta-pr:hover {
   font-family: var(--font-serif);
   font-size: 15px;
   line-height: 1.72;
-  text-align: justify;
+  text-align: left;
 }
 
 .review-document li + li {


### PR DESCRIPTION
## Summary

- left-align review paragraphs and list items so long inline code cannot create stretched word spacing
- extend the canvas styling contract to guard the alignment

## Testing

- `pnpm run ci`
- manually verified in Review Dev with the affected document