### PR TITLE
Add Review CLI PATH command

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/platform/native/common/native.ts
+++ b/apps/review-desktop/code-oss/src/vs/platform/native/common/native.ts
@@ -56,6 +56,11 @@ export interface INativeHostOptions {
 	readonly targetWindowId?: number;
 }
 
+export interface IUninstallShellCommandOptions {
+	readonly commandName?: string;
+	readonly symlinkOnly?: boolean;
+}
+
 export interface IStartTracingOptions {
 
 	/**
@@ -275,7 +280,7 @@ export interface ICommonNativeHostService {
 
 	// macOS Shell command
 	installShellCommand(): Promise<void>;
-	uninstallShellCommand(): Promise<void>;
+	uninstallShellCommand(options?: IUninstallShellCommandOptions): Promise<void>;
 
 	// Lifecycle
 	notifyReady(): Promise<void>;

--- a/apps/review-desktop/code-oss/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/apps/review-desktop/code-oss/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -27,7 +27,7 @@ import { IEnvironmentMainService } from '../../environment/electron-main/environ
 import { createDecorator, IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { ILifecycleMainService, IRelaunchOptions } from '../../lifecycle/electron-main/lifecycleMainService.js';
 import { ILogService } from '../../log/common/log.js';
-import { FocusMode, ICommonNativeHostService, INativeHostOptions, INativeSystemWideKeybinding, INativeSystemWideKeybindingResult, IOSProperties, IOSStatistics, IStartTracingOptions, IToastOptions, IToastResult, PowerSaveBlockerType, SystemIdleState, ThermalState } from '../common/native.js';
+import { FocusMode, ICommonNativeHostService, INativeHostOptions, INativeSystemWideKeybinding, INativeSystemWideKeybindingResult, IOSProperties, IOSStatistics, IStartTracingOptions, IToastOptions, IToastResult, IUninstallShellCommandOptions, PowerSaveBlockerType, SystemIdleState, ThermalState } from '../common/native.js';
 import { IGlobalKeybindingsMainService } from '../../globalKeybindings/electron-main/globalKeybindingsMainService.js';
 import { IProductService } from '../../product/common/productService.js';
 import { IPartsSplash } from '../../theme/common/themeService.js';
@@ -517,14 +517,29 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		}
 	}
 
-	async uninstallShellCommand(windowId: number | undefined): Promise<void> {
-		const { source } = await this.getShellCommandLink();
+	async uninstallShellCommand(windowId: number | undefined, options?: IUninstallShellCommandOptions): Promise<void> {
+		const source = this.getShellCommandSource(options?.commandName);
+
+		if (options?.symlinkOnly) {
+			try {
+				const { symbolicLink } = await SymlinkSupport.stat(source);
+				if (!symbolicLink) {
+					throw new Error(localize('notShellCommandLink', "Refusing to remove '{0}' because it is not a symbolic link.", source));
+				}
+			} catch (error) {
+				if (error.code === 'ENOENT') {
+					return;
+				}
+				throw error;
+			}
+		}
 
 		try {
 			await fs.promises.unlink(source);
 		} catch (error) {
 			switch (error.code) {
-				case 'EACCES': {
+				case 'EACCES':
+				case 'EPERM': {
 					const { response } = await this.showMessageBox(windowId, {
 						type: 'info',
 						message: localize('warnEscalationUninstall', "{0} will now prompt with 'osascript' for Administrator privileges to uninstall the shell command.", this.productService.nameShort),
@@ -539,7 +554,10 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 					}
 
 					try {
-						const command = `osascript -e "do shell script \\"rm \'${source}\'\\" with administrator privileges"`;
+						const removeCommand = options?.symlinkOnly
+							? `if [ -L '${source}' ]; then rm '${source}'; elif [ -e '${source}' ]; then exit 64; fi`
+							: `rm '${source}'`;
+						const command = `osascript -e "do shell script \\"${removeCommand}\\" with administrator privileges"`;
 						await promisify(exec)(command);
 					} catch (error) {
 						throw new Error(localize('cantUninstall', "Unable to uninstall the shell command '{0}'.", source));
@@ -556,7 +574,7 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 
 	private async getShellCommandLink(): Promise<{ readonly source: string; readonly target: string }> {
 		const target = resolve(this.environmentMainService.appRoot, 'bin', 'code');
-		const source = `/usr/local/bin/${this.productService.applicationName}`;
+		const source = this.getShellCommandSource();
 
 		// Ensure source exists
 		const sourceExists = await Promises.exists(target);
@@ -565,6 +583,13 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		}
 
 		return { source, target };
+	}
+
+	private getShellCommandSource(commandName = this.productService.applicationName): string {
+		if (!/^[A-Za-z0-9._-]+$/.test(commandName) || commandName === '.' || commandName === '..') {
+			throw new Error(localize('invalidShellCommandName', "Invalid shell command name '{0}'.", commandName));
+		}
+		return `/usr/local/bin/${commandName}`;
 	}
 
 	//#endregion

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewCliInstall.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewCliInstall.test.ts
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { ReviewCliInstallStatus } from './reviewProtocol.js';
+import { reviewCliInstallResyncRequest } from './reviewCliInstall.js';
+
+const baseStatus: ReviewCliInstallStatus = {
+	agents: [],
+	fingerprint: 'current',
+	stamp: null,
+	stale: true,
+	shim: {
+		path: '/home/test/.local/bin/review',
+		installed: false,
+		profileConfigured: false,
+		onPath: false,
+	},
+	fff: {
+		serverName: 'fff',
+		corpusRoot: '/home/test/.dev/trace-search',
+		binary: { path: '/home/test/.local/bin/fff-mcp', installed: false },
+		registrations: [],
+	},
+	trace: {
+		enabled: false,
+		configured: false,
+		autoActivateRepositories: false,
+		envPath: '/home/test/.dev/trace.env',
+		settingsPath: '/home/test/.dev/trace-settings.json',
+	},
+	cli: null,
+};
+
+test('resyncs a CLI-only installation', () => {
+	assert.deepEqual(
+		reviewCliInstallResyncRequest({
+			...baseStatus,
+			agents: [{ target: 'codex', present: true, installed: true }],
+			stamp: {
+				consent: 'granted',
+				targets: [],
+				shimPath: '/home/test/.local/bin/review',
+				updatedAt: '2026-09-02T00:00:00.000Z',
+			},
+		}),
+		{ targets: [], shim: true },
+	);
+});
+
+test('falls back to installed skills for a legacy stamp without targets', () => {
+	assert.deepEqual(
+		reviewCliInstallResyncRequest({
+			...baseStatus,
+			agents: [{ target: 'codex', present: true, installed: true }],
+			stamp: {
+				consent: 'granted',
+				updatedAt: '2026-09-02T00:00:00.000Z',
+			},
+		}),
+		{ targets: ['codex'], shim: false },
+	);
+});
+
+test('preserves an explicit CLI opt-out while resyncing skills', () => {
+	assert.deepEqual(
+		reviewCliInstallResyncRequest({
+			...baseStatus,
+			stamp: {
+				consent: 'granted',
+				targets: ['codex'],
+				updatedAt: '2026-09-02T00:00:00.000Z',
+			},
+		}),
+		{ targets: ['codex'], shim: false },
+	);
+});
+
+test('skips resync when neither skills nor the CLI are managed', () => {
+	assert.equal(reviewCliInstallResyncRequest(baseStatus), undefined);
+});

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewCliInstall.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewCliInstall.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { ReviewCliInstallStatus, ReviewCliInstallTarget } from './reviewProtocol.js';
+
+export interface ReviewCliInstallResyncRequest {
+	readonly targets: readonly ReviewCliInstallTarget[];
+	readonly shim: boolean;
+}
+
+export function reviewCliInstallResyncRequest(status: ReviewCliInstallStatus): ReviewCliInstallResyncRequest | undefined {
+	const targets = status.stamp?.targets !== undefined
+		? status.stamp.targets
+		: status.agents.filter(agent => agent.installed).map(agent => agent.target);
+	const shim = Boolean(status.stamp?.shimPath);
+	return targets.length > 0 || shim ? { targets, shim } : undefined;
+}

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewCommandPalette.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewCommandPalette.test.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { reviewCommandPaletteLabel } from './reviewCommandPalette.js';
+
+test('uses the human-readable command title', () => {
+	assert.equal(
+		reviewCommandPaletteLabel('review.installCliInPath', {
+			title: { value: 'Review: Install CLI in PATH', original: 'Review: Install CLI in PATH' },
+		}),
+		'Review: Install CLI in PATH',
+	);
+});
+
+test('includes a command category and removes icons', () => {
+	assert.equal(
+		reviewCommandPaletteLabel('extension.command', {
+			title: '$(zap) Run',
+			category: { value: 'Extension', original: 'Extension' },
+		}),
+		'Extension: Run',
+	);
+});
+
+test('falls back to the command id when metadata is unavailable', () => {
+	assert.equal(reviewCommandPaletteLabel('internal.command', undefined), 'internal.command');
+});

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewCommandPalette.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewCommandPalette.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { stripIcons } from '../../base/common/iconLabels.js';
+import { localize } from '../../nls.js';
+import type { ICommandAction } from '../../platform/action/common/action.js';
+
+type CommandLabel = Pick<ICommandAction, 'title' | 'category'>;
+
+export function reviewCommandPaletteLabel(commandId: string, command: CommandLabel | undefined): string {
+	if (!command) {
+		return commandId;
+	}
+
+	let label = typeof command.title === 'string' ? command.title : command.title.value;
+	const category = typeof command.category === 'string' ? command.category : command.category?.value;
+	if (category) {
+		label = localize('review.commandWithCategory', "{0}: {1}", category, label);
+	}
+
+	return stripIcons(label) || commandId;
+}

--- a/apps/review-desktop/code-oss/src/vs/review/contrib/install/reviewCliInstall.contribution.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/install/reviewCliInstall.contribution.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize, localize2 } from '../../../nls.js';
+import { isCancellationError } from '../../../base/common/errors.js';
+import { isMacintosh } from '../../../base/common/platform.js';
 import { Action2, registerAction2 } from '../../../platform/actions/common/actions.js';
 import { IDialogService } from '../../../platform/dialogs/common/dialogs.js';
 import type { ServicesAccessor } from '../../../platform/instantiation/common/instantiation.js';
@@ -23,6 +25,7 @@ import {
 	type ReviewCliInstallTarget,
 	REVIEW_TUTORIAL_PROGRESS_STORAGE_KEY,
 } from '../../common/reviewProtocol.js';
+import { reviewCliInstallResyncRequest } from '../../common/reviewCliInstall.js';
 import { IReviewCanvasEditorTabsService } from '../../services/reviewCanvasEditorTabsService.js';
 import { IReviewSessionService } from '../../services/reviewSessionService.js';
 
@@ -87,6 +90,44 @@ class OpenTutorialAction extends Action2 {
 }
 
 registerAction2(OpenTutorialAction);
+
+class InstallReviewCliInPathAction extends Action2 {
+	constructor() {
+		super({
+			id: 'review.installCliInPath',
+			title: localize2('review.installCliInPath', "Review: Install CLI in PATH"),
+			f1: true,
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const nativeHostService = accessor.get(INativeHostService);
+		const notificationService = accessor.get(INotificationService);
+		const sessionService = accessor.get(IReviewSessionService);
+		try {
+			if (isMacintosh) {
+				await nativeHostService.uninstallShellCommand({ commandName: 'review', symlinkOnly: true });
+			}
+			const installed = await sessionService.applyCliInstall({ targets: [], shim: true });
+			notificationService.info(
+				localize(
+					'review.cliInstall.installed',
+					"Review installed the CLI at {0}. New terminals can use the review command.",
+					installed.shimPath ?? '~/.local/bin/review',
+				),
+			);
+		} catch (error) {
+			if (isCancellationError(error)) {
+				return;
+			}
+			notificationService.error(
+				localize('review.cliInstall.failed', "Review could not install the CLI in PATH: {0}", String(error)),
+			);
+		}
+	}
+}
+
+registerAction2(InstallReviewCliInPathAction);
 
 /**
  * Removes everything the app installed on this machine: the tutorial, the
@@ -240,17 +281,18 @@ class ReviewCliInstallStartup implements IWorkbenchContribution {
 	}
 
 	private async resync(status: ReviewCliInstallStatus): Promise<void> {
-		const targets = status.stamp?.targets?.length
-			? status.stamp.targets
-			: status.agents.filter(agent => agent.installed).map(agent => agent.target);
-		if (targets.length === 0) {
+		const request = reviewCliInstallResyncRequest(status);
+		if (!request) {
 			return;
 		}
-		await this.reviewSessionService.applyCliInstall({
-			targets,
-		});
+		await this.reviewSessionService.applyCliInstall(request);
+		const message = request.targets.length === 0
+			? localize('review.cliInstall.resyncedCli', "Review updated the installed CLI.")
+			: request.shim
+				? localize('review.cliInstall.resynced', "Review updated the installed CLI and agent skills.")
+				: localize('review.cliInstall.resyncedSkills', "Review updated the installed agent skills.");
 		this.notificationService.status(
-			localize('review.cliInstall.resynced', "Review updated the installed CLI and agent skills."),
+			message,
 			{ hideAfter: 10_000 },
 		);
 	}

--- a/apps/review-desktop/code-oss/src/vs/review/contrib/quickaccess/reviewQuickAccess.contribution.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/quickaccess/reviewQuickAccess.contribution.ts
@@ -5,7 +5,7 @@
 
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { localize } from '../../../nls.js';
-import { registerAction2 } from '../../../platform/actions/common/actions.js';
+import { MenuRegistry, registerAction2 } from '../../../platform/actions/common/actions.js';
 import { CommandsRegistry, ICommandService } from '../../../platform/commands/common/commands.js';
 import { IDialogService } from '../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
@@ -16,6 +16,7 @@ import { Registry } from '../../../platform/registry/common/platform.js';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry.js';
 import { ShowAllCommandsAction } from '../../../workbench/contrib/quickaccess/browser/commandsQuickAccess.js';
 import { IExtensionService } from '../../../workbench/services/extensions/common/extensions.js';
+import { reviewCommandPaletteLabel } from '../../common/reviewCommandPalette.js';
 
 const FOREIGN_COMMAND = /chat|debug|extension|git|keybinding|mcp|notebook|preference|profile|remote|scm|setting|sync|task|terminal|test|update/i;
 
@@ -43,7 +44,10 @@ export class ReviewCommandsQuickAccessProvider extends AbstractCommandsQuickAcce
 		return [...CommandsRegistry.getCommands().keys()]
 			.filter(commandId => commandId.startsWith('review.') || extensionCommands.has(commandId) || !FOREIGN_COMMAND.test(commandId))
 			.sort((left, right) => left.localeCompare(right))
-			.map(commandId => ({ commandId, label: commandId }));
+			.map(commandId => ({
+				commandId,
+				label: reviewCommandPaletteLabel(commandId, MenuRegistry.getCommand(commandId)),
+			}));
 	}
 
 	protected override hasAdditionalCommandPicks(_filter: string, _token: CancellationToken): boolean {

--- a/apps/review-desktop/code-oss/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/apps/review-desktop/code-oss/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -63,7 +63,7 @@ import product from '../../platform/product/common/product.js';
 	}
 
 	// Actions: Install Shell Script (macOS only)
-	if (isMacintosh) {
+	if (isMacintosh && !product.reviewVersion) {
 		registerAction2(InstallShellScriptAction);
 		registerAction2(UninstallShellScriptAction);
 	}

--- a/apps/review-desktop/scripts/cli-path-install.test.mjs
+++ b/apps/review-desktop/scripts/cli-path-install.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (relative) =>
+  readFileSync(new URL(relative, import.meta.url), "utf8");
+
+const contribution = read(
+  "../code-oss/src/vs/review/contrib/install/reviewCliInstall.contribution.ts",
+);
+const desktopContribution = read(
+  "../code-oss/src/vs/workbench/electron-browser/desktop.contribution.ts",
+);
+const nativeHost = read(
+  "../code-oss/src/vs/platform/native/electron-main/nativeHostMainService.ts",
+);
+
+test("registers the Review CLI PATH action", () => {
+  assert.match(contribution, /id: 'review\.installCliInPath'/);
+  assert.match(contribution, /Review: Install CLI in PATH/);
+  assert.match(
+    contribution,
+    /uninstallShellCommand\(\{ commandName: 'review', symlinkOnly: true \}\)/,
+  );
+  assert.match(
+    contribution,
+    /applyCliInstall\(\{ targets: \[\], shim: true \}\)/,
+  );
+});
+
+test("suppresses the inherited editor shell commands for Review", () => {
+  assert.match(
+    desktopContribution,
+    /if \(isMacintosh && !product\.reviewVersion\) \{[\s\S]*registerAction2\(InstallShellScriptAction\);[\s\S]*registerAction2\(UninstallShellScriptAction\);/,
+  );
+});
+
+test("legacy cleanup is constrained to a validated symlink", () => {
+  assert.match(nativeHost, /\^\[A-Za-z0-9\._-\]\+\$/);
+  assert.match(
+    nativeHost,
+    /commandName === '\.' \|\| commandName === '\.\.'/,
+  );
+  assert.match(nativeHost, /if \(options\?\.symlinkOnly\)/);
+  assert.match(nativeHost, /Refusing to remove.*not a symbolic link/);
+});

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,8 +19,10 @@ offer the commands documented in the [CLI reference](cli-reference.md).
 
 ## `review: command not found`
 
-Open Review Desktop and install the command from the welcome screen or Review
-settings. Then open a new terminal and check that `~/.local/bin` is on `PATH`.
+Open Review Desktop, open the Command Palette, and run **Review: Install CLI in
+PATH**. Review refreshes `~/.local/bin/review` and removes the obsolete
+`/usr/local/bin/review` symlink if it exists. Then open a new terminal and check
+that `~/.local/bin` is on `PATH`.
 
 For a headless setup with a separately installed CLI, run:
 

--- a/packages/progressive-review/src/server/cli-install.test.ts
+++ b/packages/progressive-review/src/server/cli-install.test.ts
@@ -192,6 +192,44 @@ describe("shell profile PATH management", () => {
 });
 
 describe("skill and review command installation", () => {
+  it("installs only the command and replaces a previous app shim", async () => {
+    const homeDir = await temporaryHome("review-cli-only-shim-");
+    const env = profileEnvironment(homeDir, "/bin/zsh");
+    const cliPath = path.join(homeDir, "current-app", "cli.js");
+    const shimPath = path.join(homeDir, ".local", "bin", "review");
+    await Promise.all([
+      mkdir(path.dirname(cliPath), { recursive: true }),
+      mkdir(path.dirname(shimPath), { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(cliPath, "// current CLI\n"),
+      writeFile(
+        shimPath,
+        "#!/bin/sh\n# Managed by Review Desktop\nFALLBACK_CLI='/Applications/Old Review.app/cli.js'\n",
+        { mode: 0o755 },
+      ),
+    ]);
+
+    const applied = await applyCliInstall({
+      packageRoot,
+      targets: [],
+      shim: true,
+      cliPath,
+      homeDir,
+      env,
+    });
+
+    expect(applied).toMatchObject({ code: 0, shimPath });
+    const installed = await readFile(shimPath, "utf8");
+    expect(installed).toContain(cliPath);
+    expect(installed).not.toContain("Old Review.app");
+    expect(await readCliInstallStamp(cliInstallStampPath(env))).toMatchObject({
+      consent: "granted",
+      targets: [],
+      shimPath,
+    });
+  });
+
   it("installs the command and profile by default for a skill target", async () => {
     const homeDir = await temporaryHome("review-default-shim-");
     const env = profileEnvironment(homeDir, "/bin/zsh");

--- a/packages/progressive-review/src/server/cli-install.ts
+++ b/packages/progressive-review/src/server/cli-install.ts
@@ -487,7 +487,7 @@ export async function writePathShim(
   runtimePath?: string,
 ): Promise<void> {
   const source = `#!/bin/sh
-# Managed by Review Desktop ("Review: Manage CLI and Skills..."). Do not edit.
+# Managed by Review Desktop ("Review: Install CLI in PATH"). Do not edit.
 FALLBACK_CLI=${shSingleQuote(cliPath)}
 FALLBACK_RUNTIME=${shSingleQuote(runtimePath ?? "")}
 DISCOVERY="\${DEV_REVIEW_HOME:-$HOME/.dev}/review-desktop/server.json"


### PR DESCRIPTION
## Summary

- add Review: Install CLI in PATH to install the running app CLI at ~/.local/bin/review
- remove only legacy /usr/local/bin/review symlinks, preserve regular files, and keep CLI-only installs synchronized across app updates
- hide the inherited editor shell commands and show human-readable names in Review command quick access

## Validation

- REVIEW_DESKTOP_CI_FAST=1 REVIEW_DESKTOP_COMPILE_ONLY=1 pnpm --filter @dev-fast/review-desktop app:build
- pnpm --filter @dev-fast/review-desktop test
- npm --prefix apps/review-desktop/code-oss run test-review-harness
- pnpm --filter @dev.fast/review test
- pnpm format:check
- pnpm lint
- live disposable-home test: ran the palette action, verified the generated shim/profile/stamp, and ran review --help through the installed shim; removed the test home and verified real user PATH/profile files were unchanged