### PR TITLE
Store CLI thread replies as agent responses

### DIFF
--- a/packages/progressive-review/src/threads-cli.test.ts
+++ b/packages/progressive-review/src/threads-cli.test.ts
@@ -9,6 +9,7 @@ import { promisify } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { type StoredReview, createReviewDir } from "./review-home";
+import { requireCompletedAgentResponsesForRepublish } from "./review-publish-thread-gate";
 import { appendReviewComment } from "./review-state-store";
 import {
   closeAllReviewThreadStores,
@@ -86,9 +87,22 @@ describe("review threads CLI", () => {
       status: "resolved",
       messages: [
         { body: "Please fix.", by: "Reviewer" },
-        { body: "Fixed in the latest revision.", by: "Agent" },
+        { body: "Fixed in the latest revision.", by: "Agent", role: "agent" },
       ],
     });
+
+    // The reply counts as the completed model response the republish gate
+    // requires for current-round threads.
+    expect(() =>
+      requireCompletedAgentResponsesForRepublish({
+        ...review,
+        review: {
+          ...review.review,
+          presentedDocumentRevision: "published-revision",
+          lastPublishedAt: "2000-01-01T00:00:00.000Z",
+        },
+      }),
+    ).not.toThrow();
 
     expect(existsSync(reviewThreadDbPath(document))).toBe(true);
   });

--- a/packages/progressive-review/src/threads-cli.ts
+++ b/packages/progressive-review/src/threads-cli.ts
@@ -5,7 +5,7 @@ import { ReviewCommentThreadRecordSchema } from "./review-comment-schema";
 import { reviewUuidForManagedCheckout } from "./review-head-checkout";
 import { type StoredReview, findReview, listReviews } from "./review-home";
 import {
-  appendReviewComment,
+  appendReviewAgentMessage,
   readReviewComments,
   updateReviewComment,
 } from "./review-state-store";
@@ -149,12 +149,16 @@ export async function runReviewThreadsReply(
     throw new Error(`Comment thread not found: ${input.threadId}`);
   }
   const messageId = randomUUID();
-  appendReviewComment(document, {
-    threadId: input.threadId,
-    messageId,
-    target: thread.target,
+  // The republish gate requires a completed model response with role "agent"
+  // on every current-round thread, so a CLI reply must not read as another
+  // reviewer message.
+  appendReviewAgentMessage(document, input.threadId, {
+    id: messageId,
+    by: input.author?.trim() || "Agent",
+    at: new Date().toISOString(),
     body,
-    author: input.author?.trim() || "Agent",
+    role: "agent",
+    format: "plain",
   });
   input.stdout.write(
     `${JSON.stringify({


### PR DESCRIPTION
## Summary

- `review threads reply` stored its message without a role, so the republish gate (`requireCompletedAgentResponsesForRepublish`) counted the agent's own reply as another reviewer message and blocked `review publish` indefinitely
- the reply now writes through `appendReviewAgentMessage` with `role: "agent"`, the same record the desktop's in-app agent flows produce, so a CLI reply satisfies the gate

## Validation

- `pnpm --filter @dev.fast/review test -- src/threads-cli.test.ts src/review-publish-thread-gate.test.ts src/cli.test.ts` — the reply test now asserts the stored role and that the republish gate accepts the thread
- `pnpm lint`, `pnpm format:check`

Stacked on #61.
