### PR TITLE
Resolve squash-merged trace sessions via PR scan

### DIFF
--- a/packages/progressive-review/src/review-agent-traces.test.ts
+++ b/packages/progressive-review/src/review-agent-traces.test.ts
@@ -613,6 +613,111 @@ describe("review-agent-traces", () => {
     });
   });
 
+  describe("listReviewTraceSessions squash-merge fallback", () => {
+    it("scans PR branches when range commits carry no trailers", async () => {
+      const originBare = path.join(tempDir, "range-remote.git");
+      const clientRepo = path.join(tempDir, "range-client");
+
+      execFileSync("git", ["init", "--bare", "--quiet", originBare]);
+      execFileSync("git", ["clone", "--quiet", originBare, clientRepo]);
+      execFileSync("git", ["config", "user.name", "Test"], {
+        cwd: clientRepo,
+      });
+      execFileSync("git", ["config", "user.email", "test@test.com"], {
+        cwd: clientRepo,
+      });
+
+      writeFileSync(path.join(clientRepo, "f.txt"), "base");
+      execFileSync("git", ["add", "f.txt"], { cwd: clientRepo });
+      execFileSync("git", ["commit", "-m", "Base commit"], {
+        cwd: clientRepo,
+      });
+      execFileSync("git", ["push", "--quiet", "origin", "HEAD:main"], {
+        cwd: clientRepo,
+      });
+      const baseSha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: clientRepo,
+        encoding: "utf8",
+      }).trim();
+
+      execFileSync("git", ["checkout", "-b", "feature"], { cwd: clientRepo });
+      writeFileSync(path.join(clientRepo, "f.txt"), "branch change");
+      execFileSync("git", ["add", "f.txt"], { cwd: clientRepo });
+      execFileSync(
+        "git",
+        [
+          "commit",
+          "-m",
+          "Feature work\n\nAgent-Session: 55555555-aaaa-bbbb-cccc-000000000005",
+        ],
+        { cwd: clientRepo },
+      );
+      execFileSync(
+        "git",
+        ["push", "--quiet", "origin", "HEAD:refs/pull/7/head"],
+        { cwd: clientRepo },
+      );
+
+      execFileSync("git", ["checkout", "main"], { cwd: clientRepo });
+      writeFileSync(path.join(clientRepo, "f.txt"), "squashed branch change");
+      execFileSync("git", ["add", "f.txt"], { cwd: clientRepo });
+      execFileSync("git", ["commit", "-m", "Squash merged feature work (#7)"], {
+        cwd: clientRepo,
+      });
+      const squashSha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: clientRepo,
+        encoding: "utf8",
+      }).trim();
+
+      const sessions = await listReviewTraceSessions({
+        rootPath: clientRepo,
+        baseCommit: baseSha,
+        headCommit: squashSha,
+      });
+      expect(sessions.map((session) => session.sessionId)).toEqual([
+        "55555555-aaaa-bbbb-cccc-000000000005",
+      ]);
+      expect(sessions[0]?.commits).toEqual([
+        { sha: squashSha, subject: "Squash merged feature work (#7)" },
+      ]);
+    });
+
+    it("returns nothing when the squash subject has no PR number", async () => {
+      const gitDir = path.join(tempDir, "range-no-pr");
+      mkdirSync(gitDir, { recursive: true });
+      execFileSync("git", ["init", "--quiet"], { cwd: gitDir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: gitDir });
+      execFileSync("git", ["config", "user.email", "test@test.com"], {
+        cwd: gitDir,
+      });
+
+      writeFileSync(path.join(gitDir, "a.txt"), "base");
+      execFileSync("git", ["add", "a.txt"], { cwd: gitDir });
+      execFileSync("git", ["commit", "-m", "Base commit"], { cwd: gitDir });
+      const baseSha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: gitDir,
+        encoding: "utf8",
+      }).trim();
+
+      writeFileSync(path.join(gitDir, "a.txt"), "change");
+      execFileSync("git", ["add", "a.txt"], { cwd: gitDir });
+      execFileSync("git", ["commit", "-m", "Plain commit without trailer"], {
+        cwd: gitDir,
+      });
+      const headSha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: gitDir,
+        encoding: "utf8",
+      }).trim();
+
+      const sessions = await listReviewTraceSessions({
+        rootPath: gitDir,
+        baseCommit: baseSha,
+        headCommit: headSha,
+      });
+      expect(sessions).toEqual([]);
+    });
+  });
+
   describe("lookupReviewTraceBlame", () => {
     it("blames lines and resolves unique commits in default mode and history mode", async () => {
       const gitDir = path.join(tempDir, "repo-blame");

--- a/packages/progressive-review/src/review-agent-traces.ts
+++ b/packages/progressive-review/src/review-agent-traces.ts
@@ -152,6 +152,9 @@ export async function listReviewTraceSessions(input: {
   if (sessions.size === 0 && commits.length <= R2_COMMIT_LOOKUP_LIMIT) {
     await addSessionsFromR2Index(commits, sessions);
   }
+  if (sessions.size === 0 && commits.length <= R2_COMMIT_LOOKUP_LIMIT) {
+    await addSessionsFromPrScan(input.rootPath, commits, sessions);
+  }
 
   const descriptors: ReviewTraceSessionDescriptor[] = [];
   for (const ref of sessions.values()) {
@@ -672,56 +675,17 @@ export async function lookupReviewTraceCommit(input: {
 
   // Step 3: PR scan if commit subject ends in PR number
   if (pr !== null) {
-    const fetchRes = await runGit(input.cwd, [
-      "fetch",
-      "--quiet",
-      "origin",
-      `refs/pull/${pr}/head`,
-    ]);
-    if (fetchRes.ok) {
-      let revListRes = await runGit(input.cwd, [
-        "rev-list",
-        "FETCH_HEAD",
-        "--not",
-        `${commit}^`,
-      ]);
-      if (!revListRes.ok) {
-        revListRes = await runGit(input.cwd, [
-          "rev-list",
-          "FETCH_HEAD",
-          "--not",
-          `${commit}~1`,
-        ]);
-      }
-      if (!revListRes.ok) {
-        revListRes = await runGit(input.cwd, ["rev-list", "FETCH_HEAD"]);
-      }
-      if (revListRes.ok) {
-        const branchShas = revListRes.stdout
-          .trim()
-          .split(/\s+/)
-          .filter(Boolean);
-        const prSessions: string[] = [];
-        for (const branchSha of branchShas) {
-          const sessionsOnSha = await readTrailerSessions(input.cwd, branchSha);
-          for (const s of sessionsOnSha) {
-            if (!prSessions.includes(s)) {
-              prSessions.push(s);
-            }
-          }
-        }
-        if (prSessions.length > 0) {
-          const sessionMeta = await enrichSessionMeta(prSessions);
-          return {
-            commit,
-            sessions: prSessions,
-            pr,
-            branch: null,
-            source: "pr-scan",
-            ...(sessionMeta ? { session_meta: sessionMeta } : {}),
-          };
-        }
-      }
+    const prSessions = await prScanTrailerSessions(input.cwd, commit, pr);
+    if (prSessions.length > 0) {
+      const sessionMeta = await enrichSessionMeta(prSessions);
+      return {
+        commit,
+        sessions: prSessions,
+        pr,
+        branch: null,
+        source: "pr-scan",
+        ...(sessionMeta ? { session_meta: sessionMeta } : {}),
+      };
     }
   }
 
@@ -1380,7 +1344,10 @@ export async function readSubjectPullNumber(
     { allowFailure: true },
   );
   if (!result.ok) return null;
-  const subject = result.stdout.trim();
+  return subjectPullNumber(result.stdout.trim());
+}
+
+export function subjectPullNumber(subject: string): number | null {
   const match = /\(#(\d+)\)$/.exec(subject);
   return match ? Number(match[1]) : null;
 }
@@ -1843,6 +1810,79 @@ export async function listSessionSubagents(
   }
 
   return [...subagents].sort();
+}
+
+export async function prScanTrailerSessions(
+  cwd: string,
+  commit: string,
+  pr: number,
+): Promise<string[]> {
+  const fetchRes = await runGit(cwd, [
+    "fetch",
+    "--quiet",
+    "origin",
+    `refs/pull/${pr}/head`,
+  ]);
+  if (!fetchRes.ok) return [];
+  let revListRes = await runGit(cwd, [
+    "rev-list",
+    "FETCH_HEAD",
+    "--not",
+    `${commit}^`,
+  ]);
+  if (!revListRes.ok) {
+    revListRes = await runGit(cwd, [
+      "rev-list",
+      "FETCH_HEAD",
+      "--not",
+      `${commit}~1`,
+    ]);
+  }
+  if (!revListRes.ok) {
+    revListRes = await runGit(cwd, ["rev-list", "FETCH_HEAD"]);
+  }
+  if (!revListRes.ok) return [];
+  const branchShas = revListRes.stdout.trim().split(/\s+/).filter(Boolean);
+  const prSessions: string[] = [];
+  for (const branchSha of branchShas) {
+    const sessionsOnSha = await readTrailerSessions(cwd, branchSha);
+    for (const s of sessionsOnSha) {
+      if (!prSessions.includes(s)) {
+        prSessions.push(s);
+      }
+    }
+  }
+  return prSessions;
+}
+
+// A squash merge rewrites the commit message from the pull request title
+// and body, so the Agent-Session trailers written by the repository hooks
+// never reach the commit that lands on the target branch. When the range
+// carries no trailers and no index entries, scan each commit's pull
+// request branch for the trailers instead.
+async function addSessionsFromPrScan(
+  rootPath: string,
+  commits: CommitWithSessions[],
+  sessions: Map<string, ReviewTraceSessionRef>,
+): Promise<void> {
+  const scannedPrs = new Set<number>();
+  for (const commit of commits) {
+    const pr = subjectPullNumber(commit.subject);
+    if (pr === null || scannedPrs.has(pr)) continue;
+    scannedPrs.add(pr);
+    const prSessions = await prScanTrailerSessions(rootPath, commit.sha, pr);
+    for (const sessionId of prSessions) {
+      const existing = sessions.get(sessionId);
+      if (existing) {
+        existing.commits.push({ sha: commit.sha, subject: commit.subject });
+      } else {
+        sessions.set(sessionId, {
+          sessionId,
+          commits: [{ sha: commit.sha, subject: commit.subject }],
+        });
+      }
+    }
+  }
 }
 
 async function addSessionsFromR2Index(


### PR DESCRIPTION
## Summary

- squash merges rewrite the commit message, dropping `Agent-Session:` trailers, so Reviews pinned to a merge commit on main showed no trace tab and an empty full-trace view
- the change-range resolver behind scaffold and the desktop trace view (`listReviewTraceSessions`) now falls back to scanning the pull request branch (`refs/pull/<n>/head`) for trailers when the range carries none and the R2 index has no entries — the same third step the single-commit lookup (`lookupReviewTraceCommit`) already had
- the PR-scan logic is extracted into a shared `prScanTrailerSessions` helper used by both resolvers

## Validation

- `pnpm --filter @dev.fast/review test -- src/review-agent-traces.test.ts` (17 passing, including two new squash-merge fallback tests against a fake origin with `refs/pull/<n>/head`)
- `pnpm lint`, `pnpm format:check`
- typecheck has two pre-existing failures on main (`scripts/check-tutorial.ts`, `src/server/bug-report.ts`) untouched by this change
