### PR TITLE
feat: implement OpenCode support

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/contrib/install/reviewCliInstall.contribution.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/install/reviewCliInstall.contribution.ts
@@ -33,6 +33,7 @@ const TARGET_LABELS: Readonly<Record<ReviewCliInstallTarget, string>> = {
 	claude: 'Claude Code',
 	codex: 'Codex',
 	cursor: 'Cursor',
+	opencode: 'OpenCode',
 	pi: 'Pi',
 };
 

--- a/packages/progressive-review/app/src/agent-logos.tsx
+++ b/packages/progressive-review/app/src/agent-logos.tsx
@@ -77,9 +77,26 @@ export function PiLogo(): ReactElement {
   );
 }
 
+export function OpenCodeLogo(): ReactElement {
+  return (
+    <svg
+      aria-hidden="true"
+      className="review-agent-logo review-agent-logo--opencode"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M4 5h16v14H4V5zm4 4v6h3V9H8zm5 0v6h3V9h-3z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
 export const AGENT_LOGOS = {
   claude: ClaudeCodeLogo,
   codex: CodexLogo,
   cursor: CursorLogo,
+  opencode: OpenCodeLogo,
   pi: PiLogo,
 } as const;

--- a/packages/progressive-review/app/src/agent-setup-card.tsx
+++ b/packages/progressive-review/app/src/agent-setup-card.tsx
@@ -11,6 +11,7 @@ export const TARGET_LABELS: Record<ReviewCliInstallTarget, string> = {
   claude: "Claude Code",
   codex: "Codex",
   cursor: "Cursor",
+  opencode: "OpenCode",
   pi: "Pi",
 };
 

--- a/packages/progressive-review/app/src/prompt-card.tsx
+++ b/packages/progressive-review/app/src/prompt-card.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { CopyIcon, copyText } from "./copy-text";
 
 /** Which agent's invocation syntax the prompt uses. Derived, never asked. */
-export type PromptAgent = "claude" | "codex" | "generic";
+export type PromptAgent = "claude" | "codex" | "generic" | "opencode";
 
 /** What the review covers. This is the only choice the reader makes. */
 export type PromptKind = "change" | "architecture";
@@ -31,6 +31,8 @@ export const PROMPT_VARIANTS: Record<
       "Use the dev-review skill to review my current branch against up to date main, then open it in Review.",
     codex:
       "Use $dev-review to review my current branch against up to date main, then open it in Review.",
+    opencode:
+      "Use the dev-review skill to review my current branch against up to date main, then open it in Review.",
     generic:
       "Use the `review` CLI to review my current branch against up to date main: run `review scaffold`, write the review, then `review publish`.",
   },
@@ -39,6 +41,8 @@ export const PROMPT_VARIANTS: Record<
       "Use the dev-review skill to sketch out the main data flows, access patterns, and code paths in this repo, so I can do a full architecture review of it. Open it in Review when you're done.",
     codex:
       "Use $dev-review to sketch out the main data flows, access patterns, and code paths in this repo, so I can do a full architecture review of it. Open it in Review when you're done.",
+    opencode:
+      "Use the dev-review skill to sketch out the main data flows, access patterns, and code paths in this repo, so I can do a full architecture review of it. Open it in Review when you're done.",
     generic:
       "Use the `review` CLI to sketch out the main data flows, access patterns, and code paths in this repo, so I can do a full architecture review of it: run `review scaffold` with the same commit as base and head, write the review, then `review publish`.",
   },
@@ -137,8 +141,10 @@ export function promptAgent(
   status: ReviewCliInstallStatus | undefined,
 ): PromptAgent {
   if (!status) return "generic";
-  const has = (target: "claude" | "codex", key: "installed" | "present") =>
-    status.agents.some((agent) => agent.target === target && agent[key]);
+  const has = (
+    target: "claude" | "codex" | "opencode",
+    key: "installed" | "present",
+  ) => status.agents.some((agent) => agent.target === target && agent[key]);
   const stored = readStoredPromptAgent();
   if (stored === "generic") return "generic";
   if (stored && (has(stored, "installed") || has(stored, "present"))) {
@@ -147,6 +153,7 @@ export function promptAgent(
   for (const key of ["installed", "present"] as const) {
     if (has("claude", key)) return "claude";
     if (has("codex", key)) return "codex";
+    if (has("opencode", key)) return "opencode";
   }
   return "generic";
 }

--- a/packages/progressive-review/package.json
+++ b/packages/progressive-review/package.json
@@ -17,6 +17,7 @@
     "!app/src/**/*test-utils*",
     "dist",
     "skills",
+    "plugins",
     "tutorial",
     "src",
     "!src/**/*.test.ts",

--- a/packages/progressive-review/plugins/review.test.ts
+++ b/packages/progressive-review/plugins/review.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import reviewPlugin from "./review";
+
+describe("OpenCode Review plugin", () => {
+  it("exposes the active session to shell commands", async () => {
+    const hooks = await reviewPlugin();
+    const output = { env: {} as Record<string, string> };
+
+    await hooks["shell.env"]({ sessionID: "session-1" }, output);
+
+    expect(output.env).toEqual({
+      DEV_FAST_AGENT_SESSION: "opencode:session-1",
+    });
+  });
+});

--- a/packages/progressive-review/plugins/review.ts
+++ b/packages/progressive-review/plugins/review.ts
@@ -1,0 +1,14 @@
+// Managed by Review Desktop (@dev.fast/review).
+
+export default async function reviewPlugin() {
+  return {
+    "shell.env": async (
+      input: { sessionID?: string },
+      output: { env: Record<string, string> },
+    ) => {
+      if (input.sessionID) {
+        output.env.DEV_FAST_AGENT_SESSION = `opencode:${input.sessionID}`;
+      }
+    },
+  };
+}

--- a/packages/progressive-review/src/authoring-session.ts
+++ b/packages/progressive-review/src/authoring-session.ts
@@ -1,4 +1,4 @@
-export type ReviewAgentHarness = "claude-code" | "codex" | "pi";
+export type ReviewAgentHarness = "claude-code" | "codex" | "opencode" | "pi";
 
 export interface SessionRef {
   harness: ReviewAgentHarness;
@@ -69,7 +69,12 @@ export function resolveAuthoringSessionRef(
 }
 
 function isReviewAgentHarness(value: string): value is ReviewAgentHarness {
-  return value === "claude-code" || value === "codex" || value === "pi";
+  return (
+    value === "claude-code" ||
+    value === "codex" ||
+    value === "opencode" ||
+    value === "pi"
+  );
 }
 
 function readEnvValue(value: string | undefined): string | undefined {

--- a/packages/progressive-review/src/cli-runner.ts
+++ b/packages/progressive-review/src/cli-runner.ts
@@ -1413,6 +1413,7 @@ function progressiveReviewInstallHelp(): string {
     "  claude   Claude Code (~/.claude/skills)",
     "  codex    Codex (~/.agents/skills)",
     "  cursor   Cursor (~/.cursor/skills)",
+    "  opencode OpenCode (~/.config/opencode/plugins)",
     "  pi       Pi (~/.agents/skills and npm:@ff-labs/pi-fff)",
     "  all      Every supported agent (default)",
     "",

--- a/packages/progressive-review/src/install.test.ts
+++ b/packages/progressive-review/src/install.test.ts
@@ -41,6 +41,11 @@ async function makePackageRoot(): Promise<string> {
   for (const name of ALL_SKILLS) {
     await writeSkill(packageRoot, name);
   }
+  await mkdir(path.join(packageRoot, "plugins"), { recursive: true });
+  await writeFile(
+    path.join(packageRoot, "plugins", "review.ts"),
+    "// Managed by Review Desktop (@dev.fast/review).\n",
+  );
   return packageRoot;
 }
 
@@ -56,6 +61,29 @@ function silentStreams() {
 }
 
 describe("runInstall", () => {
+  it("installs the OpenCode shell environment plugin", async () => {
+    const packageRoot = await makePackageRoot();
+    const homeDir = await makeTempDir();
+    const streams = silentStreams();
+
+    expect(
+      await runInstall({
+        targets: ["opencode"],
+        homeDir,
+        packageRoot,
+        stdout: streams.stdout,
+        stderr: streams.stderr,
+      }),
+    ).toBe(0);
+
+    expect(
+      await readFile(
+        path.join(homeDir, ".config", "opencode", "plugins", "review.ts"),
+        "utf8",
+      ),
+    ).toContain("Managed by Review Desktop");
+  });
+
   it("installs Review skills to Claude Code, Codex, and Cursor by default", async () => {
     const packageRoot = await makePackageRoot();
     const homeDir = await makeTempDir();

--- a/packages/progressive-review/src/install.ts
+++ b/packages/progressive-review/src/install.ts
@@ -1,5 +1,7 @@
 import {
+  copyFile,
   cp,
+  lstat,
   mkdir,
   readFile,
   readdir,
@@ -21,11 +23,11 @@ import {
   installPiTraceExtension,
 } from "./agent-trace-hooks";
 import { emitJsonEvent, failWithJsonError, humanStream } from "./cli-output";
-import { isDirectory } from "./fs-utils";
+import { isDirectory, isFile } from "./fs-utils";
 import { devReviewHome } from "./review-storage";
 import { readTraceUserConfig } from "./trace-user-config";
 
-export type InstallTarget = "claude" | "codex" | "cursor" | "pi";
+export type InstallTarget = "claude" | "codex" | "cursor" | "opencode" | "pi";
 
 const REQUIRED_SKILL_NAMES = ["dev-review", "dev-review-map"] as const;
 // Installed only on machines that publish traces; removed when no repository
@@ -42,10 +44,14 @@ export const ALL_INSTALL_TARGETS: InstallTarget[] = [
   "claude",
   "codex",
   "cursor",
+  "opencode",
   "pi",
 ];
 
-type InstalledItem = { kind: "skill" | "extension"; dest: string };
+type InstalledItem = { kind: "skill" | "extension" | "plugin"; dest: string };
+
+const OPENCODE_PLUGIN_NAME = "review.ts";
+const OPENCODE_PLUGIN_MARKER = "Managed by Review Desktop (@dev.fast/review).";
 
 export function defaultPackageRoot(): string {
   return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -89,6 +95,28 @@ export async function runInstall(input: RunInstallInput): Promise<number> {
       `Bundled skills not found in ${skillsDir}: ${missingSkills.join(", ")}.`,
     );
   }
+  const openCodePluginSource = path.join(
+    packageRoot,
+    "plugins",
+    OPENCODE_PLUGIN_NAME,
+  );
+  if (input.targets.includes("opencode") && !(await isFile(openCodePluginSource))) {
+    return failWithJsonError(
+      input,
+      "install",
+      `Bundled OpenCode plugin not found: ${openCodePluginSource}.`,
+    );
+  }
+  if (
+    input.targets.includes("opencode") &&
+    (await managedOpenCodePlugin(openCodePluginPath(homeDir))) === "unmanaged"
+  ) {
+    return failWithJsonError(
+      input,
+      "install",
+      `${openCodePluginPath(homeDir)} already exists and is not managed by Review.`,
+    );
+  }
 
   // Agent hooks only make sense when this machine publishes traces. The
   // machine publishes traces once `review trace allow` records one
@@ -109,6 +137,11 @@ export async function runInstall(input: RunInstallInput): Promise<number> {
       }
       await installDirectory(skillDir.src, skillDest);
       installed.push({ kind: "skill", dest: skillDest });
+    }
+    if (target === "opencode") {
+      const pluginDest = openCodePluginPath(homeDir);
+      await installFile(openCodePluginSource, pluginDest);
+      installed.push({ kind: "plugin", dest: pluginDest });
     }
     if (!installTraceHooks) continue;
     if (target === "claude") {
@@ -213,6 +246,12 @@ export async function removeInstalledSkills(
   ]) {
     await rm(path.join(destRoot, name), { recursive: true, force: true });
   }
+  if (
+    target === "opencode" &&
+    (await managedOpenCodePlugin(openCodePluginPath(homeDir))) === "managed"
+  ) {
+    await rm(openCodePluginPath(homeDir), { force: true });
+  }
 }
 
 export async function removeTraceSkills(
@@ -240,6 +279,20 @@ export async function detectInstalledTargets(
   const installed: InstallTarget[] = [];
   for (const target of ALL_INSTALL_TARGETS) {
     const destRoot = skillsDestRoot(homeDir, target);
+    if (target === "opencode") {
+      const skillsPresent = await Promise.all(
+        REQUIRED_SKILL_NAMES.map((name) =>
+          hasValidSkillFile(path.join(destRoot, name, "SKILL.md"), name),
+        ),
+      );
+      if (
+        skillsPresent.every(Boolean) &&
+        (await managedOpenCodePlugin(openCodePluginPath(homeDir))) === "managed"
+      ) {
+        installed.push(target);
+      }
+      continue;
+    }
     const found = await Promise.all(
       knownSkillNames.map((name) => isDirectory(path.join(destRoot, name))),
     );
@@ -251,6 +304,9 @@ export async function detectInstalledTargets(
 function skillsDestRoot(homeDir: string, target: InstallTarget): string {
   if (target === "claude") return path.join(homeDir, ".claude", "skills");
   if (target === "cursor") return path.join(homeDir, ".cursor", "skills");
+  if (target === "opencode") {
+    return path.join(homeDir, ".config", "opencode", "skills");
+  }
   if (target === "pi") return path.join(homeDir, ".agents", "skills");
   return path.join(homeDir, ".agents", "skills");
 }
@@ -311,6 +367,54 @@ async function installDirectory(src: string, dest: string): Promise<void> {
     throw error;
   }
   if (movedExisting) await rm(backup, { recursive: true, force: true });
+}
+
+async function installFile(src: string, dest: string): Promise<void> {
+  await mkdir(path.dirname(dest), { recursive: true });
+  const staging = `${dest}.tmp-${process.pid}`;
+  const backup = `${dest}.bak-${process.pid}`;
+  await rm(staging, { force: true });
+  await rm(backup, { force: true });
+  await copyFile(src, staging);
+  let movedExisting = false;
+  try {
+    await rename(dest, backup);
+    movedExisting = true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  try {
+    await rename(staging, dest);
+  } catch (error) {
+    if (movedExisting) await rename(backup, dest).catch(() => {});
+    throw error;
+  }
+  if (movedExisting) await rm(backup, { force: true });
+}
+
+function openCodePluginPath(homeDir: string): string {
+  return path.join(
+    homeDir,
+    ".config",
+    "opencode",
+    "plugins",
+    OPENCODE_PLUGIN_NAME,
+  );
+}
+
+async function managedOpenCodePlugin(
+  filePath: string,
+): Promise<"managed" | "missing" | "unmanaged"> {
+  try {
+    const metadata = await lstat(filePath);
+    if (!metadata.isFile() || metadata.isSymbolicLink()) return "unmanaged";
+    return (await readFile(filePath, "utf8")).includes(OPENCODE_PLUGIN_MARKER)
+      ? "managed"
+      : "unmanaged";
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
+    throw error;
+  }
 }
 
 async function removeStaleSkills(destRoot: string): Promise<void> {

--- a/packages/progressive-review/src/install.ts
+++ b/packages/progressive-review/src/install.ts
@@ -100,7 +100,10 @@ export async function runInstall(input: RunInstallInput): Promise<number> {
     "plugins",
     OPENCODE_PLUGIN_NAME,
   );
-  if (input.targets.includes("opencode") && !(await isFile(openCodePluginSource))) {
+  if (
+    input.targets.includes("opencode") &&
+    !(await isFile(openCodePluginSource))
+  ) {
     return failWithJsonError(
       input,
       "install",

--- a/packages/progressive-review/src/install.ts
+++ b/packages/progressive-review/src/install.ts
@@ -384,6 +384,7 @@ async function installFile(src: string, dest: string): Promise<void> {
     await rename(dest, backup);
     movedExisting = true;
   } catch (error) {
+    // SAFETY: fs rename rejects with a Node errno exception.
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
   try {
@@ -415,6 +416,7 @@ async function managedOpenCodePlugin(
       ? "managed"
       : "unmanaged";
   } catch (error) {
+    // SAFETY: fs lstat and readFile reject with a Node errno exception.
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
     throw error;
   }

--- a/packages/progressive-review/src/installed-review-agent.test.ts
+++ b/packages/progressive-review/src/installed-review-agent.test.ts
@@ -8,7 +8,7 @@ function status(
   installed: ReviewCliInstallStatus["agents"][number]["target"][],
 ): ReviewCliInstallStatus {
   return {
-    agents: ["claude", "codex", "cursor", "pi"].map((target) => ({
+    agents: ["claude", "codex", "cursor", "opencode", "pi"].map((target) => ({
       target: target as ReviewCliInstallStatus["agents"][number]["target"],
       present: true,
       installed: installed.includes(
@@ -61,5 +61,11 @@ describe("preferredInstalledReviewAgent", () => {
     expect(
       preferredInstalledReviewAgent(status(["cursor"], ["cursor"])),
     ).toBeUndefined();
+  });
+
+  it("selects OpenCode when it is the installed agent", () => {
+    expect(preferredInstalledReviewAgent(status(["opencode"], ["opencode"]))).toBe(
+      "opencode",
+    );
   });
 });

--- a/packages/progressive-review/src/installed-review-agent.test.ts
+++ b/packages/progressive-review/src/installed-review-agent.test.ts
@@ -64,8 +64,8 @@ describe("preferredInstalledReviewAgent", () => {
   });
 
   it("selects OpenCode when it is the installed agent", () => {
-    expect(preferredInstalledReviewAgent(status(["opencode"], ["opencode"]))).toBe(
-      "opencode",
-    );
+    expect(
+      preferredInstalledReviewAgent(status(["opencode"], ["opencode"])),
+    ).toBe("opencode");
   });
 });

--- a/packages/progressive-review/src/installed-review-agent.ts
+++ b/packages/progressive-review/src/installed-review-agent.ts
@@ -10,6 +10,7 @@ const LAUNCHABLE_HARNESS: Partial<
 > = {
   claude: "claude-code",
   codex: "codex",
+  opencode: "opencode",
   pi: "pi",
 };
 

--- a/packages/progressive-review/src/native-agent/native-message-mirror.ts
+++ b/packages/progressive-review/src/native-agent/native-message-mirror.ts
@@ -217,6 +217,8 @@ function agentLabel(harness: SessionRef["harness"]): string {
       return "Claude Code";
     case "codex":
       return "Codex";
+    case "opencode":
+      return "OpenCode";
     case "pi":
       return "Pi";
   }

--- a/packages/progressive-review/src/native-agent/opencode.test.ts
+++ b/packages/progressive-review/src/native-agent/opencode.test.ts
@@ -49,7 +49,12 @@ const assistant = (id: string, text: string, completed?: number) => ({
 
 /** A fake `opencode serve`: sessions, prompts, messages, and an event stream. */
 async function fakeOpencode() {
-  const requests: Array<{ method: string; path: string; body: unknown }> = [];
+  const requests: Array<{
+    method: string;
+    path: string;
+    directory: string | null;
+    body: unknown;
+  }> = [];
   const messages: unknown[] = [];
   const listeners = new Set<ServerResponse>();
   const server = createServer((request, response) => {
@@ -58,7 +63,12 @@ async function fakeOpencode() {
     request.on("data", (chunk) => (raw += String(chunk)));
     request.on("end", () => {
       const body = raw ? (JSON.parse(raw) as unknown) : undefined;
-      requests.push({ method: request.method ?? "", path: url.pathname, body });
+      requests.push({
+        method: request.method ?? "",
+        path: url.pathname,
+        directory: url.searchParams.get("directory"),
+        body,
+      });
       if (
         request.headers.authorization !==
         `Basic ${Buffer.from("opencode:pw").toString("base64")}`
@@ -80,9 +90,29 @@ async function fakeOpencode() {
         response.end(JSON.stringify(value));
       };
       if (url.pathname === "/session" && request.method === "POST")
-        return reply({ id: "ses_new" });
+        return reply({
+          id: "ses_new",
+          directory: url.searchParams.get("directory"),
+        });
+      // Sessions live in a project; a lookup only finds them in that directory.
+      if (url.pathname === "/project")
+        return reply([
+          { id: "p-other", worktree: "/repo/other" },
+          { id: "p-source", worktree: "/repo/source" },
+        ]);
+      if (
+        (url.pathname === "/session/ses_src" ||
+          url.pathname === "/session/ses_1") &&
+        request.method === "GET"
+      ) {
+        if (url.searchParams.get("directory") !== "/repo/source") {
+          response.writeHead(404).end();
+          return;
+        }
+        return reply({ id: url.pathname.slice(9), directory: "/repo/source" });
+      }
       if (url.pathname === "/session/ses_src/fork")
-        return reply({ id: "ses_1" });
+        return reply({ id: "ses_1", directory: "/repo/source" });
       if (url.pathname === "/session/ses_1/prompt_async") return reply({});
       if (url.pathname === "/session/ses_1/message") return reply(messages);
       response.writeHead(404).end();
@@ -165,10 +195,21 @@ describe("OpencodeAgentServer", () => {
     const calls = oc.requests.filter(
       (request) => request.path !== "/global/event",
     );
-    expect(calls.map((request) => `${request.method} ${request.path}`)).toEqual(
-      ["POST /session/ses_src/fork", "POST /session/ses_1/prompt_async"],
-    );
-    expect(calls[1]?.body).toEqual({
+    // The fork and the prompt are scoped to the source session's project,
+    // not to the review's checkout.
+    expect(
+      calls.map(
+        (request) =>
+          `${request.method} ${request.path} ${request.directory ?? ""}`,
+      ),
+    ).toEqual([
+      "GET /project ",
+      "GET /session/ses_src /repo/other",
+      "GET /session/ses_src /repo/source",
+      "POST /session/ses_src/fork /repo/source",
+      "POST /session/ses_1/prompt_async /repo/source",
+    ]);
+    expect(calls[4]?.body).toEqual({
       parts: [{ type: "text", text: "Explain this" }],
     });
     expect(command.executable).toBe("opencode");
@@ -178,7 +219,7 @@ describe("OpencodeAgentServer", () => {
       "--session",
       "ses_1",
       "--dir",
-      "/tmp/tutorial",
+      "/repo/source",
     ]);
     expect(command.env.OPENCODE_SERVER_PASSWORD).toBe("pw");
     expect(command.env.DEV_FAST_REVIEW_AGENT_THREAD_URL).toBe(

--- a/packages/progressive-review/src/native-agent/opencode.test.ts
+++ b/packages/progressive-review/src/native-agent/opencode.test.ts
@@ -1,9 +1,15 @@
 import { mkdtemp, rm } from "node:fs/promises";
-import { createServer, type Server, type ServerResponse } from "node:http";
+import { type Server, type ServerResponse, createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
+import {
+  type JsonObject,
+  type JsonValue,
+  jsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { AgentServerOptions, SessionUpdate } from "./native-session";
@@ -37,15 +43,24 @@ const user = (id: string, text: string, created = 1_000) => ({
   info: { id, sessionID: "ses_1", role: "user", time: { created } },
   parts: [{ id: `${id}-p`, type: "text", text }],
 });
-const assistant = (id: string, text: string, completed?: number) => ({
-  info: {
-    id,
-    sessionID: "ses_1",
-    role: "assistant",
-    time: { created: 1_500, ...(completed ? { completed } : {}) },
-  },
-  parts: [{ id: `${id}-p`, type: "text", text }],
-});
+const failedAssistant = (id: string, text: string, completed: number) => {
+  const message = assistant(id, text, completed);
+  const info: JsonObject = {
+    ...jsonObject(message.info),
+    error: { name: "UnknownError" },
+  };
+  return { ...message, info };
+};
+
+const assistant = (id: string, text: string, completed?: number) => {
+  const time: JsonObject = { created: 1_500 };
+  if (completed !== undefined) time.completed = completed;
+  const message: JsonObject = {
+    info: { id, sessionID: "ses_1", role: "assistant", time },
+    parts: [{ id: `${id}-p`, type: "text", text }],
+  };
+  return message;
+};
 
 /** A fake `opencode serve`: sessions, prompts, messages, and an event stream. */
 async function fakeOpencode() {
@@ -53,16 +68,16 @@ async function fakeOpencode() {
     method: string;
     path: string;
     directory: string | null;
-    body: unknown;
+    body: JsonValue;
   }> = [];
-  const messages: unknown[] = [];
+  const messages: JsonValue[] = [];
   const listeners = new Set<ServerResponse>();
   const server = createServer((request, response) => {
     const url = new URL(request.url ?? "/", "http://localhost");
     let raw = "";
     request.on("data", (chunk) => (raw += String(chunk)));
     request.on("end", () => {
-      const body = raw ? (JSON.parse(raw) as unknown) : undefined;
+      const body = raw ? parseJsonText(raw) : null;
       requests.push({
         method: request.method ?? "",
         path: url.pathname,
@@ -85,7 +100,7 @@ async function fakeOpencode() {
         response.on("close", () => listeners.delete(response));
         return;
       }
-      const reply = (value: unknown) => {
+      const reply = (value: JsonValue) => {
         response.writeHead(200, { "content-type": "application/json" });
         response.end(JSON.stringify(value));
       };
@@ -131,7 +146,7 @@ async function fakeOpencode() {
       }),
       close: async () => undefined,
     },
-    emit(event: unknown) {
+    emit(event: JsonValue) {
       for (const listener of listeners)
         listener.write(`data: ${JSON.stringify(event)}\n\n`);
     },
@@ -157,13 +172,7 @@ describe("projectOpencodeMessages", () => {
         user("msg_1", "hello"),
         assistant("msg_2", "still streaming"),
         assistant("msg_3", "done", 2_000),
-        {
-          ...assistant("msg_4", "broken", 2_500),
-          info: {
-            ...assistant("msg_4", "broken", 2_500).info,
-            error: { name: "UnknownError" },
-          },
-        },
+        failedAssistant("msg_4", "broken", 2_500),
       ]),
     ).toEqual([
       {

--- a/packages/progressive-review/src/native-agent/opencode.test.ts
+++ b/packages/progressive-review/src/native-agent/opencode.test.ts
@@ -1,0 +1,222 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { AgentServerOptions, SessionUpdate } from "./native-session";
+import { OpencodeAgentServer, projectOpencodeMessages } from "./opencode";
+
+const temporaryDirectories: string[] = [];
+const servers: Server[] = [];
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function options(): Promise<AgentServerOptions> {
+  const directory = await mkdtemp(path.join(tmpdir(), "review-opencode-"));
+  temporaryDirectories.push(directory);
+  return {
+    runtimeDirectory: directory,
+    desktopEndpoint: { baseUrl: "http://127.0.0.1:4000", token: "s" },
+  };
+}
+
+const user = (id: string, text: string, created = 1_000) => ({
+  info: { id, sessionID: "ses_1", role: "user", time: { created } },
+  parts: [{ id: `${id}-p`, type: "text", text }],
+});
+const assistant = (id: string, text: string, completed?: number) => ({
+  info: {
+    id,
+    sessionID: "ses_1",
+    role: "assistant",
+    time: { created: 1_500, ...(completed ? { completed } : {}) },
+  },
+  parts: [{ id: `${id}-p`, type: "text", text }],
+});
+
+/** A fake `opencode serve`: sessions, prompts, messages, and an event stream. */
+async function fakeOpencode() {
+  const requests: Array<{ method: string; path: string; body: unknown }> = [];
+  const messages: unknown[] = [];
+  const listeners = new Set<ServerResponse>();
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://localhost");
+    let raw = "";
+    request.on("data", (chunk) => (raw += String(chunk)));
+    request.on("end", () => {
+      const body = raw ? (JSON.parse(raw) as unknown) : undefined;
+      requests.push({ method: request.method ?? "", path: url.pathname, body });
+      if (
+        request.headers.authorization !==
+        `Basic ${Buffer.from("opencode:pw").toString("base64")}`
+      ) {
+        response.writeHead(401).end();
+        return;
+      }
+      if (url.pathname === "/global/event") {
+        response.writeHead(200, { "content-type": "text/event-stream" });
+        response.write(
+          `data: ${JSON.stringify({ type: "server.connected", properties: {} })}\n\n`,
+        );
+        listeners.add(response);
+        response.on("close", () => listeners.delete(response));
+        return;
+      }
+      const reply = (value: unknown) => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify(value));
+      };
+      if (url.pathname === "/session" && request.method === "POST")
+        return reply({ id: "ses_new" });
+      if (url.pathname === "/session/ses_src/fork")
+        return reply({ id: "ses_1" });
+      if (url.pathname === "/session/ses_1/prompt_async") return reply({});
+      if (url.pathname === "/session/ses_1/message") return reply(messages);
+      response.writeHead(404).end();
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    requests,
+    messages,
+    host: {
+      endpoint: async () => ({
+        baseUrl: `http://127.0.0.1:${port}`,
+        password: "pw",
+      }),
+      close: async () => undefined,
+    },
+    emit(event: unknown) {
+      for (const listener of listeners)
+        listener.write(`data: ${JSON.stringify(event)}\n\n`);
+    },
+  };
+}
+
+async function nextUpdates(
+  updates: AsyncIterable<SessionUpdate>,
+  count: number,
+) {
+  const collected: SessionUpdate[] = [];
+  for await (const update of updates) {
+    collected.push(update);
+    if (collected.length === count) break;
+  }
+  return collected;
+}
+
+describe("projectOpencodeMessages", () => {
+  it("keeps user messages and completed, error-free assistant messages", () => {
+    expect(
+      projectOpencodeMessages([
+        user("msg_1", "hello"),
+        assistant("msg_2", "still streaming"),
+        assistant("msg_3", "done", 2_000),
+        {
+          ...assistant("msg_4", "broken", 2_500),
+          info: {
+            ...assistant("msg_4", "broken", 2_500).info,
+            error: { name: "UnknownError" },
+          },
+        },
+      ]),
+    ).toEqual([
+      {
+        role: "user",
+        body: "hello",
+        createdAt: "1970-01-01T00:00:01.000Z",
+        messageId: "msg_1",
+      },
+      {
+        role: "assistant",
+        body: "done",
+        createdAt: "1970-01-01T00:00:02.000Z",
+        messageId: "msg_3",
+      },
+    ]);
+  });
+});
+
+describe("OpencodeAgentServer", () => {
+  it("forks, prompts, and attaches the TUI to the shared server", async () => {
+    const oc = await fakeOpencode();
+    const server = new OpencodeAgentServer(await options(), oc.host);
+    const { sessionId, command } = await server.launch({
+      session: { forkOf: "ses_src" },
+      prompt: "Explain this",
+      cwd: "/tmp/tutorial",
+    });
+    expect(sessionId).toBe("ses_1");
+    const calls = oc.requests.filter(
+      (request) => request.path !== "/global/event",
+    );
+    expect(calls.map((request) => `${request.method} ${request.path}`)).toEqual(
+      ["POST /session/ses_src/fork", "POST /session/ses_1/prompt_async"],
+    );
+    expect(calls[1]?.body).toEqual({
+      parts: [{ type: "text", text: "Explain this" }],
+    });
+    expect(command.executable).toBe("opencode");
+    expect(command.args).toEqual([
+      "attach",
+      expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
+      "--session",
+      "ses_1",
+      "--dir",
+      "/tmp/tutorial",
+    ]);
+    expect(command.env.OPENCODE_SERVER_PASSWORD).toBe("pw");
+    expect(command.env.DEV_FAST_REVIEW_AGENT_THREAD_URL).toBe(
+      "http://127.0.0.1:4000/native-agent-events/opencode/ses_1/thread",
+    );
+    await server.close();
+  });
+
+  it("snapshots the session, then re-reads it when the event stream names it", async () => {
+    const oc = await fakeOpencode();
+    oc.messages.push(
+      user("msg_1", "first"),
+      assistant("msg_2", "answer one", 2_000),
+    );
+    const server = new OpencodeAgentServer(await options(), oc.host);
+    await server.launch({ session: { resume: "ses_1" }, cwd: "/tmp/tutorial" });
+    const pipe = await server.updates("ses_1");
+    expect(pipe.snapshot.messages.map((message) => message.body)).toEqual([
+      "first",
+      "answer one",
+    ]);
+
+    oc.messages.push(
+      user("msg_3", "second", 3_000),
+      assistant("msg_4", "streaming"),
+    );
+    oc.emit({
+      type: "message.updated",
+      properties: { info: { id: "msg_3", sessionID: "ses_1", role: "user" } },
+    });
+    oc.messages.pop();
+    oc.messages.push(assistant("msg_4", "answer two", 4_000));
+    oc.emit({ type: "session.idle", properties: { sessionID: "ses_1" } });
+    // One pass over the pipe: iterating it twice would close the queue.
+    expect(
+      (await nextUpdates(pipe.updates, 2)).map((update) => update.message.body),
+    ).toEqual(["second", "answer two"]);
+    await pipe.close();
+    await server.close();
+  });
+});

--- a/packages/progressive-review/src/native-agent/opencode.ts
+++ b/packages/progressive-review/src/native-agent/opencode.ts
@@ -504,31 +504,75 @@ export async function forkOpencodeSession(input: {
   }
 }
 
-/** Create a session and run one synchronous prompt on a throwaway server. Used for the tutorial source. */
+const REPLY_TIMEOUT_MS = 10 * 60_000;
+const REPLY_POLL_MS = 1_000;
+
+/**
+ * Create a session, prompt it, and return once the assistant has replied.
+ * Runs on a throwaway server; used for the tutorial source. The prompt is
+ * submitted asynchronously and the session polled, because one model turn
+ * can outlast any single request timeout.
+ */
 export async function createOpencodeSession(input: {
   cwd: string;
   prompt: string;
+  title: string;
+  signal?: AbortSignal;
 }): Promise<string> {
   const host = new OpencodeServeHost();
   try {
     const { baseUrl, password } = await host.endpoint();
     const client = new OpencodeClient(baseUrl, password);
     const sessionId = sessionIdOf(
-      await client.json("POST", "/session", input.cwd, {
-        title: "Review tutorial authoring",
-      }),
+      await client.json("POST", "/session", input.cwd, { title: input.title }),
     );
-    // `message` (unlike `prompt_async`) answers once the assistant finished.
     await client.json(
       "POST",
-      `/session/${encodeURIComponent(sessionId)}/message`,
+      `/session/${encodeURIComponent(sessionId)}/prompt_async`,
       input.cwd,
       { parts: [{ type: "text", text: input.prompt }] },
     );
-    return sessionId;
+    const deadline = Date.now() + REPLY_TIMEOUT_MS;
+    for (;;) {
+      if (input.signal?.aborted) {
+        throw new Error("OpenCode session creation was canceled.");
+      }
+      const messages = await client.json(
+        "GET",
+        `/session/${encodeURIComponent(sessionId)}/message`,
+        input.cwd,
+      );
+      const failure = assistantFailure(messages);
+      if (failure) throw new Error(`OpenCode could not reply: ${failure}`);
+      if (
+        projectOpencodeMessages(messages).some((m) => m.role === "assistant")
+      ) {
+        return sessionId;
+      }
+      if (Date.now() > deadline) {
+        throw new Error("OpenCode did not reply within the time limit.");
+      }
+      await new Promise((resolve) => setTimeout(resolve, REPLY_POLL_MS));
+    }
   } finally {
     await host.close();
   }
+}
+
+/** The first assistant message that ended in an error, as a short description. */
+function assistantFailure(messages: unknown): string | undefined {
+  if (!Array.isArray(messages)) return undefined;
+  for (const entry of messages) {
+    if (!isJsonRecord(entry) || !isJsonRecord(entry.info)) continue;
+    const info = entry.info;
+    if (info.role !== "assistant" || !isJsonRecord(info.error)) continue;
+    const name =
+      typeof info.error.name === "string" ? info.error.name : "error";
+    const data = isJsonRecord(info.error.data) ? info.error.data : {};
+    const message = typeof data.message === "string" ? `: ${data.message}` : "";
+    return `${name}${message}`;
+  }
+  return undefined;
 }
 
 export function server(

--- a/packages/progressive-review/src/native-agent/opencode.ts
+++ b/packages/progressive-review/src/native-agent/opencode.ts
@@ -68,36 +68,40 @@ export class OpencodeAgentServer implements AgentServer {
     input: LaunchInput,
   ): Promise<{ sessionId: string; command: NativeTerminalCommand }> {
     const client = await this.#client();
-    let sessionId: string;
+    // OpenCode sessions belong to a project keyed by directory. A fork stays
+    // in its source's project, so the session's own directory scopes every
+    // request and the terminal, not the review's checkout.
+    let session: { id: string; directory: string };
     if (!input.session) {
-      sessionId = sessionIdOf(
+      session = sessionOf(
         await client.json("POST", "/session", input.cwd, {
           title: "Review question",
         }),
       );
     } else if ("forkOf" in input.session) {
-      sessionId = sessionIdOf(
+      const source = await client.session(input.session.forkOf);
+      session = sessionOf(
         await client.json(
           "POST",
-          `/session/${encodeURIComponent(input.session.forkOf)}/fork`,
-          input.cwd,
+          `/session/${encodeURIComponent(source.id)}/fork`,
+          source.directory,
           {},
         ),
       );
     } else {
-      sessionId = input.session.resume;
+      session = await client.session(input.session.resume);
     }
-    const state = this.#session(sessionId, input.cwd);
+    const sessionId = session.id;
+    this.#session(sessionId, session.directory);
     if (input.prompt !== undefined) {
       // Review drives the turn; the TUI attaches to a session already at work.
       await client.json(
         "POST",
         `/session/${encodeURIComponent(sessionId)}/prompt_async`,
-        input.cwd,
+        session.directory,
         { parts: [{ type: "text", text: input.prompt }] },
       );
     }
-    void state;
     const pathValue = await this.#commandPath.resolve();
     return {
       sessionId,
@@ -110,7 +114,7 @@ export class OpencodeAgentServer implements AgentServer {
           "--session",
           sessionId,
           "--dir",
-          input.cwd,
+          session.directory,
         ],
         env: {
           OPENCODE_SERVER_PASSWORD: client.password,
@@ -128,6 +132,9 @@ export class OpencodeAgentServer implements AgentServer {
   ): Promise<UpdatePipe<SessionSnapshot, SessionUpdate>> {
     const client = await this.#client();
     const state = this.#session(sessionId);
+    if (!state.directory) {
+      state.directory = (await client.session(sessionId)).directory;
+    }
     if (!state.loaded) {
       await this.#refresh(client, sessionId, state);
       state.loaded = true;
@@ -300,11 +307,16 @@ function eventSessionId(event: unknown): string | undefined {
   return undefined;
 }
 
-function sessionIdOf(value: unknown): string {
-  if (!isJsonRecord(value) || typeof value.id !== "string" || !value.id) {
+function sessionOf(value: unknown): { id: string; directory: string } {
+  if (
+    !isJsonRecord(value) ||
+    typeof value.id !== "string" ||
+    !value.id ||
+    typeof value.directory !== "string"
+  ) {
     throw new Error("OpenCode returned an invalid session.");
   }
-  return value.id;
+  return { id: value.id, directory: value.directory };
 }
 
 function millisToIso(value: unknown): string {
@@ -330,9 +342,25 @@ export class OpencodeClient {
     directory: string | undefined,
     body?: unknown,
   ): Promise<unknown> {
+    const response = await this.#fetch(method, pathname, directory, body);
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(
+        `OpenCode ${method} ${pathname} failed (${response.status}): ${text}`,
+      );
+    }
+    return text ? (JSON.parse(text) as unknown) : undefined;
+  }
+
+  #fetch(
+    method: "GET" | "POST",
+    pathname: string,
+    directory: string | undefined,
+    body?: unknown,
+  ): Promise<Response> {
     const url = new URL(pathname, this.baseUrl);
     if (directory) url.searchParams.set("directory", directory);
-    const response = await fetch(url, {
+    return fetch(url, {
       method,
       headers: {
         authorization: this.#authorization,
@@ -341,13 +369,37 @@ export class OpencodeClient {
       ...(body === undefined ? {} : { body: JSON.stringify(body) }),
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
-    const text = await response.text();
-    if (!response.ok) {
-      throw new Error(
-        `OpenCode ${method} ${pathname} failed (${response.status}): ${text}`,
-      );
+  }
+
+  /**
+   * Find a session by id. Sessions are stored per project, and a lookup is
+   * scoped to one directory, so every project the server knows is tried.
+   */
+  async session(id: string): Promise<{ id: string; directory: string }> {
+    const projects = await this.json("GET", "/project", undefined);
+    if (!Array.isArray(projects)) {
+      throw new Error("OpenCode returned an invalid project list.");
     }
-    return text ? (JSON.parse(text) as unknown) : undefined;
+    const worktrees = projects.flatMap((project) =>
+      isJsonRecord(project) && typeof project.worktree === "string"
+        ? [project.worktree]
+        : [],
+    );
+    for (const worktree of new Set(worktrees)) {
+      const response = await this.#fetch(
+        "GET",
+        `/session/${encodeURIComponent(id)}`,
+        worktree,
+      );
+      if (response.status === 404) continue;
+      if (!response.ok) {
+        throw new Error(
+          `OpenCode GET /session/${id} failed (${response.status}): ${await response.text()}`,
+        );
+      }
+      return sessionOf(JSON.parse(await response.text()) as unknown);
+    }
+    throw new Error(`OpenCode has no session ${id} in any known project.`);
   }
 
   /** Parsed `/global/event` server-sent events until the signal aborts. */
@@ -491,14 +543,17 @@ export async function forkOpencodeSession(input: {
   try {
     const { baseUrl, password } = await host.endpoint();
     const client = new OpencodeClient(baseUrl, password);
-    return sessionIdOf(
+    // The fork lands in the source session's project, whatever the review's
+    // checkout is; the terminal later attaches with that directory.
+    const source = await client.session(input.sourceSessionId);
+    return sessionOf(
       await client.json(
         "POST",
-        `/session/${encodeURIComponent(input.sourceSessionId)}/fork`,
-        input.cwd,
+        `/session/${encodeURIComponent(source.id)}/fork`,
+        source.directory,
         {},
       ),
-    );
+    ).id;
   } finally {
     await host.close();
   }
@@ -523,9 +578,9 @@ export async function createOpencodeSession(input: {
   try {
     const { baseUrl, password } = await host.endpoint();
     const client = new OpencodeClient(baseUrl, password);
-    const sessionId = sessionIdOf(
+    const sessionId = sessionOf(
       await client.json("POST", "/session", input.cwd, { title: input.title }),
-    );
+    ).id;
     await client.json(
       "POST",
       `/session/${encodeURIComponent(sessionId)}/prompt_async`,

--- a/packages/progressive-review/src/native-agent/opencode.ts
+++ b/packages/progressive-review/src/native-agent/opencode.ts
@@ -1,0 +1,541 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:net";
+
+import { DEV_REVIEW_HOME_ENV, devReviewHome } from "../review-storage";
+import { AsyncQueue } from "./async-queue";
+import type {
+  AgentServer,
+  AgentServerOptions,
+  LaunchInput,
+  NativeReviewMessage,
+  NativeTerminalCommand,
+  SessionSnapshot,
+  SessionUpdate,
+  UpdatePipe,
+} from "./native-session";
+import {
+  REVIEW_AGENT_THREAD_TOKEN_ENV,
+  REVIEW_AGENT_THREAD_URL_ENV,
+  ReviewCommandPath,
+} from "./terminal-command";
+import { isJsonRecord } from "./transcript-json";
+
+const HOST = "127.0.0.1";
+const STARTUP_TIMEOUT_MS = 15_000;
+const REQUEST_TIMEOUT_MS = 60_000;
+
+/** Something that hands out the shared `opencode serve` endpoint. */
+export interface OpencodeHost {
+  /** Base URL plus the server password, once the server is healthy. */
+  endpoint(): Promise<{ baseUrl: string; password: string }>;
+  close(): Promise<void>;
+}
+
+interface SessionState {
+  /** Directory the session runs in; every request is scoped to it. */
+  directory: string;
+  messages: NativeReviewMessage[];
+  seen: Set<string>;
+  loaded: boolean;
+  subscribers: Set<AsyncQueue<SessionUpdate>>;
+}
+
+/**
+ * OpenCode is server-first: the TUI is a client of `opencode serve`. Review
+ * owns one such server; sessions are created and prompted through its HTTP
+ * API, its event stream is the session's updates, and the native TUI
+ * attaches to the same server with `opencode attach`.
+ */
+export class OpencodeAgentServer implements AgentServer {
+  readonly harness = "opencode" as const;
+  readonly #host: OpencodeHost;
+  readonly #desktop: AgentServerOptions["desktopEndpoint"];
+  readonly #commandPath: ReviewCommandPath;
+  readonly #sessions = new Map<string, SessionState>();
+  #events: { abort: AbortController; baseUrl: string } | undefined;
+
+  constructor(options: AgentServerOptions, host: OpencodeHost) {
+    this.#host = host;
+    this.#desktop = {
+      baseUrl: options.desktopEndpoint.baseUrl.replace(/\/$/u, ""),
+      token: options.desktopEndpoint.token,
+    };
+    this.#commandPath = new ReviewCommandPath(options);
+  }
+
+  async launch(
+    input: LaunchInput,
+  ): Promise<{ sessionId: string; command: NativeTerminalCommand }> {
+    const client = await this.#client();
+    let sessionId: string;
+    if (!input.session) {
+      sessionId = sessionIdOf(
+        await client.json("POST", "/session", input.cwd, {
+          title: "Review question",
+        }),
+      );
+    } else if ("forkOf" in input.session) {
+      sessionId = sessionIdOf(
+        await client.json(
+          "POST",
+          `/session/${encodeURIComponent(input.session.forkOf)}/fork`,
+          input.cwd,
+          {},
+        ),
+      );
+    } else {
+      sessionId = input.session.resume;
+    }
+    const state = this.#session(sessionId, input.cwd);
+    if (input.prompt !== undefined) {
+      // Review drives the turn; the TUI attaches to a session already at work.
+      await client.json(
+        "POST",
+        `/session/${encodeURIComponent(sessionId)}/prompt_async`,
+        input.cwd,
+        { parts: [{ type: "text", text: input.prompt }] },
+      );
+    }
+    void state;
+    const pathValue = await this.#commandPath.resolve();
+    return {
+      sessionId,
+      command: {
+        cwd: input.cwd,
+        executable: "opencode",
+        args: [
+          "attach",
+          client.baseUrl,
+          "--session",
+          sessionId,
+          "--dir",
+          input.cwd,
+        ],
+        env: {
+          OPENCODE_SERVER_PASSWORD: client.password,
+          [REVIEW_AGENT_THREAD_URL_ENV]: `${this.#desktop.baseUrl}/native-agent-events/opencode/${encodeURIComponent(sessionId)}/thread`,
+          [REVIEW_AGENT_THREAD_TOKEN_ENV]: this.#desktop.token,
+          [DEV_REVIEW_HOME_ENV]: devReviewHome(),
+          ...(pathValue ? { PATH: pathValue } : {}),
+        },
+      },
+    };
+  }
+
+  async updates(
+    sessionId: string,
+  ): Promise<UpdatePipe<SessionSnapshot, SessionUpdate>> {
+    const client = await this.#client();
+    const state = this.#session(sessionId);
+    if (!state.loaded) {
+      await this.#refresh(client, sessionId, state);
+      state.loaded = true;
+    }
+    const queue = new AsyncQueue<SessionUpdate>();
+    state.subscribers.add(queue);
+    return {
+      snapshot: { sessionId, messages: [...state.messages] },
+      updates: queue,
+      close: async () => {
+        state.subscribers.delete(queue);
+        queue.close();
+      },
+    };
+  }
+
+  async close(): Promise<void> {
+    for (const state of this.#sessions.values()) {
+      for (const queue of state.subscribers) queue.close();
+      state.subscribers.clear();
+    }
+    this.#events?.abort.abort();
+    this.#events = undefined;
+    await this.#host.close();
+  }
+
+  async #client(): Promise<OpencodeClient> {
+    const { baseUrl, password } = await this.#host.endpoint();
+    const client = new OpencodeClient(baseUrl, password);
+    if (this.#events?.baseUrl !== baseUrl) {
+      this.#events?.abort.abort();
+      const abort = new AbortController();
+      this.#events = { abort, baseUrl };
+      void this.#follow(client, abort.signal);
+    }
+    return client;
+  }
+
+  /** The event stream names sessions that changed; each is re-read and diffed. */
+  async #follow(client: OpencodeClient, signal: AbortSignal): Promise<void> {
+    try {
+      for await (const event of client.events(signal)) {
+        const sessionId = eventSessionId(event);
+        if (!sessionId) continue;
+        const state = this.#sessions.get(sessionId);
+        if (!state || !state.loaded) continue;
+        await this.#refresh(client, sessionId, state);
+      }
+    } catch (error) {
+      if (signal.aborted) return;
+      // The stream dropped; the next request reconnects it.
+      if (this.#events?.abort.signal === signal) this.#events = undefined;
+      console.error("OpenCode event stream failed:", error);
+    }
+  }
+
+  async #refresh(
+    client: OpencodeClient,
+    sessionId: string,
+    state: SessionState,
+  ): Promise<void> {
+    const messages = projectOpencodeMessages(
+      await client.json(
+        "GET",
+        `/session/${encodeURIComponent(sessionId)}/message`,
+        state.directory,
+      ),
+    );
+    for (const message of messages) {
+      if (state.seen.has(message.messageId)) continue;
+      state.seen.add(message.messageId);
+      const { messageId: _messageId, ...review } = message;
+      state.messages.push(review);
+      for (const queue of state.subscribers) {
+        queue.push({ type: "message.updated", message: review });
+      }
+    }
+  }
+
+  #session(sessionId: string, directory?: string): SessionState {
+    let state = this.#sessions.get(sessionId);
+    if (!state) {
+      state = {
+        directory: directory ?? "",
+        messages: [],
+        seen: new Set(),
+        loaded: false,
+        subscribers: new Set(),
+      };
+      this.#sessions.set(sessionId, state);
+    } else if (directory) {
+      state.directory = directory;
+    }
+    return state;
+  }
+}
+
+export interface OpencodeMessage extends NativeReviewMessage {
+  messageId: string;
+}
+
+/** Every user message, and every assistant message that completed without error. */
+export function projectOpencodeMessages(value: unknown): OpencodeMessage[] {
+  if (!Array.isArray(value)) {
+    throw new Error("OpenCode returned an invalid session message list.");
+  }
+  const messages: OpencodeMessage[] = [];
+  for (const entry of value) {
+    if (!isJsonRecord(entry) || !isJsonRecord(entry.info)) continue;
+    const info = entry.info;
+    if (typeof info.id !== "string" || !isJsonRecord(info.time)) continue;
+    const body = (Array.isArray(entry.parts) ? entry.parts : [])
+      .flatMap((part) =>
+        isJsonRecord(part) &&
+        part.type === "text" &&
+        part.ignored !== true &&
+        typeof part.text === "string"
+          ? [part.text]
+          : [],
+      )
+      .join("\n")
+      .trim();
+    if (!body) continue;
+    if (info.role === "user") {
+      messages.push({
+        role: "user",
+        body,
+        createdAt: millisToIso(info.time.created),
+        messageId: info.id,
+      });
+    } else if (
+      info.role === "assistant" &&
+      typeof info.time.completed === "number" &&
+      info.error === undefined
+    ) {
+      messages.push({
+        role: "assistant",
+        body,
+        createdAt: millisToIso(info.time.completed),
+        messageId: info.id,
+      });
+    }
+  }
+  return messages;
+}
+
+function eventSessionId(event: unknown): string | undefined {
+  if (!isJsonRecord(event) || !isJsonRecord(event.properties)) return undefined;
+  const properties = event.properties;
+  if (
+    event.type === "message.updated" &&
+    isJsonRecord(properties.info) &&
+    typeof properties.info.sessionID === "string"
+  ) {
+    return properties.info.sessionID;
+  }
+  if (
+    (event.type === "session.idle" || event.type === "session.updated") &&
+    typeof properties.sessionID === "string"
+  ) {
+    return properties.sessionID;
+  }
+  if (
+    event.type === "session.updated" &&
+    isJsonRecord(properties.info) &&
+    typeof properties.info.id === "string"
+  ) {
+    return properties.info.id;
+  }
+  return undefined;
+}
+
+function sessionIdOf(value: unknown): string {
+  if (!isJsonRecord(value) || typeof value.id !== "string" || !value.id) {
+    throw new Error("OpenCode returned an invalid session.");
+  }
+  return value.id;
+}
+
+function millisToIso(value: unknown): string {
+  return typeof value === "number"
+    ? new Date(value).toISOString()
+    : new Date(0).toISOString();
+}
+
+/** Authenticated HTTP client for one `opencode serve`. */
+export class OpencodeClient {
+  readonly #authorization: string;
+
+  constructor(
+    readonly baseUrl: string,
+    readonly password: string,
+  ) {
+    this.#authorization = `Basic ${Buffer.from(`opencode:${password}`).toString("base64")}`;
+  }
+
+  async json(
+    method: "GET" | "POST",
+    pathname: string,
+    directory: string | undefined,
+    body?: unknown,
+  ): Promise<unknown> {
+    const url = new URL(pathname, this.baseUrl);
+    if (directory) url.searchParams.set("directory", directory);
+    const response = await fetch(url, {
+      method,
+      headers: {
+        authorization: this.#authorization,
+        ...(body === undefined ? {} : { "content-type": "application/json" }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(
+        `OpenCode ${method} ${pathname} failed (${response.status}): ${text}`,
+      );
+    }
+    return text ? (JSON.parse(text) as unknown) : undefined;
+  }
+
+  /** Parsed `/global/event` server-sent events until the signal aborts. */
+  async *events(signal: AbortSignal): AsyncGenerator<unknown> {
+    const response = await fetch(new URL("/global/event", this.baseUrl), {
+      headers: {
+        authorization: this.#authorization,
+        accept: "text/event-stream",
+      },
+      signal,
+    });
+    if (!response.ok || !response.body) {
+      throw new Error(`OpenCode event stream failed (${response.status}).`);
+    }
+    const reader = response.body.getReader();
+    // Cancel the body on abort so the stream ends cleanly instead of erroring
+    // when the socket closes later.
+    const cancel = () => void reader.cancel().catch(() => undefined);
+    signal.addEventListener("abort", cancel, { once: true });
+    const decoder = new TextDecoder();
+    let buffer = "";
+    try {
+      while (!signal.aborted) {
+        const chunk = await reader.read();
+        if (chunk.done) break;
+        buffer += decoder.decode(chunk.value, { stream: true });
+        let boundary = buffer.indexOf("\n\n");
+        while (boundary >= 0) {
+          const raw = buffer.slice(0, boundary);
+          buffer = buffer.slice(boundary + 2);
+          const data = raw
+            .split("\n")
+            .filter((line) => line.startsWith("data:"))
+            .map((line) => line.slice(5).trimStart())
+            .join("\n");
+          if (data) yield JSON.parse(data) as unknown;
+          boundary = buffer.indexOf("\n\n");
+        }
+      }
+    } finally {
+      signal.removeEventListener("abort", cancel);
+      cancel();
+    }
+  }
+}
+
+/** Owns one `opencode serve` process on a reserved loopback port. */
+export class OpencodeServeHost implements OpencodeHost {
+  #started:
+    | Promise<{ child: ChildProcess; baseUrl: string; password: string }>
+    | undefined;
+
+  async endpoint(): Promise<{ baseUrl: string; password: string }> {
+    const { baseUrl, password } = await this.#start();
+    return { baseUrl, password };
+  }
+
+  async close(): Promise<void> {
+    if (!this.#started) return;
+    const started = this.#started;
+    this.#started = undefined;
+    const { child } = await started;
+    if (child.exitCode === null) child.kill("SIGTERM");
+  }
+
+  #start(): Promise<{
+    child: ChildProcess;
+    baseUrl: string;
+    password: string;
+  }> {
+    if (this.#started) return this.#started;
+    const started = (async () => {
+      const port = await reservePort();
+      const password = randomBytes(24).toString("base64url");
+      const baseUrl = `http://${HOST}:${port}`;
+      const child = spawn(
+        "opencode",
+        ["serve", "--hostname", HOST, "--port", String(port)],
+        {
+          cwd: "/",
+          env: { ...process.env, OPENCODE_SERVER_PASSWORD: password },
+          stdio: ["ignore", "ignore", "pipe"],
+          windowsHide: true,
+        },
+      );
+      let stderr = "";
+      child.stderr?.setEncoding("utf8");
+      child.stderr?.on("data", (chunk: string) => {
+        stderr = `${stderr}${chunk}`.slice(-8_000);
+      });
+      child.once("exit", () => {
+        this.#started = undefined;
+      });
+      const client = new OpencodeClient(baseUrl, password);
+      const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+      while (child.exitCode === null) {
+        try {
+          const health = await client.json("GET", "/global/health", undefined);
+          if (isJsonRecord(health) && health.healthy === true) {
+            return { child, baseUrl, password };
+          }
+        } catch {
+          // Not up yet.
+        }
+        if (Date.now() > deadline) break;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      if (child.exitCode === null) child.kill("SIGTERM");
+      throw new Error(
+        `OpenCode server did not become ready.\n\n${stderr.trim()}`,
+      );
+    })();
+    this.#started = started;
+    return started;
+  }
+}
+
+async function reservePort(): Promise<number> {
+  const server = createServer();
+  server.unref();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, HOST, resolve);
+  });
+  const address = server.address();
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  if (!address || typeof address === "string") {
+    throw new Error("Could not reserve a loopback port for OpenCode.");
+  }
+  return address.port;
+}
+
+/** Fork a session on a throwaway server. Used by the CLI to freeze a review's source. */
+export async function forkOpencodeSession(input: {
+  sourceSessionId: string;
+  cwd: string;
+}): Promise<string> {
+  const host = new OpencodeServeHost();
+  try {
+    const { baseUrl, password } = await host.endpoint();
+    const client = new OpencodeClient(baseUrl, password);
+    return sessionIdOf(
+      await client.json(
+        "POST",
+        `/session/${encodeURIComponent(input.sourceSessionId)}/fork`,
+        input.cwd,
+        {},
+      ),
+    );
+  } finally {
+    await host.close();
+  }
+}
+
+/** Create a session and run one synchronous prompt on a throwaway server. Used for the tutorial source. */
+export async function createOpencodeSession(input: {
+  cwd: string;
+  prompt: string;
+}): Promise<string> {
+  const host = new OpencodeServeHost();
+  try {
+    const { baseUrl, password } = await host.endpoint();
+    const client = new OpencodeClient(baseUrl, password);
+    const sessionId = sessionIdOf(
+      await client.json("POST", "/session", input.cwd, {
+        title: "Review tutorial authoring",
+      }),
+    );
+    // `message` (unlike `prompt_async`) answers once the assistant finished.
+    await client.json(
+      "POST",
+      `/session/${encodeURIComponent(sessionId)}/message`,
+      input.cwd,
+      { parts: [{ type: "text", text: input.prompt }] },
+    );
+    return sessionId;
+  } finally {
+    await host.close();
+  }
+}
+
+export function server(
+  options: AgentServerOptions & { host?: OpencodeHost },
+): AgentServer {
+  return new OpencodeAgentServer(
+    options,
+    options.host ?? new OpencodeServeHost(),
+  );
+}

--- a/packages/progressive-review/src/native-agent/opencode.ts
+++ b/packages/progressive-review/src/native-agent/opencode.ts
@@ -1,6 +1,16 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
+import type { AddressInfo } from "node:net";
 import { createServer } from "node:net";
+
+import {
+  type JsonValue,
+  jsonArray,
+  jsonNumber,
+  jsonObject,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
 
 import { DEV_REVIEW_HOME_ENV, devReviewHome } from "../review-storage";
 import { AsyncQueue } from "./async-queue";
@@ -19,7 +29,6 @@ import {
   REVIEW_AGENT_THREAD_URL_ENV,
   ReviewCommandPath,
 } from "./terminal-command";
-import { isJsonRecord } from "./transcript-json";
 
 const HOST = "127.0.0.1";
 const STARTUP_TIMEOUT_MS = 15_000;
@@ -103,6 +112,13 @@ export class OpencodeAgentServer implements AgentServer {
       );
     }
     const pathValue = await this.#commandPath.resolve();
+    const env: NativeTerminalCommand["env"] = {
+      OPENCODE_SERVER_PASSWORD: client.password,
+      [REVIEW_AGENT_THREAD_URL_ENV]: `${this.#desktop.baseUrl}/native-agent-events/opencode/${encodeURIComponent(sessionId)}/thread`,
+      [REVIEW_AGENT_THREAD_TOKEN_ENV]: this.#desktop.token,
+      [DEV_REVIEW_HOME_ENV]: devReviewHome(),
+    };
+    if (pathValue) env.PATH = pathValue;
     return {
       sessionId,
       command: {
@@ -116,13 +132,7 @@ export class OpencodeAgentServer implements AgentServer {
           "--dir",
           session.directory,
         ],
-        env: {
-          OPENCODE_SERVER_PASSWORD: client.password,
-          [REVIEW_AGENT_THREAD_URL_ENV]: `${this.#desktop.baseUrl}/native-agent-events/opencode/${encodeURIComponent(sessionId)}/thread`,
-          [REVIEW_AGENT_THREAD_TOKEN_ENV]: this.#desktop.token,
-          [DEV_REVIEW_HOME_ENV]: devReviewHome(),
-          ...(pathValue ? { PATH: pathValue } : {}),
-        },
+        env,
       },
     };
   }
@@ -237,24 +247,30 @@ export interface OpencodeMessage extends NativeReviewMessage {
 }
 
 /** Every user message, and every assistant message that completed without error. */
-export function projectOpencodeMessages(value: unknown): OpencodeMessage[] {
-  if (!Array.isArray(value)) {
+export function projectOpencodeMessages(
+  value: JsonValue | undefined,
+): OpencodeMessage[] {
+  const list = jsonArray(value);
+  if (!list) {
     throw new Error("OpenCode returned an invalid session message list.");
   }
   const messages: OpencodeMessage[] = [];
-  for (const entry of value) {
-    if (!isJsonRecord(entry) || !isJsonRecord(entry.info)) continue;
-    const info = entry.info;
-    if (typeof info.id !== "string" || !isJsonRecord(info.time)) continue;
-    const body = (Array.isArray(entry.parts) ? entry.parts : [])
-      .flatMap((part) =>
-        isJsonRecord(part) &&
-        part.type === "text" &&
-        part.ignored !== true &&
-        typeof part.text === "string"
-          ? [part.text]
-          : [],
-      )
+  for (const entry of list) {
+    const record = jsonObject(entry);
+    const info = jsonObject(record?.info);
+    const time = jsonObject(info?.time);
+    const messageId = jsonString(info?.id);
+    if (!record || !info || !time || messageId === undefined) continue;
+    const body = (jsonArray(record.parts) ?? [])
+      .flatMap((item) => {
+        const part = jsonObject(item);
+        const text = jsonString(part?.text);
+        return part?.type === "text" &&
+          part.ignored !== true &&
+          text !== undefined
+          ? [text]
+          : [];
+      })
       .join("\n")
       .trim();
     if (!body) continue;
@@ -262,67 +278,61 @@ export function projectOpencodeMessages(value: unknown): OpencodeMessage[] {
       messages.push({
         role: "user",
         body,
-        createdAt: millisToIso(info.time.created),
-        messageId: info.id,
+        createdAt: millisToIso(time.created),
+        messageId,
       });
-    } else if (
+      continue;
+    }
+    const completed = jsonNumber(time.completed);
+    if (
       info.role === "assistant" &&
-      typeof info.time.completed === "number" &&
+      completed !== undefined &&
       info.error === undefined
     ) {
       messages.push({
         role: "assistant",
         body,
-        createdAt: millisToIso(info.time.completed),
-        messageId: info.id,
+        createdAt: millisToIso(completed),
+        messageId,
       });
     }
   }
   return messages;
 }
 
-function eventSessionId(event: unknown): string | undefined {
-  if (!isJsonRecord(event) || !isJsonRecord(event.properties)) return undefined;
-  const properties = event.properties;
-  if (
-    event.type === "message.updated" &&
-    isJsonRecord(properties.info) &&
-    typeof properties.info.sessionID === "string"
-  ) {
-    return properties.info.sessionID;
-  }
-  if (
-    (event.type === "session.idle" || event.type === "session.updated") &&
-    typeof properties.sessionID === "string"
-  ) {
-    return properties.sessionID;
-  }
-  if (
-    event.type === "session.updated" &&
-    isJsonRecord(properties.info) &&
-    typeof properties.info.id === "string"
-  ) {
-    return properties.info.id;
+function eventSessionId(event: JsonValue): string | undefined {
+  const record = jsonObject(event);
+  const properties = jsonObject(record?.properties);
+  if (!record || !properties) return undefined;
+  const info = jsonObject(properties.info);
+  if (record.type === "message.updated") return jsonString(info?.sessionID);
+  if (record.type === "session.idle") return jsonString(properties.sessionID);
+  if (record.type === "session.updated") {
+    return jsonString(properties.sessionID) ?? jsonString(info?.id);
   }
   return undefined;
 }
 
-function sessionOf(value: unknown): { id: string; directory: string } {
-  if (
-    !isJsonRecord(value) ||
-    typeof value.id !== "string" ||
-    !value.id ||
-    typeof value.directory !== "string"
-  ) {
-    throw new Error("OpenCode returned an invalid session.");
-  }
-  return { id: value.id, directory: value.directory };
+interface OpencodeSession {
+  id: string;
+  directory: string;
 }
 
-function millisToIso(value: unknown): string {
-  return typeof value === "number"
-    ? new Date(value).toISOString()
-    : new Date(0).toISOString();
+function sessionOf(value: JsonValue | undefined): OpencodeSession {
+  const record = jsonObject(value);
+  const id = jsonString(record?.id);
+  const directory = jsonString(record?.directory);
+  if (!id || directory === undefined) {
+    throw new Error("OpenCode returned an invalid session.");
+  }
+  return { id, directory };
+}
+
+function millisToIso(value: JsonValue | undefined): string {
+  const millis = jsonNumber(value);
+  return millis === undefined
+    ? new Date(0).toISOString()
+    : new Date(millis).toISOString();
 }
 
 /** Authenticated HTTP client for one `opencode serve`. */
@@ -340,8 +350,8 @@ export class OpencodeClient {
     method: "GET" | "POST",
     pathname: string,
     directory: string | undefined,
-    body?: unknown,
-  ): Promise<unknown> {
+    body?: JsonValue,
+  ): Promise<JsonValue | undefined> {
     const response = await this.#fetch(method, pathname, directory, body);
     const text = await response.text();
     if (!response.ok) {
@@ -349,42 +359,43 @@ export class OpencodeClient {
         `OpenCode ${method} ${pathname} failed (${response.status}): ${text}`,
       );
     }
-    return text ? (JSON.parse(text) as unknown) : undefined;
+    return text ? parseJsonText(text) : undefined;
   }
 
   #fetch(
     method: "GET" | "POST",
     pathname: string,
     directory: string | undefined,
-    body?: unknown,
+    body?: JsonValue,
   ): Promise<Response> {
     const url = new URL(pathname, this.baseUrl);
     if (directory) url.searchParams.set("directory", directory);
-    return fetch(url, {
+    const headers = new Headers({ authorization: this.#authorization });
+    const init: RequestInit = {
       method,
-      headers: {
-        authorization: this.#authorization,
-        ...(body === undefined ? {} : { "content-type": "application/json" }),
-      },
-      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      headers,
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
+    };
+    if (body !== undefined) {
+      headers.set("content-type", "application/json");
+      init.body = JSON.stringify(body);
+    }
+    return fetch(url, init);
   }
 
   /**
    * Find a session by id. Sessions are stored per project, and a lookup is
    * scoped to one directory, so every project the server knows is tried.
    */
-  async session(id: string): Promise<{ id: string; directory: string }> {
-    const projects = await this.json("GET", "/project", undefined);
-    if (!Array.isArray(projects)) {
+  async session(id: string): Promise<OpencodeSession> {
+    const projects = jsonArray(await this.json("GET", "/project", undefined));
+    if (!projects) {
       throw new Error("OpenCode returned an invalid project list.");
     }
-    const worktrees = projects.flatMap((project) =>
-      isJsonRecord(project) && typeof project.worktree === "string"
-        ? [project.worktree]
-        : [],
-    );
+    const worktrees = projects.flatMap((project) => {
+      const worktree = jsonString(jsonObject(project)?.worktree);
+      return worktree === undefined ? [] : [worktree];
+    });
     for (const worktree of new Set(worktrees)) {
       const response = await this.#fetch(
         "GET",
@@ -397,13 +408,13 @@ export class OpencodeClient {
           `OpenCode GET /session/${id} failed (${response.status}): ${await response.text()}`,
         );
       }
-      return sessionOf(JSON.parse(await response.text()) as unknown);
+      return sessionOf(parseJsonText(await response.text()));
     }
     throw new Error(`OpenCode has no session ${id} in any known project.`);
   }
 
   /** Parsed `/global/event` server-sent events until the signal aborts. */
-  async *events(signal: AbortSignal): AsyncGenerator<unknown> {
+  async *events(signal: AbortSignal): AsyncGenerator<JsonValue> {
     const response = await fetch(new URL("/global/event", this.baseUrl), {
       headers: {
         authorization: this.#authorization,
@@ -435,7 +446,7 @@ export class OpencodeClient {
             .filter((line) => line.startsWith("data:"))
             .map((line) => line.slice(5).trimStart())
             .join("\n");
-          if (data) yield JSON.parse(data) as unknown;
+          if (data) yield parseJsonText(data);
           boundary = buffer.indexOf("\n\n");
         }
       }
@@ -498,7 +509,7 @@ export class OpencodeServeHost implements OpencodeHost {
       while (child.exitCode === null) {
         try {
           const health = await client.json("GET", "/global/health", undefined);
-          if (isJsonRecord(health) && health.healthy === true) {
+          if (jsonObject(health)?.healthy === true) {
             return { child, baseUrl, password };
           }
         } catch {
@@ -528,10 +539,11 @@ async function reservePort(): Promise<number> {
   await new Promise<void>((resolve, reject) =>
     server.close((error) => (error ? reject(error) : resolve())),
   );
-  if (!address || typeof address === "string") {
+  if (!address) {
     throw new Error("Could not reserve a loopback port for OpenCode.");
   }
-  return address.port;
+  // SAFETY: a TCP listener bound to a port reports an AddressInfo, never a pipe path.
+  return (address as AddressInfo).port;
 }
 
 /** Fork a session on a throwaway server. Used by the CLI to freeze a review's source. */
@@ -615,17 +627,14 @@ export async function createOpencodeSession(input: {
 }
 
 /** The first assistant message that ended in an error, as a short description. */
-function assistantFailure(messages: unknown): string | undefined {
-  if (!Array.isArray(messages)) return undefined;
-  for (const entry of messages) {
-    if (!isJsonRecord(entry) || !isJsonRecord(entry.info)) continue;
-    const info = entry.info;
-    if (info.role !== "assistant" || !isJsonRecord(info.error)) continue;
-    const name =
-      typeof info.error.name === "string" ? info.error.name : "error";
-    const data = isJsonRecord(info.error.data) ? info.error.data : {};
-    const message = typeof data.message === "string" ? `: ${data.message}` : "";
-    return `${name}${message}`;
+function assistantFailure(messages: JsonValue | undefined): string | undefined {
+  for (const entry of jsonArray(messages) ?? []) {
+    const info = jsonObject(jsonObject(entry)?.info);
+    const error = jsonObject(info?.error);
+    if (info?.role !== "assistant" || !error) continue;
+    const name = jsonString(error.name) ?? "error";
+    const message = jsonString(jsonObject(error.data)?.message);
+    return message === undefined ? name : `${name}: ${message}`;
   }
   return undefined;
 }

--- a/packages/progressive-review/src/review-source-agent-session.ts
+++ b/packages/progressive-review/src/review-source-agent-session.ts
@@ -13,6 +13,7 @@ import type { SessionRef } from "./authoring-session";
 import { errorMessage } from "./error-message";
 import { findClaudeTranscript } from "./native-agent/claude-transcript";
 import { forkCodexThread } from "./native-agent/codex-app-server";
+import { forkOpencodeSession } from "./native-agent/opencode";
 
 /**
  * Fork the invoking session once and bind the frozen copy to the Review.
@@ -30,6 +31,15 @@ export async function createReviewSourceAgentSession(input: {
   }
   if (input.agent.harness === "pi") {
     return createPiReviewSourceSession(input);
+  }
+  if (input.agent.harness === "opencode") {
+    return {
+      harness: "opencode",
+      sessionId: await forkOpencodeSession({
+        sourceSessionId: input.agent.sessionId,
+        cwd: input.rootPath,
+      }),
+    };
   }
   return {
     harness: "codex",

--- a/packages/progressive-review/src/server/cli-install.ts
+++ b/packages/progressive-review/src/server/cli-install.ts
@@ -56,6 +56,7 @@ const AGENT_HOME_DIR: Record<InstallTarget, string> = {
   claude: ".claude",
   codex: ".codex",
   cursor: ".cursor",
+  opencode: ".config/opencode",
   pi: ".pi",
 };
 const SHIM_MARKER = "Managed by Review Desktop";
@@ -430,8 +431,9 @@ export async function removeCliInstall(input: {
 
 /**
  * Fingerprint of everything the app distributes: the package version, the
- * built CLI, and the skill sources. Content-based so it works identically in
- * a dev checkout and a packaged review-runtime, with no build-time stamping.
+ * built CLI, skill sources, and agent integrations. Content-based so it works
+ * identically in a dev checkout and a packaged review-runtime, with no
+ * build-time stamping.
  */
 export async function installFingerprint(packageRoot: string): Promise<string> {
   const hash = createHash("sha256");
@@ -441,6 +443,13 @@ export async function installFingerprint(packageRoot: string): Promise<string> {
   hash.update(await readTextIfExists(cliPath));
   for (const file of await listFilesRecursive(
     path.join(packageRoot, "skills"),
+  )) {
+    hash.update(`${file.relPath}\0`);
+    hash.update(await readFile(file.absPath));
+    hash.update("\0");
+  }
+  for (const file of await listFilesRecursive(
+    path.join(packageRoot, "plugins"),
   )) {
     hash.update(`${file.relPath}\0`);
     hash.update(await readFile(file.absPath));

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -45,6 +45,7 @@ import { preferredInstalledReviewAgent } from "../installed-review-agent";
 import * as claudeCode from "../native-agent/claude-code";
 import * as codex from "../native-agent/codex";
 import type { AgentServer } from "../native-agent/native-session";
+import * as opencode from "../native-agent/opencode";
 import * as pi from "../native-agent/pi";
 import { readProgressiveReviewPackageVersion } from "../package-paths";
 import {
@@ -289,7 +290,7 @@ export function createGlobalReviewServer(
   const tutorialAuthoringStates = new Map<string, TutorialAuthoringState>();
   let reviewReaper: ReturnType<typeof setInterval> | undefined;
   let closing = false;
-  const harnesses = { "claude-code": claudeCode, codex, pi } as const;
+  const harnesses = { "claude-code": claudeCode, codex, opencode, pi } as const;
   const agentServers = new Map<ReviewAgentHarness, AgentServer>();
   const agentServerFor = (harness: ReviewAgentHarness): AgentServer => {
     let server = agentServers.get(harness);

--- a/packages/progressive-review/src/tutorial-authoring-session.ts
+++ b/packages/progressive-review/src/tutorial-authoring-session.ts
@@ -9,6 +9,7 @@ import {
 } from "@dev.fast/review-protocol";
 
 import { type ReviewAgentHarness, type SessionRef } from "./authoring-session";
+import { createOpencodeSession } from "./native-agent/opencode";
 
 const TUTORIAL_AUTHORING_TIMEOUT_MS = 120_000;
 
@@ -82,6 +83,15 @@ export async function createTutorialAuthoringSession(input: {
       return {
         harness: input.harness,
         sessionId: codexThreadId(result.stdout),
+      };
+    }
+    case "opencode": {
+      return {
+        harness: input.harness,
+        sessionId: await createOpencodeSession({
+          cwd: input.rootPath,
+          prompt,
+        }),
       };
     }
     case "pi": {

--- a/packages/progressive-review/src/tutorial-authoring-session.ts
+++ b/packages/progressive-review/src/tutorial-authoring-session.ts
@@ -91,6 +91,8 @@ export async function createTutorialAuthoringSession(input: {
         sessionId: await createOpencodeSession({
           cwd: input.rootPath,
           prompt,
+          title: "Review tutorial authoring",
+          signal: input.signal,
         }),
       };
     }

--- a/packages/review-protocol/src/bug-report.ts
+++ b/packages/review-protocol/src/bug-report.ts
@@ -64,7 +64,9 @@ export const ReviewBugReportMetaV2Schema = z
     has_diff: z.boolean(),
     has_screenshot: z.boolean(),
     has_trace: z.boolean(),
-    trace_harness: z.enum(["claude-code", "codex", "pi"]).optional(),
+    trace_harness: z
+      .enum(["claude-code", "codex", "opencode", "pi"])
+      .optional(),
     payload_bytes: z
       .number()
       .int()

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1340,8 +1340,8 @@ export const ReviewStackResponseSchema = z.strictObject({
 export type ReviewStackResponse = z.infer<typeof ReviewStackResponseSchema>;
 
 export const ReviewCliInstallTargetSchema = z.enum(
-  ["claude", "codex", "cursor", "pi"],
-  { error: "must be claude, codex, cursor, or pi" },
+  ["claude", "codex", "cursor", "opencode", "pi"],
+  { error: "must be claude, codex, cursor, opencode, or pi" },
 );
 export type ReviewCliInstallTarget = z.infer<
   typeof ReviewCliInstallTargetSchema

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -473,7 +473,7 @@ export type CreateReviewCommentInput = z.infer<
 >;
 
 export const ReviewCommentAgentSessionSchema = z.strictObject({
-  harness: z.enum(["codex", "claude-code", "pi"]),
+  harness: z.enum(["codex", "claude-code", "opencode", "pi"]),
   sessionId: threadTargetNonEmptyStringSchema,
 });
 export type ReviewCommentAgentSession = z.infer<
@@ -1250,7 +1250,7 @@ export type ReviewDocumentVersionWire = z.infer<
 
 /** The native agent session that authored the review. */
 export const AuthoringAgentSessionSchema = z.strictObject({
-  harness: z.enum(["claude-code", "codex", "pi"]),
+  harness: z.enum(["claude-code", "codex", "opencode", "pi"]),
   sessionId: requiredString,
 });
 export type AuthoringAgentSessionWire = z.infer<


### PR DESCRIPTION
## OpenCode on AgentServer

Stacked on #83. The OpenCode translation of #48 on the new model: one module (`native-agent/opencode.ts`) with a host that owns an `opencode serve` process on a reserved loopback port, an HTTP + SSE client, and `OpencodeAgentServer`. Sessions are created or forked over HTTP, prompted with `prompt_async`, and the TUI attaches with `opencode attach <url> --session <id> --dir <dir>`. Updates come from `/global/event`; each session it names is re-read and diffed by message id.

Plumbing: `"opencode"` in the harness union, the protocol enum, the thread label, the desktop's harness table, the review-source fork and the tutorial source.

Fixed during the regression run against `opencode serve` 1.1.53:
- `createOpencodeSession` now submits with `prompt_async` and polls (a model turn outlasted the 60s request timeout).
- OpenCode sessions are project-scoped by directory; forks and the TUI attach now run in the source session's project (the review's pinned checkout is a different project). Consequence: an OpenCode question session runs in the source worktree.

What remains of #48 outside the agent layer (identification tool + hidden CLI flags, install/setup UI, docs) rebases as-is.

Agent-Session: ba208f4e-0500-4cca-bc8c-67aafcc19811

https://claude.ai/code/session_01B7X8ez8cgtCW9qMS1iPYGP
