### PR TITLE
Keep the trace scroll position stable across elision changes

### DIFF
--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -10058,6 +10058,9 @@ a.review-doc-meta-pr:hover {
 
 .review-view-region--trace {
   overflow: auto;
+  /* The trace view anchors scroll itself across elision changes; the
+     browser's own heuristic would otherwise adjust a second time. */
+  overflow-anchor: none;
 }
 
 .review-trace-view {

--- a/packages/progressive-review/app/src/trace-document.test.tsx
+++ b/packages/progressive-review/app/src/trace-document.test.tsx
@@ -156,6 +156,8 @@ describe("TraceDocument", () => {
     const initialGaps = container.querySelectorAll(".review-trace-lens-gap");
     expect(initialGaps.length).toBe(1);
     expect(initialGaps[0].textContent).toContain("5 hidden events");
+    // The chip carries its gap start so scroll anchoring can find it after a fold.
+    expect(initialGaps[0].getAttribute("data-trace-gap")).toBe("0");
 
     // Click to expand gap
     const gapButton = initialGaps[0] as HTMLButtonElement;

--- a/packages/progressive-review/app/src/trace-document.tsx
+++ b/packages/progressive-review/app/src/trace-document.tsx
@@ -1,5 +1,12 @@
 import type { ReviewAgentTraceEvent } from "@dev.fast/review-protocol";
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import {
+  type ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { AgentChatUserMessage } from "./agent-chat";
 import { AgentMarkdown } from "./agent-markdown";
@@ -7,6 +14,12 @@ import {
   HighlightedText,
   findWhitespaceNormalizedSpan,
 } from "./highlighted-text";
+import {
+  type TraceScrollAnchor,
+  captureTraceScrollAnchor,
+  findScrollContainer,
+  restoreTraceScrollAnchor,
+} from "./trace-scroll-anchor";
 
 export type TraceTurnEvent = Exclude<
   ReviewAgentTraceEvent,
@@ -680,6 +693,7 @@ export function TraceGapChip({
       key={`gap-${from}`}
       type="button"
       className="review-trace-lens-gap"
+      data-trace-gap={from}
       onClick={onExpand}
     >
       <span className="review-trace-lens-gap-line" />
@@ -1088,11 +1102,46 @@ export function TraceDocument({
     return map;
   }, [baseIncluded, expandedGaps, events.length]);
 
+  // Expanding or collapsing an elision changes the rows above or below the
+  // reader while the browser holds scrollTop still. Capture a visible row
+  // before each change and restore its viewport offset once React commits,
+  // so the reader's position never moves; the revealed content lands above
+  // or below, in reach by scrolling.
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const pendingAnchorRef = useRef<{
+    anchor: TraceScrollAnchor;
+    fallbackGap?: number;
+  } | null>(null);
+
+  const captureAnchor = (fallbackGap?: number) => {
+    const root = rootRef.current;
+    const container = root ? findScrollContainer(root) : null;
+    if (!container) return;
+    const anchor = captureTraceScrollAnchor(container);
+    pendingAnchorRef.current = anchor
+      ? fallbackGap === undefined
+        ? { anchor }
+        : { anchor, fallbackGap }
+      : null;
+  };
+
+  useLayoutEffect(() => {
+    const pending = pendingAnchorRef.current;
+    if (!pending) return;
+    pendingAnchorRef.current = null;
+    const root = rootRef.current;
+    const container = root ? findScrollContainer(root) : null;
+    if (!container) return;
+    restoreTraceScrollAnchor(container, pending.anchor, pending.fallbackGap);
+  }, [expandedGaps, expandedEvents]);
+
   const handleExpandGap = (from: number, _count: number) => {
+    captureAnchor();
     setExpandedGaps((prev) => new Set(prev).add(from));
   };
 
   const handleCollapseGap = (from: number) => {
+    captureAnchor(from);
     setExpandedGaps((prev) => {
       const next = new Set(prev);
       next.delete(from);
@@ -1119,6 +1168,7 @@ export function TraceDocument({
   }, [baseIncluded, expandedGaps, events.length]);
 
   const handleExpandEvent = (index: number) => {
+    captureAnchor();
     setExpandedEvents((prev) => new Set(prev).add(index));
   };
 
@@ -1242,6 +1292,7 @@ export function TraceDocument({
 
   return (
     <div
+      ref={rootRef}
       className={
         className ? `review-trace-events ${className}` : "review-trace-events"
       }

--- a/packages/progressive-review/app/src/trace-ruler.tsx
+++ b/packages/progressive-review/app/src/trace-ruler.tsx
@@ -13,6 +13,7 @@ import {
   buildIndexedTraceTurns,
   extractEventText,
 } from "./trace-document";
+import { findScrollContainer } from "./trace-scroll-anchor";
 
 /**
  * Turn-ruler scrollbar for the agent trace view. A left-edge column of
@@ -140,21 +141,6 @@ export function rulerPreview(
 
 function collapseWhitespace(text: string): string {
   return text.replace(/\s+/g, " ").trim();
-}
-
-function findScrollContainer(element: HTMLElement): HTMLElement | null {
-  let parent = element.parentElement;
-  while (parent) {
-    const style = window.getComputedStyle(parent);
-    if (
-      /(auto|scroll)/.test(style.overflowY) ||
-      /(auto|scroll)/.test(style.overflow)
-    ) {
-      return parent;
-    }
-    parent = parent.parentElement;
-  }
-  return null;
 }
 
 export function TraceRuler({

--- a/packages/progressive-review/app/src/trace-scroll-anchor.test.ts
+++ b/packages/progressive-review/app/src/trace-scroll-anchor.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  captureTraceScrollAnchor,
+  chooseTraceAnchor,
+  restoreTraceScrollAnchor,
+  traceScrollAdjustment,
+} from "./trace-scroll-anchor";
+
+/** A scroll container whose rows report stubbed layout positions. */
+function makeContainer(
+  rows: Array<{ index?: number; gap?: number; top: number }>,
+) {
+  const container = document.createElement("div");
+  let scrollTop = 0;
+  Object.defineProperty(container, "scrollTop", {
+    get: () => scrollTop,
+    set: (value: number) => {
+      scrollTop = value;
+    },
+  });
+  container.getBoundingClientRect = () =>
+    ({
+      top: 100,
+      left: 0,
+      width: 800,
+      height: 600,
+      bottom: 700,
+      right: 800,
+    }) as DOMRect;
+  const setTop = (element: HTMLElement, top: number) => {
+    element.getBoundingClientRect = () =>
+      ({
+        top,
+        left: 0,
+        width: 800,
+        height: 40,
+        bottom: top + 40,
+        right: 800,
+      }) as DOMRect;
+  };
+  const elements = rows.map((row) => {
+    const element = document.createElement("div");
+    if (row.index !== undefined) element.dataset.traceEvent = String(row.index);
+    if (row.gap !== undefined) element.dataset.traceGap = String(row.gap);
+    setTop(element, row.top);
+    container.append(element);
+    return element;
+  });
+  document.body.append(container);
+  return { container, elements, setTop };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("chooseTraceAnchor", () => {
+  it("anchors the first row at or below the viewport top", () => {
+    const anchor = chooseTraceAnchor(
+      [
+        { index: 0, top: -50 },
+        { index: 1, top: 20 },
+        { index: 2, top: 120 },
+        { index: 3, top: 220 },
+      ],
+      100,
+    );
+    expect(anchor).toEqual({ index: 2, offset: 20 });
+  });
+
+  it("falls back to the last row when every row is above the viewport", () => {
+    expect(
+      chooseTraceAnchor(
+        [
+          { index: 4, top: -300 },
+          { index: 5, top: -200 },
+        ],
+        100,
+      ),
+    ).toEqual({ index: 5, offset: -300 });
+    expect(chooseTraceAnchor([], 100)).toBeNull();
+  });
+});
+
+describe("traceScrollAdjustment", () => {
+  it("returns the delta that restores the saved offset", () => {
+    expect(traceScrollAdjustment({ index: 2, offset: 20 }, 420, 100)).toBe(300);
+    expect(traceScrollAdjustment({ index: 2, offset: 20 }, 120, 100)).toBe(0);
+  });
+});
+
+describe("capture and restore across an elision change", () => {
+  it("keeps a row below the expanded gap still by scrolling past the inserted height", () => {
+    const { container, elements, setTop } = makeContainer([
+      { index: 0, top: 40 },
+      { index: 7, top: 110 },
+      { index: 8, top: 170 },
+    ]);
+    const anchor = captureTraceScrollAnchor(container);
+    expect(anchor).toEqual({ index: 7, offset: 10 });
+
+    // Expanding a gap above row 7 pushes it and its followers down 300px.
+    setTop(elements[1], 410);
+    setTop(elements[2], 470);
+    expect(restoreTraceScrollAnchor(container, anchor!)).toBe(300);
+    expect(container.scrollTop).toBe(300);
+  });
+
+  it("makes no adjustment when the anchored row sits above the change", () => {
+    const { container, elements, setTop } = makeContainer([
+      { index: 3, top: 130 },
+      { index: 9, top: 200 },
+    ]);
+    const anchor = captureTraceScrollAnchor(container);
+    expect(anchor).toEqual({ index: 3, offset: 30 });
+
+    // Expanding a gap below row 3 moves only the rows after it.
+    setTop(elements[1], 900);
+    expect(restoreTraceScrollAnchor(container, anchor!)).toBe(0);
+    expect(container.scrollTop).toBe(0);
+  });
+
+  it("lands on the gap chip when the anchored row was inside the folded span", () => {
+    const { container, elements } = makeContainer([
+      { index: 2, top: 50 },
+      { index: 5, top: 130 },
+      { index: 6, top: 190 },
+      { index: 9, top: 250 },
+    ]);
+    const anchor = captureTraceScrollAnchor(container);
+    expect(anchor).toEqual({ index: 5, offset: 30 });
+
+    // Folding events 5..6 replaces them with the gap chip for `from: 5`.
+    elements[1].remove();
+    elements[2].remove();
+    const chip = document.createElement("button");
+    chip.dataset.traceGap = "5";
+    chip.getBoundingClientRect = () =>
+      ({
+        top: 250,
+        left: 0,
+        width: 800,
+        height: 22,
+        bottom: 272,
+        right: 800,
+      }) as DOMRect;
+    container.insertBefore(chip, elements[3]);
+
+    expect(restoreTraceScrollAnchor(container, anchor!, 5)).toBe(120);
+    expect(container.scrollTop).toBe(120);
+    expect(
+      restoreTraceScrollAnchor(container, { index: 42, offset: 0 }),
+    ).toBeNull();
+  });
+});

--- a/packages/progressive-review/app/src/trace-scroll-anchor.ts
+++ b/packages/progressive-review/app/src/trace-scroll-anchor.ts
@@ -1,0 +1,119 @@
+/**
+ * Scroll anchoring for the agent trace view.
+ *
+ * Expanding or collapsing an elision inserts or removes rows in place while
+ * the browser keeps `scrollTop` constant, so a gap opened near the top of the
+ * viewport teleports the reader into the revealed span. These helpers pin one
+ * visible row to its viewport offset across the DOM change: capture the row
+ * before the state update, then restore its offset after React commits.
+ *
+ * The anchor is the first row at or below the viewport top. A row below the
+ * changed span moves by the inserted (or removed) height, so restoring it
+ * keeps the reader's view still and the revealed content lands above, in
+ * reach by scrolling. A row above the span never moves, so the adjustment is
+ * zero and the content grows downward beneath what the reader was looking at.
+ */
+
+export interface TraceScrollAnchor {
+  /** Event index carried by the anchored row's `data-trace-event`. */
+  index: number;
+  /** Row top relative to the scroll container's top, before the change. */
+  offset: number;
+}
+
+export interface TraceAnchorCandidate {
+  index: number;
+  top: number;
+}
+
+/** Nearest ancestor whose computed overflow scrolls. */
+export function findScrollContainer(element: HTMLElement): HTMLElement | null {
+  let parent = element.parentElement;
+  while (parent) {
+    const style = window.getComputedStyle(parent);
+    if (
+      /(auto|scroll)/.test(style.overflowY) ||
+      /(auto|scroll)/.test(style.overflow)
+    ) {
+      return parent;
+    }
+    parent = parent.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Choose the anchor among measured rows (in document order): the first row
+ * whose top sits at or below the viewport top. When every row is above the
+ * viewport, the last row is the closest one and anchors instead.
+ */
+export function chooseTraceAnchor(
+  rows: readonly TraceAnchorCandidate[],
+  viewportTop: number,
+): TraceScrollAnchor | null {
+  if (rows.length === 0) return null;
+  const visible = rows.find((row) => row.top >= viewportTop - 0.5);
+  const chosen = visible ?? rows[rows.length - 1];
+  return { index: chosen.index, offset: chosen.top - viewportTop };
+}
+
+/** Scroll delta that returns the anchor to its saved viewport offset. */
+export function traceScrollAdjustment(
+  anchor: TraceScrollAnchor,
+  currentTop: number,
+  viewportTop: number,
+): number {
+  return currentTop - viewportTop - anchor.offset;
+}
+
+function measureRows(container: HTMLElement): TraceAnchorCandidate[] {
+  const rows: TraceAnchorCandidate[] = [];
+  for (const element of container.querySelectorAll<HTMLElement>(
+    "[data-trace-event]",
+  )) {
+    const index = Number(element.dataset.traceEvent);
+    if (!Number.isFinite(index)) continue;
+    rows.push({ index, top: element.getBoundingClientRect().top });
+  }
+  return rows;
+}
+
+/** Capture the anchor for `container` before the trace DOM changes. */
+export function captureTraceScrollAnchor(
+  container: HTMLElement,
+): TraceScrollAnchor | null {
+  return chooseTraceAnchor(
+    measureRows(container),
+    container.getBoundingClientRect().top,
+  );
+}
+
+/**
+ * Restore the anchor after the trace DOM changed. When the anchored row is
+ * gone (it sat inside a span that was just folded), the gap chip that took
+ * the span's place stands in for it, so folding lands the reader on the chip.
+ * Returns the applied delta, or null when nothing could be anchored.
+ */
+export function restoreTraceScrollAnchor(
+  container: HTMLElement,
+  anchor: TraceScrollAnchor,
+  fallbackGap?: number,
+): number | null {
+  const row =
+    container.querySelector<HTMLElement>(
+      `[data-trace-event="${anchor.index}"]`,
+    ) ??
+    (fallbackGap === undefined
+      ? null
+      : container.querySelector<HTMLElement>(
+          `[data-trace-gap="${fallbackGap}"]`,
+        ));
+  if (!row) return null;
+  const delta = traceScrollAdjustment(
+    anchor,
+    row.getBoundingClientRect().top,
+    container.getBoundingClientRect().top,
+  );
+  if (delta !== 0) container.scrollTop += delta;
+  return delta;
+}


### PR DESCRIPTION
## Summary

- expanding an elision near the top of the trace viewport teleported the reader into the revealed span: rows were inserted in place while the browser held `scrollTop` constant (a gap below the viewport changed nothing, hence the asymmetry)
- the trace document now pins one visible row across every expand/collapse: `captureTraceScrollAnchor` records the first row at or below the viewport top before the state update, and a layout effect restores its offset after React commits (`trace-scroll-anchor.ts`)
- a row below the changed span moves by the inserted height, so the view stays still and the revealed content lands above, in reach by scrolling; a row above the span never moves, so content grows downward beneath what the reader was looking at
- folding a span whose anchor row disappears falls back to the gap chip, which now carries `data-trace-gap`; the scroll container sets `overflow-anchor: none` so the browser's own heuristic doesn't adjust a second time; the ruler shares the scroll-container resolver

## Validation

- `pnpm --filter @dev.fast/review test -- app/src` — 486 passing, including new `trace-scroll-anchor.test.ts` (anchor below gap adjusts by inserted height, anchor above gap makes no adjustment, collapse with the anchor inside the folded span lands on the chip) and a chip-attribute assertion in the elision round-trip test
- `pnpm lint`, `pnpm format:check`; typecheck carries only the two pre-existing failures on main

Stacked on #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LWtzi73apjPVBkuenssHW
