### PR TITLE
Add Review Desktop preview release channel

### DIFF
--- a/.github/workflows/review-desktop-preview.yml
+++ b/.github/workflows/review-desktop-preview.yml
@@ -1,0 +1,400 @@
+name: Review Desktop Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or commit to build"
+        required: true
+        type: string
+        default: main
+      dry_run:
+        description: "Build and validate only. Do not upload."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: review-desktop-preview
+  cancel-in-progress: false
+
+jobs:
+  version:
+    name: Compute preview version
+    # Approval gates every downstream job before any preview code reaches the
+    # release-only build infrastructure or signing credentials.
+    environment: review-release
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      commit: ${{ steps.version.outputs.commit }}
+    steps:
+      - name: Checkout preview ref
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Compute preview version
+        id: version
+        shell: bash
+        run: |
+          CURRENT=$(node -p "require('./apps/review-desktop/package.json').version")
+          if [[ "$CURRENT" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)([-+].*)?$ ]]; then
+            PATCH="${BASH_REMATCH[3]}"
+            NEXT_PATCH="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((PATCH + 1))"
+          else
+            echo "::error::Cannot compute next patch from ${CURRENT}"
+            exit 1
+          fi
+          VERSION="${NEXT_PATCH}-preview.$(date -u +%Y%m%d).${GITHUB_RUN_NUMBER}"
+          COMMIT=$(git rev-parse HEAD)
+
+          echo "Building Review Desktop ${VERSION} from ${COMMIT}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
+
+  compile:
+    name: Compile Darwin payload on Linux
+    needs: version
+    runs-on: review_big_boy
+    timeout-minutes: 45
+    steps:
+      - name: Checkout preview ref
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Stamp preview release channel
+        run: |
+          node apps/review-desktop/scripts/stamp-release-channel.mjs \
+            --version "${{ needs.version.outputs.version }}" \
+            --quality preview
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+
+      - name: Setup monorepo Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install monorepo dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Headers for the Code OSS native modules npm ci builds from source.
+      - name: Install Code OSS native build prerequisites
+        run: |
+          # The hosted runner image lists an HTTP Azure mirror first. That
+          # mirror can accept the release file and then hang on package indexes.
+          echo 'https://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libx11-dev libxkbfile-dev libkrb5-dev libsecret-1-dev
+
+      - name: Setup Code OSS Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: apps/review-desktop/code-oss/.nvmrc
+          cache: npm
+          cache-dependency-path: apps/review-desktop/code-oss/**/package-lock.json
+
+      - name: Restore Code OSS dependencies
+        id: code-oss-deps
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            apps/review-desktop/code-oss/node_modules
+            apps/review-desktop/code-oss/build/node_modules
+            apps/review-desktop/code-oss/extensions/node_modules
+            apps/review-desktop/code-oss/extensions/*/node_modules
+            apps/review-desktop/code-oss/extensions/*/server/node_modules
+            apps/review-desktop/code-oss/.build/distro/npm/node_modules
+            apps/review-desktop/code-oss/.build/distro/npm/remote/node_modules
+            apps/review-desktop/code-oss/.build/distro/npm/remote/web/node_modules
+            ~/.cache/node-gyp
+          key: ${{ runner.os }}-code-oss-deps-v2-${{ hashFiles('apps/review-desktop/code-oss/**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-code-oss-deps-v2-
+
+      # Linux owns every platform-independent build output and also downloads
+      # the pinned darwin-arm64 VSIX payloads. The macOS job packages this
+      # archive; it must not silently rebuild or omit anything transferred here.
+      - name: Compile Darwin payload on Linux
+        env:
+          # Embeds the PostHog project key into the review runtime build so
+          # released apps ship telemetry enabled. Source builds embed nothing.
+          REVIEW_POSTHOG_KEY: ${{ vars.REVIEW_POSTHOG_KEY }}
+        run: bash apps/review-desktop/scripts/compile-darwin-payload.sh
+
+      - name: Upload darwin payload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: darwin-payload
+          path: apps/review-desktop/dist/darwin-payload.tar.zst
+          retention-days: 3
+          compression-level: 0
+
+      - name: Check for existing Code OSS dependency cache
+        if: steps.code-oss-deps.outputs.cache-hit != 'true'
+        id: code-oss-deps-lookup
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            apps/review-desktop/code-oss/node_modules
+          key: ${{ runner.os }}-code-oss-deps-v2-${{ hashFiles('apps/review-desktop/code-oss/**/package-lock.json') }}
+          lookup-only: true
+
+      - name: Save Code OSS dependencies
+        if: steps.code-oss-deps.outputs.cache-hit != 'true' && steps.code-oss-deps-lookup.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            apps/review-desktop/code-oss/node_modules
+            apps/review-desktop/code-oss/build/node_modules
+            apps/review-desktop/code-oss/extensions/node_modules
+            apps/review-desktop/code-oss/extensions/*/node_modules
+            apps/review-desktop/code-oss/extensions/*/server/node_modules
+            apps/review-desktop/code-oss/.build/distro/npm/node_modules
+            apps/review-desktop/code-oss/.build/distro/npm/remote/node_modules
+            apps/review-desktop/code-oss/.build/distro/npm/remote/web/node_modules
+            ~/.cache/node-gyp
+          key: ${{ runner.os }}-code-oss-deps-v2-${{ hashFiles('apps/review-desktop/code-oss/**/package-lock.json') }}
+
+  build:
+    name: Build, sign, publish preview
+    needs: [version, compile]
+    runs-on: macos-15-xlarge
+    timeout-minutes: 90
+    env:
+      RELEASE_VERSION: ${{ needs.version.outputs.version }}
+      RELEASE_COMMIT: ${{ needs.version.outputs.commit }}
+    steps:
+      - name: Checkout preview ref
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Stamp preview release channel
+        run: |
+          node apps/review-desktop/scripts/stamp-release-channel.mjs \
+            --version "$RELEASE_VERSION" \
+            --quality preview
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+
+      - name: Setup monorepo Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install monorepo dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Code OSS Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: apps/review-desktop/code-oss/.nvmrc
+          cache: npm
+          cache-dependency-path: apps/review-desktop/code-oss/**/package-lock.json
+
+      - name: Restore Code OSS dependencies
+        id: code-oss-deps
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            apps/review-desktop/code-oss/node_modules
+            apps/review-desktop/code-oss/build/node_modules
+            apps/review-desktop/code-oss/extensions/node_modules
+            apps/review-desktop/code-oss/extensions/*/node_modules
+            apps/review-desktop/code-oss/extensions/*/server/node_modules
+            apps/review-desktop/code-oss/.build/distro/npm/node_modules
+            apps/review-desktop/code-oss/.build/distro/npm/remote/node_modules
+            apps/review-desktop/code-oss/.build/distro/npm/remote/web/node_modules
+            apps/review-desktop/code-oss/.build/electron
+            ~/.cache/node-gyp
+          key: ${{ runner.os }}-code-oss-deps-v2-${{ hashFiles('apps/review-desktop/code-oss/**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-code-oss-deps-v2-
+
+      - name: Download darwin payload
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: darwin-payload
+          path: ${{ runner.temp }}/darwin-payload
+
+      - name: Extract darwin payload
+        run: |
+          zstd -dc "$RUNNER_TEMP/darwin-payload/darwin-payload.tar.zst" | tar -xf - -C .
+
+      # package-macos.sh checks the complete handoff before Gulp runs, stages
+      # every manifest-selected curated extension, and verifies the final app
+      # before signing. validate-release-artifacts.mjs repeats that extension
+      # check after notarization and before any upload.
+
+      # Carson's keychain bootstrap: decode the Developer ID cert into a
+      # throwaway keychain that sign.ts finds via AGENT_TEMPDIRECTORY.
+      - name: Import Apple signing certificate
+        env:
+          APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+        run: |
+          CERT_PATH="$RUNNER_TEMP/apple-signing-cert.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/buildagent.keychain"
+          echo "$APPLE_CERT_BASE64" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign
+          # Append rather than replace: `-s "$KEYCHAIN_PATH"` alone evicts
+          # login.keychain from the search list for the rest of the job.
+          # shellcheck disable=SC2046
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | xargs)
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+          rm -f "$CERT_PATH"
+
+      # An App Store Connect team key, not an Apple ID password: it survives
+      # password and 2FA changes on the Apple ID, and the private key stays a
+      # file rather than an environment value.
+      - name: Write App Store Connect notary key
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          KEY_PATH="$RUNNER_TEMP/notary-key.p8"
+          printf '%s\n' "$APPLE_API_KEY_P8" > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+
+      - name: Package, sign, and notarize
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          AGENT_TEMPDIRECTORY: ${{ runner.temp }}
+          CODESIGN_IDENTITY: "Developer ID Application: ${{ vars.APPLE_SIGN_IDENTITY }}"
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/notary-key.p8
+          APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ vars.APPLE_API_ISSUER_ID }}
+          SKIP_NOTARIZE: ${{ vars.SKIP_NOTARIZE }}
+          REVIEW_DESKTOP_PRECOMPILED: "1"
+        run: |
+          # The build can run well over an hour before the first codesign call.
+          security unlock-keychain -p "${{ secrets.APPLE_KEYCHAIN_PASSWORD }}" \
+            "$RUNNER_TEMP/buildagent.keychain"
+          pnpm --filter @dev-fast/review-desktop app:package:macos
+
+      - name: Check for existing Code OSS dependency cache
+        if: steps.code-oss-deps.outputs.cache-hit != 'true'
+        id: code-oss-deps-lookup
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            apps/review-desktop/code-oss/node_modules
+          key: ${{ runner.os }}-code-oss-deps-v2-${{ hashFiles('apps/review-desktop/code-oss/**/package-lock.json') }}
+          lookup-only: true
+
+      - name: Save Code OSS dependencies
+        if: steps.code-oss-deps.outputs.cache-hit != 'true' && steps.code-oss-deps-lookup.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            apps/review-desktop/code-oss/node_modules
+            apps/review-desktop/code-oss/build/node_modules
+            apps/review-desktop/code-oss/extensions/node_modules
+            apps/review-desktop/code-oss/extensions/*/node_modules
+            apps/review-desktop/code-oss/extensions/*/server/node_modules
+            apps/review-desktop/code-oss/.build/distro/npm/node_modules
+            apps/review-desktop/code-oss/.build/distro/npm/remote/node_modules
+            apps/review-desktop/code-oss/.build/distro/npm/remote/web/node_modules
+            apps/review-desktop/code-oss/.build/electron
+            ~/.cache/node-gyp
+          key: ${{ runner.os }}-code-oss-deps-v2-${{ hashFiles('apps/review-desktop/code-oss/**/package-lock.json') }}
+
+      - name: Validate release artifacts
+        run: |
+          node apps/review-desktop/scripts/validate-release-artifacts.mjs \
+            --version "$RELEASE_VERSION" \
+            --commit "$RELEASE_COMMIT" \
+            --channel preview
+
+      # Signed and stapled says nothing about whether the app runs. Launch it
+      # and require a renderer before anything reaches R2.
+      - name: Smoke launch the packaged app
+        run: node apps/review-desktop/scripts/smoke-launch-packaged.mjs
+
+      # Payloads first, manifest last: a client must never see a latest.json
+      # whose zip is not yet downloadable.
+      - name: Upload preview to R2
+        if: ${{ !inputs.dry_run }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_ENDPOINT_URL: ${{ vars.R2_ENDPOINT_URL }}
+          AWS_REGION: auto
+          R2_BUCKET: ${{ vars.R2_RELEASE_BUCKET }}
+        run: |
+          DIST=apps/review-desktop/dist
+          RELEASE_PREFIX="s3://${R2_BUCKET}/releases/${RELEASE_VERSION}/darwin-arm64"
+          DMG_DISPOSITION="attachment; filename=\"df-review-${RELEASE_VERSION}.dmg\""
+
+          aws s3 cp "$DIST/Review-darwin-arm64-${RELEASE_VERSION}.zip" \
+            "${RELEASE_PREFIX}/Review-darwin-arm64-${RELEASE_VERSION}.zip" \
+            --content-type application/zip
+          aws s3 cp "$DIST/Review-darwin-arm64-${RELEASE_VERSION}.dmg" \
+            "${RELEASE_PREFIX}/Review-darwin-arm64-${RELEASE_VERSION}.dmg" \
+            --content-type application/x-apple-diskimage \
+            --content-disposition "$DMG_DISPOSITION"
+          aws s3 cp "$DIST/Review-darwin-arm64-${RELEASE_VERSION}.dmg" \
+            "s3://${R2_BUCKET}/releases/preview-latest/darwin-arm64/Review.dmg" \
+            --content-type application/x-apple-diskimage \
+            --content-disposition "$DMG_DISPOSITION"
+
+          aws s3 cp "$DIST/latest.json" \
+            "s3://${R2_BUCKET}/update/preview/darwin-arm64/latest.json" \
+            --content-type application/json
+
+      - name: Verify preview update feed
+        if: ${{ !inputs.dry_run }}
+        run: |
+          echo "Feed for an outdated preview client (expect 200 with ${RELEASE_VERSION}):"
+          RESPONSE=$(curl -sf "https://update.dev.fast/api/update/darwin-arm64/preview/0000000000000000000000000000000000000000")
+          echo "$RESPONSE"
+          echo "$RESPONSE" | grep -F "\"productVersion\":\"${RELEASE_VERSION}\""
+          echo "$RESPONSE" | grep -F "\"version\":\"${RELEASE_COMMIT}\""
+
+          echo "Feed for the just-released commit (expect 204):"
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://update.dev.fast/api/update/darwin-arm64/preview/${RELEASE_COMMIT}")
+          echo "$STATUS"
+          test "$STATUS" = "204"
+
+      - name: Verify install landing
+        if: ${{ !inputs.dry_run }}
+        run: |
+          echo "install.dev.fast (expect 302 to the disk image):"
+          LOCATION=$(curl -s -o /dev/null -w "%{redirect_url}" https://install.dev.fast/)
+          echo "$LOCATION"
+          test "$LOCATION" = "https://install.dev.fast/releases/latest/darwin-arm64/Review.dmg"
+
+          echo "Following it (expect 200 and a disk image):"
+          curl -sfL -o /dev/null -w "%{http_code} %{content_type}\n" https://install.dev.fast/ \
+            | grep -F "200 application/x-apple-diskimage"
+
+      - name: Upload preview DMG artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: review-desktop-${{ env.RELEASE_VERSION }}-dmg
+          path: apps/review-desktop/dist/Review-darwin-arm64-${{ env.RELEASE_VERSION }}.dmg
+          retention-days: 3
+          compression-level: 0
+
+      - name: Remove signing credentials
+        if: always()
+        run: |
+          security delete-keychain "$RUNNER_TEMP/buildagent.keychain" || true
+          rm -f "$RUNNER_TEMP/notary-key.p8"

--- a/apps/review-desktop/README.md
+++ b/apps/review-desktop/README.md
@@ -87,9 +87,9 @@ session; candidates never appear on Home.
 
 ## Packaging and releases
 
-macOS arm64 is the only packaged platform with a release channel; Linux has a
+macOS arm64 is the only packaged platform with release channels; Linux has a
 packaging script but no distribution. Signed builds auto-update from
-`https://update.dev.fast` on the `stable` channel.
+`https://update.dev.fast` on either the `stable` or `preview` channel.
 
 ### Local packaging
 
@@ -134,6 +134,30 @@ patch/minor/major bump. The workflow:
    last — so a client can never see a manifest whose payload is missing;
 6. curls the live feed to confirm the new release is served, attaches the dmg
    to the GitHub release, and publishes it.
+
+### Preview builds
+
+Run the **Review Desktop Preview** workflow from `main`, and pass the branch,
+tag, or commit to build as its `ref` input:
+
+```sh
+gh workflow run review-desktop-preview.yml -f ref=<branch>
+```
+
+The workflow makes no commit, tag, or GitHub release. It stamps the working
+tree with the next patch version plus
+`-preview.<yyyymmdd>.<run-number>`, then publishes only to preview R2 keys.
+The ref must include the preview tooling, so branch it from a `main` that
+already contains this workflow and its scripts. Updates are keyed by commit;
+publishing an older commit intentionally rolls preview installations back to
+that build.
+
+Install the latest preview from
+<https://install.dev.fast/releases/preview-latest/darwin-arm64/Review.dmg>.
+Preview and stable use the same app name and bundle identifier, so installing
+one replaces the other while retaining settings and data. To return to stable,
+reinstall from <https://install.dev.fast>; the stable app points the updater
+back at the stable feed.
 
 ### Linux-to-macOS build handoff
 
@@ -190,9 +214,13 @@ download always does.
 
 ```
 update/stable/darwin-arm64/latest.json     current-release manifest
+update/preview/darwin-arm64/latest.json    current-preview manifest
 releases/<version>/darwin-arm64/           Review-darwin-arm64-<version>.zip + .dmg
 releases/latest/darwin-arm64/Review.dmg    direct-download alias, saved as
                                            df-review-<version>.dmg
+releases/preview-latest/darwin-arm64/Review.dmg
+                                           preview-download alias, saved as
+                                           df-review-<preview-version>.dmg
 ```
 
 `GET /api/update/:platform/:quality/:commit` answers 204 when the caller's
@@ -213,9 +241,12 @@ embedded into release builds; source builds embed none), and `SKIP_NOTARIZE`
 
 Normal CI uses GitHub's standard Ubuntu runner. The manual release workflow
 uses the `review_big_boy` larger runner. Its `review_release` runner group
-allows only `review-desktop-release.yml` from `main`. The first release job
-also uses the `review-release` environment, which requires repository-admin
-approval before GitHub assigns the job to the runner.
+allows `review-desktop-release.yml` and `review-desktop-preview.yml` from
+`main`. The first stable or preview job also uses the `review-release`
+environment, which requires repository-admin approval before downstream jobs
+can use the release infrastructure. Adding the preview workflow requires a
+repository admin to add `review-desktop-preview.yml @ main` to that runner
+group's allowed-workflows list.
 
 ## Curated extensions
 

--- a/apps/review-desktop/scripts/product-hardening.test.mjs
+++ b/apps/review-desktop/scripts/product-hardening.test.mjs
@@ -45,7 +45,10 @@ test("keeps Review disconnected from Microsoft update and extension services", (
 
 test("updates only from the sanctioned dev.fast feed", () => {
   assert.equal(product.updateUrl, "https://update.dev.fast");
-  assert.equal(product.quality, "stable");
+  assert.equal(
+    product.quality,
+    process.env.REVIEW_EXPECTED_QUALITY ?? "stable",
+  );
 });
 
 test("publishes the release number the About panel shows", async () => {

--- a/apps/review-desktop/scripts/stamp-release-channel.mjs
+++ b/apps/review-desktop/scripts/stamp-release-channel.mjs
@@ -1,0 +1,76 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { parseArgs } from "node:util";
+
+const APP_DIR = path.resolve(import.meta.dirname, "..");
+const RELEASE_QUALITIES = new Set(["stable", "preview"]);
+
+function replaceRequired(source, pattern, replacement, marker, file) {
+  if (!pattern.test(source)) {
+    throw new Error(`${marker} not found in ${file}`);
+  }
+  return source.replace(pattern, replacement);
+}
+
+export function stampReleaseChannel({
+  version,
+  quality = "stable",
+  packagePath = path.join(APP_DIR, "package.json"),
+  productPath = path.join(APP_DIR, "code-oss", "product.json"),
+}) {
+  if (!version) {
+    throw new Error("version is required");
+  }
+  if (!RELEASE_QUALITIES.has(quality)) {
+    throw new Error(
+      `quality must be one of stable or preview, received ${JSON.stringify(quality)}`,
+    );
+  }
+
+  const pkg = JSON.parse(readFileSync(packagePath, "utf8"));
+  pkg.version = version;
+
+  const product = readFileSync(productPath, "utf8");
+  const withVersion = replaceRequired(
+    product,
+    /("reviewVersion":\s*")[^"]*(")/,
+    `$1${version}$2`,
+    "reviewVersion",
+    productPath,
+  );
+  const withQuality = replaceRequired(
+    withVersion,
+    /("quality":\s*")[^"]*(")/,
+    `$1${quality}$2`,
+    "quality",
+    productPath,
+  );
+
+  writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+  writeFileSync(productPath, withQuality);
+}
+
+function main() {
+  const { values } = parseArgs({
+    options: {
+      version: { type: "string" },
+      quality: { type: "string", default: "stable" },
+    },
+  });
+
+  if (!values.version) {
+    console.error(
+      "usage: stamp-release-channel.mjs --version <semver> [--quality stable|preview]",
+    );
+    process.exit(2);
+  }
+
+  stampReleaseChannel({
+    version: values.version,
+    quality: values.quality,
+  });
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  main();
+}

--- a/apps/review-desktop/scripts/stamp-release-channel.test.mjs
+++ b/apps/review-desktop/scripts/stamp-release-channel.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { after, test } from "node:test";
+
+import { stampReleaseChannel } from "./stamp-release-channel.mjs";
+
+const temporaryRoots = [];
+after(async () => {
+  await Promise.all(
+    temporaryRoots.map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function writeFixtures(product) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "review-release-stamp-"));
+  temporaryRoots.push(root);
+  const packagePath = path.join(root, "package.json");
+  const productPath = path.join(root, "code-oss", "product.json");
+  await mkdir(path.dirname(productPath), { recursive: true });
+  await writeFile(packagePath, '{"name":"fixture","version":"1.2.3"}\n');
+  await writeFile(productPath, `${JSON.stringify(product, null, "\t")}\n`);
+  return { packagePath, productPath };
+}
+
+test("stamps the package version, review version, and release quality", async () => {
+  const paths = await writeFixtures({
+    nameShort: "Review",
+    reviewVersion: "1.2.3",
+    quality: "stable",
+  });
+
+  stampReleaseChannel({
+    version: "1.2.4-preview.20260901.42",
+    quality: "preview",
+    ...paths,
+  });
+
+  const pkg = JSON.parse(await readFile(paths.packagePath, "utf8"));
+  const product = JSON.parse(await readFile(paths.productPath, "utf8"));
+  assert.equal(pkg.version, "1.2.4-preview.20260901.42");
+  assert.equal(product.reviewVersion, "1.2.4-preview.20260901.42");
+  assert.equal(product.quality, "preview");
+});
+
+test("defaults to the stable release quality", async () => {
+  const paths = await writeFixtures({
+    reviewVersion: "1.2.3",
+    quality: "stable",
+  });
+
+  stampReleaseChannel({ version: "1.2.4", ...paths });
+
+  const product = JSON.parse(await readFile(paths.productPath, "utf8"));
+  assert.equal(product.reviewVersion, "1.2.4");
+  assert.equal(product.quality, "stable");
+});
+
+for (const marker of ["reviewVersion", "quality"]) {
+  test(`rejects a product without a ${marker} marker`, async () => {
+    const product = {
+      reviewVersion: "1.2.3",
+      quality: "stable",
+    };
+    delete product[marker];
+    const paths = await writeFixtures(product);
+
+    assert.throws(
+      () =>
+        stampReleaseChannel({
+          version: "1.2.4",
+          quality: "preview",
+          ...paths,
+        }),
+      new RegExp(marker),
+    );
+  });
+}
+
+test("rejects an unsupported release quality", async () => {
+  const paths = await writeFixtures({
+    reviewVersion: "1.2.3",
+    quality: "stable",
+  });
+  assert.throws(
+    () =>
+      stampReleaseChannel({ version: "1.2.4", quality: "nightly", ...paths }),
+    /stable or preview/,
+  );
+});
+
+test("requires a release version", async () => {
+  const paths = await writeFixtures({
+    reviewVersion: "1.2.3",
+    quality: "stable",
+  });
+  assert.throws(() => stampReleaseChannel({ ...paths }), /version is required/);
+});

--- a/apps/review-desktop/scripts/validate-release-artifacts.mjs
+++ b/apps/review-desktop/scripts/validate-release-artifacts.mjs
@@ -5,7 +5,8 @@
 // Curated extension checks also read code-oss/package.json from this checkout.
 //
 //   node scripts/validate-release-artifacts.mjs \
-//     --version 1.2.3 --commit <tag sha> [--artifact-dir dist]
+//     --version 1.2.3 --commit <tag sha> [--channel stable|preview]
+//     [--artifact-dir dist]
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { lstatSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
@@ -16,6 +17,14 @@ import { verifyCuratedExtensions } from "./curated-extensions.mjs";
 
 const APP_DIR = path.resolve(import.meta.dirname, "..");
 const UPDATE_URL = "https://update.dev.fast";
+
+export function assertReleaseChannel(channel) {
+  if (channel !== "stable" && channel !== "preview") {
+    throw new Error(
+      `channel must be one of stable or preview, received ${JSON.stringify(channel)}`,
+    );
+  }
+}
 
 export function buildManifest({
   version,
@@ -34,10 +43,11 @@ export function buildManifest({
   };
 }
 
-export function assertPackagedProduct(product, { commit }) {
+export function assertPackagedProduct(product, { commit, channel = "stable" }) {
+  assertReleaseChannel(channel);
   const expectations = {
     commit,
-    quality: "stable",
+    quality: channel,
     updateUrl: UPDATE_URL,
     darwinBundleIdentifier: "dev.fast.review",
   };
@@ -90,16 +100,18 @@ function main() {
     options: {
       version: { type: "string" },
       commit: { type: "string" },
+      channel: { type: "string", default: "stable" },
       "artifact-dir": { type: "string" },
     },
   });
-  const { version, commit } = values;
+  const { version, commit, channel } = values;
   if (!version || !commit) {
     console.error(
-      "usage: validate-release-artifacts.mjs --version <semver> --commit <sha> [--artifact-dir <dir>]",
+      "usage: validate-release-artifacts.mjs --version <semver> --commit <sha> [--channel stable|preview] [--artifact-dir <dir>]",
     );
     process.exit(2);
   }
+  assertReleaseChannel(channel);
 
   const artifactDir = path.resolve(
     values["artifact-dir"] ?? path.join(APP_DIR, "dist"),
@@ -115,7 +127,7 @@ function main() {
       "utf8",
     ),
   );
-  assertPackagedProduct(product, { commit });
+  assertPackagedProduct(product, { commit, channel });
   verifyCuratedExtensions({
     root: path.join(app, "Contents", "Resources", "app", "extensions"),
     target: "darwin-arm64",

--- a/apps/review-desktop/scripts/validate-release-artifacts.test.mjs
+++ b/apps/review-desktop/scripts/validate-release-artifacts.test.mjs
@@ -6,6 +6,7 @@ import { after, test } from "node:test";
 
 import {
   assertPackagedProduct,
+  assertReleaseChannel,
   assertUpdaterCompatibleApp,
   buildManifest,
 } from "./validate-release-artifacts.mjs";
@@ -46,6 +47,28 @@ test("buildManifest emits the schema the update Worker serves", () => {
 
 test("assertPackagedProduct accepts a correctly stamped product", () => {
   assertPackagedProduct(PRODUCT, { commit: "abc123" });
+});
+
+test("assertPackagedProduct accepts a preview-stamped product", () => {
+  assertPackagedProduct(
+    { ...PRODUCT, quality: "preview" },
+    { commit: "abc123", channel: "preview" },
+  );
+});
+
+test("assertPackagedProduct rejects a cross-channel product", () => {
+  assert.throws(
+    () =>
+      assertPackagedProduct(PRODUCT, {
+        commit: "abc123",
+        channel: "preview",
+      }),
+    /quality/,
+  );
+});
+
+test("assertReleaseChannel rejects an unsupported channel", () => {
+  assert.throws(() => assertReleaseChannel("nightly"), /stable or preview/);
 });
 
 test("assertPackagedProduct rejects a mismatched commit", () => {


### PR DESCRIPTION
## Summary

- add a manually dispatched, main-defined preview workflow that builds any requested ref without repository writes, tags, or GitHub releases
- stamp prerelease version and preview quality transiently, validate packaged artifacts against their selected channel, and publish only preview R2 keys
- document preview installation, rollback behavior, R2 layout, and runner-group setup

## Test plan

- pnpm --filter @dev-fast/review-desktop test
- REVIEW_EXPECTED_QUALITY=preview node --test apps/review-desktop/scripts/product-hardening.test.mjs after a transient preview stamp
- actionlint .github/workflows/review-desktop-preview.yml
- pnpm lint
- pnpm format:check
- git diff --check

## Required out-of-repo follow-up

- A repository admin must allow review-desktop-preview.yml at main in the review_release runner group.
- Before the first real preview publish, verify the update Worker treats preview as a generic quality key, returns 204 for a missing manifest, and streams arbitrary releases keys.
- After merge, dispatch dry_run=true from main before a real preview publish. Do not set SKIP_NOTARIZE.
