### PR TITLE
Re-collapse expanded trace elisions

### DIFF
--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -10739,6 +10739,72 @@ a.review-doc-meta-pr:hover {
   border-color: var(--ink-faint);
 }
 
+/* Collapse rows bracket an expanded elision. Same geometry as the gap row,
+   but solid: dashed marks hidden content, solid marks the boundary of a
+   revealed span. */
+.review-trace-lens-collapse {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 4px 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  width: 100%;
+}
+
+.review-trace-lens-collapse-line {
+  flex-grow: 1;
+  height: 1px;
+  border-top: 1px solid var(--rule-soft);
+}
+
+.review-trace-lens-collapse-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 22px;
+  padding: 0 10px;
+  border: 1px solid var(--rule-soft);
+  border-radius: 999px;
+  background: var(--surface);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
+.review-trace-lens-collapse-chevron {
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.review-trace-lens-collapse:hover .review-trace-lens-collapse-chip {
+  color: var(--ink-soft);
+  border-color: var(--ink-faint);
+}
+
+.review-trace-lens-collapse:hover .review-trace-lens-collapse-line {
+  border-color: var(--ink-faint);
+}
+
+.review-trace-user-slot {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  width: 100%;
+}
+
 .review-trace-lens-elided {
   display: inline;
 }

--- a/packages/progressive-review/app/src/trace-document.test.tsx
+++ b/packages/progressive-review/app/src/trace-document.test.tsx
@@ -174,6 +174,53 @@ describe("TraceDocument", () => {
     expect(toolGroups[0].textContent).toContain("Edited 3 files");
   });
 
+  it("brackets an expanded gap with collapse rows that fold it back", async () => {
+    const picks = [
+      { event: 5, keep: ["Second turn"] },
+      { events: [6, 9] as [number, number] },
+    ];
+
+    await act(async () => {
+      root?.render(
+        <TraceDocument
+          events={sampleEvents}
+          targetEventIndex={5}
+          picks={picks}
+        />,
+      );
+    });
+
+    const gapButton = container.querySelector(
+      ".review-trace-lens-gap",
+    ) as HTMLButtonElement;
+    await act(async () => {
+      gapButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    // The revealed span is bracketed by one collapse row at each end.
+    const collapseRows = container.querySelectorAll(
+      ".review-trace-lens-collapse",
+    );
+    expect(collapseRows.length).toBe(2);
+    expect(collapseRows[0].textContent).toContain("collapse 5 events");
+    expect(collapseRows[1].textContent).toContain("collapse 5 events");
+
+    // The bottom row re-collapses the whole span back to a gap chip.
+    await act(async () => {
+      (collapseRows[1] as HTMLButtonElement).dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    expect(
+      container.querySelectorAll(".review-trace-lens-collapse").length,
+    ).toBe(0);
+    expect(container.textContent).not.toContain("First turn question");
+    const gapsAfter = container.querySelectorAll(".review-trace-lens-gap");
+    expect(gapsAfter.length).toBe(1);
+    expect(gapsAfter[0].textContent).toContain("5 hidden events");
+  });
+
   it("expands elided message text when ellipsis chip is clicked", async () => {
     const picks = [{ event: 9, keep: ["optimize database queries"] }];
 

--- a/packages/progressive-review/app/src/trace-document.tsx
+++ b/packages/progressive-review/app/src/trace-document.tsx
@@ -691,12 +691,55 @@ export function TraceGapChip({
   );
 }
 
+export interface TraceCollapseSpan {
+  from: number;
+  count: number;
+}
+
+export function TraceCollapseRow({
+  span,
+  edge,
+  onCollapse,
+}: {
+  span: TraceCollapseSpan;
+  edge: "top" | "bottom";
+  onCollapse: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="review-trace-lens-collapse"
+      onClick={onCollapse}
+    >
+      <span className="review-trace-lens-collapse-line" />
+      <span className="review-trace-lens-collapse-chip">
+        <svg
+          viewBox="0 0 16 16"
+          className="review-trace-lens-collapse-chevron"
+          aria-hidden="true"
+        >
+          {edge === "top" ? (
+            <polyline points="4 6 8 10 12 6" />
+          ) : (
+            <polyline points="4 10 8 6 12 10" />
+          )}
+        </svg>
+        collapse {span.count} {span.count === 1 ? "event" : "events"}
+      </span>
+      <span className="review-trace-lens-collapse-line" />
+    </button>
+  );
+}
+
 export function TraceTurn({
   turn,
   effectiveIncluded,
   expandedEvents,
+  collapseStarts,
+  collapseEnds,
   onExpandGap,
   onExpandEvent,
+  onCollapseGap,
   targetEventIndex,
   highlightQuote,
   turnCoalesce,
@@ -704,8 +747,11 @@ export function TraceTurn({
   turn: IndexedTraceTurnGroup;
   effectiveIncluded: Map<number, string[] | null> | null;
   expandedEvents: ReadonlySet<number>;
+  collapseStarts?: ReadonlyMap<number, TraceCollapseSpan> | null;
+  collapseEnds?: ReadonlyMap<number, TraceCollapseSpan> | null;
   onExpandGap: (from: number, count: number) => void;
   onExpandEvent: (index: number) => void;
+  onCollapseGap?: (from: number) => void;
   targetEventIndex?: number;
   highlightQuote?: string;
   turnCoalesce: boolean;
@@ -758,6 +804,21 @@ export function TraceTurn({
           <TraceEvent event={item.event} highlightQuote={quote} />
         )}
       </div>
+    );
+  };
+
+  // Rows that bracket an expanded elision so the reader can fold it back.
+  const collapseRowFor = (index: number, edge: "top" | "bottom"): ReactNode => {
+    const span =
+      edge === "top" ? collapseStarts?.get(index) : collapseEnds?.get(index);
+    if (!span || !onCollapseGap) return null;
+    return (
+      <TraceCollapseRow
+        key={`collapse-${edge}-${span.from}`}
+        span={span}
+        edge={edge}
+        onCollapse={() => onCollapseGap(span.from)}
+      />
     );
   };
 
@@ -831,11 +892,21 @@ export function TraceTurn({
       }
 
       flushGapRun();
+      const topRow = collapseRowFor(item.index, "top");
+      if (topRow) {
+        flushToolRun();
+        elements.push(topRow);
+      }
       if (turnCoalesce && item.event.kind === "tool") {
         toolRun.push(item as IndexedTraceToolItem);
       } else {
         flushToolRun();
         elements.push(renderTurnEvent(item));
+      }
+      const bottomRow = collapseRowFor(item.index, "bottom");
+      if (bottomRow) {
+        flushToolRun();
+        elements.push(bottomRow);
       }
     }
     flushToolRun();
@@ -875,7 +946,11 @@ export function TraceTurn({
         }
       } else {
         flushGapRun();
+        const topRow = collapseRowFor(item.index, "top");
+        if (topRow) elements.push(topRow);
         elements.push(renderTurnEvent(item));
+        const bottomRow = collapseRowFor(item.index, "bottom");
+        if (bottomRow) elements.push(bottomRow);
       }
     }
     flushGapRun();
@@ -885,7 +960,21 @@ export function TraceTurn({
   let userElement: ReactNode = null;
   if (turn.user) {
     if (effectiveIncluded === null || effectiveIncluded.has(turn.user.index)) {
-      userElement = renderTurnEvent(turn.user);
+      const topRow = collapseRowFor(turn.user.index, "top");
+      const bottomRow = collapseRowFor(turn.user.index, "bottom");
+      userElement =
+        topRow || bottomRow ? (
+          <div
+            key={`user-${turn.user.index}`}
+            className="review-trace-user-slot"
+          >
+            {topRow}
+            {renderTurnEvent(turn.user)}
+            {bottomRow}
+          </div>
+        ) : (
+          renderTurnEvent(turn.user)
+        );
     } else {
       userElement = (
         <TraceGapChip
@@ -1002,6 +1091,32 @@ export function TraceDocument({
     setExpandedGaps((prev) => new Set(prev).add(from));
   };
 
+  const handleCollapseGap = (from: number) => {
+    setExpandedGaps((prev) => {
+      const next = new Set(prev);
+      next.delete(from);
+      return next;
+    });
+  };
+
+  // Each expanded gap becomes a collapse span bracketed by rows at its first
+  // and last event, so the reader can fold the reveal back from either end.
+  const collapseMarkers = useMemo(() => {
+    if (!baseIncluded) return null;
+    const starts = new Map<number, TraceCollapseSpan>();
+    const ends = new Map<number, TraceCollapseSpan>();
+    for (const from of expandedGaps) {
+      let cursor = from;
+      while (cursor < events.length && !baseIncluded.has(cursor)) cursor++;
+      const count = cursor - from;
+      if (count <= 0) continue;
+      const span = { from, count };
+      starts.set(from, span);
+      ends.set(cursor - 1, span);
+    }
+    return { starts, ends };
+  }, [baseIncluded, expandedGaps, events.length]);
+
   const handleExpandEvent = (index: number) => {
     setExpandedEvents((prev) => new Set(prev).add(index));
   };
@@ -1101,8 +1216,11 @@ export function TraceDocument({
           turn={turn}
           effectiveIncluded={effectiveIncluded}
           expandedEvents={expandedEvents}
+          collapseStarts={collapseMarkers?.starts}
+          collapseEnds={collapseMarkers?.ends}
           onExpandGap={handleExpandGap}
           onExpandEvent={handleExpandEvent}
+          onCollapseGap={handleCollapseGap}
           targetEventIndex={targetEventIndex}
           highlightQuote={highlightQuote}
           turnCoalesce={turnCoalesce}
@@ -1115,6 +1233,7 @@ export function TraceDocument({
     turns,
     effectiveIncluded,
     expandedEvents,
+    collapseMarkers,
     targetEventIndex,
     highlightQuote,
     coalesce,


### PR DESCRIPTION
## Summary

- an expanded trace elision had no way back: clicking the "⋯ N hidden events" gap chip revealed the span and the chip disappeared
- the revealed span is now bracketed by "collapse N events" rows at both its top and bottom — same pill-on-rule geometry as the gap row, but solid where the gap row is dashed (dashed marks hidden content, solid marks the boundary of a revealed span), with a down chevron on the top row and an up chevron on the bottom
- either row folds the whole span back to its gap chip; hover darkens the chip and rules exactly like the existing gap chip, in both themes (all colors ride the existing theme tokens)

## Validation

- `pnpm --filter @dev.fast/review test -- app/src/trace-document.test.tsx app/src/ReviewTraceView.test.tsx app/src/trace-quote.test.tsx app/src/review-components.test.tsx app/src/App.test.ts` — includes a new test that expands a gap, asserts one collapse row at each end, folds it back from the bottom row, and asserts the gap chip returns
- `pnpm lint`, `pnpm format:check`
- typecheck carries only the two pre-existing failures on main (`scripts/check-tutorial.ts`, `src/server/bug-report.ts`), untouched here
