### PR TITLE
Pin Review Desktop preview builds to the resolved commit

### DIFF
--- a/.github/workflows/review-desktop-preview.yml
+++ b/.github/workflows/review-desktop-preview.yml
@@ -32,6 +32,8 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       commit: ${{ steps.version.outputs.commit }}
     steps:
+      # Resolve the mutable input only once. Downstream jobs pin this commit so
+      # retries cannot silently build a branch that moved after versioning.
       - name: Checkout preview ref
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
@@ -62,10 +64,10 @@ jobs:
     runs-on: review_big_boy
     timeout-minutes: 45
     steps:
-      - name: Checkout preview ref
+      - name: Checkout resolved preview commit
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.version.outputs.commit }}
 
       - name: Stamp preview release channel
         run: |
@@ -173,10 +175,10 @@ jobs:
       RELEASE_VERSION: ${{ needs.version.outputs.version }}
       RELEASE_COMMIT: ${{ needs.version.outputs.commit }}
     steps:
-      - name: Checkout preview ref
+      - name: Checkout resolved preview commit
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.version.outputs.commit }}
 
       - name: Stamp preview release channel
         run: |

--- a/apps/review-desktop/scripts/preview-release-workflow.test.mjs
+++ b/apps/review-desktop/scripts/preview-release-workflow.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const workflow = readFileSync(
+  path.resolve(
+    import.meta.dirname,
+    "../../../.github/workflows/review-desktop-preview.yml",
+  ),
+  "utf8",
+);
+
+function job(name, nextName) {
+  const start = workflow.indexOf(`  ${name}:`);
+  const end = nextName
+    ? workflow.indexOf(`  ${nextName}:`, start + 1)
+    : workflow.length;
+  assert.notEqual(start, -1, `${name} job is missing`);
+  assert.notEqual(end, -1, `${nextName} job is missing`);
+  return workflow.slice(start, end);
+}
+
+test("preview downstream jobs pin the commit resolved by versioning", () => {
+  const version = job("version", "compile");
+  const compile = job("compile", "build");
+  const build = job("build");
+
+  assert.match(version, /ref: \$\{\{ inputs\.ref \}\}/);
+  assert.match(version, /commit=\$COMMIT/);
+
+  for (const downstream of [compile, build]) {
+    assert.match(
+      downstream,
+      /ref: \$\{\{ needs\.version\.outputs\.commit \}\}/,
+    );
+    assert.doesNotMatch(downstream, /ref: \$\{\{ inputs\.ref \}\}/);
+  }
+});


### PR DESCRIPTION
## Summary

- resolve the requested preview ref once in the version job
- make the Linux compile and macOS package jobs check out that immutable commit
- add a regression test preventing downstream jobs from resolving the mutable input ref again

This fixes the commit mismatch seen in [preview run 33531766684](https://github.com/devdotfast/review/actions/runs/33531766684/job/99942047553). The version job recorded b9a8802, while a retry checked out the subsequently advanced main at adf3ccf in both downstream jobs. Artifact validation correctly blocked publication.

The stable release workflow is unchanged.

## Validation

- pnpm format:check
- pnpm lint
- pnpm --filter @dev-fast/review-desktop test
- actionlint .github/workflows/review-desktop-preview.yml
- git diff --check