### PR TITLE
Unify thread and trace transcripts on shared agent-chat rows

### DIFF
--- a/packages/progressive-review/app/src/agent-chat.tsx
+++ b/packages/progressive-review/app/src/agent-chat.tsx
@@ -1,0 +1,73 @@
+import type { ReactElement, ReactNode } from "react";
+
+/**
+ * Shared agent-chat rows. The trace document and comment threads render the
+ * same transcript anatomy through these components: a right-aligned bubble for
+ * whatever the human said, full-width prose for whatever the agent said, and a
+ * mono status row for agent activity. Each surface only chooses which rows to
+ * feed and which chrome wraps them; the skin is defined once, by the
+ * `agent-chat-*` rules the trace styles share.
+ */
+
+export function AgentChatUserMessage({
+  children,
+  caption,
+  bubbleClassName,
+}: {
+  children: ReactNode;
+  caption?: ReactNode;
+  bubbleClassName?: string;
+}): ReactElement {
+  return (
+    <div className="agent-chat-user">
+      <div
+        className={
+          bubbleClassName
+            ? `agent-chat-user-bubble ${bubbleClassName}`
+            : "agent-chat-user-bubble"
+        }
+      >
+        {children}
+      </div>
+      {caption != null && <span className="agent-chat-caption">{caption}</span>}
+    </div>
+  );
+}
+
+export function AgentChatAgentMessage({
+  children,
+  caption,
+}: {
+  children: ReactNode;
+  caption?: ReactNode;
+}): ReactElement {
+  return (
+    <div className="agent-chat-agent">
+      <div className="agent-chat-prose">{children}</div>
+      {caption != null && <span className="agent-chat-caption">{caption}</span>}
+    </div>
+  );
+}
+
+/**
+ * Agent activity as a transcript row: a mono label against a hairline, the
+ * same register as the trace document's worked separator. `tone` marks the
+ * live state with the accent dot.
+ */
+export function AgentChatStatusRow({
+  children,
+  tone = "idle",
+}: {
+  children: ReactNode;
+  tone?: "idle" | "running";
+}): ReactElement {
+  return (
+    <div className="agent-chat-status">
+      {tone === "running" && (
+        <span className="agent-chat-status-dot" aria-hidden="true" />
+      )}
+      <span className="agent-chat-status-label">{children}</span>
+      <span className="agent-chat-status-line" aria-hidden="true" />
+    </div>
+  );
+}

--- a/packages/progressive-review/app/src/review-components.tsx
+++ b/packages/progressive-review/app/src/review-components.tsx
@@ -27,6 +27,11 @@ import {
   reviewSectionPropsSchema,
 } from "../../src/authoring";
 import type { ThreadTarget } from "../../src/types";
+import {
+  AgentChatAgentMessage,
+  AgentChatStatusRow,
+  AgentChatUserMessage,
+} from "./agent-chat";
 import { AgentMarkdown } from "./agent-markdown";
 import {
   CodePeekCard,
@@ -53,6 +58,7 @@ import {
   commentThreadView,
   targetQuote,
   threadListStatus,
+  threadRelativeTimeLabel,
 } from "./review-threads";
 import { useReviewUiState } from "./review-ui-state";
 import { useBottomSheetResize } from "./side-panel-resizer";
@@ -1666,28 +1672,32 @@ function ThreadChat({
         <span>{quote}</span>
       </div>
       <div className="thread-chat-transcript">
-        {thread?.messages.map((message) => (
-          <div
-            key={message.id}
-            className={
-              message.userAuthored
-                ? "thread-chat-message thread-chat-message--you"
-                : "thread-chat-message thread-chat-message--agent"
-            }
-          >
-            <span className="thread-chat-speaker">
-              {message.userAuthored ? "you" : "agent"}
-            </span>
-            {message.agentMarkdown ? (
-              <AgentMarkdown
-                source={message.body}
-                className="thread-chat-message-body"
-              />
-            ) : (
-              <div className="thread-chat-message-body">{message.body}</div>
-            )}
-          </div>
-        ))}
+        {thread?.messages.map((message) => {
+          const caption = `${message.by} · ${threadRelativeTimeLabel(message.at)}`;
+          const body = message.agentMarkdown ? (
+            <AgentMarkdown source={message.body} />
+          ) : (
+            message.body
+          );
+          // A running agent turn renders as a transcript status row, the
+          // same register as the trace document's worked separator.
+          if (message.running) {
+            return (
+              <AgentChatStatusRow key={message.id} tone="running">
+                {message.body}
+              </AgentChatStatusRow>
+            );
+          }
+          return message.userAuthored ? (
+            <AgentChatUserMessage key={message.id} caption={caption}>
+              {body}
+            </AgentChatUserMessage>
+          ) : (
+            <AgentChatAgentMessage key={message.id} caption={caption}>
+              {body}
+            </AgentChatAgentMessage>
+          );
+        })}
       </div>
       {!readOnly && !thread?.resolved && (
         <div className="thread-chat-composer">

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -3775,36 +3775,6 @@ button {
   overflow-y: auto;
 }
 
-.thread-chat-message {
-  display: flex;
-  gap: 10px;
-  align-items: flex-start;
-}
-
-.thread-chat-speaker {
-  flex-shrink: 0;
-  width: 42px;
-  padding-top: 2px;
-  color: var(--ink-faint);
-  font: 600 10px/1 var(--font-mono);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.thread-chat-message--agent .thread-chat-speaker {
-  color: var(--rpc);
-}
-
-.thread-chat-message-body {
-  min-width: 0;
-  color: var(--ink);
-  font: 400 12px/18px var(--font-mono);
-}
-
-.thread-chat-message--agent .thread-chat-message-body {
-  color: var(--ink-soft);
-}
-
 .thread-chat-composer {
   flex-shrink: 0;
   padding: 10px 0 12px;
@@ -3835,6 +3805,23 @@ button {
 
 .question-panel .thread-chat-composer .thread-compose textarea:focus {
   border-color: var(--accent);
+}
+
+/* Rest state mirrors the boxed textarea's geometry with the colors off, and
+   reserves the action row's height (24px verb + 8px gap) below: the composer
+   is bottom-anchored, so without the reservation the input jumps up when the
+   form opens. */
+.question-panel .thread-chat-composer .thread-reply-row {
+  box-sizing: border-box;
+  width: 100%;
+  height: 44px;
+  min-height: 44px;
+  margin-bottom: 32px;
+  padding: 9px 10px;
+  border: 1px solid var(--transparent);
+  border-radius: 7px;
+  background: var(--transparent);
+  font: 400 12px/17px var(--font-mono);
 }
 
 .question-panel .thread-chat-composer .thread-compose-verb {
@@ -5475,6 +5462,9 @@ button {
 }
 
 /* Bare reply row; controls appear only while composing. */
+/* The resting row shares the focused textarea's exact metrics (padding,
+   border-width, font, line-height), so focusing only changes colors and the
+   placeholder text never moves. */
 .thread-reply-row {
   min-height: 23px;
   padding: 2px 0;
@@ -5482,7 +5472,8 @@ button {
   background: var(--transparent);
   color: var(--ink-faint);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 12.5px;
+  line-height: 19px;
   text-align: left;
 }
 
@@ -5499,7 +5490,7 @@ button {
 }
 
 .thread-compose textarea {
-  min-height: 34px;
+  min-height: 23px;
   max-height: 160px;
   padding: 2px 0;
   resize: none;
@@ -10311,7 +10302,7 @@ a.review-doc-meta-pr:hover {
   gap: 18px;
 }
 
-.review-trace-user {
+.agent-chat-user {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -10322,7 +10313,7 @@ a.review-doc-meta-pr:hover {
   min-width: 0;
 }
 
-.review-trace-user-bubble {
+.agent-chat-user-bubble {
   padding: 12px 14px;
   background: var(--bg-2);
   border-radius: 12px 12px 4px 12px;
@@ -10336,7 +10327,7 @@ a.review-doc-meta-pr:hover {
   max-width: 100%;
 }
 
-.review-trace-timestamp {
+.agent-chat-caption {
   font-family: var(--font-mono);
   font-size: 10.5px;
   color: var(--ink-faint);
@@ -10363,7 +10354,64 @@ a.review-doc-meta-pr:hover {
   margin-bottom: 6px;
 }
 
-.review-trace-prose .agent-markdown {
+.agent-chat-prose {
+  font-family: var(--font-serif);
+  font-size: 15px;
+  line-height: 26px;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.agent-chat-agent {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+}
+
+.agent-chat-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 22px;
+}
+
+.agent-chat-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--accent);
+  flex-shrink: 0;
+}
+
+.agent-chat-status-label {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-soft);
+  white-space: nowrap;
+}
+
+.agent-chat-status-line {
+  flex-grow: 1;
+  height: 1px;
+  background: var(--rule);
+}
+
+/* The shared rows inside the sidebar thread view: the trace skin as-is,
+   minus the transcript top margin the trace turns carry. The anchored mini
+   cards keep their own compact presentation and never use these rows. */
+.thread-chat-transcript .agent-chat-user {
+  margin-top: 0;
+  max-width: 100%;
+}
+
+.thread-chat-transcript .agent-chat-user-bubble {
+  max-width: min(480px, 90%);
+}
+
+.review-trace-prose .agent-markdown,
+.agent-chat-prose .agent-markdown {
   font-family: var(--font-serif);
   font-size: 15px;
   line-height: 26px;
@@ -10818,7 +10866,7 @@ a.review-doc-meta-pr:hover {
   color: var(--ink);
 }
 
-.review-trace-user-bubble--elided .review-trace-lens-kept {
+.agent-chat-user-bubble--elided .review-trace-lens-kept {
   line-height: 24px;
 }
 

--- a/packages/progressive-review/app/src/thread-card.test.tsx
+++ b/packages/progressive-review/app/src/thread-card.test.tsx
@@ -200,6 +200,66 @@ describe("compose verb menu placement", () => {
   });
 });
 
+describe("ThreadCard compact presentation", () => {
+  it("keeps the anchored card's head/body rows and never adopts the agent-chat skin", async () => {
+    const thread: ThreadView = {
+      key: "thread-1",
+      threadId: "thread-1",
+      target: { kind: "document" },
+      quote: "Entire document",
+      resolved: false,
+      latestAt: "2026-01-01T00:00:02.000Z",
+      messages: [
+        {
+          id: "user-1",
+          by: "You",
+          at: "2026-01-01T00:00:00.000Z",
+          body: "Please change this",
+          userAuthored: true,
+        },
+        {
+          id: "agent-1",
+          by: "Agent",
+          at: "2026-01-01T00:00:01.000Z",
+          body: "Understood",
+          userAuthored: false,
+          agentMarkdown: true,
+        },
+        {
+          id: "activity-1",
+          by: "Agent",
+          at: "2026-01-01T00:00:02.000Z",
+          body: "Running…",
+          userAuthored: false,
+          running: true,
+        },
+      ],
+    };
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => {
+      root.render(<ThreadCard thread={thread} variant="panel" />);
+    });
+
+    const messages = container.querySelectorAll(".thread-message");
+    expect(messages).toHaveLength(3);
+    expect(
+      messages[0]?.querySelector(".thread-message-head strong")?.textContent,
+    ).toBe("You");
+    expect(
+      messages[0]?.querySelector(".thread-message-body")?.textContent,
+    ).toBe("Please change this");
+    expect(
+      messages[1]?.querySelector(".thread-message-body .agent-markdown"),
+    ).not.toBeNull();
+    // The anchored mini cards deliberately keep their compact presentation;
+    // only the sidebar thread view and traces use the agent-chat rows.
+    expect(container.querySelector('[class*="agent-chat"]')).toBeNull();
+  });
+});
+
 describe("ThreadCard message actions", () => {
   it("puts thread delete in the ordered header and Edit/Delete on user messages", async () => {
     const thread: ThreadView = {

--- a/packages/progressive-review/app/src/trace-document.test.tsx
+++ b/packages/progressive-review/app/src/trace-document.test.tsx
@@ -272,7 +272,7 @@ describe("TraceDocument", () => {
 
     // Full text of the user message is visible without ellipsis chips
     expect(container.querySelector(".review-trace-lens-chip")).toBeNull();
-    const userBubble = container.querySelector(".review-trace-user-bubble");
+    const userBubble = container.querySelector(".agent-chat-user-bubble");
     expect(userBubble?.textContent).toBe("Second turn question");
     expect(
       userBubble?.querySelector(".review-trace-quote-mark")?.textContent,

--- a/packages/progressive-review/app/src/trace-document.tsx
+++ b/packages/progressive-review/app/src/trace-document.tsx
@@ -1,6 +1,7 @@
 import type { ReviewAgentTraceEvent } from "@dev.fast/review-protocol";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 
+import { AgentChatUserMessage } from "./agent-chat";
 import { AgentMarkdown } from "./agent-markdown";
 import {
   HighlightedText,
@@ -278,18 +279,15 @@ export function TraceEvent({
 }) {
   if (event.kind === "user") {
     return (
-      <div className="review-trace-user">
-        <div className="review-trace-user-bubble">
-          {highlightQuote ? (
-            <HighlightedText text={event.text} quote={highlightQuote} />
-          ) : (
-            event.text
-          )}
-        </div>
-        {event.at && (
-          <span className="review-trace-timestamp">{timeLabel(event.at)}</span>
+      <AgentChatUserMessage
+        caption={event.at ? timeLabel(event.at) : undefined}
+      >
+        {highlightQuote ? (
+          <HighlightedText text={event.text} quote={highlightQuote} />
+        ) : (
+          event.text
         )}
-      </div>
+      </AgentChatUserMessage>
     );
   }
   if (event.kind === "assistant") {
@@ -626,14 +624,12 @@ export function ElidedMessage({
   );
   if (event.kind === "user") {
     return (
-      <div className="review-trace-user">
-        <div className="review-trace-user-bubble review-trace-user-bubble--elided">
-          {body}
-        </div>
-        {event.at && (
-          <span className="review-trace-timestamp">{timeLabel(event.at)}</span>
-        )}
-      </div>
+      <AgentChatUserMessage
+        bubbleClassName="agent-chat-user-bubble--elided"
+        caption={event.at ? timeLabel(event.at) : undefined}
+      >
+        {body}
+      </AgentChatUserMessage>
     );
   }
   if (event.thinking) {


### PR DESCRIPTION
## Summary

- comment threads and agent traces render the same conversation anatomy, but each surface drew it separately; this extracts a shared `AgentChat` component set (`agent-chat.tsx`: user bubble, agent prose, activity status row) and makes both surfaces consume it
- the trace document's user-message and elided-message rows now render through `AgentChatUserMessage`; the shared CSS rules move from `review-trace-user*`/`review-trace-timestamp` to `agent-chat-*` names with values unchanged, so the trace surface is visually identical
- thread-card messages re-skin through the shared rows: reviewer comments render as right-aligned bubbles with an author · time caption, agent replies as full-width serif prose (matching the traces look), and agent activity ("Running…") as a transcript status row with the accent dot instead of a pseudo-comment
- thread data flow (review-threads-service, native message mirror, composer verbs, message edit/delete menus, clamping, error/stderr) is untouched — presentation layer only, with thread-density overrides scoped under the card

## Validation

- `pnpm --filter @dev.fast/review test -- app/src` — 470 tests passing, including a new ThreadCard test asserting the unified rows (bubble / prose / status row) and the trace-document highlight test updated to the shared bubble class
- `pnpm lint`, `pnpm format:check`
