### PR TITLE
Attach authoring traces to bug reports

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -75,13 +75,19 @@ The **Report bug** dialog sends a report only after you select **Send**.
 ![The previous Review bug-report dialog with all three diagnostic attachments selected by default.](assets/bug-report-consent.png)
 
 > This image is stale. Re-capture `docs/assets/bug-report-consent.png` with the
-> two-checkbox dialog and screenshot preview after the UI lands.
+> three-checkbox dialog and screenshot preview after the UI lands.
 
-Under **Include diagnostic attachments**, two independent checkboxes control
+Under **Include diagnostic attachments**, three independent checkboxes control
 whether Review attaches:
 
 - **Review**: the current Review source and head software-map source
 - changed-file diffs used by the review codepeeks (only the diff lines)
+- **Agent session trace**: the raw local JSONL trace for the agent session that
+  authored the Review
+
+The Review and changed-file diff attachments are selected by default. The agent
+session trace is opt-in and starts unselected. An information icon beside it
+explains the trace's redaction limits and what it sends.
 
 Review captures a screenshot before the dialog opens, so the dialog itself is
 not in the image. The screenshot is attached by default with a visible preview.
@@ -89,7 +95,16 @@ You can remove it with the × button, or paste or drag an image to replace it.
 Pasted and dropped PNG, JPEG, and WebP images are normalized to JPEG and limited
 to 3 MiB.
 
-You can turn off either checkbox and remove the screenshot before sending.
+You can turn off either default attachment, leave the trace unselected, and
+remove the screenshot before sending.
+
+When selected, the agent trace includes prompts, model output, source code, and
+file paths. Review redacts recognizable Google API keys, JWTs, Slack tokens,
+GitHub tokens, and Microsoft Entra tokens on your machine before attaching the
+trace. Other credentials and secrets that do not match those formats may remain
+and are sent. Review deliberately does not redact paths, URLs, email addresses,
+prompts, or code. The trace comes directly from the supported agent harness's
+local storage and does not require trace sync or remote trace storage.
 
 The checkboxes control only those optional attachments. Every submitted report
 also includes the optional description (which may be empty), app and CLI
@@ -101,6 +116,12 @@ If a selected attachment is unavailable, Review omits it and sends the other
 available data. The report never attaches Review metadata, comment threads, or
 question threads. Review stores submitted reports in a private /dev/fast
 Cloudflare R2 bucket and deletes them after 90 days.
+
+Review caps the main trace at its newest 6 MiB and includes the ten most recently
+modified subagent traces, each capped at its newest 1 MiB, retaining complete
+JSONL lines. If the compressed report still exceeds 10 MiB, Review drops the
+complete trace attachment before dropping diffs, the software map, the
+screenshot, or Review source.
 
 An explicit bug report is separate from passive telemetry and is sent even when
 anonymous telemetry is disabled. Review shows the attachment choices before

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -374,11 +374,12 @@ frame a second time. Both steps run on your machine, before anything is sent.
 The **Report bug** dialog sends data only after the user selects **Send**. The
 description is optional. It has one **Review** consent control for both the
 current review source and head software map source, plus a separate control for
-changed-file diffs. Both controls are on by default. Review also captures a
-screenshot before the dialog opens and attaches it by default. The dialog shows
-a removable preview and accepts a replacement image by paste or drag. A
-selected attachment can be unavailable. The report still sends the other
-available data.
+changed-file diffs. Both controls are on by default. A third **Agent session
+trace** control attaches the raw local JSONL trace for the session that authored
+the Review and is off by default. Review also captures a screenshot before the
+dialog opens and attaches it by default. The dialog shows a removable preview
+and accepts a replacement image by paste or drag. A selected attachment can be
+unavailable. The report still sends the other available data.
 
 A review does not always have a software map. The report then omits the map and
 records no error, because an absent map is a normal state.
@@ -387,7 +388,7 @@ The report payload contains these fields:
 
 | Field                              | Value                                                                               |
 | ---------------------------------- | ----------------------------------------------------------------------------------- |
-| `schema_version`                   | Payload schema version `2`                                                          |
+| `schema_version`                   | Payload schema version `3`                                                          |
 | `description`                      | Optional user-entered description, limited to 64 KiB of UTF-8 data                  |
 | `screenshot.mime`                  | `image/jpeg` when a screenshot is attached                                          |
 | `screenshot.base64`                | JPEG screenshot data, limited to 3 MiB decoded                                      |
@@ -402,6 +403,12 @@ The report payload contains these fields:
 | `diff.files[].additions`           | Added line count                                                                    |
 | `diff.files[].deletions`           | Deleted line count                                                                  |
 | `diff.files[].patch`               | Unified patch used to resolve the review's exact CodePeek ranges                    |
+| `trace.harness`                    | Authoring harness: `claude-code`, `codex`, or `pi`                                  |
+| `trace.session_id`                 | Authoring session identifier from the Review record                                 |
+| `trace.files["trace.jsonl"]`       | Tail-capped raw JSONL for the authoring session, when the user opts in              |
+| `trace.files["subagents/<name>"]`  | Tail-capped raw JSONL for an included subagent                                      |
+| `trace.omitted_files`              | Subagent trace names omitted because of limits or read failures                     |
+| `trace.truncated`                  | Whether any trace was tail-capped or omitted                                        |
 | `diagnostics.app_version`          | Review Desktop product version                                                      |
 | `diagnostics.cli_version`          | `@dev.fast/review` package version                                                  |
 | `diagnostics.platform`             | Node platform enum                                                                  |
@@ -422,6 +429,24 @@ The report never sends these review files:
 - the compiled document in `.bundle/`, and the build output in `.build/`
 - `review.db`, which holds the comment threads and the questions
 
+The trace attachment is independent of trace sync. Review finds the source
+session's raw trace directly in the supported harness's local home-directory
+storage, so disabling remote trace storage does not disable this explicit
+attachment.
+
+Before attaching a selected trace, Review replaces recognizable Google API
+keys, JWTs, Slack tokens, GitHub tokens, and Microsoft Entra tokens with labelled
+markers. This secret-format redaction preserves the surrounding JSONL. It does
+not detect every credential or secret format, and it does not anonymize file
+paths, URLs, email addresses, prompts, model output, or source code; those
+values are sent when the user selects the trace checkbox.
+
+The main trace keeps at most its newest 6 MiB on complete JSONL line boundaries.
+Review includes the ten most recently modified subagent files, each keeping at
+most its newest 1 MiB, and records omitted names. If the complete compressed
+multipart report still exceeds 10 MiB, the size ladder drops the whole trace
+first, followed by the diff, map, screenshot, and Review source.
+
 The local server compresses the payload and sends it to
 `https://bug.dev.fast/api/v1/reports`. The Worker stores it in the private
 `dev-fast-bug-reports` Cloudflare R2 bucket. Only credentialed dev.fast
@@ -432,8 +457,9 @@ The Worker sends a `review_bug_report` PostHog event after the R2
 write. The event contains the report ID, UTC report date, description byte
 length, attachment presence flags (including `has_screenshot`), compressed
 payload size, app version, platform, and map, diff, or screenshot truncation
-flags (including `truncated_screenshot`). It does not contain the description
-or attachments.
+flags (including `truncated_screenshot`). It also receives `has_trace`,
+`truncated_trace`, and, after a trace resolves, the closed `trace_harness` enum.
+It does not contain the description or attachments.
 
 Cloudflare uses `CF-Connecting-IP` only as the rate-limit key. The Worker does
 not store that value in R2. The Worker does not send it to PostHog as report

--- a/packages/progressive-review/app/src/bug-report-dialog.test.tsx
+++ b/packages/progressive-review/app/src/bug-report-dialog.test.tsx
@@ -92,11 +92,8 @@ describe("BugReportControl", () => {
 
   it("maps the Review checkbox to both wire flags", async () => {
     await renderAndOpen();
-    const reviewCheckbox = [...container.querySelectorAll("label")]
-      .find((label) => label.textContent?.trim() === "Review")
-      ?.querySelector<HTMLInputElement>('input[type="checkbox"]');
 
-    await act(async () => reviewCheckbox?.click());
+    await act(async () => checkbox("Review").click());
     await act(async () => sendButton().click());
 
     expect(reportBody()).toMatchObject({
@@ -104,7 +101,35 @@ describe("BugReportControl", () => {
       include_review: false,
       include_map: false,
       include_diff: true,
+      include_trace: false,
     });
+  });
+
+  it("requires trace consent and exposes its privacy tooltip", async () => {
+    await renderAndOpen();
+    const traceCheckbox = checkbox("Agent session trace");
+    const privacyButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Agent session trace privacy information"]',
+    );
+    const tooltipId = privacyButton?.getAttribute("aria-describedby") ?? "";
+    const tooltip = document.getElementById(tooltipId);
+
+    expect(traceCheckbox.checked).toBe(false);
+    expect(privacyButton).not.toBeNull();
+    expect(tooltip?.getAttribute("role")).toBe("tooltip");
+    expect(tooltip?.textContent).toContain(
+      "Recognizable secrets are redacted, but other secrets may be included. The trace includes your prompts and code and is sent to /dev/fast",
+    );
+
+    await act(async () => traceCheckbox.click());
+
+    expect(traceCheckbox.checked).toBe(true);
+
+    await act(async () => sendButton().click());
+    expect(reportBody()).toMatchObject({ include_trace: true });
+
+    await act(async () => reportButton().click());
+    expect(checkbox("Agent session trace").checked).toBe(false);
   });
 
   it("shows an automatic screenshot and omits it after removal", async () => {
@@ -198,6 +223,14 @@ describe("BugReportControl", () => {
     );
     if (!button) throw new Error("Report bug button not found");
     return button;
+  }
+
+  function checkbox(labelText: string) {
+    const input = [...container.querySelectorAll("label")]
+      .find((label) => label.textContent?.trim() === labelText)
+      ?.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    if (!input) throw new Error(labelText + " checkbox not found");
+    return input;
   }
 
   function reportBody(): Record<string, unknown> {

--- a/packages/progressive-review/app/src/bug-report-dialog.tsx
+++ b/packages/progressive-review/app/src/bug-report-dialog.tsx
@@ -4,6 +4,7 @@ import {
   type DragEvent,
   type FormEvent,
   useEffect,
+  useId,
   useRef,
   useState,
 } from "react";
@@ -20,6 +21,8 @@ import { useTutorial } from "./tutorial-context";
 import { captureUiEvent, clientErrorName } from "./ui-telemetry";
 
 const MAX_DESCRIPTION_BYTES = 64 * 1024;
+const TRACE_PRIVACY_COPY =
+  "Recognizable secrets are redacted, but other secrets may be included. The trace includes your prompts and code and is sent to /dev/fast.";
 
 type Toast = { kind: "success" | "error"; text: string };
 
@@ -30,11 +33,13 @@ export function BugReportControl() {
   const [description, setDescription] = useState("");
   const [includeContext, setIncludeContext] = useState(true);
   const [includeDiff, setIncludeDiff] = useState(true);
+  const [includeTrace, setIncludeTrace] = useState(false);
   const [screenshot, setScreenshot] = useState<string | null>(null);
   const [dropActive, setDropActive] = useState(false);
   const [capturing, setCapturing] = useState(false);
   const [sending, setSending] = useState(false);
   const [toast, setToast] = useState<Toast | null>(null);
+  const tracePrivacyTooltipId = useId();
   const capturePending = useRef(false);
   const descriptionBytes = new TextEncoder().encode(description).byteLength;
   const canSend = descriptionBytes <= MAX_DESCRIPTION_BYTES && !sending;
@@ -49,6 +54,7 @@ export function BugReportControl() {
     setDescription("");
     setIncludeContext(true);
     setIncludeDiff(true);
+    setIncludeTrace(false);
     setScreenshot(null);
     setDropActive(false);
     setSending(false);
@@ -71,6 +77,7 @@ export function BugReportControl() {
           include_review: includeContext,
           include_map: includeContext,
           include_diff: includeDiff,
+          include_trace: includeTrace,
           ...(screenshot
             ? {
                 screenshot: {
@@ -252,6 +259,34 @@ export function BugReportControl() {
                   />
                   Changed-file diffs used by CodePeeks
                 </label>
+                <div className="bug-report-option">
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={includeTrace}
+                      onChange={(event) =>
+                        setIncludeTrace(event.target.checked)
+                      }
+                    />
+                    Agent session trace
+                  </label>
+                  <span className="bug-report-trace-info">
+                    <button
+                      type="button"
+                      aria-label="Agent session trace privacy information"
+                      aria-describedby={tracePrivacyTooltipId}
+                    >
+                      i
+                    </button>
+                    <span
+                      id={tracePrivacyTooltipId}
+                      role="tooltip"
+                      className="bug-report-trace-tooltip"
+                    >
+                      {TRACE_PRIVACY_COPY}
+                    </span>
+                  </span>
+                </div>
                 <div className="bug-report-screenshot">
                   {screenshot ? (
                     <>

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -3051,6 +3051,64 @@ button {
   align-items: center;
 }
 
+.bug-report-option {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.bug-report-trace-info {
+  position: relative;
+  display: inline-flex;
+}
+
+.bug-report-trace-info > button {
+  display: grid;
+  width: 15px;
+  height: 15px;
+  place-items: center;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  padding: 0;
+  background: transparent;
+  color: var(--ink-faint);
+  font: 600 9px/1 var(--font-mono);
+  cursor: help;
+}
+
+.bug-report-trace-info > button:hover,
+.bug-report-trace-info > button:focus-visible {
+  color: var(--ink);
+  outline: none;
+}
+
+.bug-report-trace-tooltip {
+  position: absolute;
+  top: calc(100% + 7px);
+  right: -8px;
+  z-index: 13;
+  width: min(320px, calc(100vw - 64px));
+  padding: 7px 9px;
+  border: 1px solid var(--rule-soft);
+  border-radius: 6px;
+  background: var(--surface-raised);
+  box-shadow: 0 8px 20px var(--shadow-color-strong);
+  color: var(--ink-soft);
+  font: 10px/1.45 var(--font-mono);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-2px);
+  transition:
+    opacity 100ms ease,
+    transform 100ms ease;
+}
+
+.bug-report-trace-info:hover .bug-report-trace-tooltip,
+.bug-report-trace-info:focus-within .bug-report-trace-tooltip {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 .bug-report-screenshot {
   display: flex;
   min-height: 54px;

--- a/packages/progressive-review/src/server/bug-report-trace.test.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.test.ts
@@ -1,0 +1,280 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { REVIEW_SCHEMA_VERSION } from "@dev.fast/review-protocol";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ReviewAgentHarness } from "../authoring-session";
+import { clearTraceEnvCache } from "../review-agent-traces";
+import { readAuthoringTraceAttachment } from "./bug-report-trace";
+
+const TRACE_CAP_BYTES = 6 * 1024 * 1024;
+const SUBAGENT_TRACE_CAP_BYTES = 1024 * 1024;
+
+describe("readAuthoringTraceAttachment", () => {
+  let tempDir: string;
+  let reviewRootPath: string;
+  let claudeRoot: string;
+  let codexRoot: string;
+  let piRoot: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "bug-report-trace-"));
+    reviewRootPath = path.join(tempDir, "review");
+    claudeRoot = path.join(tempDir, "claude");
+    codexRoot = path.join(tempDir, "codex");
+    piRoot = path.join(tempDir, "pi");
+    for (const directory of [reviewRootPath, claudeRoot, codexRoot, piRoot]) {
+      mkdirSync(directory, { recursive: true });
+    }
+    process.env.TRACE_LOCAL_TRACE_ROOT = claudeRoot;
+    process.env.TRACE_CODEX_SESSIONS_ROOT = codexRoot;
+    process.env.TRACE_PI_SESSIONS_ROOT = piRoot;
+    clearTraceEnvCache();
+  });
+
+  afterEach(() => {
+    delete process.env.TRACE_LOCAL_TRACE_ROOT;
+    delete process.env.TRACE_CODEX_SESSIONS_ROOT;
+    delete process.env.TRACE_PI_SESSIONS_ROOT;
+    clearTraceEnvCache();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns null without an attributable source session or local trace", async () => {
+    writeReview("disabled:review");
+    await expect(
+      readAuthoringTraceAttachment({ reviewRootPath }),
+    ).resolves.toBeNull();
+
+    writeReview("codex:missing-session");
+    await expect(
+      readAuthoringTraceAttachment({ reviewRootPath }),
+    ).resolves.toBeNull();
+  });
+
+  it.each([
+    ["claude-code", "11111111-aaaa-bbbb-cccc-000000000001"],
+    ["codex", "22222222-aaaa-bbbb-cccc-000000000002"],
+    ["pi", "33333333-aaaa-bbbb-cccc-000000000003"],
+  ] as const)(
+    "reads a %s trace from its local harness root",
+    async (harness, id) => {
+      writeReview(harness + ":" + id);
+      writeHarnessTrace(harness, id, jsonLine({ harness, id }));
+
+      await expect(
+        readAuthoringTraceAttachment({ reviewRootPath }),
+      ).resolves.toEqual({
+        harness,
+        session_id: id,
+        files: {
+          "trace.jsonl": jsonLine({ harness, id }),
+        },
+        truncated: false,
+      });
+    },
+  );
+
+  it("redacts complete known-secret values while retaining paths, prompts, and code", async () => {
+    const id = "44444444-aaaa-bbbb-cccc-000000000004";
+    const googleKey = "AIza" + "a".repeat(35);
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature";
+    const slackToken = [
+      "xoxb",
+      "123456789012",
+      "123456789012",
+      "abcdefghijklmnopqrstuvwx",
+    ].join("-");
+    const githubToken = "ghp_" + "b".repeat(36);
+    const entraToken =
+      "eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJhcGkifQ.microsoft-signature";
+    const ordinaryBase64Json = "eyJmb28iOiJiYXIifQ==";
+    const source = [
+      {
+        prompt: "Use " + googleKey + " and " + slackToken,
+        path: "/Users/reviewer/project/src/auth.ts",
+        code: "export const answer = 42;",
+        ordinaryBase64Json,
+      },
+      {
+        jwt,
+        githubToken,
+        entraToken,
+      },
+    ]
+      .map(jsonLine)
+      .join("");
+    writeReview("claude-code:" + id);
+    writeHarnessTrace("claude-code", id, source);
+
+    const attachment = await readAuthoringTraceAttachment({ reviewRootPath });
+    const trace = attachment?.files["trace.jsonl"] ?? "";
+
+    expect(trace).toContain("<REDACTED: Google API Key>");
+    expect(trace).toContain("<REDACTED: Slack Token>");
+    expect(trace).toContain("<REDACTED: JWT>");
+    expect(trace).toContain("<REDACTED: GitHub Token>");
+    expect(trace).not.toContain(googleKey);
+    expect(trace).not.toContain(jwt);
+    expect(trace).not.toContain(slackToken);
+    expect(trace).not.toContain(githubToken);
+    expect(trace).not.toContain(entraToken);
+    expect(trace).toContain(ordinaryBase64Json);
+    expect(trace).toContain("/Users/reviewer/project/src/auth.ts");
+    expect(trace).toContain("export const answer = 42;");
+    for (const line of trace.trimEnd().split("\n")) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+  });
+
+  it("keeps the newest complete main-trace lines within the byte cap", async () => {
+    const id = "55555555-aaaa-bbbb-cccc-000000000005";
+    const oversizedOldLine = jsonLine({ old: "x".repeat(TRACE_CAP_BYTES) });
+    const recentLines = [jsonLine({ recent: 1 }), jsonLine({ recent: 2 })].join(
+      "",
+    );
+    writeReview("claude-code:" + id);
+    writeHarnessTrace("claude-code", id, oversizedOldLine + recentLines);
+
+    const attachment = await readAuthoringTraceAttachment({ reviewRootPath });
+
+    expect(attachment?.truncated).toBe(true);
+    expect(attachment?.files["trace.jsonl"]).toBe(recentLines);
+    for (const line of recentLines.trimEnd().split("\n")) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+  });
+
+  it("drops an incomplete final line from a trace being written", async () => {
+    const id = "56565656-aaaa-bbbb-cccc-000000000005";
+    const completeLine = jsonLine({ complete: true });
+    writeReview("claude-code:" + id);
+    writeHarnessTrace("claude-code", id, completeLine + '{"partial":');
+
+    const attachment = await readAuthoringTraceAttachment({ reviewRootPath });
+
+    expect(attachment?.files["trace.jsonl"]).toBe(completeLine);
+    expect(attachment?.truncated).toBe(true);
+  });
+
+  it("treats a capped main trace without a complete line as unavailable", async () => {
+    const id = "57575757-aaaa-bbbb-cccc-000000000005";
+    writeReview("claude-code:" + id);
+    writeHarnessTrace(
+      "claude-code",
+      id,
+      JSON.stringify({ oversized: "x".repeat(TRACE_CAP_BYTES) }),
+    );
+
+    await expect(
+      readAuthoringTraceAttachment({ reviewRootPath }),
+    ).resolves.toBeNull();
+  });
+
+  it("keeps the ten newest subagent traces and names unreadable or excess files as omitted", async () => {
+    const id = "66666666-aaaa-bbbb-cccc-000000000006";
+    writeReview("claude-code:" + id);
+    const tracePath = writeHarnessTrace(
+      "claude-code",
+      id,
+      jsonLine({ main: true }),
+    );
+    const subagentsDir = path.join(
+      tracePath.slice(0, -".jsonl".length),
+      "subagents",
+    );
+    mkdirSync(subagentsDir, { recursive: true });
+    for (let index = 0; index < 11; index++) {
+      const name = "agent-" + String(index).padStart(2, "0") + ".jsonl";
+      const subagentPath = path.join(subagentsDir, name);
+      if (index === 9) {
+        mkdirSync(subagentPath);
+      } else {
+        const contents =
+          index === 10
+            ? jsonLine({ old: "x".repeat(SUBAGENT_TRACE_CAP_BYTES) }) +
+              jsonLine({ recent: true })
+            : jsonLine({ index });
+        writeFileSync(subagentPath, contents);
+      }
+      const modifiedAt = new Date(1_700_000_000_000 + index * 1000);
+      utimesSync(subagentPath, modifiedAt, modifiedAt);
+    }
+
+    const attachment = await readAuthoringTraceAttachment({ reviewRootPath });
+
+    expect(attachment?.truncated).toBe(true);
+    expect(attachment?.files["subagents/agent-10.jsonl"]).toBe(
+      jsonLine({ recent: true }),
+    );
+    expect(attachment?.files).not.toHaveProperty("subagents/agent-00.jsonl");
+    expect(attachment?.files).not.toHaveProperty("subagents/agent-09.jsonl");
+    expect(attachment?.omitted_files).toEqual([
+      "subagents/agent-00.jsonl",
+      "subagents/agent-09.jsonl",
+    ]);
+  });
+
+  function writeReview(sourceSession: string): void {
+    writeFileSync(
+      path.join(reviewRootPath, "review.json"),
+      JSON.stringify({
+        schemaVersion: REVIEW_SCHEMA_VERSION,
+        uuid: "00000000-0000-4000-8000-000000000000",
+        repoKey: "example/review",
+        worktreePath: tempDir,
+        baseRef: "main",
+        baseCommit: "a".repeat(40),
+        sourceCommit: null,
+        sourceIdentity: null,
+        pullRequestNumber: null,
+        pullRequestUrl: null,
+        title: "Trace test",
+        sourceSession,
+        status: "draft",
+        presentedDocumentRevision: null,
+        presentedSoftwareMapRevision: null,
+        createdAt: "2026-08-31T12:00:00.000Z",
+        lastPublishedAt: null,
+      }),
+    );
+  }
+
+  function writeHarnessTrace(
+    harness: ReviewAgentHarness,
+    id: string,
+    contents: string,
+  ): string {
+    let tracePath: string;
+    if (harness === "claude-code") {
+      const projectDir = path.join(claudeRoot, "project");
+      mkdirSync(projectDir, { recursive: true });
+      tracePath = path.join(projectDir, id + ".jsonl");
+    } else if (harness === "codex") {
+      const dateDir = path.join(codexRoot, "2026", "08", "31");
+      mkdirSync(dateDir, { recursive: true });
+      tracePath = path.join(
+        dateDir,
+        "rollout-2026-08-31T12-00-00-" + id + ".jsonl",
+      );
+    } else {
+      const projectDir = path.join(piRoot, "project");
+      mkdirSync(projectDir, { recursive: true });
+      tracePath = path.join(projectDir, "2026-08-31T12-00-00_" + id + ".jsonl");
+    }
+    writeFileSync(tracePath, contents);
+    return tracePath;
+  }
+});
+
+function jsonLine(value: unknown): string {
+  return JSON.stringify(value) + "\n";
+}

--- a/packages/progressive-review/src/server/bug-report-trace.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.ts
@@ -1,0 +1,178 @@
+import { open, stat } from "node:fs/promises";
+
+import {
+  type ReviewAgentHarness,
+  parseAuthoringSessionKey,
+} from "../authoring-session";
+import { findLocalTrace } from "../review-agent-traces";
+import { readReviewStoreRecord } from "../review-worktree-target";
+import { USER_DATA_REGEXES } from "../telemetry-clean-text";
+
+const MAX_TRACE_BYTES = 6 * 1024 * 1024;
+const MAX_SUBAGENT_TRACE_BYTES = 1024 * 1024;
+const MAX_SUBAGENT_TRACES = 10;
+
+export interface AuthoringTraceAttachment {
+  harness: ReviewAgentHarness;
+  session_id: string;
+  files: Record<string, string>;
+  omitted_files?: string[];
+  truncated: boolean;
+}
+
+const TRACE_SECRET_LABELS = new Set([
+  "Google API Key",
+  "JWT",
+  "Slack Token",
+  "GitHub Token",
+  "Microsoft Entra ID",
+]);
+
+const TRACE_SECRET_REGEXES = USER_DATA_REGEXES.filter(({ label }) =>
+  TRACE_SECRET_LABELS.has(label),
+).map(({ label, regex }) => ({
+  label,
+  // The shared Slack and Entra expressions detect that a line should be
+  // discarded by telemetry, so they only need to match a token prefix. Bug
+  // report traces preserve the rest of the line, which requires consuming the
+  // complete token instead.
+  regex:
+    label === "Slack Token"
+      ? /xox[pbar]-[A-Za-z0-9-]+/g
+      : label === "Microsoft Entra ID"
+        ? /eyJ(?:0eXAiOiJKV1Qi|hbGci)[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g
+        : new RegExp(
+            regex.source,
+            regex.flags.includes("g") ? regex.flags : `${regex.flags}g`,
+          ),
+}));
+
+export async function readAuthoringTraceAttachment(input: {
+  reviewRootPath: string;
+}): Promise<AuthoringTraceAttachment | null> {
+  const review = readReviewStoreRecord(input.reviewRootPath);
+  const sourceSession = parseAuthoringSessionKey(review.sourceSession);
+  if (!sourceSession) return null;
+
+  const localTrace = await findLocalTrace(sourceSession.sessionId);
+  if (!localTrace) return null;
+
+  const mainTrace = await readTailTraceFile(
+    localTrace.tracePath,
+    MAX_TRACE_BYTES,
+  );
+  if (!mainTrace.contents) return null;
+
+  const files: Record<string, string> = {
+    "trace.jsonl": mainTrace.contents,
+  };
+  const subagentPaths = await Promise.all(
+    localTrace.subagentPaths.map(async (subagent) => ({
+      ...subagent,
+      modifiedAt: await stat(subagent.path).then(
+        ({ mtimeMs }) => mtimeMs,
+        () => Number.NEGATIVE_INFINITY,
+      ),
+    })),
+  );
+  subagentPaths.sort(
+    (left, right) =>
+      right.modifiedAt - left.modifiedAt || left.name.localeCompare(right.name),
+  );
+  const omittedFiles = subagentPaths
+    .slice(MAX_SUBAGENT_TRACES)
+    .map(({ name }) => `subagents/${name}`);
+  let truncated = mainTrace.truncated || omittedFiles.length > 0;
+
+  const subagentResults = await Promise.all(
+    subagentPaths.slice(0, MAX_SUBAGENT_TRACES).map(async ({ name, path }) => {
+      const attachmentName = `subagents/${name}`;
+      try {
+        return {
+          attachmentName,
+          trace: await readTailTraceFile(path, MAX_SUBAGENT_TRACE_BYTES),
+        };
+      } catch {
+        return { attachmentName, trace: null };
+      }
+    }),
+  );
+  for (const result of subagentResults) {
+    if (!result.trace) {
+      omittedFiles.push(result.attachmentName);
+      truncated = true;
+      continue;
+    }
+    files[result.attachmentName] = result.trace.contents;
+    truncated ||= result.trace.truncated;
+  }
+
+  return {
+    harness: sourceSession.harness,
+    session_id: sourceSession.sessionId,
+    files,
+    ...(omittedFiles.length > 0 ? { omitted_files: omittedFiles.sort() } : {}),
+    truncated,
+  };
+}
+
+async function readTailTraceFile(
+  filePath: string,
+  maxBytes: number,
+): Promise<{ contents: string; truncated: boolean }> {
+  const handle = await open(filePath, "r");
+  try {
+    const { size } = await handle.stat();
+    const start = Math.max(0, size - maxBytes);
+    const buffer = Buffer.alloc(size - start);
+    let offset = 0;
+    while (offset < buffer.byteLength) {
+      const { bytesRead } = await handle.read(
+        buffer,
+        offset,
+        buffer.byteLength - offset,
+        start + offset,
+      );
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+
+    let tail = buffer.subarray(0, offset);
+    const truncated = start > 0;
+    if (truncated) {
+      const firstLineBreak = tail.indexOf(0x0a);
+      tail =
+        firstLineBreak === -1
+          ? Buffer.alloc(0)
+          : tail.subarray(firstLineBreak + 1);
+    }
+    const decoded = tail.toString("utf8");
+    const completeJsonl = retainCompleteJsonlLines(decoded);
+    return {
+      contents: redactTraceJsonl(completeJsonl),
+      truncated: truncated || completeJsonl.length < decoded.length,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+function retainCompleteJsonlLines(contents: string): string {
+  if (!contents || contents.endsWith("\n")) return contents;
+  const lastLineBreak = contents.lastIndexOf("\n");
+  const finalLine = contents.slice(lastLineBreak + 1);
+  try {
+    JSON.parse(finalLine);
+    return contents;
+  } catch {
+    return lastLineBreak === -1 ? "" : contents.slice(0, lastLineBreak + 1);
+  }
+}
+
+function redactTraceJsonl(contents: string): string {
+  let redacted = contents;
+  for (const { label, regex } of TRACE_SECRET_REGEXES) {
+    redacted = redacted.replace(regex, `<REDACTED: ${label}>`);
+  }
+  return redacted;
+}

--- a/packages/progressive-review/src/server/bug-report.test.ts
+++ b/packages/progressive-review/src/server/bug-report.test.ts
@@ -1,0 +1,272 @@
+import { randomBytes } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { gunzipSync } from "node:zlib";
+
+import {
+  REVIEW_SCHEMA_VERSION,
+  type ReviewBugReportRequest,
+} from "@dev.fast/review-protocol";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { clearTraceEnvCache } from "../review-agent-traces";
+import {
+  buildSizedBugReportRequest,
+  submitReviewBugReport,
+} from "./bug-report";
+import type { AuthoringTraceAttachment } from "./bug-report-trace";
+
+describe("submitReviewBugReport", () => {
+  let tempDir: string;
+  let reviewRootPath: string;
+  let codexRoot: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "bug-report-submit-"));
+    reviewRootPath = path.join(tempDir, "review");
+    codexRoot = path.join(tempDir, "codex");
+    const claudeRoot = path.join(tempDir, "claude");
+    const piRoot = path.join(tempDir, "pi");
+    for (const directory of [reviewRootPath, codexRoot, claudeRoot, piRoot]) {
+      mkdirSync(directory, { recursive: true });
+    }
+    process.env.TRACE_LOCAL_TRACE_ROOT = claudeRoot;
+    process.env.TRACE_CODEX_SESSIONS_ROOT = codexRoot;
+    process.env.TRACE_PI_SESSIONS_ROOT = piRoot;
+    clearTraceEnvCache();
+  });
+
+  afterEach(() => {
+    delete process.env.TRACE_LOCAL_TRACE_ROOT;
+    delete process.env.TRACE_CODEX_SESSIONS_ROOT;
+    delete process.env.TRACE_PI_SESSIONS_ROOT;
+    clearTraceEnvCache();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("attaches the resolved authoring trace and exposes filterable metadata", async () => {
+    const sessionId = "77777777-aaaa-bbbb-cccc-000000000007";
+    writeReview("codex:" + sessionId);
+    const dateDir = path.join(codexRoot, "2026", "08", "31");
+    mkdirSync(dateDir, { recursive: true });
+    writeFileSync(
+      path.join(dateDir, "rollout-2026-08-31T12-00-00-" + sessionId + ".jsonl"),
+      JSON.stringify({ prompt: "Fix the bug" }) + "\n",
+    );
+    const capture = captureFetch();
+
+    await submitReviewBugReport({
+      report: report({ include_trace: true }),
+      reviewDocumentPath: path.join(reviewRootPath, "review.mdx"),
+      reviewRootPath,
+      clientErrorNames: ["TypeError"],
+      fetchImpl: capture.fetchImpl,
+    });
+
+    const { meta, payload } = parseMultipart(capture.body());
+    expect(meta).toMatchObject({
+      has_trace: true,
+      trace_harness: "codex",
+      truncated_trace: false,
+    });
+    expect(payload).toMatchObject({
+      schema_version: 3,
+      trace: {
+        harness: "codex",
+        session_id: sessionId,
+        truncated: false,
+      },
+    });
+  });
+
+  it("records an unavailable trace without failing the report", async () => {
+    writeReview("codex:missing-session");
+    const capture = captureFetch();
+
+    await submitReviewBugReport({
+      report: report({ include_trace: true }),
+      reviewDocumentPath: path.join(reviewRootPath, "review.mdx"),
+      reviewRootPath,
+      clientErrorNames: [],
+      fetchImpl: capture.fetchImpl,
+    });
+
+    const { meta, payload } = parseMultipart(capture.body());
+    expect(meta).not.toHaveProperty("has_trace");
+    expect(meta).not.toHaveProperty("trace_harness");
+    expect(meta).not.toHaveProperty("truncated_trace");
+    expect(payload).not.toHaveProperty("trace");
+    expect(payload).toMatchObject({
+      diagnostics: {
+        attachment_errors: [{ attachment: "trace", error: "unavailable" }],
+      },
+    });
+  });
+
+  it("drops an oversized trace before a changed-file diff", () => {
+    const payload = bugReportPayload(largeTraceAttachment());
+
+    const request = buildSizedBugReportRequest(payload, {
+      appVersion: "1.2.3",
+      cliVersion: "0.0.1",
+    });
+
+    const { meta, payload: fittedPayload } = parseMultipart(request.body);
+    expect(meta).toMatchObject({
+      has_trace: false,
+      has_diff: true,
+      trace_harness: "claude-code",
+      truncated_trace: true,
+      truncated_diff: false,
+    });
+    expect(fittedPayload).not.toHaveProperty("trace");
+    expect(fittedPayload).toHaveProperty("diff.files.0.path", "src/example.ts");
+  });
+
+  function writeReview(sourceSession: string): void {
+    writeFileSync(
+      path.join(reviewRootPath, "review.json"),
+      JSON.stringify({
+        schemaVersion: REVIEW_SCHEMA_VERSION,
+        uuid: "00000000-0000-4000-8000-000000000000",
+        repoKey: "example/review",
+        worktreePath: tempDir,
+        baseRef: "main",
+        baseCommit: "a".repeat(40),
+        sourceCommit: null,
+        sourceIdentity: null,
+        pullRequestNumber: null,
+        pullRequestUrl: null,
+        title: "Bug report test",
+        sourceSession,
+        status: "draft",
+        presentedDocumentRevision: null,
+        presentedSoftwareMapRevision: null,
+        createdAt: "2026-08-31T12:00:00.000Z",
+        lastPublishedAt: null,
+      }),
+    );
+  }
+});
+
+function report(
+  overrides: Partial<ReviewBugReportRequest> = {},
+): ReviewBugReportRequest {
+  return {
+    description: "",
+    include_review: false,
+    include_map: false,
+    include_diff: false,
+    include_trace: false,
+    app_session_id: "session-1234567890",
+    app_version: "1.2.3",
+    ...overrides,
+  };
+}
+
+function captureFetch(): {
+  fetchImpl: typeof fetch;
+  body: () => Buffer;
+} {
+  let body: Buffer | undefined;
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    body = Buffer.from(init?.body as Buffer);
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        report_id: "00000000-0000-4000-8000-000000000000",
+        short_id: "123456789012",
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+  return {
+    fetchImpl,
+    body: () => {
+      if (!body) throw new Error("Bug-report body was not captured");
+      return body;
+    },
+  };
+}
+
+function parseMultipart(body: Buffer): {
+  meta: Record<string, unknown>;
+  payload: Record<string, unknown>;
+} {
+  const metaHeader = Buffer.from('Content-Disposition: form-data; name="meta"');
+  const payloadHeader = Buffer.from(
+    'Content-Disposition: form-data; name="payload"',
+  );
+  const metaPart = body.indexOf(metaHeader);
+  const metaStart = body.indexOf(Buffer.from("\r\n\r\n"), metaPart) + 4;
+  const metaEnd = body.indexOf(Buffer.from("\r\n--"), metaStart);
+  const payloadPart = body.indexOf(payloadHeader);
+  const payloadStart = body.indexOf(Buffer.from("\r\n\r\n"), payloadPart) + 4;
+  const payloadEnd = body.lastIndexOf(Buffer.from("\r\n--"));
+  return {
+    meta: JSON.parse(body.subarray(metaStart, metaEnd).toString("utf8")),
+    payload: JSON.parse(
+      gunzipSync(body.subarray(payloadStart, payloadEnd)).toString("utf8"),
+    ),
+  };
+}
+
+function bugReportPayload(
+  trace: AuthoringTraceAttachment,
+): Parameters<typeof buildSizedBugReportRequest>[0] {
+  return {
+    schema_version: 3,
+    description: "",
+    trace,
+    diff: {
+      baseRef: "base",
+      headRef: "head",
+      files: [
+        {
+          path: "src/example.ts",
+          status: "modified",
+          additions: 1,
+          deletions: 1,
+          patch: "@@ -1 +1 @@\n-old\n+new",
+        },
+      ],
+    },
+    diagnostics: {
+      app_version: "1.2.3",
+      cli_version: "0.0.1",
+      platform: process.platform,
+      app_session_id: "session-1234567890",
+      client_error_names: [],
+    },
+  };
+}
+
+function largeTraceAttachment(): AuthoringTraceAttachment {
+  const files: Record<string, string> = {
+    "trace.jsonl": incompressibleJsonl(6 * 1024 * 1024),
+  };
+  for (let index = 0; index < 10; index++) {
+    files["subagents/agent-" + index + ".jsonl"] = incompressibleJsonl(
+      1024 * 1024,
+    );
+  }
+  return {
+    harness: "claude-code",
+    session_id: "session-oversized",
+    files,
+    truncated: false,
+  };
+}
+
+function incompressibleJsonl(targetBytes: number): string {
+  const lines: string[] = [];
+  let bytes = 0;
+  while (bytes < targetBytes) {
+    const line =
+      JSON.stringify({ data: randomBytes(768).toString("base64") }) + "\n";
+    lines.push(line);
+    bytes += Buffer.byteLength(line);
+  }
+  return lines.join("");
+}

--- a/packages/progressive-review/src/server/bug-report.ts
+++ b/packages/progressive-review/src/server/bug-report.ts
@@ -18,6 +18,10 @@ import {
   resolveReviewSourceTarget,
 } from "../review-worktree-target";
 import { readSoftwareMapSourceForRef } from "../software-map-artifact";
+import {
+  type AuthoringTraceAttachment,
+  readAuthoringTraceAttachment,
+} from "./bug-report-trace";
 
 const BUG_REPORT_URL = "https://bug.dev.fast/api/v1/reports";
 const MAX_MULTIPART_BYTES = 10 * 1024 * 1024;
@@ -38,14 +42,14 @@ const MAX_REVIEW_SOURCE_FILES = 20;
 // 2 MiB leaves room for a generated one.
 const MAX_REVIEW_SOURCE_FILE_BYTES = 2 * 1024 * 1024;
 
-type AttachmentName = "review" | "map" | "diff";
+type AttachmentName = "review" | "map" | "diff" | "trace";
 type AttachmentError = {
   attachment: AttachmentName;
   error: "unavailable";
 };
 
 interface BugReportPayload {
-  schema_version: 2;
+  schema_version: 3;
   description: string;
   screenshot?: { mime: "image/jpeg"; base64: string };
   // File name to text. The document alone cannot render: every anchor lives in
@@ -53,6 +57,7 @@ interface BugReportPayload {
   review?: Record<string, string>;
   map?: string;
   diff?: ReviewDiffFilesResult;
+  trace?: AuthoringTraceAttachment;
   diagnostics: {
     app_version: string;
     cli_version: string;
@@ -86,7 +91,7 @@ export async function submitReviewBugReport(input: {
   const cliVersion = readProgressiveReviewPackageVersion();
   const attachmentErrors: AttachmentError[] = [];
   const payload: BugReportPayload = {
-    schema_version: 2,
+    schema_version: 3,
     description: input.report.description,
     ...(input.report.screenshot ? { screenshot: input.report.screenshot } : {}),
     diagnostics: {
@@ -102,6 +107,7 @@ export async function submitReviewBugReport(input: {
   let omittedReviewFiles: string[] | undefined;
   let mapSource: string | undefined;
   let changedFileDiffs: ReviewDiffFilesResult | undefined;
+  let traceAttachment: AuthoringTraceAttachment | undefined;
   let sourceTargetPromise: Promise<ReviewSourceTarget> | undefined;
   const sourceTarget = () =>
     (sourceTargetPromise ??= resolveReviewSourceTarget({
@@ -153,6 +159,24 @@ export async function submitReviewBugReport(input: {
         ),
     );
   }
+  if (input.report.include_trace) {
+    tasks.push(
+      readAuthoringTraceAttachment({
+        reviewRootPath: input.reviewRootPath,
+      }).then(
+        (trace) => {
+          if (trace === null) {
+            attachmentErrors.push(unavailable("trace"));
+            return;
+          }
+          traceAttachment = trace;
+        },
+        () => {
+          attachmentErrors.push(unavailable("trace"));
+        },
+      ),
+    );
+  }
   await Promise.all(tasks);
   if (reviewSource !== undefined) payload.review = reviewSource;
   if (omittedReviewFiles !== undefined) {
@@ -160,68 +184,17 @@ export async function submitReviewBugReport(input: {
   }
   if (mapSource !== undefined) payload.map = mapSource;
   if (changedFileDiffs !== undefined) payload.diff = changedFileDiffs;
+  if (traceAttachment !== undefined) payload.trace = traceAttachment;
   if (attachmentErrors.length > 0) {
     payload.diagnostics.attachment_errors = attachmentErrors.sort(
       (left, right) => left.attachment.localeCompare(right.attachment),
     );
   }
 
-  let truncatedDiff = false;
-  let truncatedMap = false;
-  let truncatedScreenshot = false;
-  let request = buildBugReportRequest(payload, {
+  const request = buildSizedBugReportRequest(payload, {
     appVersion: input.report.app_version,
     cliVersion,
-    truncatedDiff,
-    truncatedMap,
-    truncatedScreenshot,
   });
-  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.diff) {
-    delete payload.diff;
-    truncatedDiff = true;
-    request = buildBugReportRequest(payload, {
-      appVersion: input.report.app_version,
-      cliVersion,
-      truncatedDiff,
-      truncatedMap,
-      truncatedScreenshot,
-    });
-  }
-  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.map) {
-    delete payload.map;
-    truncatedMap = true;
-    request = buildBugReportRequest(payload, {
-      appVersion: input.report.app_version,
-      cliVersion,
-      truncatedDiff,
-      truncatedMap,
-      truncatedScreenshot,
-    });
-  }
-  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.screenshot) {
-    delete payload.screenshot;
-    truncatedScreenshot = true;
-    request = buildBugReportRequest(payload, {
-      appVersion: input.report.app_version,
-      cliVersion,
-      truncatedDiff,
-      truncatedMap,
-      truncatedScreenshot,
-    });
-  }
-  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.review) {
-    delete payload.review;
-    request = buildBugReportRequest(payload, {
-      appVersion: input.report.app_version,
-      cliVersion,
-      truncatedDiff,
-      truncatedMap,
-      truncatedScreenshot,
-    });
-  }
-  if (request.body.byteLength > MAX_MULTIPART_BYTES) {
-    throw new BugReportUpstreamError(413, "Bug report is too large.");
-  }
 
   const response = await (input.fetchImpl ?? fetch)(BUG_REPORT_URL, {
     method: "POST",
@@ -250,6 +223,59 @@ export async function submitReviewBugReport(input: {
   const result = parseReviewBugReportResponse(responseBody);
   if (!result.ok) throw new BugReportUpstreamError(502, result.error);
   return result;
+}
+
+export function buildSizedBugReportRequest(
+  payload: BugReportPayload,
+  input: {
+    appVersion: string;
+    cliVersion: string;
+  },
+) {
+  let truncatedDiff = false;
+  let truncatedMap = false;
+  let truncatedScreenshot = false;
+  let truncatedTrace = payload.trace?.truncated ?? false;
+  const traceHarness = payload.trace?.harness;
+  const build = () =>
+    buildBugReportRequest(payload, {
+      ...input,
+      truncatedDiff,
+      truncatedMap,
+      truncatedScreenshot,
+      truncatedTrace,
+      traceHarness,
+    });
+
+  let request = build();
+  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.trace) {
+    delete payload.trace;
+    truncatedTrace = true;
+    request = build();
+  }
+  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.diff) {
+    delete payload.diff;
+    truncatedDiff = true;
+    request = build();
+  }
+  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.map) {
+    delete payload.map;
+    truncatedMap = true;
+    request = build();
+  }
+  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.screenshot) {
+    delete payload.screenshot;
+    truncatedScreenshot = true;
+    request = build();
+  }
+  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.review) {
+    delete payload.review;
+    request = build();
+  }
+  if (request.body.byteLength > MAX_MULTIPART_BYTES) {
+    throw new BugReportUpstreamError(413, "Bug report is too large.");
+  }
+  return request;
 }
 
 // The document is required: a failure to read it makes the attachment
@@ -331,6 +357,8 @@ function buildBugReportRequest(
     truncatedDiff: boolean;
     truncatedMap: boolean;
     truncatedScreenshot: boolean;
+    truncatedTrace: boolean;
+    traceHarness?: AuthoringTraceAttachment["harness"];
   },
 ) {
   const payloadBytes = gzipSync(Buffer.from(JSON.stringify(payload)), {
@@ -343,6 +371,13 @@ function buildBugReportRequest(
     has_map: payload.map !== undefined,
     has_diff: payload.diff !== undefined,
     has_screenshot: payload.screenshot !== undefined,
+    ...(input.traceHarness
+      ? {
+          has_trace: payload.trace !== undefined,
+          trace_harness: input.traceHarness,
+          truncated_trace: input.truncatedTrace,
+        }
+      : {}),
     payload_bytes: payloadBytes.byteLength,
     app_version: input.appVersion,
     cli_version: input.cliVersion,

--- a/packages/progressive-review/src/server/review-api-parsers.test.ts
+++ b/packages/progressive-review/src/server/review-api-parsers.test.ts
@@ -22,6 +22,7 @@ const bugReport = {
   include_review: true,
   include_map: true,
   include_diff: true,
+  include_trace: false,
   app_session_id: "session-1234567890",
   app_version: "1.2.3",
 };

--- a/packages/review-protocol/src/bug-report.test.ts
+++ b/packages/review-protocol/src/bug-report.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseReviewBugReportMeta,
+  parseReviewBugReportRequest,
+} from "./bug-report.js";
+
+describe("bug report protocol", () => {
+  it("round-trips trace consent and defaults it off for older clients", () => {
+    const request = {
+      description: "",
+      include_review: true,
+      include_map: true,
+      include_diff: true,
+      include_trace: false,
+      app_session_id: "session-1234567890",
+      app_version: "1.2.3",
+    };
+
+    expect(parseReviewBugReportRequest(request)).toEqual(request);
+
+    const { include_trace: _includeTrace, ...withoutTraceConsent } = request;
+    expect(parseReviewBugReportRequest(withoutTraceConsent)).toEqual(request);
+  });
+
+  it("round-trips trace metadata and defaults new fields for older senders", () => {
+    const meta = {
+      schema_version: 1,
+      description_length: 0,
+      has_review: true,
+      has_map: true,
+      has_diff: true,
+      has_screenshot: false,
+      has_trace: true,
+      trace_harness: "codex" as const,
+      payload_bytes: 1024,
+      app_version: "1.2.3",
+      cli_version: "0.0.1",
+      platform: "darwin",
+      truncated_diff: false,
+      truncated_map: false,
+      truncated_screenshot: false,
+      truncated_trace: true,
+    };
+
+    expect(parseReviewBugReportMeta(meta)).toEqual(meta);
+
+    const {
+      has_trace: _hasTrace,
+      trace_harness: _traceHarness,
+      truncated_trace: _truncatedTrace,
+      ...olderMeta
+    } = meta;
+    expect(parseReviewBugReportMeta(olderMeta)).toEqual({
+      ...olderMeta,
+      has_trace: false,
+      truncated_trace: false,
+    });
+  });
+});

--- a/packages/review-protocol/src/bug-report.ts
+++ b/packages/review-protocol/src/bug-report.ts
@@ -9,6 +9,7 @@ export const ReviewBugReportRequestSchema = z.strictObject({
   include_review: z.boolean(),
   include_map: z.boolean(),
   include_diff: z.boolean(),
+  include_trace: z.boolean().default(false),
   screenshot: z
     .strictObject({
       mime: z.literal("image/jpeg"),
@@ -32,6 +33,8 @@ export const ReviewBugReportMetaSchema = z.strictObject({
   has_map: z.boolean(),
   has_diff: z.boolean(),
   has_screenshot: z.boolean(),
+  has_trace: z.boolean().default(false),
+  trace_harness: z.enum(["claude-code", "codex", "pi"]).optional(),
   payload_bytes: z
     .number()
     .int()
@@ -55,6 +58,7 @@ export const ReviewBugReportMetaSchema = z.strictObject({
   truncated_diff: z.boolean(),
   truncated_map: z.boolean(),
   truncated_screenshot: z.boolean(),
+  truncated_trace: z.boolean().default(false),
 });
 export type ReviewBugReportMeta = z.infer<typeof ReviewBugReportMetaSchema>;
 


### PR DESCRIPTION
## Summary

- add an opt-in Agent session trace attachment to Review Desktop bug reports
- resolve the Review authoring session directly from each supported harness local trace store
- tail-cap main and subagent JSONL files, retain newest subagents, redact recognizable secret formats, and preserve code, prompts, and paths
- drop the trace first when the compressed report exceeds the upload cap
- expose trace presence, harness, and truncation metadata for triage
- move trace-specific privacy details behind an accessible information tooltip beside the checkbox
- document the attachment, privacy scope, retention, and size behavior

## Compatibility

Installed Desktop clients and stale SPA tabs cannot be assumed current. The request and shared metadata additions default to false, and the sender omits trace metadata entirely unless it resolves an authoring harness. This lets no-trace and unavailable-trace submissions retain the legacy metadata shape.

The separately deployed bug Worker accepts legacy, screenshot-era, and trace-aware shapes. The reader-first dependency is satisfied: Fix-Fast/dev#1037 merged as `0d42d99a0a58640c16c752d123db24753a5e3aa4`, and Worker version `fc035031-633c-40e0-9f39-fe1970b7e4a7` is serving 100% of traffic at bug.dev.fast. Synthetic legacy and trace-aware uploads both returned 200 in production, and both payloads were read back successfully from the remote R2 bucket.

## Privacy

The trace checkbox defaults off. Its information tooltip states that recognizable secrets are redacted, other secrets may remain, and prompts and code are sent to /dev/fast. Reports remain restricted to authorized team members and retain the existing 90-day deletion policy.

## Testing

- pnpm --filter @dev.fast/review test (148 files, 1,127 tests)
- pnpm --filter @dev.fast/review-protocol test (106 tests)
- pnpm --filter @dev.fast/review-protocol typecheck
- pnpm lint
- pnpm format:check
- focused trace reader, multipart/size ladder, and dialog tests
- local Review Desktop production build and launch
- production Worker uploads using both the legacy and trace-aware metadata shapes, with remote R2 readback

Worker integration coverage in Fix-Fast/dev#1037 also sends a trace-aware gzip multipart request through the Workers runtime, reads the stored bytes back through a local R2 binding, decompresses the trace payload, and verifies PostHog metadata.
