### PR TITLE
Event-ruler scrollbar for the agent trace view

### DIFF
--- a/packages/progressive-review/app/src/ReviewTraceView.tsx
+++ b/packages/progressive-review/app/src/ReviewTraceView.tsx
@@ -13,6 +13,7 @@ import {
   type TraceTurnEvent,
   formatDuration,
 } from "./trace-document";
+import { TraceRuler } from "./trace-ruler";
 import {
   type LoadedAgentTrace,
   makeTraceKey,
@@ -200,6 +201,9 @@ export function ReviewTraceView({
 
   return (
     <div className="review-trace-view">
+      {detail.status === "loaded" && (
+        <TraceRuler events={detail.trace.events} />
+      )}
       <div className="review-trace-column">
         {list.status === "loading" && (
           <p className="review-trace-note">Resolving agent sessions…</p>

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -10071,7 +10071,9 @@ a.review-doc-meta-pr:hover {
 
 .review-trace-view {
   min-height: 100%;
-  padding: 36px 24px 96px;
+  /* The left inset clears the event ruler: 14px edge inset + 6px resting
+     tick + 28px gap, so the 30px hover comb stops just short of the text. */
+  padding: 36px 24px 96px 48px;
 }
 
 .review-trace-column {
@@ -10818,6 +10820,84 @@ a.review-doc-meta-pr:hover {
 
 .review-trace-user-bubble--elided .review-trace-lens-kept {
   line-height: 24px;
+}
+
+/* Event-ruler scrollbar: a left-edge column of uniform dashes mapping the
+   whole session at even pitch. Brightness marks the events currently in the
+   viewport; hovering bulges nearby ticks toward the content and shows a
+   preview card. Strictly grayscale via the ink tokens. */
+
+.review-trace-ruler {
+  height: 0;
+  overflow: visible;
+}
+
+.review-trace-ruler-rail {
+  position: fixed;
+  width: 40px;
+  z-index: 3;
+}
+
+.review-trace-ruler-tick {
+  position: absolute;
+  /* Inset from the panel edge; the comb grows rightward from here. */
+  left: 8px;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--ink-faint);
+  opacity: 0.55;
+  transition:
+    width 90ms ease,
+    opacity 90ms ease;
+  pointer-events: none;
+}
+
+.review-trace-ruler-tick--visible {
+  background: var(--ink);
+  opacity: 0.9;
+}
+
+.review-trace-ruler-tick--hovered {
+  background: var(--ink);
+  opacity: 1;
+}
+
+.review-trace-ruler-card {
+  position: absolute;
+  left: 52px;
+  width: 300px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.25);
+  pointer-events: none;
+}
+
+.review-trace-ruler-card-title {
+  font-family: var(--font-serif);
+  font-size: 14px;
+  line-height: 19px;
+  font-weight: 600;
+  color: var(--ink);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.review-trace-ruler-card-snippet {
+  font-family: var(--font-serif);
+  font-size: 13px;
+  line-height: 18px;
+  color: var(--ink-soft);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .review-trace-lens-chip {

--- a/packages/progressive-review/app/src/trace-document.tsx
+++ b/packages/progressive-review/app/src/trace-document.tsx
@@ -198,7 +198,11 @@ export function TraceToolGroup({
     items.some((item) => item.index === targetEventIndex);
   const events = items.map((i) => i.event);
   return (
-    <details className="review-trace-toolgroup" open={hasTarget}>
+    <details
+      className="review-trace-toolgroup"
+      open={hasTarget}
+      data-trace-event={items[0]?.index}
+    >
       <summary>
         <span className="review-trace-tool-icon">
           {iconSvg(
@@ -787,6 +791,7 @@ export function TraceTurn({
         key={item.index}
         id={isTarget ? "review-trace-target-event" : undefined}
         className={isTarget ? "review-trace-target-turn" : undefined}
+        data-trace-event={item.index}
       >
         {shouldElide ? (
           <ElidedMessage

--- a/packages/progressive-review/app/src/trace-ruler.test.tsx
+++ b/packages/progressive-review/app/src/trace-ruler.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+
+import type { ReviewAgentTraceEvent } from "@dev.fast/review-protocol";
+import { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { buildIndexedTraceTurns } from "./trace-document";
+import {
+  RULER_PAD,
+  RULER_TICK_PITCH,
+  TraceRuler,
+  rulerBucketRange,
+  rulerCombWidth,
+  rulerNearestTick,
+  rulerPreview,
+  rulerTickCount,
+  rulerTickForEvent,
+  rulerTurnForEvent,
+  rulerTurnStarts,
+} from "./trace-ruler";
+
+function userEvent(text: string): ReviewAgentTraceEvent {
+  return { kind: "user", text };
+}
+
+function assistantEvent(markdown: string): ReviewAgentTraceEvent {
+  return { kind: "assistant", markdown };
+}
+
+function toolEvent(title: string): ReviewAgentTraceEvent {
+  return { kind: "tool", tool: "shell", verb: "Ran", title };
+}
+
+describe("ruler geometry", () => {
+  it("caps the tick count at one tick per event and at the rail capacity", () => {
+    expect(rulerTickCount(RULER_PAD * 2 + RULER_TICK_PITCH * 40, 597)).toBe(40);
+    expect(rulerTickCount(RULER_PAD * 2 + RULER_TICK_PITCH * 40, 6)).toBe(6);
+    expect(rulerTickCount(0, 100)).toBe(0);
+    expect(rulerTickCount(400, 0)).toBe(0);
+  });
+
+  it("covers every event exactly once across bucket ranges", () => {
+    const tickCount = 7;
+    const eventCount = 23;
+    let next = 0;
+    for (let tick = 0; tick < tickCount; tick += 1) {
+      const { start, end } = rulerBucketRange(tick, tickCount, eventCount);
+      expect(start).toBe(next);
+      expect(end).toBeGreaterThan(start);
+      next = end;
+    }
+    expect(next).toBe(eventCount);
+  });
+
+  it("maps events back to the tick whose bucket contains them", () => {
+    const tickCount = 7;
+    const eventCount = 23;
+    for (let index = 0; index < eventCount; index += 1) {
+      const tick = rulerTickForEvent(index, tickCount, eventCount);
+      const { start, end } = rulerBucketRange(tick, tickCount, eventCount);
+      expect(index).toBeGreaterThanOrEqual(start);
+      expect(index).toBeLessThan(end);
+    }
+  });
+
+  it("elongates the hovered tick most and tapers to rest width", () => {
+    expect(rulerCombWidth(10, null)).toBe(6);
+    expect(rulerCombWidth(10, 10)).toBe(30);
+    const near = rulerCombWidth(11, 10);
+    const far = rulerCombWidth(13, 10);
+    expect(near).toBeGreaterThan(far);
+    expect(far).toBeGreaterThanOrEqual(6);
+    expect(rulerCombWidth(20, 10)).toBe(6);
+  });
+});
+
+describe("rulerNearestTick", () => {
+  const rects = [
+    { top: 110, bottom: 112 },
+    { top: 124, bottom: 126 },
+    { top: 138, bottom: 140 },
+    { top: 152, bottom: 154 },
+  ];
+
+  it("picks the tick whose rendered center is nearest the pointer", () => {
+    expect(rulerNearestTick(rects, 111)).toBe(0);
+    expect(rulerNearestTick(rects, 130)).toBe(1);
+    expect(rulerNearestTick(rects, 133)).toBe(2);
+    expect(rulerNearestTick(rects, 900)).toBe(3);
+    expect(rulerNearestTick(rects, 0)).toBe(0);
+  });
+
+  it("ignores assumed pitch: uneven rendered spacing still resolves exactly", () => {
+    const uneven = [
+      { top: 10, bottom: 12 },
+      { top: 50, bottom: 52 },
+      { top: 53, bottom: 55 },
+    ];
+    expect(rulerNearestTick(uneven, 30)).toBe(0);
+    expect(rulerNearestTick(uneven, 52.4)).toBe(1);
+    expect(rulerNearestTick(uneven, 53.6)).toBe(2);
+  });
+
+  it("returns null with no rendered ticks", () => {
+    expect(rulerNearestTick([], 100)).toBe(null);
+  });
+});
+
+describe("turn ticks", () => {
+  const events: ReviewAgentTraceEvent[] = [
+    toolEvent("setup"),
+    userEvent("can you help root cause this"),
+    assistantEvent("I will isolate the break."),
+    toolEvent("rg -n reviewUnifiedTargetForRange"),
+    toolEvent("sed -n 280,340p"),
+    assistantEvent("Root cause confirmed."),
+    userEvent("whats the clean fix here"),
+    assistantEvent("Keep the synthetic buffer and delegate."),
+    userEvent("ok do it"),
+  ];
+  const turns = buildIndexedTraceTurns(events);
+
+  it("uses the trace view's own turn grouping: one turn per user prompt", () => {
+    expect(turns.map((turn) => turn.user?.index ?? null)).toEqual([
+      null,
+      1,
+      6,
+      8,
+    ]);
+    expect(rulerTurnStarts(turns)).toEqual([0, 1, 6, 8]);
+  });
+
+  it("maps every event to the turn that contains it", () => {
+    const starts = rulerTurnStarts(turns);
+    expect([0, 1, 5, 6, 7, 8].map((i) => rulerTurnForEvent(i, starts))).toEqual(
+      [0, 1, 1, 2, 2, 3],
+    );
+  });
+
+  it("previews a turn as its prompt plus the final agent response", () => {
+    // Consecutive turns preview consecutive prompts; the snippet is the
+    // trailing response after the collapsed work, not the first assistant
+    // message inside it.
+    expect(rulerPreview(turns[1])).toEqual({
+      title: "can you help root cause this",
+      snippet: "Root cause confirmed.",
+    });
+    expect(rulerPreview(turns[2])).toEqual({
+      title: "whats the clean fix here",
+      snippet: "Keep the synthetic buffer and delegate.",
+    });
+    expect(rulerPreview(turns[3])).toEqual({ title: "ok do it", snippet: "" });
+  });
+
+  it("returns null for a promptless leading turn or a missing turn", () => {
+    expect(rulerPreview(turns[0])).toBe(null);
+    expect(rulerPreview(undefined)).toBe(null);
+  });
+
+  it("collapses whitespace in titles and snippets", () => {
+    const [turn] = buildIndexedTraceTurns([
+      userEvent("a\n\n  b"),
+      assistantEvent("c\td"),
+    ]);
+    expect(rulerPreview(turn)).toEqual({ title: "a b", snippet: "c d" });
+  });
+});
+
+describe("TraceRuler", () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root?.unmount());
+      root = null;
+    }
+    document.body.replaceChildren();
+  });
+
+  it("renders nothing for an empty trace", async () => {
+    await act(async () => {
+      root?.render(<TraceRuler events={[]} />);
+    });
+    expect(container.querySelector(".review-trace-ruler")).toBe(null);
+  });
+
+  it("renders the ruler anchor for a populated trace", async () => {
+    await act(async () => {
+      root?.render(<TraceRuler events={[userEvent("hi")]} />);
+    });
+    expect(container.querySelector(".review-trace-ruler")).not.toBe(null);
+  });
+});

--- a/packages/progressive-review/app/src/trace-ruler.tsx
+++ b/packages/progressive-review/app/src/trace-ruler.tsx
@@ -1,0 +1,374 @@
+import type { ReviewAgentTraceEvent } from "@dev.fast/review-protocol";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  type IndexedTraceTurnGroup,
+  buildIndexedTraceTurns,
+  extractEventText,
+} from "./trace-document";
+
+/**
+ * Turn-ruler scrollbar for the agent trace view. A left-edge column of
+ * uniform dashes maps the whole session at even pitch: one tick per turn
+ * (a user prompt, its collapsed work, and the final response — the same
+ * grouping the trace view renders via buildIndexedTraceTurns), bucketed only
+ * when turns outnumber the rail. Brightness marks the turns currently in the
+ * viewport. Hovering bulges nearby ticks toward the content and previews the
+ * turn's prompt plus its final response; clicking a tick jumps to the turn.
+ * There is no proportional thumb.
+ */
+
+export const RULER_TICK_PITCH = 11;
+export const RULER_PAD = 10;
+const RULER_TICK_WIDTH = 6;
+const RULER_HOVER_WIDTH = 30;
+const RULER_COMB_REACH = 4;
+
+export function rulerTickCount(height: number, eventCount: number): number {
+  if (eventCount <= 0) return 0;
+  const fit = Math.floor((height - RULER_PAD * 2) / RULER_TICK_PITCH);
+  return Math.max(0, Math.min(eventCount, fit));
+}
+
+/** Half-open event range [start, end) represented by one tick. */
+export function rulerBucketRange(
+  tick: number,
+  tickCount: number,
+  eventCount: number,
+): { start: number; end: number } {
+  const start = Math.floor((tick * eventCount) / tickCount);
+  const end = Math.max(
+    start + 1,
+    Math.floor(((tick + 1) * eventCount) / tickCount),
+  );
+  return { start, end: Math.min(end, eventCount) };
+}
+
+export function rulerTickForEvent(
+  index: number,
+  tickCount: number,
+  eventCount: number,
+): number {
+  if (eventCount <= 0 || tickCount <= 0) return 0;
+  // Inverse of rulerBucketRange's floor boundaries: the tick whose
+  // half-open bucket contains the event index.
+  const tick = Math.ceil(((index + 1) * tickCount) / eventCount) - 1;
+  return Math.min(tickCount - 1, Math.max(0, tick));
+}
+
+/** Comb widths: the hovered tick is longest, neighbors taper back to rest. */
+export function rulerCombWidth(tick: number, hoverTick: number | null): number {
+  if (hoverTick === null) return RULER_TICK_WIDTH;
+  const distance = Math.abs(tick - hoverTick);
+  if (distance > RULER_COMB_REACH) return RULER_TICK_WIDTH;
+  const falloff = (RULER_COMB_REACH - distance) / RULER_COMB_REACH;
+  return Math.round(
+    RULER_TICK_WIDTH + (RULER_HOVER_WIDTH - RULER_TICK_WIDTH) * falloff ** 1.6,
+  );
+}
+
+/**
+ * Index of the tick whose rendered center is nearest the pointer. Hit-testing
+ * against the real tick rects keeps hover exact regardless of layout.
+ */
+export function rulerNearestTick(
+  rects: readonly { top: number; bottom: number }[],
+  clientY: number,
+): number | null {
+  let best: number | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  rects.forEach((rect, index) => {
+    const distance = Math.abs((rect.top + rect.bottom) / 2 - clientY);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = index;
+    }
+  });
+  return best;
+}
+
+/** First event index of each turn; the last entry's span runs to eventCount. */
+export function rulerTurnStarts(
+  turns: readonly IndexedTraceTurnGroup[],
+): number[] {
+  return turns.map(
+    (turn) =>
+      turn.user?.index ?? turn.work[0]?.index ?? turn.final[0]?.index ?? 0,
+  );
+}
+
+/** The turn whose span contains an event index (binary search over starts). */
+export function rulerTurnForEvent(
+  index: number,
+  starts: readonly number[],
+): number {
+  let lo = 0;
+  let hi = starts.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (starts[mid] <= index) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo;
+}
+
+/**
+ * Preview for one turn, mirroring what the trace view shows for it: the user
+ * prompt as the title and the final agent response (the trailing assistant
+ * text after the collapsed work) as the snippet.
+ */
+export function rulerPreview(
+  turn: IndexedTraceTurnGroup | undefined,
+): { title: string; snippet: string } | null {
+  if (!turn?.user) return null;
+  const title = collapseWhitespace(extractEventText(turn.user.event));
+  if (!title) return null;
+  let snippet = "";
+  for (const item of turn.final) {
+    snippet = collapseWhitespace(extractEventText(item.event));
+    if (snippet) break;
+  }
+  return { title, snippet };
+}
+
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function findScrollContainer(element: HTMLElement): HTMLElement | null {
+  let parent = element.parentElement;
+  while (parent) {
+    const style = window.getComputedStyle(parent);
+    if (
+      /(auto|scroll)/.test(style.overflowY) ||
+      /(auto|scroll)/.test(style.overflow)
+    ) {
+      return parent;
+    }
+    parent = parent.parentElement;
+  }
+  return null;
+}
+
+export function TraceRuler({
+  events,
+}: {
+  events: readonly ReviewAgentTraceEvent[];
+}) {
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const railRef = useRef<HTMLDivElement | null>(null);
+  const containerRef = useRef<HTMLElement | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const [rect, setRect] = useState<{
+    top: number;
+    left: number;
+    height: number;
+  } | null>(null);
+  const railHeight = rect?.height ?? 0;
+  const [visibleRange, setVisibleRange] = useState<{
+    lo: number;
+    hi: number;
+  } | null>(null);
+  const [hoverTick, setHoverTick] = useState<number | null>(null);
+
+  const eventCount = events.length;
+  const turns = useMemo(() => buildIndexedTraceTurns([...events]), [events]);
+  const turnStarts = useMemo(() => rulerTurnStarts(turns), [turns]);
+  const turnCount = turns.length;
+  const tickCount = rulerTickCount(railHeight, turnCount);
+
+  const measureVisible = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const containerRect = container.getBoundingClientRect();
+    let lo = Number.POSITIVE_INFINITY;
+    let hi = Number.NEGATIVE_INFINITY;
+    const wrappers =
+      container.querySelectorAll<HTMLElement>("[data-trace-event]");
+    for (const wrapper of wrappers) {
+      const index = Number(wrapper.dataset.traceEvent);
+      if (!Number.isFinite(index)) continue;
+      const rect = wrapper.getBoundingClientRect();
+      if (rect.bottom > containerRect.top && rect.top < containerRect.bottom) {
+        lo = Math.min(lo, index);
+        hi = Math.max(hi, index);
+      }
+    }
+    setVisibleRange(lo <= hi ? { lo, hi } : null);
+  }, []);
+
+  useEffect(() => {
+    const anchor = anchorRef.current;
+    if (!anchor) return;
+    const container = findScrollContainer(anchor);
+    containerRef.current = container;
+    if (!container) return;
+
+    const measureHeight = () => {
+      const bounds = container.getBoundingClientRect();
+      setRect({
+        top: bounds.top,
+        left: bounds.left,
+        height: container.clientHeight,
+      });
+    };
+    measureHeight();
+    measureVisible();
+
+    const onScroll = () => {
+      if (frameRef.current !== null) return;
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = null;
+        measureVisible();
+      });
+    };
+    container.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", measureHeight);
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(() => {
+            measureHeight();
+            measureVisible();
+          })
+        : null;
+    resizeObserver?.observe(container);
+    return () => {
+      container.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", measureHeight);
+      resizeObserver?.disconnect();
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    };
+  }, [measureVisible, eventCount]);
+
+  const tickTop = useCallback(
+    (tick: number) => RULER_PAD + tick * RULER_TICK_PITCH,
+    [],
+  );
+
+  const tickFromPointer = useCallback((clientY: number) => {
+    const rail = railRef.current;
+    if (!rail) return null;
+    const rects = [
+      ...rail.querySelectorAll<HTMLElement>(".review-trace-ruler-tick"),
+    ].map((tick) => tick.getBoundingClientRect());
+    return rulerNearestTick(rects, clientY);
+  }, []);
+
+  const jumpToTick = useCallback(
+    (tick: number) => {
+      const container = containerRef.current;
+      if (!container || tickCount === 0) return;
+      const { start: turn } = rulerBucketRange(tick, tickCount, turnCount);
+      const start = turnStarts[turn] ?? 0;
+      const wrappers = [
+        ...container.querySelectorAll<HTMLElement>("[data-trace-event]"),
+      ]
+        .map((wrapper) => ({
+          wrapper,
+          index: Number(wrapper.dataset.traceEvent),
+        }))
+        .filter((entry) => Number.isFinite(entry.index))
+        .sort((left, right) => left.index - right.index);
+      const target =
+        wrappers.find((entry) => entry.index >= start) ?? wrappers.at(-1);
+      if (target && typeof target.wrapper.scrollIntoView === "function") {
+        target.wrapper.scrollIntoView({ block: "start", behavior: "auto" });
+        return;
+      }
+      container.scrollTop =
+        (start / Math.max(1, eventCount)) *
+        (container.scrollHeight - container.clientHeight);
+    },
+    [tickCount, turnCount, turnStarts, eventCount],
+  );
+
+  const preview = useMemo(() => {
+    if (hoverTick === null || tickCount === 0) return null;
+    const { start } = rulerBucketRange(hoverTick, tickCount, turnCount);
+    return rulerPreview(turns[start]);
+  }, [hoverTick, tickCount, turnCount, turns]);
+
+  if (eventCount === 0 || turnCount === 0) return null;
+
+  // Visible events map onto the turns that contain them.
+  const visibleTurns =
+    visibleRange === null
+      ? null
+      : {
+          lo: rulerTurnForEvent(visibleRange.lo, turnStarts),
+          hi: rulerTurnForEvent(visibleRange.hi, turnStarts),
+        };
+
+  const ticks: ReactNode[] = [];
+  for (let tick = 0; tick < tickCount; tick += 1) {
+    const { start, end } = rulerBucketRange(tick, tickCount, turnCount);
+    const isVisible =
+      visibleTurns !== null &&
+      start <= visibleTurns.hi &&
+      end > visibleTurns.lo;
+    const width = rulerCombWidth(tick, hoverTick);
+    const className = [
+      "review-trace-ruler-tick",
+      // While the comb is active only the hover treatment shows; the
+      // viewport run returns when the pointer leaves.
+      isVisible && hoverTick === null ? "review-trace-ruler-tick--visible" : "",
+      tick === hoverTick ? "review-trace-ruler-tick--hovered" : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+    ticks.push(
+      <div
+        key={tick}
+        className={className}
+        style={{ top: tickTop(tick), width }}
+      />,
+    );
+  }
+
+  const cardTop =
+    hoverTick !== null
+      ? Math.max(RULER_PAD, Math.min(tickTop(hoverTick) - 24, railHeight - 140))
+      : 0;
+
+  return (
+    <div ref={anchorRef} className="review-trace-ruler" aria-hidden="true">
+      <div
+        ref={railRef}
+        className="review-trace-ruler-rail"
+        style={{
+          height: railHeight,
+          top: rect?.top ?? 0,
+          left: (rect?.left ?? 0) + 6,
+        }}
+        onMouseMove={(event) => setHoverTick(tickFromPointer(event.clientY))}
+        onMouseLeave={() => setHoverTick(null)}
+        onClick={(event) => {
+          const tick = tickFromPointer(event.clientY);
+          if (tick !== null) jumpToTick(tick);
+        }}
+      >
+        {ticks}
+        {preview && hoverTick !== null && (
+          <div className="review-trace-ruler-card" style={{ top: cardTop }}>
+            <span className="review-trace-ruler-card-title">
+              {preview.title}
+            </span>
+            {preview.snippet && (
+              <span className="review-trace-ruler-card-snippet">
+                {preview.snippet}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- the agent trace view gains a Codex-style event-ruler scrollbar: a left-edge column of uniform 8×2px rounded dashes mapping the whole session at even pitch (events bucketed one-per-tick when they outnumber the rail)
- brightness is the viewport indicator — the contiguous bright run tracks the events currently on screen, updating on scroll; there is no proportional thumb
- hovering bulges nearby ticks toward the content (hovered tick longest and brightest) and floats a preview card with the nearest user prompt in bold plus its response snippet; clicking a tick jumps to that part of the trace
- strictly grayscale through the existing ink tokens, so light and dark themes both inherit the treatment
- trace event wrappers and tool groups now carry `data-trace-event` indexes for visibility measurement and jump targeting

## Validation

- `pnpm --filter @dev.fast/review test -- app/src` — 478 passing, plus 18 new tests in `app/src/trace-ruler.test.tsx` covering tick bucketing round-trips, comb falloff, preview selection, and render guards
- `pnpm lint`, `pnpm format:check`
- typecheck carries only the two pre-existing failures on main (`scripts/check-tutorial.ts`, `src/server/bug-report.ts`)

Design source: the "Codex Scrollbar" Paper file (in-context panel + states/anatomy artboards), aligned with the user's Codex reference screenshots.
