### PR TITLE
Give preview builds a distinct app identity

### DIFF
--- a/.github/workflows/review-desktop-preview.yml
+++ b/.github/workflows/review-desktop-preview.yml
@@ -344,7 +344,7 @@ jobs:
         run: |
           DIST=apps/review-desktop/dist
           RELEASE_PREFIX="s3://${R2_BUCKET}/releases/${RELEASE_VERSION}/darwin-arm64"
-          DMG_DISPOSITION="attachment; filename=\"df-review-${RELEASE_VERSION}.dmg\""
+          DMG_DISPOSITION="attachment; filename=\"df-review-preview-${RELEASE_VERSION}.dmg\""
 
           aws s3 cp "$DIST/Review-darwin-arm64-${RELEASE_VERSION}.zip" \
             "${RELEASE_PREFIX}/Review-darwin-arm64-${RELEASE_VERSION}.zip" \
@@ -376,22 +376,22 @@ jobs:
           echo "$STATUS"
           test "$STATUS" = "204"
 
-      - name: Verify install landing
+      - name: Verify preview install landing
         if: ${{ !inputs.dry_run }}
         run: |
-          echo "install.dev.fast (expect 302 to the disk image):"
-          LOCATION=$(curl -s -o /dev/null -w "%{redirect_url}" https://install.dev.fast/)
+          echo "install.dev.fast/preview (expect 302 to the preview disk image):"
+          LOCATION=$(curl -s -o /dev/null -w "%{redirect_url}" https://install.dev.fast/preview)
           echo "$LOCATION"
-          test "$LOCATION" = "https://install.dev.fast/releases/latest/darwin-arm64/Review.dmg"
+          test "$LOCATION" = "https://install.dev.fast/releases/preview-latest/darwin-arm64/Review.dmg"
 
           echo "Following it (expect 200 and a disk image):"
-          curl -sfL -o /dev/null -w "%{http_code} %{content_type}\n" https://install.dev.fast/ \
+          curl -sfL -o /dev/null -w "%{http_code} %{content_type}\n" https://install.dev.fast/preview \
             | grep -F "200 application/x-apple-diskimage"
 
       - name: Upload preview DMG artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: review-desktop-${{ env.RELEASE_VERSION }}-dmg
+          name: review-desktop-preview-${{ env.RELEASE_VERSION }}-dmg
           path: apps/review-desktop/dist/Review-darwin-arm64-${{ env.RELEASE_VERSION }}.dmg
           retention-days: 3
           compression-level: 0

--- a/apps/review-desktop/README.md
+++ b/apps/review-desktop/README.md
@@ -152,14 +152,19 @@ already contains this workflow and its scripts. Updates are keyed by commit;
 publishing an older commit intentionally rolls preview installations back to
 that build.
 
-Install the latest preview from
-<https://install.dev.fast/releases/preview-latest/darwin-arm64/Review.dmg>.
-Preview builds use an orange app-icon background so they stay visually distinct
-from stable installs in Finder, the Dock, and the app switcher.
-Preview and stable use the same app name and bundle identifier, so installing
-one replaces the other while retaining settings and data. To return to stable,
-reinstall from <https://install.dev.fast>; the stable app points the updater
-back at the stable feed.
+Install the latest preview from <https://install.dev.fast/preview>. It installs
+as `Review Preview.app`, displays as `/dev/fast Review Preview`, and uses an
+orange app-icon background so it stays visually distinct from stable in Finder,
+the Dock, and the app switcher.
+
+Preview uses its own bundle identifier, URL scheme, CLI name, and data folders,
+so it can run beside stable without replacing the stable app or sharing its
+settings. Preview updates continue to use the preview feed. To return to stable,
+open the existing `Review.app` or install it from <https://install.dev.fast>.
+
+Builds from before the preview identity split installed as `Review.app`.
+Reinstall once from <https://install.dev.fast/preview> after the split so the
+preview lands at the new application path; later preview updates retain it.
 
 ### Linux-to-macOS build handoff
 
@@ -204,15 +209,17 @@ disjoint, so both hostnames answer all of them and the Worker needs no
 host discrimination; the two names exist to give humans and Squirrel separate
 front doors.
 
-`GET /` is the install landing: it redirects to the
-`releases/latest/darwin-arm64/Review.dmg` alias, so
+`GET /` is the stable install landing: it redirects to the
+`releases/latest/darwin-arm64/Review.dmg` alias, while `GET /preview` redirects
+to `releases/preview-latest/darwin-arm64/Review.dmg`. For example,
 `curl -fLOJ https://install.dev.fast` downloads the current disk image. It
 deliberately does not read `latest.json` — the alias is uploaded with the
 payloads, so the download keeps working while the manifest is mid-upload. The
-key stays version-free for that reason, so the version rides on the object's
-`Content-Disposition: attachment; filename="df-review-<version>.dmg"` instead
-and the saved file names itself. curl only honours that with `-J`; a browser
-download always does.
+keys stay version-free for that reason, so the version rides on each object's
+`Content-Disposition` instead and the saved file names itself. Stable uses
+`df-review-<version>.dmg`; preview uses
+`df-review-preview-<preview-version>.dmg`. curl only honours that with `-J`; a
+browser download always does.
 
 ```
 update/stable/darwin-arm64/latest.json     current-release manifest
@@ -222,7 +229,7 @@ releases/latest/darwin-arm64/Review.dmg    direct-download alias, saved as
                                            df-review-<version>.dmg
 releases/preview-latest/darwin-arm64/Review.dmg
                                            preview-download alias, saved as
-                                           df-review-<preview-version>.dmg
+                                           df-review-preview-<preview-version>.dmg
 ```
 
 `GET /api/update/:platform/:quality/:commit` answers 204 when the caller's

--- a/apps/review-desktop/scripts/desktop-branding.test.mjs
+++ b/apps/review-desktop/scripts/desktop-branding.test.mjs
@@ -42,12 +42,19 @@ test("keeps compatibility-sensitive Desktop identifiers unchanged", () => {
   assert.equal(product.urlProtocol, "dev-fast-review");
   assert.equal(product.dataFolderName, ".dev-fast-review");
   assert.equal(product.sharedDataFolderName, ".dev-fast-review-shared");
+
+  assert.match(
+    electronBuild,
+    /darwinBundleIdentifier: product\.darwinBundleIdentifier/,
+  );
+  assert.match(electronBuild, /urlSchemes: \[product\.urlProtocol\]/);
 });
 
-test("uses Review.app instead of putting the branded name in paths", async () => {
+test("uses the product short name for app bundle paths", async () => {
   assert.equal(product.nameShort, "Review");
   assert.equal(product.win32DirName, "Review");
   assert.match(electronBuild, /productAppName: product\.nameShort/);
+  assert.match(electronBuild, /darwinExecutable: product\.nameShort/);
 
   const bundlePathSources = await Promise.all(
     [
@@ -76,11 +83,15 @@ test("uses Review.app instead of putting the branded name in paths", async () =>
     assert.doesNotMatch(source, /\$\{product\.nameLong\}\.app/);
   }
 
-  assert.match(await readSource("./package-macos.sh"), /Review\.app/);
-  assert.match(await readSource("./notarize-macos.sh"), /Review\.app/);
-  assert.match(await readSource("./smoke-launch-packaged.mjs"), /Review\.app/);
-  assert.match(
-    await readSource("./validate-release-artifacts.mjs"),
-    /Review\.app/,
-  );
+  for (const source of await Promise.all(
+    [
+      "./package-macos.sh",
+      "./notarize-macos.sh",
+      "./smoke-launch-packaged.mjs",
+      "./validate-release-artifacts.mjs",
+    ].map(readSource),
+  )) {
+    assert.match(source, /nameShort/);
+    assert.doesNotMatch(source, /Review\.app/);
+  }
 });

--- a/apps/review-desktop/scripts/notarize-macos.sh
+++ b/apps/review-desktop/scripts/notarize-macos.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 MONOREPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
 APP_DIR="$MONOREPO_ROOT/apps/review-desktop"
 CHECKOUT="$APP_DIR/code-oss"
-PACKAGED_APP="$APP_DIR/VSCode-darwin-arm64/Review.app"
+PRODUCT_NAME="$(node -p "require('$CHECKOUT/product.json').nameShort")"
+PACKAGED_APP="$APP_DIR/VSCode-darwin-arm64/$PRODUCT_NAME.app"
 VERSION="$(node -p "require('$APP_DIR/package.json').version")"
 ARTIFACT_DIR="${DEV_FAST_REVIEW_ARTIFACT_DIR:-$APP_DIR/dist}"
 UPDATE_ZIP="$ARTIFACT_DIR/Review-darwin-arm64-$VERSION.zip"
@@ -139,10 +140,10 @@ mkdir -p "$ARTIFACT_DIR"
 rm -f -- "$UPDATE_ZIP" "$DMG"
 
 mkdir -p "$DMG_STAGE"
-ditto "$PACKAGED_APP" "$DMG_STAGE/Review.app"
+ditto "$PACKAGED_APP" "$DMG_STAGE/$PRODUCT_NAME.app"
 ln -s /Applications "$DMG_STAGE/Applications"
 hdiutil create \
-  -volname "Review" \
+  -volname "$PRODUCT_NAME" \
   -srcfolder "$DMG_STAGE" \
   -ov \
   -format UDZO \

--- a/apps/review-desktop/scripts/package-macos.sh
+++ b/apps/review-desktop/scripts/package-macos.sh
@@ -8,7 +8,9 @@ set -euo pipefail
 MONOREPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
 APP_DIR="$MONOREPO_ROOT/apps/review-desktop"
 CHECKOUT="$APP_DIR/code-oss"
-PACKAGED_APP="$APP_DIR/VSCode-darwin-arm64/Review.app"
+PRODUCT_NAME="$(node -p "require('$CHECKOUT/product.json').nameShort")"
+PACKAGED_APP="$APP_DIR/VSCode-darwin-arm64/$PRODUCT_NAME.app"
+PACKAGED_BINARY="$PACKAGED_APP/Contents/MacOS/$PRODUCT_NAME"
 
 # shellcheck source=darwin-payload-manifest.sh
 source "$APP_DIR/scripts/darwin-payload-manifest.sh"
@@ -61,8 +63,8 @@ else
   npm --prefix "$CHECKOUT" run gulp -- vscode-darwin-arm64-min
 fi
 
-if [[ ! -x "$PACKAGED_APP/Contents/MacOS/Review" ]]; then
-  echo "Review Desktop packaging did not create $PACKAGED_APP/Contents/MacOS/Review" >&2
+if [[ ! -x "$PACKAGED_BINARY" ]]; then
+  echo "Review Desktop packaging did not create $PACKAGED_BINARY" >&2
   exit 1
 fi
 node "$APP_DIR/scripts/copy-canvas.mjs" --packaged-root "$PACKAGED_APP"

--- a/apps/review-desktop/scripts/preview-release-workflow.test.mjs
+++ b/apps/review-desktop/scripts/preview-release-workflow.test.mjs
@@ -37,3 +37,22 @@ test("preview downstream jobs pin the commit resolved by versioning", () => {
     assert.doesNotMatch(downstream, /ref: \$\{\{ inputs\.ref \}\}/);
   }
 });
+
+test("preview publishing preserves a distinct installer identity", () => {
+  const build = job("build");
+
+  assert.match(
+    build,
+    /DMG_DISPOSITION="attachment; filename=\\"df-review-preview-\$\{RELEASE_VERSION\}\.dmg\\""/,
+  );
+  assert.match(build, /https:\/\/install\.dev\.fast\/preview/);
+  assert.match(
+    build,
+    /https:\/\/install\.dev\.fast\/releases\/preview-latest\/darwin-arm64\/Review\.dmg/,
+  );
+  assert.match(
+    build,
+    /name: review-desktop-preview-\$\{\{ env\.RELEASE_VERSION \}\}-dmg/,
+  );
+  assert.doesNotMatch(build, /curl[^\n]*https:\/\/install\.dev\.fast\/$/m);
+});

--- a/apps/review-desktop/scripts/release-channel.mjs
+++ b/apps/review-desktop/scripts/release-channel.mjs
@@ -1,0 +1,33 @@
+const RELEASE_IDENTITIES = Object.freeze({
+  stable: Object.freeze({
+    nameShort: "Review",
+    nameLong: "/dev/fast Review",
+    applicationName: "review",
+    dataFolderName: ".dev-fast-review",
+    sharedDataFolderName: ".dev-fast-review-shared",
+    darwinBundleIdentifier: "dev.fast.review",
+    urlProtocol: "dev-fast-review",
+  }),
+  preview: Object.freeze({
+    nameShort: "Review Preview",
+    nameLong: "/dev/fast Review Preview",
+    applicationName: "review-preview",
+    dataFolderName: ".dev-fast-review-preview",
+    sharedDataFolderName: ".dev-fast-review-preview-shared",
+    darwinBundleIdentifier: "dev.fast.review.preview",
+    urlProtocol: "dev-fast-review-preview",
+  }),
+});
+
+export function assertReleaseChannel(channel) {
+  if (!Object.hasOwn(RELEASE_IDENTITIES, channel)) {
+    throw new Error(
+      `channel must be one of stable or preview, received ${JSON.stringify(channel)}`,
+    );
+  }
+}
+
+export function releaseIdentityFor(channel) {
+  assertReleaseChannel(channel);
+  return RELEASE_IDENTITIES[channel];
+}

--- a/apps/review-desktop/scripts/smoke-launch-packaged.mjs
+++ b/apps/review-desktop/scripts/smoke-launch-packaged.mjs
@@ -21,13 +21,21 @@
  * announce a ready server.
  */
 import { execFileSync, spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { parseArgs } from "node:util";
 
 const APP_DIR = path.resolve(import.meta.dirname, "..");
-const DEFAULT_APP = path.join(APP_DIR, "VSCode-darwin-arm64", "Review.app");
+const PRODUCT_NAME = JSON.parse(
+  readFileSync(path.join(APP_DIR, "code-oss", "product.json"), "utf8"),
+).nameShort;
+const DEFAULT_APP = path.join(
+  APP_DIR,
+  "VSCode-darwin-arm64",
+  `${PRODUCT_NAME}.app`,
+);
 const POLL_INTERVAL_MS = 500;
 const SERVER_READY_PATTERN = /\[Review Desktop\] server ready at https?:\/\//;
 
@@ -97,7 +105,7 @@ export async function smokeLaunch({
   app = DEFAULT_APP,
   timeoutMs = 90_000,
 } = {}) {
-  const binary = path.join(app, "Contents", "MacOS", "Review");
+  const binary = path.join(app, "Contents", "MacOS", PRODUCT_NAME);
   const userDataDir = await mkdtemp(path.join(os.tmpdir(), "review-smoke-"));
 
   // A launch that finds a running instance hands its arguments over and exits 0

--- a/apps/review-desktop/scripts/stamp-release-channel.mjs
+++ b/apps/review-desktop/scripts/stamp-release-channel.mjs
@@ -2,8 +2,12 @@ import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { parseArgs } from "node:util";
 
+import {
+  assertReleaseChannel,
+  releaseIdentityFor,
+} from "./release-channel.mjs";
+
 const APP_DIR = path.resolve(import.meta.dirname, "..");
-const RELEASE_QUALITIES = new Set(["stable", "preview"]);
 
 function replaceRequired(source, pattern, replacement, marker, file) {
   if (!pattern.test(source)) {
@@ -21,33 +25,30 @@ export function stampReleaseChannel({
   if (!version) {
     throw new Error("version is required");
   }
-  if (!RELEASE_QUALITIES.has(quality)) {
-    throw new Error(
-      `quality must be one of stable or preview, received ${JSON.stringify(quality)}`,
-    );
-  }
+  assertReleaseChannel(quality);
 
   const pkg = JSON.parse(readFileSync(packagePath, "utf8"));
   pkg.version = version;
 
   const product = readFileSync(productPath, "utf8");
-  const withVersion = replaceRequired(
-    product,
-    /("reviewVersion":\s*")[^"]*(")/,
-    `$1${version}$2`,
-    "reviewVersion",
-    productPath,
-  );
-  const withQuality = replaceRequired(
-    withVersion,
-    /("quality":\s*")[^"]*(")/,
-    `$1${quality}$2`,
-    "quality",
-    productPath,
-  );
+  const fields = {
+    reviewVersion: version,
+    quality,
+    ...releaseIdentityFor(quality),
+  };
+  let stampedProduct = product;
+  for (const [field, value] of Object.entries(fields)) {
+    stampedProduct = replaceRequired(
+      stampedProduct,
+      new RegExp(`("${field}":\\s*")[^"]*(")`),
+      `$1${value}$2`,
+      field,
+      productPath,
+    );
+  }
 
   writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
-  writeFileSync(productPath, withQuality);
+  writeFileSync(productPath, stampedProduct);
 }
 
 function main() {

--- a/apps/review-desktop/scripts/stamp-release-channel.test.mjs
+++ b/apps/review-desktop/scripts/stamp-release-channel.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { after, test } from "node:test";
 
+import { releaseIdentityFor } from "./release-channel.mjs";
 import { stampReleaseChannel } from "./stamp-release-channel.mjs";
 
 const temporaryRoots = [];
@@ -26,7 +27,7 @@ async function writeFixtures(product) {
 
 test("stamps the package version, review version, and release quality", async () => {
   const paths = await writeFixtures({
-    nameShort: "Review",
+    ...releaseIdentityFor("stable"),
     reviewVersion: "1.2.3",
     quality: "stable",
   });
@@ -42,10 +43,14 @@ test("stamps the package version, review version, and release quality", async ()
   assert.equal(pkg.version, "1.2.4-preview.20260901.42");
   assert.equal(product.reviewVersion, "1.2.4-preview.20260901.42");
   assert.equal(product.quality, "preview");
+  for (const [field, value] of Object.entries(releaseIdentityFor("preview"))) {
+    assert.equal(product[field], value, field);
+  }
 });
 
 test("defaults to the stable release quality", async () => {
   const paths = await writeFixtures({
+    ...releaseIdentityFor("stable"),
     reviewVersion: "1.2.3",
     quality: "stable",
   });
@@ -55,11 +60,19 @@ test("defaults to the stable release quality", async () => {
   const product = JSON.parse(await readFile(paths.productPath, "utf8"));
   assert.equal(product.reviewVersion, "1.2.4");
   assert.equal(product.quality, "stable");
+  for (const [field, value] of Object.entries(releaseIdentityFor("stable"))) {
+    assert.equal(product[field], value, field);
+  }
 });
 
-for (const marker of ["reviewVersion", "quality"]) {
+for (const marker of [
+  "reviewVersion",
+  "quality",
+  ...Object.keys(releaseIdentityFor("stable")),
+]) {
   test(`rejects a product without a ${marker} marker`, async () => {
     const product = {
+      ...releaseIdentityFor("stable"),
       reviewVersion: "1.2.3",
       quality: "stable",
     };
@@ -80,6 +93,7 @@ for (const marker of ["reviewVersion", "quality"]) {
 
 test("rejects an unsupported release quality", async () => {
   const paths = await writeFixtures({
+    ...releaseIdentityFor("stable"),
     reviewVersion: "1.2.3",
     quality: "stable",
   });
@@ -92,6 +106,7 @@ test("rejects an unsupported release quality", async () => {
 
 test("requires a release version", async () => {
   const paths = await writeFixtures({
+    ...releaseIdentityFor("stable"),
     reviewVersion: "1.2.3",
     quality: "stable",
   });

--- a/apps/review-desktop/scripts/validate-release-artifacts.mjs
+++ b/apps/review-desktop/scripts/validate-release-artifacts.mjs
@@ -14,17 +14,15 @@ import path from "node:path";
 import { parseArgs } from "node:util";
 
 import { verifyCuratedExtensions } from "./curated-extensions.mjs";
+import {
+  assertReleaseChannel,
+  releaseIdentityFor,
+} from "./release-channel.mjs";
 
 const APP_DIR = path.resolve(import.meta.dirname, "..");
 const UPDATE_URL = "https://update.dev.fast";
 
-export function assertReleaseChannel(channel) {
-  if (channel !== "stable" && channel !== "preview") {
-    throw new Error(
-      `channel must be one of stable or preview, received ${JSON.stringify(channel)}`,
-    );
-  }
-}
+export { assertReleaseChannel };
 
 export function buildManifest({
   version,
@@ -49,7 +47,7 @@ export function assertPackagedProduct(product, { commit, channel = "stable" }) {
     commit,
     quality: channel,
     updateUrl: UPDATE_URL,
-    darwinBundleIdentifier: "dev.fast.review",
+    ...releaseIdentityFor(channel),
   };
   for (const [key, expected] of Object.entries(expectations)) {
     if (product[key] !== expected) {
@@ -116,7 +114,14 @@ function main() {
   const artifactDir = path.resolve(
     values["artifact-dir"] ?? path.join(APP_DIR, "dist"),
   );
-  const app = path.join(APP_DIR, "VSCode-darwin-arm64", "Review.app");
+  const sourceProduct = JSON.parse(
+    readFileSync(path.join(APP_DIR, "code-oss", "product.json"), "utf8"),
+  );
+  const app = path.join(
+    APP_DIR,
+    "VSCode-darwin-arm64",
+    `${sourceProduct.nameShort}.app`,
+  );
   const zip = path.join(artifactDir, `Review-darwin-arm64-${version}.zip`);
   const dmg = path.join(artifactDir, `Review-darwin-arm64-${version}.dmg`);
 

--- a/apps/review-desktop/scripts/validate-release-artifacts.test.mjs
+++ b/apps/review-desktop/scripts/validate-release-artifacts.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { after, test } from "node:test";
 
+import { releaseIdentityFor } from "./release-channel.mjs";
 import {
   assertPackagedProduct,
   assertReleaseChannel,
@@ -19,10 +20,10 @@ after(async () => {
 });
 
 const PRODUCT = {
+  ...releaseIdentityFor("stable"),
   commit: "abc123",
   quality: "stable",
   updateUrl: "https://update.dev.fast",
-  darwinBundleIdentifier: "dev.fast.review",
 };
 
 test("buildManifest emits the schema the update Worker serves", () => {
@@ -51,8 +52,23 @@ test("assertPackagedProduct accepts a correctly stamped product", () => {
 
 test("assertPackagedProduct accepts a preview-stamped product", () => {
   assertPackagedProduct(
-    { ...PRODUCT, quality: "preview" },
+    {
+      ...PRODUCT,
+      ...releaseIdentityFor("preview"),
+      quality: "preview",
+    },
     { commit: "abc123", channel: "preview" },
+  );
+});
+
+test("assertPackagedProduct rejects stable identity on a preview build", () => {
+  assert.throws(
+    () =>
+      assertPackagedProduct(
+        { ...PRODUCT, quality: "preview" },
+        { commit: "abc123", channel: "preview" },
+      ),
+    /nameShort/,
   );
 });
 


### PR DESCRIPTION
## Summary

- install preview releases as Review Preview.app with /dev/fast Review Preview display branding
- separate the preview bundle identifier, URL scheme, CLI name, data folders, shared storage, and updater cache from stable
- derive macOS packaging, notarization, smoke-launch, and validation paths from the stamped product identity
- publish and verify the install.dev.fast/preview alias with a preview-specific DMG download name
- add release guards that reject preview artifacts carrying stable identity fields

## Validation

- pnpm --filter @dev-fast/review-desktop test (189 passed, 1 skipped)
- focused release identity tests (27 passed)
- bash syntax checks for macOS packaging scripts
- preview workflow YAML parse
- formatting and git diff checks