### PR TITLE
Document Review authoring guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Review works especially well for large changes where a file-by-file diff does
 not explain whether the system is right. See the
 [quickstart](docs/quickstart.md) for the complete first-review flow.
 
+Review authors can add user and repository guidance for generated documents.
+See [Review guidance](docs/quickstart.md#add-review-guidance).
+
 ## Documentation
 
 [How Review works](docs/how-review-works.md) · [Coding agents](docs/agents.md) ·

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,8 @@ directory as a reference.
 
 ## Start here
 
-- [Quickstart](quickstart.md) — install Review and complete a first review.
+- [Quickstart](quickstart.md) — install Review, add authoring guidance, and
+  complete a first review.
 - [How Review works](how-review-works.md) — understand documents, live code,
   maps, threads, and the review lifecycle.
 - [Coding agents](agents.md) — connect Claude Code, Codex, and other coding

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,6 +53,16 @@ The agent scaffolds a Review, writes and validates the walkthrough, publishes
 it, and opens it in Review Desktop. You can also review a specific GitHub pull
 request or ask for an architecture review of a repository.
 
+### Add Review guidance
+
+You can add optional guidance for generated Review documents:
+
+- User-level guidance: `$DEV_REVIEW_HOME/DEV-REVIEW.md`. Review uses
+  `~/.dev/DEV-REVIEW.md` by default.
+- Repository guidance: `DEV-REVIEW.md` at the source repository root.
+
+Repository guidance takes precedence over user-level guidance.
+
 ## 4. Read and respond
 
 Use the three main surfaces together:

--- a/packages/progressive-review/README.md
+++ b/packages/progressive-review/README.md
@@ -7,6 +7,16 @@ has a durable UUID directory under
 it of sealed revisions. The server owns review discovery, session state, and
 presentation.
 
+## Review guidance
+
+You can add optional guidance for generated Review documents:
+
+- User-level guidance: `$DEV_REVIEW_HOME/DEV-REVIEW.md`. Review uses
+  `~/.dev/DEV-REVIEW.md` by default.
+- Repository guidance: `DEV-REVIEW.md` at the source repository root.
+
+Repository guidance takes precedence over user-level guidance.
+
 ## Migration
 
 To move legacy Review data with a compatible `review` command, run:

--- a/packages/progressive-review/onboarding.md
+++ b/packages/progressive-review/onboarding.md
@@ -11,22 +11,26 @@ are edited with normal file tools. Read and mutate comment threads only through
    Review matches the requested change, run `review scaffold --json`.
 3. Read the JSONL event for the UUID directory, source binding, sync state,
    and unresolved threads.
-4. Edit `review.mdx` and `data.ts` in that directory. Keep the H1 and write
+4. Read `$DEV_REVIEW_HOME/DEV-REVIEW.md` when it exists. Use
+   `~/.dev/DEV-REVIEW.md` when `DEV_REVIEW_HOME` is not set. Then read
+   `DEV-REVIEW.md` at the source repository root when it exists. Repository
+   guidance takes precedence when the files conflict.
+5. Edit `review.mdx` and `data.ts` in that directory. Keep the H1 and write
    short, evidence-backed prose. Link each code claim to an anchored source
    range. Read that exact range from the pinned worktree before you write it.
-5. For any code evidence, `softwareMap` frontmatter must pin the persisted
+6. For any code evidence, `softwareMap` frontmatter must pin the persisted
    review commits from `review.json` (`baseCommit` and `sourceCommit`), never a
    moving branch such as `HEAD` or `origin/main`.
-6. Run `npm test` in the UUID directory. It validates TypeScript and MDX
+7. Run `npm test` in the UUID directory. It validates TypeScript and MDX
    without launching a renderer.
-7. Run `review publish` (agents: `review publish --json` — every `review`
+8. Run `review publish` (agents: `review publish --json` — every `review`
    command accepts `--json`, and it keeps stdout to JSON events only). It is the only
    promotion gate, and it runs entirely in the CLI: compilation, the
    software-map check, and resolution of every source range against the pinned
    worktree. A validation failure preserves the last good revision.
    On success the CLI seals the revision and Review Desktop mounts it.
-8. Run `review app pick --review <uuid> --json` to select the published Review.
-9. Run `review threads list` for open comment threads and questions. Make the
+9. Run `review app pick --review <uuid> --json` to select the published Review.
+10. Run `review threads list` for open comment threads and questions. Make the
    relevant change, and publish again. Resolve a comment with `review threads
 resolve <threadId>` only after its exact target is addressed. Question
    records remain `running`, `answered`, or `error`.

--- a/packages/progressive-review/skills/dev-review/SKILL.md
+++ b/packages/progressive-review/skills/dev-review/SKILL.md
@@ -22,7 +22,12 @@ Answer the question without launching Review Desktop, scaffolding a Review, or p
 
 ## Before authoring
 
-Read `DEV-REVIEW.md` at the source repository root when it exists. Follow its review rules and domain language.
+Read these Review guidance files when they exist, in this order:
+
+1. `$DEV_REVIEW_HOME/DEV-REVIEW.md` for user-level guidance. Use `~/.dev/DEV-REVIEW.md` when `DEV_REVIEW_HOME` is not set.
+2. `DEV-REVIEW.md` at the source repository root for repository guidance.
+
+Follow the review rules and domain language in both files. The repository guidance takes precedence when the files conflict.
 
 Read [Document authoring](references/document-authoring.md) for writing rules and document structure.
 


### PR DESCRIPTION
## Summary

- add user-level Review guidance at `$DEV_REVIEW_HOME/DEV-REVIEW.md`
- keep repository guidance in root `DEV-REVIEW.md` with repository precedence
- document both guidance locations in the public quickstart, package README, and onboarding flow

## Validation

- Review skill validator
- `git diff --check`

## Tests

Not run, per request.