### PR TITLE
Support S3-compatible trace stores beyond R2

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
@@ -1401,6 +1401,7 @@ export const ReviewCliInstallStatusSchema = z.strictObject({
     settingsPath: requiredString,
     endpoint: requiredString.optional(),
     bucket: requiredString.optional(),
+    region: requiredString.optional(),
     accessKeyIdPrefix: requiredString.optional(),
     verifiedAt: requiredString.optional(),
     error: requiredString.optional(),
@@ -1431,6 +1432,7 @@ export const ReviewCliInstallApplyRequestSchema = z
           bucket: requiredString.optional(),
           key: requiredString.optional(),
           secret: requiredString.optional(),
+          region: requiredString.optional(),
         }),
       ])
       .optional(),

--- a/packages/progressive-review/app/src/trace-capture-section.tsx
+++ b/packages/progressive-review/app/src/trace-capture-section.tsx
@@ -31,6 +31,9 @@ export function TraceCaptureSection({
   const [traceBucket, setTraceBucket] = useState(
     install.status.trace.bucket ?? "",
   );
+  const [traceRegion, setTraceRegion] = useState(
+    install.status.trace.region ?? "",
+  );
   const [traceKey, setTraceKey] = useState("");
   const [traceSecret, setTraceSecret] = useState("");
 
@@ -99,41 +102,47 @@ export function TraceCaptureSection({
               : "off"}
         </span>
         <span className="review-agent-setup-cli">
-          Records agent sessions to your own R2 bucket so reviews can quote
+          Records agent sessions to your own S3/R2 bucket so reviews can quote
           them. Session hooks activate each Git or Jujutsu repository when an
           agent session starts.
         </span>
       </div>
       <div className="review-agent-setup-trace-fields">
         <input
-          aria-label="R2 endpoint URL"
-          placeholder="R2 endpoint URL"
+          aria-label="S3/R2 endpoint URL"
+          placeholder="S3/R2 endpoint URL"
           value={traceEndpoint}
           onChange={(event) => setTraceEndpoint(event.currentTarget.value)}
         />
         <input
-          aria-label="R2 bucket"
-          placeholder="R2 bucket"
+          aria-label="S3/R2 bucket"
+          placeholder="S3/R2 bucket"
           value={traceBucket}
           onChange={(event) => setTraceBucket(event.currentTarget.value)}
         />
         <input
-          aria-label="R2 access key ID"
+          aria-label="S3/R2 region"
+          placeholder="Region (auto for R2)"
+          value={traceRegion}
+          onChange={(event) => setTraceRegion(event.currentTarget.value)}
+        />
+        <input
+          aria-label="S3/R2 access key ID"
           placeholder={
             status.trace.accessKeyIdPrefix
               ? `Access key (${status.trace.accessKeyIdPrefix}…)`
-              : "R2 access key ID"
+              : "S3/R2 access key ID"
           }
           value={traceKey}
           onChange={(event) => setTraceKey(event.currentTarget.value)}
         />
         <input
-          aria-label="R2 secret access key"
+          aria-label="S3/R2 secret access key"
           type="password"
           placeholder={
             status.trace.configured
               ? "Secret key (unchanged)"
-              : "R2 secret access key"
+              : "S3/R2 secret access key"
           }
           value={traceSecret}
           onChange={(event) => setTraceSecret(event.currentTarget.value)}
@@ -166,6 +175,7 @@ export function TraceCaptureSection({
                 trace: {
                   ...(traceEndpoint ? { endpoint: traceEndpoint } : {}),
                   ...(traceBucket ? { bucket: traceBucket } : {}),
+                  ...(traceRegion ? { region: traceRegion } : {}),
                   ...(traceKey ? { key: traceKey } : {}),
                   ...(traceSecret ? { secret: traceSecret } : {}),
                 },

--- a/packages/progressive-review/src/cli-runner.ts
+++ b/packages/progressive-review/src/cli-runner.ts
@@ -553,19 +553,23 @@ export async function runProgressiveReviewCli(
       )
       .option(
         "--trace-endpoint <url>",
-        "R2 endpoint URL (experimental trace capture)",
+        "S3/R2 endpoint URL (experimental trace capture)",
       )
       .option(
         "--trace-bucket <name>",
-        "R2 bucket name (experimental trace capture)",
+        "S3/R2 bucket name (experimental trace capture)",
       )
       .option(
         "--trace-key <id>",
-        "R2 access key ID (experimental trace capture)",
+        "S3/R2 access key ID (experimental trace capture)",
       )
       .option(
         "--trace-secret <key>",
-        "R2 secret access key (experimental trace capture)",
+        "S3/R2 secret access key (experimental trace capture)",
+      )
+      .option(
+        "--trace-region <region>",
+        "SigV4 signing region; default auto for R2, set the bucket region for S3",
       )
       .option(
         "--without-traces",
@@ -588,6 +592,7 @@ export async function runProgressiveReviewCli(
         traceBucket?: string;
         traceKey?: string;
         traceSecret?: string;
+        traceRegion?: string;
         shim?: boolean;
       },
     ) => {
@@ -612,6 +617,7 @@ export async function runProgressiveReviewCli(
                   bucket: options.traceBucket,
                   key: options.traceKey,
                   secret: options.traceSecret,
+                  region: options.traceRegion,
                 },
               },
             }
@@ -775,7 +781,7 @@ export async function runProgressiveReviewCli(
   configureOutput(
     trace
       .command("status")
-      .description("Verify R2 trace storage configuration and connectivity"),
+      .description("Verify S3/R2 trace storage configuration and connectivity"),
     "plain",
   ).action(async () => {
     state.exitCode = await runtime.runReviewTraceStatus({
@@ -1347,7 +1353,7 @@ function progressiveReviewInstallHelp(): string {
     "  review install claude cursor",
     "  review install all",
     "",
-    "Trace capture (experimental) is off unless R2 credentials are given:",
+    "Trace capture (experimental) is off unless S3/R2 credentials are given:",
     "  review install codex --trace-endpoint <url> --trace-bucket <name> --trace-key <id> --trace-secret <key>",
   ].join("\n");
 }

--- a/packages/progressive-review/src/review-agent-traces.ts
+++ b/packages/progressive-review/src/review-agent-traces.ts
@@ -1066,7 +1066,7 @@ export async function syncReviewTrace(input: {
   }
   if (!isTraceR2Configured()) {
     throw new Error(
-      "R2 storage is not configured. Use Review Agent Setup to configure trace capture.",
+      "S3/R2 storage is not configured. Use Review Agent Setup to configure trace capture.",
     );
   }
 
@@ -1136,7 +1136,7 @@ export async function syncReviewTrace(input: {
   );
   if (!metaSaved) {
     throw new Error(
-      `Failed to update session metadata for ${sessionId} in R2 storage.`,
+      `Failed to update session metadata for ${sessionId} in S3/R2 storage.`,
     );
   }
 
@@ -1216,7 +1216,7 @@ export async function checkReviewTraceDoctor(input?: {
       ok: false,
       envPath,
       reachable: false,
-      error: "Configuration is missing one or more required R2 values.",
+      error: "Configuration is missing one or more required S3/R2 values.",
     };
   }
 
@@ -1225,7 +1225,7 @@ export async function checkReviewTraceDoctor(input?: {
       "aws",
       [
         "--region",
-        "auto",
+        config.region,
         "--endpoint-url",
         config.endpoint,
         "s3api",
@@ -1448,6 +1448,9 @@ export interface TraceR2Config {
   endpoint: string;
   accessKeyId: string;
   secretAccessKey: string;
+  // SigV4 signing region. R2 accepts "auto"; AWS S3 needs the bucket's
+  // real region.
+  region: string;
 }
 
 let cachedTraceEnv: Record<string, string> | null = null;
@@ -1490,7 +1493,8 @@ export function traceR2Config(): TraceR2Config | null {
     traceEnvValue("TRACE_R2_SECRET_ACCESS_KEY") ??
     traceEnvValue("AWS_SECRET_ACCESS_KEY");
   if (!bucket || !endpoint || !accessKeyId || !secretAccessKey) return null;
-  return { bucket, endpoint, accessKeyId, secretAccessKey };
+  const region = traceEnvValue("TRACE_R2_REGION") ?? "auto";
+  return { bucket, endpoint, accessKeyId, secretAccessKey, region };
 }
 
 const execFileAsync = promisify(execFile);
@@ -1515,7 +1519,7 @@ export async function r2HeadObjectSize(key: string): Promise<number | null> {
       "aws",
       [
         "--region",
-        "auto",
+        config.region,
         "--endpoint-url",
         config.endpoint,
         "s3api",
@@ -1569,7 +1573,7 @@ export async function r2GetObject(
       "aws",
       [
         "--region",
-        "auto",
+        config.region,
         "--endpoint-url",
         config.endpoint,
         "s3api",
@@ -1653,7 +1657,7 @@ export async function r2PutFile(
       "aws",
       [
         "--region",
-        "auto",
+        config.region,
         "--endpoint-url",
         config.endpoint,
         "s3",
@@ -1724,7 +1728,7 @@ export async function r2PutIfGrown(
   }
   const uploaded = await r2PutFile(key, filePath);
   if (!uploaded) {
-    throw new Error(`Failed to upload ${key} to R2 storage.`);
+    throw new Error(`Failed to upload ${key} to S3/R2 storage.`);
   }
   return true;
 }
@@ -1771,7 +1775,7 @@ export async function listSessionSubagents(
           "aws",
           [
             "--region",
-            "auto",
+            config.region,
             "--endpoint-url",
             config.endpoint,
             "s3api",

--- a/packages/progressive-review/src/review-scaffold.ts
+++ b/packages/progressive-review/src/review-scaffold.ts
@@ -354,7 +354,7 @@ function reportTraceSessionsProgress(
           : s.harness === "pi"
             ? "Pi"
             : "unknown";
-    const syncLabel = s.available ? "[R2 synced]" : "[not synced]";
+    const syncLabel = s.available ? "[S3/R2 synced]" : "[not synced]";
     progress(`  ${shortId} (${harness})  ${syncLabel}`);
   }
 }

--- a/packages/progressive-review/src/trace-cli.test.ts
+++ b/packages/progressive-review/src/trace-cli.test.ts
@@ -73,6 +73,26 @@ describe("trace-cli", () => {
     expect(content).toContain(
       'export TRACE_R2_SECRET_ACCESS_KEY="test-secret-key"',
     );
+    // Without an explicit region the machine keeps R2's "auto" signing region.
+    expect(content).toContain('export TRACE_R2_REGION="auto"');
+    expect(status.region).toBe("auto");
+  });
+
+  it("stores an explicit S3 signing region", async () => {
+    const status = await configureTraceMachine({
+      credentials: {
+        endpoint: "https://s3.us-east-1.amazonaws.com",
+        bucket: "test-bucket",
+        key: "test-key-id",
+        secret: "test-secret-key",
+        region: "us-east-1",
+      },
+    });
+
+    expect(readFileSync(envFile, "utf8")).toContain(
+      'export TRACE_R2_REGION="us-east-1"',
+    );
+    expect(status.region).toBe("us-east-1");
   });
 
   it("fails setup when required options are missing in nonInteractive mode", async () => {

--- a/packages/progressive-review/src/trace-cli.ts
+++ b/packages/progressive-review/src/trace-cli.ts
@@ -64,13 +64,15 @@ export async function runReviewTraceStatus(input: {
   }
 
   if (doctor.reachable && doctor.config) {
-    input.stdout.write(`✓ R2 bucket "${doctor.config.bucket}" is reachable.\n`);
+    input.stdout.write(
+      `✓ S3/R2 bucket "${doctor.config.bucket}" is reachable.\n`,
+    );
     return 0;
   }
 
   if (doctor.config) {
     input.stderr.write(
-      `✗ Cannot reach R2 bucket "${doctor.config.bucket}": ${doctor.error ?? "unknown error"}\n`,
+      `✗ Cannot reach S3/R2 bucket "${doctor.config.bucket}": ${doctor.error ?? "unknown error"}\n`,
     );
   }
   return 1;
@@ -183,7 +185,7 @@ export async function runReviewTraceList(input: {
   for (const session of publicSessions) {
     input.stdout.write(
       `${session.id}  (${session.harness}, ${
-        session.available ? "R2 synced" : "not synced"
+        session.available ? "S3/R2 synced" : "not synced"
       })\n`,
     );
     for (const commit of session.commits) {

--- a/packages/progressive-review/src/trace-machine-setup.ts
+++ b/packages/progressive-review/src/trace-machine-setup.ts
@@ -13,6 +13,9 @@ export interface TraceCredentialsInput {
   bucket?: string;
   key?: string;
   secret?: string;
+  // SigV4 signing region. R2 accepts "auto"; AWS S3 needs the bucket's
+  // real region.
+  region?: string;
 }
 
 export interface TraceMachineStatus {
@@ -23,6 +26,7 @@ export interface TraceMachineStatus {
   settingsPath: string;
   endpoint?: string;
   bucket?: string;
+  region?: string;
   accessKeyIdPrefix?: string;
   verifiedAt?: string;
   error?: string;
@@ -80,7 +84,11 @@ export async function readTraceCredentials(
     secret:
       env.TRACE_R2_SECRET_ACCESS_KEY ?? values.TRACE_R2_SECRET_ACCESS_KEY ?? "",
   };
-  return Object.values(credentials).every(Boolean) ? credentials : null;
+  if (!Object.values(credentials).every(Boolean)) return null;
+  return {
+    ...credentials,
+    region: env.TRACE_R2_REGION ?? values.TRACE_R2_REGION ?? "auto",
+  };
 }
 
 export async function traceMachineStatus(
@@ -106,6 +114,7 @@ export async function traceMachineStatus(
       ? {
           endpoint: credentials.endpoint,
           bucket: credentials.bucket,
+          region: credentials.region,
           accessKeyIdPrefix: credentials.key.slice(0, 6),
         }
       : {}),
@@ -140,9 +149,11 @@ export async function configureTraceMachine(input: {
   };
   if (!Object.values(credentials).every(Boolean)) {
     throw new Error(
-      "Trace setup needs an R2 endpoint, bucket, access key ID, and secret access key.",
+      "Trace setup needs an S3/R2 endpoint, bucket, access key ID, and secret access key.",
     );
   }
+  const region =
+    input.credentials?.region?.trim() || existing?.region || "auto";
 
   const envPath = traceEnvPath(homeDir, env);
   await mkdir(path.dirname(envPath), { recursive: true });
@@ -153,6 +164,7 @@ export async function configureTraceMachine(input: {
       `export TRACE_R2_BUCKET=${JSON.stringify(credentials.bucket)}`,
       `export TRACE_R2_ACCESS_KEY_ID=${JSON.stringify(credentials.key)}`,
       `export TRACE_R2_SECRET_ACCESS_KEY=${JSON.stringify(credentials.secret)}`,
+      `export TRACE_R2_REGION=${JSON.stringify(region)}`,
       "",
     ].join("\n"),
     { mode: 0o600 },
@@ -171,7 +183,7 @@ export async function configureTraceMachine(input: {
           "aws",
           [
             "--region",
-            "auto",
+            region,
             "--endpoint-url",
             credentials.endpoint,
             "s3api",

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1398,6 +1398,7 @@ export const ReviewCliInstallStatusSchema = z.strictObject({
     settingsPath: requiredString,
     endpoint: requiredString.optional(),
     bucket: requiredString.optional(),
+    region: requiredString.optional(),
     accessKeyIdPrefix: requiredString.optional(),
     verifiedAt: requiredString.optional(),
     error: requiredString.optional(),
@@ -1428,6 +1429,7 @@ export const ReviewCliInstallApplyRequestSchema = z
           bucket: requiredString.optional(),
           key: requiredString.optional(),
           secret: requiredString.optional(),
+          region: requiredString.optional(),
         }),
       ])
       .optional(),


### PR DESCRIPTION
## Summary

- trace storage already speaks pure S3 (aws CLI `s3api` calls with a configurable endpoint), but every call hardcoded `--region auto`, which R2 accepts and AWS S3 rejects in the SigV4 credential scope
- the signing region is now configurable: `TRACE_R2_REGION` in the machine env file (default `auto`), threaded through all six aws call sites, `--trace-region` on `review install`, an optional `region` on the trace credentials protocol, and a Region field in the trace settings UI
- product-facing trace settings now say S3/R2 instead of R2 (description, field labels/placeholders, setup error, CLI option help)

## Validation

- `pnpm --filter @dev.fast/review test -- src/trace-cli.test.ts src/review-agent-traces.test.ts app/src/trace-capture-section.test.tsx src/cli.test.ts src/server/cli-install.test.ts` — new tests cover the `auto` default and an explicit `us-east-1` region round-tripping through the env file and status
- `pnpm --filter @dev.fast/review-protocol test`, `pnpm lint`, `pnpm format:check`; protocol mirror synced via `protocol:sync`
- typecheck carries the two pre-existing failures on main (`check-tutorial.ts`, `bug-report.ts`), untouched here

Stacked on #62.
