### PR TITLE
Bundle Review command with skill installs

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
@@ -1375,7 +1375,12 @@ export const ReviewCliInstallStatusSchema = z.strictObject({
   fingerprint: requiredString,
   stamp: ReviewCliInstallStampSchema.nullable(),
   stale: z.boolean(),
-  shim: z.strictObject({ path: requiredString, onPath: z.boolean() }),
+  shim: z.strictObject({
+    path: requiredString,
+    installed: z.boolean(),
+    profileConfigured: z.boolean(),
+    onPath: z.boolean(),
+  }),
   fff: z.strictObject({
     serverName: z.literal("fff"),
     corpusRoot: requiredString,
@@ -1409,9 +1414,10 @@ export type ReviewCliInstallStatus = z.infer<
   typeof ReviewCliInstallStatusSchema
 >;
 
-// Skills and FFF integrations are per-agent. The review command, FFF binary,
-// and trace configuration are per-machine. Silent app updates omit `fff` and
-// `trace`, so they do not run an installer or contact R2.
+// Skills and FFF integrations are per-agent. Skill requests install the review
+// command by default. The command, FFF binary, and trace configuration are
+// per-machine. Silent app updates omit `fff` and `trace`, so they do not run an
+// FFF installer or contact R2.
 export const ReviewCliInstallApplyRequestSchema = z
   .strictObject({
     targets: z.array(ReviewCliInstallTargetSchema),

--- a/apps/review-desktop/code-oss/src/vs/review/contrib/install/reviewCliInstall.contribution.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/install/reviewCliInstall.contribution.ts
@@ -248,7 +248,6 @@ class ReviewCliInstallStartup implements IWorkbenchContribution {
 		}
 		await this.reviewSessionService.applyCliInstall({
 			targets,
-			shim: Boolean(status.stamp?.shimPath),
 		});
 		this.notificationService.status(
 			localize('review.cliInstall.resynced', "Review updated the installed CLI and agent skills."),

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
@@ -588,7 +588,7 @@ export class ReviewSessionService
 			},
 			body: JSON.stringify({
 				targets: request.targets,
-				...(request.shim ? { shim: true } : {}),
+				...(request.shim !== undefined ? { shim: request.shim } : {}),
 				...(request.fff ? { fff: true } : {}),
 				...(request.trace !== undefined ? { trace: request.trace } : {}),
 			}),

--- a/packages/progressive-review/app/src/agent-setup-card.test.tsx
+++ b/packages/progressive-review/app/src/agent-setup-card.test.tsx
@@ -30,70 +30,6 @@ describe("AgentSetupCard", () => {
     vi.restoreAllMocks();
   });
 
-  it("persists a skip before it closes the setup card", async () => {
-    let finishSkip: ((status: ReviewCliInstallStatus) => void) | undefined;
-    const skip = vi.fn<ReviewCanvasInstallContent["skip"]>(
-      () =>
-        new Promise<ReviewCliInstallStatus>((resolve) => {
-          finishSkip = resolve;
-        }),
-    );
-    const onSkip = vi.fn<() => void>();
-    const install: ReviewCanvasInstallContent = {
-      status,
-      apply: vi.fn<ReviewCanvasInstallContent["apply"]>(),
-      remove: vi.fn<ReviewCanvasInstallContent["remove"]>(),
-      decline: vi.fn<ReviewCanvasInstallContent["decline"]>(),
-      skip,
-      enablePrompts: vi.fn<ReviewCanvasInstallContent["enablePrompts"]>(),
-    };
-
-    await act(async () =>
-      root.render(<AgentSetupCard install={install} onSkip={onSkip} />),
-    );
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>("button.review-agent-setup-subtle")
-        ?.click();
-    });
-
-    expect(skip).toHaveBeenCalledOnce();
-    expect(onSkip).not.toHaveBeenCalled();
-    expect(container.textContent).toContain("Skipping…");
-
-    await act(async () => finishSkip?.(skippedStatus));
-    expect(onSkip).toHaveBeenCalledOnce();
-  });
-
-  it("reports the refreshed status after the first-run install", async () => {
-    const onStatusChange = vi.fn<(status: ReviewCliInstallStatus) => void>();
-    const apply = vi.fn<ReviewCanvasInstallContent["apply"]>(
-      async () => grantedStatus,
-    );
-    const install: ReviewCanvasInstallContent = {
-      status,
-      apply,
-      remove: vi.fn<ReviewCanvasInstallContent["remove"]>(),
-      decline: vi.fn<ReviewCanvasInstallContent["decline"]>(),
-      skip: vi.fn<ReviewCanvasInstallContent["skip"]>(),
-      enablePrompts: vi.fn<ReviewCanvasInstallContent["enablePrompts"]>(),
-    };
-
-    await act(async () =>
-      root.render(
-        <AgentSetupCard install={install} onStatusChange={onStatusChange} />,
-      ),
-    );
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>("button.review-agent-setup-primary")
-        ?.click();
-    });
-
-    expect(apply).toHaveBeenCalledOnce();
-    expect(onStatusChange).toHaveBeenCalledExactlyOnceWith(grantedStatus);
-  });
-
   it("reports the refreshed status after a per-agent install", async () => {
     const onStatusChange = vi.fn<(status: ReviewCliInstallStatus) => void>();
     const apply = vi.fn<ReviewCanvasInstallContent["apply"]>(
@@ -128,6 +64,34 @@ describe("AgentSetupCard", () => {
     });
     expect(onStatusChange).toHaveBeenCalledExactlyOnceWith(grantedStatus);
   });
+
+  it("only shows per-agent install controls and the command disclosure", async () => {
+    const install: ReviewCanvasInstallContent = {
+      status: {
+        ...grantedStatus,
+        shim: {
+          ...grantedStatus.shim,
+          installed: true,
+          profileConfigured: true,
+          onPath: false,
+        },
+      },
+      apply: vi.fn<ReviewCanvasInstallContent["apply"]>(),
+      remove: vi.fn<ReviewCanvasInstallContent["remove"]>(),
+      decline: vi.fn<ReviewCanvasInstallContent["decline"]>(),
+      skip: vi.fn<ReviewCanvasInstallContent["skip"]>(),
+      enablePrompts: vi.fn<ReviewCanvasInstallContent["enablePrompts"]>(),
+    };
+
+    await act(async () => root.render(<AgentSetupCard install={install} />));
+
+    expect(container.textContent).toContain(
+      "Installing skills will also install review to your shell PATH.",
+    );
+    expect(container.textContent).not.toContain("Install for");
+    expect(container.textContent).not.toContain("terminal command");
+    expect(container.querySelectorAll("button")).toHaveLength(2);
+  });
 });
 
 const status: ReviewCliInstallStatus = {
@@ -135,7 +99,12 @@ const status: ReviewCliInstallStatus = {
   fingerprint: "fingerprint",
   stamp: null,
   stale: false,
-  shim: { path: "/tmp/review", onPath: false },
+  shim: {
+    path: "/tmp/review",
+    installed: false,
+    profileConfigured: false,
+    onPath: false,
+  },
   fff: {
     serverName: "fff",
     corpusRoot: "/tmp/trace-search",
@@ -150,11 +119,6 @@ const status: ReviewCliInstallStatus = {
     settingsPath: "/tmp/trace-settings.json",
   },
   cli: { path: "/tmp/cli.js", version: "0.0.1" },
-};
-
-const skippedStatus: ReviewCliInstallStatus = {
-  ...status,
-  stamp: { consent: "skipped", updatedAt: "2026-08-09T00:00:00.000Z" },
 };
 
 const grantedStatus: ReviewCliInstallStatus = {

--- a/packages/progressive-review/app/src/agent-setup-card.tsx
+++ b/packages/progressive-review/app/src/agent-setup-card.tsx
@@ -15,30 +15,14 @@ export const TARGET_LABELS: Record<ReviewCliInstallTarget, string> = {
 };
 
 /**
- * Card that shows the app-managed CLI + skills install and lets the reviewer
- * install or reinstall per agent. Status updates come back from the install
- * actions themselves, so the card owns a local copy of the status.
- *
- * Before the first consent (no stamp) the card leads with a one-click
- * first-run block: install everything, skip, or turn the auto-open off.
- *
- * `embedded` drops the card's own header — the onboarding page supplies the
- * heading instead. `manageOnly` also drops the one-click first-run block:
- * Settings manages what is installed, it does not onboard. `onStatusChange`
- * reports the refreshed status after every action, so the surrounding page
- * can advance without waiting for the host to re-render.
+ * Lets the reviewer install or reinstall skills per agent. The card keeps the
+ * latest action result so its parent can advance without a host re-render.
  */
 export function AgentSetupCard({
   install,
-  onSkip,
-  embedded,
-  manageOnly,
   onStatusChange,
 }: {
   install: ReviewCanvasInstallContent;
-  onSkip?: () => void;
-  embedded?: boolean;
-  manageOnly?: boolean;
   onStatusChange?: (status: ReviewCliInstallStatus) => void;
 }) {
   const [status, setStatus] = useState<ReviewCliInstallStatus>(install.status);
@@ -50,7 +34,6 @@ export function AgentSetupCard({
   const run = async (
     key: string,
     action: () => Promise<ReviewCliInstallStatus>,
-    onSuccess?: (status: ReviewCliInstallStatus) => void,
   ) => {
     setBusy(key);
     setError(null);
@@ -58,7 +41,6 @@ export function AgentSetupCard({
       const next = await action();
       setStatus(next);
       onStatusChange?.(next);
-      onSuccess?.(next);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
@@ -66,126 +48,8 @@ export function AgentSetupCard({
     }
   };
 
-  const staleTargets = status.stamp?.targets?.length
-    ? status.stamp.targets
-    : status.agents
-        .filter((agent) => agent.installed)
-        .map((agent) => agent.target);
-
-  const presentTargets = status.agents
-    .filter((agent) => agent.present)
-    .map((agent) => agent.target);
-  const fffTargets = status.agents
-    .filter(
-      (agent) =>
-        supportsFff(agent.target) &&
-        (agent.present ||
-          agent.installed ||
-          status.fff.registrations.some(
-            (registration) =>
-              registration.target === agent.target && registration.present,
-          )),
-    )
-    .map((agent) => agent.target);
-  const firstRun = !status.stamp || status.stamp.consent === "skipped";
-
   return (
     <section className="review-agent-setup" aria-label="Agent setup">
-      {embedded ? null : (
-        <>
-          <div className="review-agent-setup-header">
-            <h2>Agent setup</h2>
-            <span className="review-agent-setup-cli">
-              {status.cli
-                ? `This app bundles Review CLI v${status.cli.version}`
-                : "This app has no built Review CLI"}
-            </span>
-          </div>
-          <p className="review-agent-setup-subtitle">
-            Install puts the Review skills in each agent's skills folder.
-          </p>
-        </>
-      )}
-      {firstRun && status.cli && !manageOnly ? (
-        <div className="review-agent-setup-firstrun">
-          <p>
-            {presentTargets.length > 0
-              ? "One click installs the Review skills for your agents and the "
-              : "No coding agents were detected on this machine. You can still install the "}
-            <code>review</code> terminal command.
-          </p>
-          {status.trace.enabled && fffTargets.length > 0 ? (
-            <p>
-              This action also installs FFF when needed. It registers the
-              standard <code>fff</code> server for Claude and Codex, and
-              installs the Pi FFF extension.
-            </p>
-          ) : null}
-          <div className="review-agent-setup-firstrun-actions">
-            <button
-              type="button"
-              className="review-agent-setup-primary"
-              disabled={busy !== null}
-              onClick={() =>
-                void run("firstrun", () =>
-                  install.apply({
-                    targets: presentTargets,
-                    shim: true,
-                    ...(status.trace.enabled && fffTargets.length > 0
-                      ? { fff: true }
-                      : {}),
-                  }),
-                )
-              }
-            >
-              {busy === "firstrun"
-                ? "Installing…"
-                : presentTargets.length > 0
-                  ? `Install for ${presentTargets
-                      .map((target) => TARGET_LABELS[target])
-                      .join(", ")}`
-                  : "Install the review command"}
-            </button>
-            {onSkip ? (
-              <button
-                type="button"
-                className="review-agent-setup-subtle"
-                disabled={busy !== null}
-                onClick={() => void run("skip", () => install.skip(), onSkip)}
-              >
-                {busy === "skip" ? "Skipping…" : "Skip for now"}
-              </button>
-            ) : null}
-            <button
-              type="button"
-              className="review-agent-setup-subtle"
-              disabled={busy !== null}
-              onClick={() => void run("decline", () => install.decline())}
-            >
-              {busy === "decline" ? "Turning off…" : "Don't ask again"}
-            </button>
-          </div>
-        </div>
-      ) : null}
-      {status.stale ? (
-        <div className="review-agent-setup-banner">
-          <span>The installed skills are older than this app.</span>
-          <button
-            type="button"
-            disabled={busy !== null || staleTargets.length === 0}
-            onClick={() =>
-              void run("all", () =>
-                install.apply({
-                  targets: staleTargets,
-                  shim: Boolean(status.stamp?.shimPath),
-                }),
-              )
-            }
-          >
-            {busy === "all" ? "Updating…" : "Update all"}
-          </button>
-        </div>
-      ) : null}
       <ul className="review-agent-setup-agents">
         {status.agents.map((agent) => {
           const Logo = AGENT_LOGOS[agent.target];
@@ -255,67 +119,10 @@ export function AgentSetupCard({
           );
         })}
       </ul>
-      {status.cli ? (
-        <div className="review-agent-setup-terminal">
-          <div className="review-agent-setup-terminal-info">
-            <span className="review-agent-setup-name">
-              <code>review</code> terminal command
-            </span>
-            <span
-              className="review-agent-setup-state"
-              data-installed={Boolean(status.stamp?.shimPath)}
-              title={status.shim.path}
-            >
-              {status.stamp?.shimPath
-                ? status.shim.onPath
-                  ? "installed"
-                  : "installed, not on PATH"
-                : "not installed"}
-            </span>
-          </div>
-          {status.stamp?.shimPath ? (
-            <button
-              type="button"
-              className="review-agent-setup-subtle"
-              disabled={busy !== null}
-              onClick={() =>
-                void run("remove-command", () =>
-                  install.remove({ targets: [], shim: true }),
-                )
-              }
-            >
-              {busy === "remove-command" ? "Removing…" : "Uninstall"}
-            </button>
-          ) : null}
-          <button
-            type="button"
-            disabled={busy !== null}
-            onClick={() =>
-              void run("command", () =>
-                install.apply({ targets: [], shim: true }),
-              )
-            }
-          >
-            {busy === "command"
-              ? "Installing…"
-              : status.stamp?.shimPath
-                ? "Reinstall"
-                : "Install command"}
-          </button>
-        </div>
-      ) : null}
-      {status.stamp?.consent === "declined" ? (
-        <div className="review-agent-setup-footer">
-          <span>Setup does not open at startup.</span>
-          <button
-            type="button"
-            disabled={busy !== null}
-            onClick={() => void run("prompts", () => install.enablePrompts())}
-          >
-            {busy === "prompts" ? "Turning on…" : "Turn on"}
-          </button>
-        </div>
-      ) : null}
+      <p className="review-agent-setup-disclosure">
+        Installing skills will also install <code>review</code> to your shell
+        PATH.
+      </p>
       {error ? <p className="review-agent-setup-error">{error}</p> : null}
     </section>
   );

--- a/packages/progressive-review/app/src/review-home-view.test.tsx
+++ b/packages/progressive-review/app/src/review-home-view.test.tsx
@@ -371,7 +371,12 @@ describe("setupBannerMessage", () => {
         updatedAt: "2026-08-09T00:00:00.000Z",
       },
       stale: false,
-      shim: { path: "/tmp/review", onPath: false },
+      shim: {
+        path: "/tmp/review",
+        installed: false,
+        profileConfigured: false,
+        onPath: false,
+      },
       fff: {
         serverName: "fff",
         corpusRoot: "/tmp/trace-search",

--- a/packages/progressive-review/app/src/settings-page.tsx
+++ b/packages/progressive-review/app/src/settings-page.tsx
@@ -115,8 +115,6 @@ export function SettingsPage({
             <Section label="Agents">
               <AgentSetupCard
                 install={install}
-                embedded
-                manageOnly
                 onStatusChange={setInstallStatus}
               />
             </Section>

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -9252,32 +9252,7 @@ a.review-doc-meta-pr:hover {
   background: var(--bg);
 }
 
-.review-agent-setup-header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.review-agent-setup-header h2 {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-}
-
 .review-agent-setup-cli {
-  color: var(--review-home-meta);
-  font-size: 12px;
-}
-
-.review-agent-setup-banner,
-.review-agent-setup-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-top: 10px;
   color: var(--review-home-meta);
   font-size: 12px;
 }
@@ -9333,10 +9308,19 @@ a.review-doc-meta-pr:hover {
   white-space: pre-wrap;
 }
 
-.review-agent-setup-subtitle {
-  margin: 6px 0 0;
+.review-agent-setup-disclosure {
+  margin: 10px 0 0;
   color: var(--review-home-meta);
   font-size: 12px;
+}
+
+.review-agent-setup-disclosure code {
+  padding: 1px 4px;
+  border: 1px solid var(--review-home-rule-soft);
+  border-radius: 4px;
+  color: var(--ink);
+  background: var(--review-home-card-active);
+  font-family: inherit;
 }
 
 .review-agent-setup-terminal {
@@ -9602,7 +9586,7 @@ a.review-doc-meta-pr:hover {
   font-size: 13px;
 }
 
-/* The embedded card drops its own frame — the step card is the frame. */
+/* The onboarding step supplies the frame for the setup card. */
 .review-onboarding-step-body .review-agent-setup {
   margin-top: 0;
   padding: 0;
@@ -9765,37 +9749,6 @@ a.review-doc-meta-pr:hover {
   color: var(--change-removed);
   font-size: 12px;
   white-space: pre-wrap;
-}
-
-.review-agent-setup-firstrun {
-  margin-top: 12px;
-  padding: 12px 14px;
-  border: 1px solid var(--review-home-rule-soft);
-  border-radius: 6px;
-  background: var(--review-home-card-active);
-}
-
-.review-agent-setup-firstrun p {
-  margin: 0 0 10px;
-  font-size: 13px;
-}
-
-.review-agent-setup-firstrun code {
-  font-family: inherit;
-}
-
-.review-agent-setup-firstrun-actions {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
-.review-agent-setup button.review-agent-setup-primary {
-  padding: 5px 14px;
-  border-color: var(--review-home-comment);
-  color: var(--review-home-comment);
-  font-weight: 600;
 }
 
 .review-home-setup-banner {

--- a/packages/progressive-review/app/src/trace-capture-section.test.tsx
+++ b/packages/progressive-review/app/src/trace-capture-section.test.tsx
@@ -104,7 +104,12 @@ const traceStatus: ReviewCliInstallStatus = {
     targets: ["codex"],
   },
   stale: false,
-  shim: { path: "/tmp/review", onPath: false },
+  shim: {
+    path: "/tmp/review",
+    installed: false,
+    profileConfigured: false,
+    onPath: false,
+  },
   fff: {
     serverName: "fff",
     corpusRoot: "/tmp/trace-search",

--- a/packages/progressive-review/app/src/welcome-page.tsx
+++ b/packages/progressive-review/app/src/welcome-page.tsx
@@ -52,12 +52,7 @@ export function WelcomePage({
       done: installed,
       note: installedLabels(status) ?? "not installed yet",
       body: install ? (
-        <AgentSetupCard
-          install={install}
-          onSkip={onClose}
-          embedded
-          onStatusChange={setCardStatus}
-        />
+        <AgentSetupCard install={install} onStatusChange={setCardStatus} />
       ) : (
         <p className="review-home-empty">
           The install status is unavailable. Restart Review Desktop and open
@@ -184,13 +179,14 @@ function onboardingSetupComplete(status: ReviewCliInstallStatus): boolean {
   // Trace capture is experimental and lives in Settings; onboarding does
   // not depend on it.
   return (
-    fffAgents.length === 0 ||
-    fffAgents.every((agent) =>
-      status.fff.registrations.some(
-        (registration) =>
-          registration.target === agent.target && registration.present,
-      ),
-    )
+    (!status.cli || status.shim.installed) &&
+    (fffAgents.length === 0 ||
+      fffAgents.every((agent) =>
+        status.fff.registrations.some(
+          (registration) =>
+            registration.target === agent.target && registration.present,
+        ),
+      ))
   );
 }
 

--- a/packages/progressive-review/src/cli-runner.ts
+++ b/packages/progressive-review/src/cli-runner.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 
 import { devfastPrepareCommands } from "@dev.fast/local-vcs";
@@ -10,7 +10,13 @@ import {
   requireCodexThreadId,
   startCodexWaitProcess,
 } from "./codex-thread-wakeup";
-import { ALL_INSTALL_TARGETS, type InstallTarget, runInstall } from "./install";
+import { readReviewDesktopDiscovery } from "./desktop-discovery";
+import {
+  ALL_INSTALL_TARGETS,
+  type InstallTarget,
+  defaultPackageRoot,
+  runInstall,
+} from "./install";
 import { parseSoftwareMapCliArgs, runSoftwareMapCli } from "./map-cli";
 import { runReviewMigration } from "./migrate";
 import { readProgressiveReviewPackageVersion } from "./package-paths";
@@ -45,6 +51,8 @@ import {
 } from "./review-reopen-marker";
 import { runReviewScaffold } from "./review-scaffold";
 import { runReviewWait, validateReviewWait } from "./review-wait";
+import { installReviewCommand, pathShimPath } from "./server/cli-install";
+import { reviewDesktopDiscoveryPath } from "./server/desktop-paths";
 import {
   runReviewThreadsGet,
   runReviewThreadsList,
@@ -87,6 +95,7 @@ interface ProgressiveReviewCliRuntime {
   }>;
   validateReviewWait: typeof validateReviewWait;
   runInstall: typeof runInstall;
+  installReviewCommand: typeof installReviewCommand;
   runReviewMigration: typeof runReviewMigration;
   runSoftwareMapCli: typeof runSoftwareMapCli;
   runReviewTraceStatus: typeof runReviewTraceStatus;
@@ -562,6 +571,10 @@ export async function runProgressiveReviewCli(
         "--without-traces",
         "Deprecated: trace capture is off unless --trace-* options are given",
       )
+      .option(
+        "--no-shim",
+        "Install skills without the review command or PATH changes",
+      )
       .addHelpText("after", progressiveReviewInstallHelp()),
     "plain",
   );
@@ -575,12 +588,19 @@ export async function runProgressiveReviewCli(
         traceBucket?: string;
         traceKey?: string;
         traceSecret?: string;
+        shim?: boolean;
       },
     ) => {
+      const selectedTargets = installTargets(targets);
+      const installShim = options.shim !== false;
+      const cliSource = installShim
+        ? await resolveInstallCliSource(env)
+        : undefined;
       state.exitCode = await runtime.runInstall({
-        targets: installTargets(targets),
+        targets: selectedTargets,
         env,
         fff: true,
+        ...(installShim ? { reviewCommand: pathShimPath() } : {}),
         // Trace capture is experimental and opt-in: only a request that names
         // R2 credentials configures it. --without-traces stays accepted so
         // existing scripts keep working.
@@ -600,6 +620,27 @@ export async function runProgressiveReviewCli(
         stdout: input.stdout,
         stderr: input.stderr,
       });
+      if (state.exitCode !== 0 || !installShim) return;
+
+      const human = humanStream({
+        json: options.json,
+        stdout: input.stdout,
+        stderr: input.stderr,
+      });
+      if (!cliSource) {
+        human.write(
+          "Review did not install the review command because no built CLI was found. The skills were installed.\n",
+        );
+        return;
+      }
+      const installed = await runtime.installReviewCommand({
+        cliPath: cliSource.cliPath,
+        ...(cliSource.cliRuntimePath
+          ? { cliRuntimePath: cliSource.cliRuntimePath }
+          : {}),
+        env,
+      });
+      human.write(installed.output);
     },
   );
 
@@ -1181,6 +1222,7 @@ function progressiveReviewCliRuntime(
     startCodexWaitProcess,
     validateReviewWait,
     runInstall,
+    installReviewCommand,
     runReviewMigration,
     runSoftwareMapCli,
     runReviewTraceStatus,
@@ -1199,6 +1241,39 @@ function progressiveReviewCliRuntime(
     prepareReviewPinnedCheckout,
     ...overrides,
   };
+}
+
+async function resolveInstallCliSource(
+  env: NodeJS.ProcessEnv,
+): Promise<{ cliPath: string; cliRuntimePath?: string } | undefined> {
+  try {
+    const discovery = await readReviewDesktopDiscovery(
+      reviewDesktopDiscoveryPath(env),
+    );
+    if (discovery?.cliPath && (await isFile(discovery.cliPath))) {
+      return {
+        cliPath: discovery.cliPath,
+        ...(discovery.cliRuntimePath
+          ? { cliRuntimePath: discovery.cliRuntimePath }
+          : {}),
+      };
+    }
+  } catch {
+    // A packaged CLI remains a valid fallback when discovery is stale.
+  }
+
+  const packageCliPath = path.join(defaultPackageRoot(), "dist", "cli.js");
+  return (await isFile(packageCliPath))
+    ? { cliPath: packageCliPath }
+    : undefined;
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    return (await stat(filePath)).isFile();
+  } catch {
+    return false;
+  }
 }
 
 function progressiveReviewTopLevelHelp(): string {

--- a/packages/progressive-review/src/cli.test.ts
+++ b/packages/progressive-review/src/cli.test.ts
@@ -1,4 +1,11 @@
-import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
@@ -21,12 +28,98 @@ import { runReviewInfo as runReviewInfoActual } from "./review-info";
 import { runReviewPublish as runReviewPublishActual } from "./review-publish";
 import { runReviewScaffold as runReviewScaffoldActual } from "./review-scaffold";
 import {
+  installReviewCommand as installReviewCommandActual,
+  pathShimPath,
+} from "./server/cli-install";
+import {
   runReviewThreadsList as runReviewThreadsListActual,
   runReviewThreadsReply as runReviewThreadsReplyActual,
   runReviewThreadsResolve as runReviewThreadsResolveActual,
 } from "./threads-cli";
 
 describe("Review CLI", () => {
+  it("installs the review command with headless skills", async () => {
+    const rootPath = await mkdtemp(
+      path.join(os.tmpdir(), "review-cli-shim-install-"),
+    );
+    const discoveryDir = path.join(rootPath, ".dev", "review-desktop");
+    const cliPath = path.join(rootPath, "cli.js");
+    const cliRuntimePath = path.join(rootPath, "runtime");
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      DEV_REVIEW_HOME: path.join(rootPath, ".dev"),
+    };
+    await mkdir(discoveryDir, { recursive: true });
+    await Promise.all([
+      writeFile(cliPath, "// test CLI\n"),
+      writeFile(
+        path.join(discoveryDir, "server.json"),
+        `${JSON.stringify({
+          version: 3,
+          instanceId: "test-instance",
+          url: "http://127.0.0.1:43819",
+          appPid: 100,
+          serverPid: 101,
+          token: "test-token",
+          startedAt: 1,
+          cliPath,
+          cliRuntimePath,
+        })}\n`,
+      ),
+    ]);
+    const runInstall = vi.fn<typeof runInstallActual>(async () => 0);
+    const installReviewCommand = vi.fn<typeof installReviewCommandActual>(
+      async () => ({
+        shimPath: pathShimPath(),
+        output: "[ok] installed review command\n",
+      }),
+    );
+
+    try {
+      await expect(
+        runProgressiveReviewCli({
+          argv: ["install", "codex"],
+          env,
+          stdout: outputStream(),
+          stderr: outputStream(),
+          runtime: { runInstall, installReviewCommand },
+        }),
+      ).resolves.toBe(0);
+
+      expect(runInstall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targets: ["codex"],
+          reviewCommand: pathShimPath(),
+        }),
+      );
+      expect(installReviewCommand).toHaveBeenCalledExactlyOnceWith({
+        cliPath,
+        cliRuntimePath,
+        env,
+      });
+    } finally {
+      await rm(rootPath, { force: true, recursive: true });
+    }
+  });
+
+  it("supports a headless shim opt-out", async () => {
+    const runInstall = vi.fn<typeof runInstallActual>(async () => 0);
+    const installReviewCommand = vi.fn<typeof installReviewCommandActual>();
+
+    await expect(
+      runProgressiveReviewCli({
+        argv: ["install", "codex", "--no-shim"],
+        stdout: outputStream(),
+        stderr: outputStream(),
+        runtime: { runInstall, installReviewCommand },
+      }),
+    ).resolves.toBe(0);
+
+    expect(runInstall).toHaveBeenCalledOnce();
+    expect(runInstall.mock.calls[0]?.[0]).not.toHaveProperty("reviewCommand");
+    expect(installReviewCommand).not.toHaveBeenCalled();
+  });
+
   it("routes trace configuration through the shared installer", async () => {
     const runInstall = vi.fn<typeof runInstallActual>(async () => 0);
 

--- a/packages/progressive-review/src/installed-review-agent.test.ts
+++ b/packages/progressive-review/src/installed-review-agent.test.ts
@@ -22,7 +22,12 @@ function status(
       updatedAt: "2026-08-25T00:00:00.000Z",
     },
     stale: false,
-    shim: { path: "/tmp/review", onPath: true },
+    shim: {
+      path: "/tmp/review",
+      installed: true,
+      profileConfigured: true,
+      onPath: true,
+    },
     fff: {
       serverName: "fff",
       corpusRoot: "/tmp/fff",

--- a/packages/progressive-review/src/server/cli-install.test.ts
+++ b/packages/progressive-review/src/server/cli-install.test.ts
@@ -8,8 +8,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   applyCliInstall,
   cliInstallStampPath,
+  ensureShellProfilePath,
   readCliInstallStamp,
   removeCliInstall,
+  removeShellProfilePath,
   resolveCliInstallStatus,
   resolveInstalledReviewAgentStatus,
   skipCliInstall,
@@ -17,6 +19,10 @@ import {
 import { writePrivateJsonAtomic } from "./desktop-paths";
 
 const temporaryDirectories: string[] = [];
+const packageRoot = path.resolve(import.meta.dirname, "../..");
+const profileMarker =
+  "# Managed by Review Desktop: review command PATH. Do not edit.";
+const profileExport = 'export PATH="$HOME/.local/bin:$PATH"';
 
 afterEach(async () => {
   await Promise.all(
@@ -66,8 +72,6 @@ describe("trace capture installation", () => {
       TRACE_SETTINGS_FILE: path.join(homeDir, "trace-settings.json"),
       TRACE_R2_MODE: "mock",
     };
-    const packageRoot = path.resolve(import.meta.dirname, "../..");
-
     const applied = await applyCliInstall({
       packageRoot,
       targets: [],
@@ -104,6 +108,257 @@ describe("trace capture installation", () => {
     expect(await readFile(env.TRACE_ENV_FILE!, "utf8")).toContain(
       "mock-secret-value",
     );
+  });
+});
+
+describe("shell profile PATH management", () => {
+  it("adds the zsh profile block once", async () => {
+    const homeDir = await temporaryHome("review-zsh-profile-");
+    const env = profileEnvironment(homeDir, "/bin/zsh");
+
+    await expect(ensureShellProfilePath({ homeDir, env })).resolves.toContain(
+      ".zprofile",
+    );
+    const first = await readFile(path.join(homeDir, ".zprofile"), "utf8");
+    expect(first).toBe(`\n${profileMarker}\n${profileExport}\n`);
+
+    await expect(ensureShellProfilePath({ homeDir, env })).resolves.toBe("");
+    expect(await readFile(path.join(homeDir, ".zprofile"), "utf8")).toBe(first);
+  });
+
+  it("leaves an existing local bin profile entry unchanged", async () => {
+    const homeDir = await temporaryHome("review-existing-profile-");
+    const profilePath = path.join(homeDir, ".zprofile");
+    const source = 'export PATH="$HOME/.local/bin:$PATH"\n# user content\n';
+    await writeFile(profilePath, source);
+
+    await expect(
+      ensureShellProfilePath({
+        homeDir,
+        env: profileEnvironment(homeDir, "/bin/zsh"),
+      }),
+    ).resolves.toBe("");
+    expect(await readFile(profilePath, "utf8")).toBe(source);
+  });
+
+  it("uses the bash profile", async () => {
+    const homeDir = await temporaryHome("review-bash-profile-");
+
+    await ensureShellProfilePath({
+      homeDir,
+      env: profileEnvironment(homeDir, "/bin/bash"),
+    });
+
+    expect(await readFile(path.join(homeDir, ".bash_profile"), "utf8")).toBe(
+      `\n${profileMarker}\n${profileExport}\n`,
+    );
+  });
+
+  it("warns without changing a fish profile", async () => {
+    const homeDir = await temporaryHome("review-fish-profile-");
+
+    await expect(
+      ensureShellProfilePath({
+        homeDir,
+        env: profileEnvironment(homeDir, "/opt/homebrew/bin/fish"),
+      }),
+    ).resolves.toContain("fish_add_path ~/.local/bin");
+    await expect(
+      readFile(path.join(homeDir, ".zprofile"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      readFile(path.join(homeDir, ".bash_profile"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("removes only exact managed blocks", async () => {
+    const homeDir = await temporaryHome("review-remove-profile-");
+    const zprofile = path.join(homeDir, ".zprofile");
+    const bashProfile = path.join(homeDir, ".bash_profile");
+    const userContent = "export EDITOR=vim\n";
+    const markerFree = `# ${profileMarker}\n${profileExport}\n`;
+    await Promise.all([
+      writeFile(
+        zprofile,
+        `${userContent}\n${profileMarker}\n${profileExport}\n`,
+      ),
+      writeFile(bashProfile, markerFree),
+    ]);
+
+    await expect(removeShellProfilePath(homeDir)).resolves.toEqual([zprofile]);
+    expect(await readFile(zprofile, "utf8")).toBe(userContent);
+    expect(await readFile(bashProfile, "utf8")).toBe(markerFree);
+  });
+});
+
+describe("skill and review command installation", () => {
+  it("installs the command and profile by default for a skill target", async () => {
+    const homeDir = await temporaryHome("review-default-shim-");
+    const env = profileEnvironment(homeDir, "/bin/zsh");
+    const cliPath = path.join(homeDir, "cli.js");
+    await writeFile(cliPath, "// test CLI\n");
+
+    const applied = await applyCliInstall({
+      packageRoot,
+      targets: ["codex"],
+      cliPath,
+      homeDir,
+      env,
+    });
+
+    expect(applied).toMatchObject({
+      code: 0,
+      shimPath: path.join(homeDir, ".local", "bin", "review"),
+    });
+    expect(applied.output).toContain("review command");
+    expect(await readFile(applied.shimPath!, "utf8")).toContain(
+      "Managed by Review Desktop",
+    );
+    expect(await readFile(path.join(homeDir, ".zprofile"), "utf8")).toContain(
+      profileExport,
+    );
+    expect(
+      await readFile(
+        path.join(homeDir, ".agents", "skills", "dev-review", "SKILL.md"),
+        "utf8",
+      ),
+    ).toContain("name: dev-review");
+    await rm(cliInstallStampPath(env), { force: true });
+    const status = await resolveCliInstallStatus({ packageRoot, homeDir, env });
+    expect(status.shim).toMatchObject({
+      installed: true,
+      profileConfigured: true,
+      onPath: false,
+    });
+  });
+
+  it("supports an explicit shim opt-out", async () => {
+    const homeDir = await temporaryHome("review-no-shim-");
+    const env = profileEnvironment(homeDir, "/bin/zsh");
+
+    const applied = await applyCliInstall({
+      packageRoot,
+      targets: ["codex"],
+      shim: false,
+      homeDir,
+      env,
+    });
+
+    expect(applied.code).toBe(0);
+    await expect(
+      readFile(path.join(homeDir, ".local", "bin", "review"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      readFile(path.join(homeDir, ".zprofile"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("warns when the default shim has no CLI", async () => {
+    const homeDir = await temporaryHome("review-missing-default-cli-");
+    const env = profileEnvironment(homeDir, "/bin/zsh");
+
+    const applied = await applyCliInstall({
+      packageRoot,
+      targets: ["codex"],
+      homeDir,
+      env,
+    });
+
+    expect(applied.code).toBe(0);
+    expect(applied.output).toContain("The skills were installed");
+  });
+
+  it("fails when an explicit shim has no CLI", async () => {
+    const homeDir = await temporaryHome("review-missing-explicit-cli-");
+    const env = profileEnvironment(homeDir, "/bin/zsh");
+
+    const applied = await applyCliInstall({
+      packageRoot,
+      targets: ["codex"],
+      shim: true,
+      homeDir,
+      env,
+    });
+
+    expect(applied.code).toBe(1);
+    expect(applied.output).toContain("no built CLI");
+  });
+
+  it("warns when another review command comes first on PATH", async () => {
+    const homeDir = await temporaryHome("review-shadowed-command-");
+    const foreignBin = path.join(homeDir, "foreign-bin");
+    const cliPath = path.join(homeDir, "cli.js");
+    await mkdir(foreignBin, { recursive: true });
+    await Promise.all([
+      writeFile(cliPath, "// test CLI\n"),
+      writeFile(path.join(foreignBin, "review"), "#!/bin/sh\n", {
+        mode: 0o755,
+      }),
+    ]);
+    const env = {
+      ...profileEnvironment(homeDir, "/bin/zsh"),
+      PATH: foreignBin,
+    };
+
+    const applied = await applyCliInstall({
+      packageRoot,
+      targets: ["codex"],
+      cliPath,
+      homeDir,
+      env,
+    });
+
+    expect(applied.output).toContain(path.join(foreignBin, "review"));
+    expect(applied.output).toContain(
+      "docs/troubleshooting.md#the-command-opens-a-browser-or-shows-old-options",
+    );
+  });
+
+  it("removes the owned command and profile block", async () => {
+    const homeDir = await temporaryHome("review-remove-command-");
+    const env = profileEnvironment(homeDir, "/bin/zsh");
+    const cliPath = path.join(homeDir, "cli.js");
+    await writeFile(cliPath, "// test CLI\n");
+    await applyCliInstall({
+      packageRoot,
+      targets: ["codex"],
+      cliPath,
+      homeDir,
+      env,
+    });
+
+    const removed = await removeCliInstall({
+      targets: [],
+      shim: true,
+      homeDir,
+      env,
+    });
+
+    expect(removed.output).toContain("removed Review PATH entry");
+    await expect(
+      readFile(path.join(homeDir, ".local", "bin", "review"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readFile(path.join(homeDir, ".zprofile"), "utf8")).toBe("");
+  });
+
+  it("preserves a foreign command while removing the managed profile block", async () => {
+    const homeDir = await temporaryHome("review-foreign-command-");
+    const env = profileEnvironment(homeDir, "/bin/zsh");
+    const shimPath = path.join(homeDir, ".local", "bin", "review");
+    await mkdir(path.dirname(shimPath), { recursive: true });
+    await writeFile(shimPath, "#!/bin/sh\necho foreign\n", { mode: 0o755 });
+    await ensureShellProfilePath({ homeDir, env });
+
+    const removed = await removeCliInstall({
+      targets: [],
+      shim: true,
+      homeDir,
+      env,
+    });
+
+    expect(removed.output).toContain("left in place");
+    expect(await readFile(shimPath, "utf8")).toContain("echo foreign");
+    expect(await readFile(path.join(homeDir, ".zprofile"), "utf8")).toBe("");
   });
 });
 
@@ -156,4 +411,18 @@ async function isolatedEnvironment(): Promise<NodeJS.ProcessEnv> {
   const directory = await mkdtemp(path.join(tmpdir(), "review-cli-install-"));
   temporaryDirectories.push(directory);
   return { DEV_REVIEW_HOME: directory };
+}
+
+async function temporaryHome(prefix: string): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function profileEnvironment(homeDir: string, shell: string): NodeJS.ProcessEnv {
+  return {
+    DEV_REVIEW_HOME: path.join(homeDir, ".dev"),
+    PATH: "/usr/bin:/bin",
+    SHELL: shell,
+  };
 }

--- a/packages/progressive-review/src/server/cli-install.ts
+++ b/packages/progressive-review/src/server/cli-install.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
+import { constants } from "node:fs";
 import {
+  access,
   chmod,
   mkdir,
   readFile,
@@ -56,6 +58,15 @@ const AGENT_HOME_DIR: Record<InstallTarget, string> = {
   cursor: ".cursor",
   pi: ".pi",
 };
+const SHIM_MARKER = "Managed by Review Desktop";
+const PROFILE_MARKER =
+  "# Managed by Review Desktop: review command PATH. Do not edit.";
+const PROFILE_EXPORT = 'export PATH="$HOME/.local/bin:$PATH"';
+const PROFILE_BLOCK = `\n${PROFILE_MARKER}\n${PROFILE_EXPORT}\n`;
+const SHELL_PROFILE_NAMES = [".zprofile", ".bash_profile"] as const;
+const SHADOWING_HELP_URL =
+  "https://github.com/devdotfast/review/blob/main/docs/troubleshooting.md#the-command-opens-a-browser-or-shows-old-options";
+
 export function cliInstallStampPath(
   env: NodeJS.ProcessEnv = process.env,
 ): string {
@@ -132,11 +143,9 @@ export async function resolveCliInstallStatus(input: {
     stale: stamp?.consent === "granted" && stamp.fingerprint !== fingerprint,
     shim: {
       path: shimPath,
-      onPath: (env.PATH ?? "")
-        .split(path.delimiter)
-        .some(
-          (entry) => entry && path.resolve(entry) === path.dirname(shimPath),
-        ),
+      installed: await isOwnedShim(shimPath),
+      profileConfigured: await isShellProfileConfigured(homeDir),
+      onPath: pathContainsDirectory(env.PATH, path.dirname(shimPath)),
     },
     fff: {
       serverName: FFF_SERVER_NAME,
@@ -169,6 +178,7 @@ export async function applyCliInstall(input: {
 }): Promise<{ code: number; output: string; shimPath?: string }> {
   const homeDir = input.homeDir ?? os.homedir();
   const env = input.env ?? process.env;
+  const wantShim = input.shim ?? input.targets.length > 0;
   const chunks: string[] = [];
   const sink = {
     write: (chunk: string) => (chunks.push(chunk), true),
@@ -193,7 +203,7 @@ export async function applyCliInstall(input: {
       env,
       fff: input.fff,
       reviewCommand:
-        input.shim || (await isFile(pathShimPath(homeDir)))
+        wantShim || (await isFile(pathShimPath(homeDir)))
           ? pathShimPath(homeDir)
           : "review",
       ...(input.trace !== undefined
@@ -210,16 +220,26 @@ export async function applyCliInstall(input: {
   }
 
   let shimPath: string | undefined;
-  if (input.shim) {
+  if (wantShim) {
     if (!input.cliPath) {
       chunks.push(
-        "This server has no built CLI to install the command from.\n",
+        input.shim === true
+          ? "This server has no built CLI to install the command from.\n"
+          : "Review did not install the review command because this server has no built CLI. The skills were installed.\n",
       );
-      return { code: 1, output: chunks.join("") };
+      if (input.shim === true) {
+        return { code: 1, output: chunks.join("") };
+      }
+    } else {
+      const installed = await installReviewCommand({
+        cliPath: input.cliPath,
+        cliRuntimePath: input.cliRuntimePath,
+        homeDir,
+        env,
+      });
+      shimPath = installed.shimPath;
+      chunks.push(installed.output);
     }
-    shimPath = pathShimPath(homeDir);
-    await writePathShim(shimPath, input.cliPath, input.cliRuntimePath);
-    chunks.push(`[ok] review command -> ${shimPath}\n`);
   }
 
   const createdFffRegistrations: ReviewFffManagedRegistration[] = [];
@@ -298,8 +318,6 @@ export async function resetCliInstall(
   await rm(cliInstallStampPath(env), { force: true });
 }
 
-const SHIM_MARKER = "Managed by Review Desktop";
-
 export async function removeCliInstall(input: {
   targets: InstallTarget[];
   shim?: boolean;
@@ -331,6 +349,9 @@ export async function removeCliInstall(input: {
       chunks.push(
         `${shimPath} was not installed by Review Desktop; left in place.\n`,
       );
+    }
+    for (const profilePath of await removeShellProfilePath(homeDir)) {
+      chunks.push(`[ok] removed Review PATH entry from ${profilePath}\n`);
     }
   }
 
@@ -515,8 +536,143 @@ exec node "$cli" "$@"
   await chmod(shimPath, 0o755);
 }
 
+export async function installReviewCommand(input: {
+  cliPath: string;
+  cliRuntimePath?: string;
+  homeDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<{ shimPath: string; output: string }> {
+  const homeDir = input.homeDir ?? os.homedir();
+  const env = input.env ?? process.env;
+  const shimPath = pathShimPath(homeDir);
+  const shadowingCommand = await resolvePathCommand("review", shimPath, env);
+
+  await writePathShim(shimPath, input.cliPath, input.cliRuntimePath);
+  const profileOutput = await ensureShellProfilePath({ homeDir, env });
+  const shadowingOutput = shadowingCommand
+    ? `Warning: ${shadowingCommand} currently shadows ${shimPath}. See ${SHADOWING_HELP_URL}\n`
+    : "";
+  return {
+    shimPath,
+    output: `[ok] review command -> ${shimPath}\n${profileOutput}${shadowingOutput}`,
+  };
+}
+
+export async function ensureShellProfilePath(input: {
+  homeDir: string;
+  env: NodeJS.ProcessEnv;
+}): Promise<string> {
+  const shimDirectory = path.dirname(pathShimPath(input.homeDir));
+  if (pathContainsDirectory(input.env.PATH, shimDirectory)) return "";
+
+  const shell = path.basename(input.env.SHELL?.trim() ?? "");
+  let profileName: (typeof SHELL_PROFILE_NAMES)[number] | undefined;
+  if (shell === "bash") {
+    profileName = ".bash_profile";
+  } else if (
+    shell === "zsh" ||
+    (shell !== "fish" && process.platform === "darwin")
+  ) {
+    profileName = ".zprofile";
+  }
+  if (!profileName) {
+    return "Review did not update PATH for this shell. Add ~/.local/bin to PATH. Fish users can run: fish_add_path ~/.local/bin\n";
+  }
+
+  const profilePath = path.join(input.homeDir, profileName);
+  const source = await readTextIfExists(profilePath);
+  if (source.includes(PROFILE_MARKER) || source.includes(".local/bin")) {
+    return "";
+  }
+  await writeTextAtomic(profilePath, `${source}${PROFILE_BLOCK}`);
+  return `[ok] added ${shimDirectory} to PATH in ${profilePath}\n`;
+}
+
+export async function removeShellProfilePath(
+  homeDir: string,
+): Promise<string[]> {
+  const removed: string[] = [];
+  for (const profileName of SHELL_PROFILE_NAMES) {
+    const profilePath = path.join(homeDir, profileName);
+    const source = await readTextIfExists(profilePath);
+    if (!source.includes(PROFILE_BLOCK)) continue;
+    await writeTextAtomic(profilePath, source.replaceAll(PROFILE_BLOCK, ""));
+    removed.push(profilePath);
+  }
+  return removed;
+}
+
 function shSingleQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+async function resolvePathCommand(
+  command: string,
+  shimPath: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string | undefined> {
+  const entries = (env.PATH ?? "").split(path.delimiter);
+  const shimDirectory = path.resolve(path.dirname(shimPath));
+  const shimIndex = entries.findIndex(
+    (entry) => path.resolve(entry || ".") === shimDirectory,
+  );
+  for (let index = 0; index < entries.length; index += 1) {
+    const candidate = path.join(entries[index] || ".", command);
+    if (!(await isExecutableFile(candidate))) continue;
+    if ((await readTextIfExists(candidate)).includes(SHIM_MARKER)) {
+      return undefined;
+    }
+    return shimIndex === -1 || index < shimIndex
+      ? path.resolve(candidate)
+      : undefined;
+  }
+  return undefined;
+}
+
+function pathContainsDirectory(
+  pathValue: string | undefined,
+  directory: string,
+): boolean {
+  return (pathValue ?? "")
+    .split(path.delimiter)
+    .some(
+      (entry) =>
+        entry.length > 0 && path.resolve(entry) === path.resolve(directory),
+    );
+}
+
+async function isOwnedShim(shimPath: string): Promise<boolean> {
+  return (await readTextIfExists(shimPath)).includes(SHIM_MARKER);
+}
+
+async function isShellProfileConfigured(homeDir: string): Promise<boolean> {
+  const profiles = await Promise.all(
+    SHELL_PROFILE_NAMES.map((profileName) =>
+      readTextIfExists(path.join(homeDir, profileName)),
+    ),
+  );
+  return profiles.some((source) => source.includes(PROFILE_MARKER));
+}
+
+async function writeTextAtomic(
+  filePath: string,
+  source: string,
+): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  let mode = 0o644;
+  try {
+    mode = (await stat(filePath)).mode & 0o777;
+  } catch {
+    // Use the default profile mode for a new file.
+  }
+  const staging = `${filePath}.tmp-${process.pid}`;
+  try {
+    await writeFile(staging, source, { encoding: "utf8", mode });
+    await rename(staging, filePath);
+  } finally {
+    await rm(staging, { force: true });
+  }
+  await chmod(filePath, mode);
 }
 
 async function listFilesRecursive(
@@ -561,6 +717,16 @@ async function isDirectory(target: string): Promise<boolean> {
 async function isFile(target: string): Promise<boolean> {
   try {
     return (await stat(target)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function isExecutableFile(target: string): Promise<boolean> {
+  if (!(await isFile(target))) return false;
+  try {
+    await access(target, constants.X_OK);
+    return true;
   } catch {
     return false;
   }

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -728,7 +728,7 @@ export function createGlobalReviewServer(
     const result = await applyCliInstall({
       packageRoot: input.packageRoot,
       targets: request.targets,
-      ...(request.shim ? { shim: true } : {}),
+      ...(request.shim !== undefined ? { shim: request.shim } : {}),
       ...(request.fff ? { fff: true } : {}),
       ...(request.trace !== undefined ? { trace: request.trace } : {}),
       ...(discovery.cliPath ? { cliPath: discovery.cliPath } : {}),

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1372,7 +1372,12 @@ export const ReviewCliInstallStatusSchema = z.strictObject({
   fingerprint: requiredString,
   stamp: ReviewCliInstallStampSchema.nullable(),
   stale: z.boolean(),
-  shim: z.strictObject({ path: requiredString, onPath: z.boolean() }),
+  shim: z.strictObject({
+    path: requiredString,
+    installed: z.boolean(),
+    profileConfigured: z.boolean(),
+    onPath: z.boolean(),
+  }),
   fff: z.strictObject({
     serverName: z.literal("fff"),
     corpusRoot: requiredString,
@@ -1406,9 +1411,10 @@ export type ReviewCliInstallStatus = z.infer<
   typeof ReviewCliInstallStatusSchema
 >;
 
-// Skills and FFF integrations are per-agent. The review command, FFF binary,
-// and trace configuration are per-machine. Silent app updates omit `fff` and
-// `trace`, so they do not run an installer or contact R2.
+// Skills and FFF integrations are per-agent. Skill requests install the review
+// command by default. The command, FFF binary, and trace configuration are
+// per-machine. Silent app updates omit `fff` and `trace`, so they do not run an
+// FFF installer or contact R2.
 export const ReviewCliInstallApplyRequestSchema = z
   .strictObject({
     targets: z.array(ReviewCliInstallTargetSchema),


### PR DESCRIPTION
## Summary

- install the app-managed `review` command whenever an agent skill install runs, unless the caller opts out
- add marker-guarded shell profile setup, exact uninstall cleanup, shadow warnings, and disk-backed command status
- make the headless `review install` command install the shim and use its absolute path for hooks
- simplify agent setup to per-agent controls with a clear shell PATH disclosure

## Validation

- `pnpm --filter @dev.fast/review test -- src/server/cli-install.test.ts src/cli.test.ts app/src/agent-setup-card.test.tsx`
- `pnpm --filter @dev.fast/review-protocol test`
- `pnpm lint`
- `pnpm format:check`
- `pnpm desktop:build`
- fresh Node 24 Docker install: skills, shim, Bash profile block, and new-login-shell command resolution

The Docker package check used the matching workspace `@dev.fast/local-vcs` tarball. The current published package lacks an export that current Review needs.