### PR TITLE
fix(review): record CLI replies as agent responses

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -154,9 +154,10 @@ review threads reply <thread-id> --body <text> [--author <name>] --review <uuid>
 review threads resolve <thread-id> --review <uuid>
 ```
 
-Thread commands return JSON. Replies use `Agent` as the author unless
-`--author` is provided. Resolve a comment only after its exact request is
-addressed. Review owns the SQLite thread store; do not edit it directly.
+Thread commands return JSON. Replies are recorded as agent responses and use
+`Agent` as the author unless `--author` is provided. After addressing a
+submitted comment, reply with a concise disposition and then resolve it. Review
+owns the SQLite thread store; do not edit it directly.
 
 ## Software maps
 

--- a/packages/progressive-review/skills/dev-review/SKILL.md
+++ b/packages/progressive-review/skills/dev-review/SKILL.md
@@ -159,7 +159,7 @@ review wait --requires-agent --codex --review <uuid>
 
 Use only one wait command.
 
-- For `awaiting-agent-updates`, read the threads with `review threads list`. Address every open thread. Mark each addressed thread with `review threads resolve <threadId> --review <uuid>`. A document re-publish requires zero open comment threads. Update moved pins with `review scaffold --update` when required. If pins move, dispatch a new map worker with the new pins. Publish the document without waiting for the new map. Then publish the new map after both checks pass.
+- For `awaiting-agent-updates`, read the threads with `review threads list`. Address every open thread. Reply to each addressed thread with `review threads reply <threadId> --body <text> --review <uuid>`, then mark it resolved with `review threads resolve <threadId> --review <uuid>`. A document re-publish requires zero open comment threads and a completed agent response for every current-round reviewer message. Update moved pins with `review scaffold --update` when required. If pins move, dispatch a new map worker with the new pins. Publish the document without waiting for the new map. Then publish the new map after both checks pass.
 - For `review-dismissed` or `review-deleted`, stop the loop.
 - While the status is `awaiting-review`, the reviewer owns the next action.
 

--- a/packages/progressive-review/skills/dev-review/references/lifecycle-and-storage.md
+++ b/packages/progressive-review/skills/dev-review/references/lifecycle-and-storage.md
@@ -108,9 +108,9 @@ review threads reply <threadId> --body <text> --review <uuid>
 review threads resolve <threadId> --review <uuid>
 ```
 
-Do not invent, rewrite, or merge opaque thread targets. Resolve a thread only after its requested document or code change is present.
+Do not invent, rewrite, or merge opaque thread targets. After making the requested document or code change, reply with a concise disposition and then resolve the thread.
 
-A document re-publish requires zero open comment threads. Before each re-publish, run `review threads list`. Address every open thread. Mark each addressed thread with `review threads resolve <threadId> --review <uuid>`. Run `review threads list` again. Do not re-publish until no comment thread has `status: "open"`. The first document publication does not use this gate.
+A document re-publish requires zero open comment threads and a completed agent response for every current-round reviewer message. Before each re-publish, run `review threads list`. Address every open thread, reply with `review threads reply`, and mark it with `review threads resolve`. Run `review threads list` again. Do not re-publish until no comment thread has `status: "open"`. The first document publication does not use this gate.
 
 ## Migration
 


### PR DESCRIPTION
Agent-Session: 01a0600c-8adb-7663-ba10-a0207d0507b8
Agent-Session: 01a0602c-1d0f-7b03-8356-7a3614e78dc3
Agent-Session: 01a06048-aee8-7142-84b8-ef4838717f58
Agent-Session: 01a06050-6825-7661-94cc-512afb8a405e
Agent-Session: 01a060a7-1371-7d61-8a00-a54bee4571bd

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>