### PR TITLE
optionally capture traces in bug reports

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -111,8 +111,10 @@ sanitized JavaScript error class names seen during that canvas session. It does
 not include error messages in that list.
 
 If a selected Review, map, or diff attachment is unavailable, Review omits it
-and sends the other available data. Review does not send a partial source or
-parent trace.
+and sends the other available data. The source session's own trace is sent
+complete or the report fails. Ancestor history is sent as far as Review can
+read it, and the report names any ancestor it omits. If the compressed report
+would exceed the upload limit, Review drops the trace and sends the rest.
 
 The report never attaches Review metadata, comment threads, or question
 threads. Review stores completed reports in a private /dev/fast Cloudflare R2

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -72,11 +72,6 @@ Review document or does not pass a second local path-and-secret check.
 
 The **Report bug** dialog sends a report only after you select **Send**.
 
-![The previous Review bug-report dialog with all three diagnostic attachments selected by default.](assets/bug-report-consent.png)
-
-> This image is stale. Re-capture `docs/assets/bug-report-consent.png` with the
-> three-checkbox dialog and screenshot preview after the UI lands.
-
 Under **Include diagnostic attachments**, three independent checkboxes control
 whether Review attaches:
 
@@ -86,9 +81,9 @@ whether Review attaches:
   session that authored the Review and, for a forked Codex session, its complete
   parent history through the fork point
 
-The Review and changed-file diff attachments are selected by default. The agent
-session trace is opt-in and starts unselected. An information icon beside it
-explains the trace's redaction limits and what it sends.
+The Review and changed-file diff attachments are selected by default. **The
+agent session trace is off by default and is included only when you explicitly
+select it for that report.**
 
 Review captures a screenshot before the dialog opens, so the dialog itself is
 not in the image. The screenshot is attached by default with a visible preview.
@@ -99,13 +94,16 @@ to 3 MiB.
 You can turn off either default attachment, leave the trace unselected, and
 remove the screenshot before sending.
 
-When selected, the agent trace includes prompts, model output, source code, and
-file paths. Review redacts recognizable Google API keys, JWTs, Slack tokens,
-GitHub tokens, and Microsoft Entra tokens on your machine before attaching the
-trace. Other credentials and secrets that do not match those formats may remain
-and are sent. Review deliberately does not redact paths, URLs, email addresses,
-prompts, or code. The trace comes directly from the supported agent harness's
-local storage and does not require trace sync or remote trace storage.
+If you opt in, the report includes the complete source-session JSONL trace and,
+for a forked Codex session, its parent history through the fork point. It can
+also include up to ten of the most recently modified subagent traces. This data
+can contain prompts, model output, source code, file paths, URLs, and email
+addresses.
+
+Review replaces recognizable Google API keys, JWTs, Slack tokens, GitHub
+tokens, and Microsoft Entra tokens before attaching the trace. Other
+credentials or secrets may remain. Passive telemetry and trace-sync settings do
+not enable this attachment.
 
 The checkboxes control only those optional attachments. Every submitted report
 also includes the optional description (which may be empty), app and CLI
@@ -114,21 +112,8 @@ sanitized JavaScript error class names seen during that canvas session. It does
 not include error messages in that list.
 
 If a selected Review, map, or diff attachment is unavailable, Review omits it
-and sends the other available data. A selected trace is different. Review stops
-the report if the source trace, a declared Codex parent, or any JSONL record is
-unavailable or invalid. It does not silently send a partial main trace.
-
-Review sends the complete source trace. For a forked Codex session, it also
-sends the complete logical parent history through the exact recorded ordinal
-and byte offset. It follows nested parent references up to 32 levels. It rejects
-a deeper chain, a cycle, or inconsistent fork metadata. Review still includes
-only the ten most recently modified subagent traces, each capped at its newest
-1 MiB on complete JSONL lines.
-
-The compressed payload remains limited to 10 MiB. Review can drop the diff,
-map, screenshot, or Review source to fit that payload. It never drops or
-shortens a selected main trace to fit. The complete multipart upload is limited
-by the Cloudflare request limit; an oversized report fails.
+and sends the other available data. Review does not send a partial source or
+parent trace.
 
 The report never attaches Review metadata, comment threads, or question
 threads. Review stores completed reports in a private /dev/fast Cloudflare R2

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -77,9 +77,9 @@ whether Review attaches:
 
 - **Review**: the current Review source and head software-map source
 - changed-file diffs used by the review codepeeks (only the diff lines)
-- **Agent session trace**: the complete raw local JSONL trace for the agent
-  session that authored the Review and, for a forked Codex session, its complete
-  parent history through the fork point
+- **Agent session trace**: the complete local trace records for the session that
+  authored the Review and available ancestor-session history through each fork
+  point
 
 The Review and changed-file diff attachments are selected by default. **The
 agent session trace is off by default and is included only when you explicitly
@@ -94,10 +94,9 @@ to 3 MiB.
 You can turn off either default attachment, leave the trace unselected, and
 remove the screenshot before sending.
 
-If you opt in, the report includes the complete source-session JSONL trace and,
-for a forked Codex session, its parent history through the fork point. It can
-also include up to ten of the most recently modified subagent traces. This data
-can contain prompts, model output, source code, file paths, URLs, and email
+If you opt in, the report includes those session records and can also include
+up to ten of the most recently modified subagent trace tails. This data can
+contain prompts, model output, source code, file paths, URLs, and email
 addresses.
 
 Review replaces recognizable Google API keys, JWTs, Slack tokens, GitHub

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -82,8 +82,9 @@ whether Review attaches:
 
 - **Review**: the current Review source and head software-map source
 - changed-file diffs used by the review codepeeks (only the diff lines)
-- **Agent session trace**: the raw local JSONL trace for the agent session that
-  authored the Review
+- **Agent session trace**: the complete raw local JSONL trace for the agent
+  session that authored the Review and, for a forked Codex session, its complete
+  parent history through the fork point
 
 The Review and changed-file diff attachments are selected by default. The agent
 session trace is opt-in and starts unselected. An information icon beside it
@@ -112,16 +113,26 @@ versions, operating-system category, a random app-session ID, and up to 20
 sanitized JavaScript error class names seen during that canvas session. It does
 not include error messages in that list.
 
-If a selected attachment is unavailable, Review omits it and sends the other
-available data. The report never attaches Review metadata, comment threads, or
-question threads. Review stores submitted reports in a private /dev/fast
-Cloudflare R2 bucket and deletes them after 90 days.
+If a selected Review, map, or diff attachment is unavailable, Review omits it
+and sends the other available data. A selected trace is different. Review stops
+the report if the source trace, a declared Codex parent, or any JSONL record is
+unavailable or invalid. It does not silently send a partial main trace.
 
-Review caps the main trace at its newest 6 MiB and includes the ten most recently
-modified subagent traces, each capped at its newest 1 MiB, retaining complete
-JSONL lines. If the compressed report still exceeds 10 MiB, Review drops the
-complete trace attachment before dropping diffs, the software map, the
-screenshot, or Review source.
+Review sends the complete source trace. For a forked Codex session, it also
+sends the complete logical parent history through the exact recorded ordinal
+and byte offset. It follows nested parent references up to 32 levels. It rejects
+a deeper chain, a cycle, or inconsistent fork metadata. Review still includes
+only the ten most recently modified subagent traces, each capped at its newest
+1 MiB on complete JSONL lines.
+
+The compressed payload remains limited to 10 MiB. Review can drop the diff,
+map, screenshot, or Review source to fit that payload. It never drops or
+shortens a selected main trace to fit. The complete multipart upload is limited
+by the Cloudflare request limit; an oversized report fails.
+
+The report never attaches Review metadata, comment threads, or question
+threads. Review stores completed reports in a private /dev/fast Cloudflare R2
+bucket and deletes them after 90 days.
 
 An explicit bug report is separate from passive telemetry and is sent even when
 anonymous telemetry is disabled. Review shows the attachment choices before

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -406,7 +406,7 @@ The report payload contains these fields:
 | `diff.files[].patch`               | Unified patch used to resolve the review's exact CodePeek ranges                    |
 | `trace.harness`                    | Authoring harness: `claude-code`, `codex`, or `pi`                                  |
 | `trace.session_id`                 | Authoring session identifier from the Review record                                 |
-| `trace.parent_session_id`          | Immediate Codex parent session identifier, when the source session is forked        |
+| `trace.sessions[]`                 | Attached session identifiers and available parent fork points                       |
 | `trace.files["subagents/<name>"]`  | Tail-capped raw JSONL for an included subagent                                      |
 | `trace.omitted_files`              | Subagent trace names omitted because of limits or read failures                     |
 | `trace.truncated`                  | Whether any subagent trace was tail-capped or omitted                               |
@@ -432,9 +432,9 @@ The report never sends these review files:
 
 Trace attachment consent is independent of passive telemetry and trace sync.
 Neither setting enables trace attachment for a bug report. If the user opts in,
-the report includes the complete source-session JSONL trace and, for a forked
-Codex session, its parent history through the fork point. It can also include
-up to ten of the most recently modified subagent traces.
+the report includes the complete authoring-session trace and available ancestor
+history through each fork point. It can also include up to ten of the most
+recently modified subagent trace tails.
 
 The trace can contain prompts, model output, source code, file paths, URLs, and
 email addresses. Review replaces recognizable Google API keys, JWTs, Slack

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -59,14 +59,14 @@ dialog. Bug reports do not pass through the passive telemetry system.
 
 ## What Review collects
 
-| Category | Examples | What is not included |
-| --- | --- | --- |
-| App usage | A review opened, a tab viewed, a map expanded | Review text, code, paths, or repository details |
-| CLI usage | Command category, success or failure, duration | Command arguments, refs, process output, or exception text |
-| Code navigation | Feature category, language category, editor surface | Symbols, declarations, search text, or source code |
-| Extensions | An allowlisted extension ID, install outcome and duration | Extension version, configuration, or extension data |
-| Review outcome | Approve, request changes, dismiss, comment count | Comments, questions, thread text, or reviewer identity |
-| Reliability | Error class, cleaned message, Review-only stack frames | User paths, repository frames, secrets, or authored Review text |
+| Category        | Examples                                                  | What is not included                                            |
+| --------------- | --------------------------------------------------------- | --------------------------------------------------------------- |
+| App usage       | A review opened, a tab viewed, a map expanded             | Review text, code, paths, or repository details                 |
+| CLI usage       | Command category, success or failure, duration            | Command arguments, refs, process output, or exception text      |
+| Code navigation | Feature category, language category, editor surface       | Symbols, declarations, search text, or source code              |
+| Extensions      | An allowlisted extension ID, install outcome and duration | Extension version, configuration, or extension data             |
+| Review outcome  | Approve, request changes, dismiss, comment count          | Comments, questions, thread text, or reviewer identity          |
+| Reliability     | Error class, cleaned message, Review-only stack frames    | User paths, repository frames, secrets, or authored Review text |
 
 Every event is checked against an allowlist on your machine. Unknown events,
 unknown properties, and values outside their allowed categories are dropped.
@@ -169,19 +169,19 @@ event includes only `reason`, `count`, and the random installation identifier.
 
 ### CLI and lifecycle events
 
-| Event                                     | Additional properties                                                      | When                               |
-| ----------------------------------------- | -------------------------------------------------------------------------- | ---------------------------------- |
-| `review_installation_created` | None                                                                       | The first enabled Review use       |
-| `review_command_started`      | `command_path`, `command_run_id`, `agent_kind`                             | A public CLI handler is about to run |
-| `review_command_bound`        | Start properties plus `review_id`                                          | Scaffold or publish resolves its Review |
-| `review_command_succeeded`    | `command_path`, `command_run_id`, `exit_code`, `duration_ms`, optional `review_id`, and closed command flags | A public CLI command succeeds      |
-| `review_command_failed`       | The success properties plus `error_name` and `error_category` closed enums | A public CLI command fails         |
-| `review_session_started`      | `source_kind`, `agent_kind`, `review_id`, `presentation_id`, optional `app_session_id` | A Desktop review session opens     |
-| `review_session_ended`        | Start properties plus `outcome`, `duration_ms`                             | A review submits or is dismissed   |
-| `review_review_deleted`       | None                                                                       | A user deletes a stored review     |
-| `review_review_reaped`        | `retention_days`                                                           | Retention deletes a dismissed review |
-| `review_publish_gate_rejected` | `gate` in publish_ready, map_publish_ready                                | A publish readiness gate rejects   |
-| `review_telemetry_dropped`    | `reason`, `count`                                                          | The queue drops one or more events |
+| Event                          | Additional properties                                                                                        | When                                    |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
+| `review_installation_created`  | None                                                                                                         | The first enabled Review use            |
+| `review_command_started`       | `command_path`, `command_run_id`, `agent_kind`                                                               | A public CLI handler is about to run    |
+| `review_command_bound`         | Start properties plus `review_id`                                                                            | Scaffold or publish resolves its Review |
+| `review_command_succeeded`     | `command_path`, `command_run_id`, `exit_code`, `duration_ms`, optional `review_id`, and closed command flags | A public CLI command succeeds           |
+| `review_command_failed`        | The success properties plus `error_name` and `error_category` closed enums                                   | A public CLI command fails              |
+| `review_session_started`       | `source_kind`, `agent_kind`, `review_id`, `presentation_id`, optional `app_session_id`                       | A Desktop review session opens          |
+| `review_session_ended`         | Start properties plus `outcome`, `duration_ms`                                                               | A review submits or is dismissed        |
+| `review_review_deleted`        | None                                                                                                         | A user deletes a stored review          |
+| `review_review_reaped`         | `retention_days`                                                                                             | Retention deletes a dismissed review    |
+| `review_publish_gate_rejected` | `gate` in publish_ready, map_publish_ready                                                                   | A publish readiness gate rejects        |
+| `review_telemetry_dropped`     | `reason`, `count`                                                                                            | The queue drops one or more events      |
 
 `command_path` is a closed enum for all public commands. It includes `help`,
 `version`, `app.launch`, `app.pick`, `rebind`, `publish`, `wait`, `info`,
@@ -220,38 +220,38 @@ text, and only as described in "Error reports".
 The server checks all properties in this table against
 `packages/progressive-review/src/ui-telemetry-events.ts`.
 
-| Event                                         | Additional properties                                                                                    | When                                      |
-| --------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `review_app_opened`               | None                                                                                                     | The canvas app opens                      |
-| `review_tab_viewed`               | `tab` in review, commits, map, files; `duration_ms`; `reason` in tab_change, visibility_hidden, pagehide, unmount | A tab dwell period ends                   |
-| `review_peek_opened`              | `via` in prose_link, diagram, marker, map, db_lens                                                       | A user opens a code peek                  |
-| `review_peek_resolved`            | `root_kind` in symbol, declaration, range                                                                | A code peek resolves                      |
-| `review_peek_resolve_failed`      | `root_kind` in symbol, declaration, range                                                                | A code peek does not resolve              |
-| `review_tour_started`             | `steps`                                                                                                  | A user starts a tour                      |
-| `review_tour_step_advanced`       | `step`, `steps`                                                                                          | A user moves to the next tour step        |
-| `review_tour_abandoned`           | `step`, `steps`                                                                                          | A user closes an incomplete tour          |
-| `review_tour_completed`           | `steps`                                                                                                  | A user completes a tour                   |
-| `review_map_expanded`             | `level` in system, container, component, code                                                            | A user expands a map element              |
-| `review_commit_expanded`          | `expanded`                                                                                               | A user expands or collapses a commit      |
-| `review_commit_diff_opened`       | `via` in row, file, footer                                                                                | A user opens a commit diff                |
-| `review_thread_draft_opened`      | `intent` in comment, ask-agent                                                                           | A user opens a thread draft               |
-| `review_threads_opened`           | `thread_count`                                                                                           | A user opens the Threads panel            |
-| `review_new_ask_opened`           | `via` in topbar, threads_panel                                                                           | A user opens the new-ask composer         |
-| `review_source_tree_opened`       | `via` in topbar, home                                                                                    | A user opens the source tree              |
-| `review_comment_created`          | `is_reply`                                                                                               | A user creates a comment                  |
-| `review_agent_run_started`        | None                                                                                                     | A user starts an agent run                |
-| `review_thread_resolved`          | `kind: comment`                                                                                          | A user resolves a comment                 |
-| `review_client_error`             | See "Error reports"                                                                                      | A part of Review reports an error         |
-| `review_update_started`           | Random `update_attempt_id`, `target_version`                                                              | An update is downloaded and ready to install |
-| `review_update_completed`         | Start properties plus `duration_ms`                                                                      | The downloaded target launches after restart |
-| `review_update_failed`            | `phase` in check, download, install; `message_source` in electron, request, shipit, fallback; optional start properties and `duration_ms`; see "Error reports" | An update check, download, or install fails |
-| `review_bug_report_dialog_opened` | None                                                                                                     | A user opens the bug report dialog        |
-| `review_bug_report_cancelled`     | None                                                                                                     | A user closes the dialog without a report |
-| `review_bug_report_send_failed`   | Short `error_name`                                                                                       | A bug report request fails                |
-| `review_setting_changed`          | `setting` in telemetry_enabled, keymap, dismissed_retention_days, software_map_enabled; `enabled`        | A user changes a Review setting           |
-| `review_review_opened`            | `via` in home, cli, other                                                                                | A user opens a review                     |
-| `review_review_presented`         | `review_id`, `presentation_id`                                                                           | A visible canvas loads and signals ready  |
-| `review_home_empty_state_viewed`  | None                                                                                                     | The empty Home state opens                |
+| Event                             | Additional properties                                                                                                                                          | When                                         |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `review_app_opened`               | None                                                                                                                                                           | The canvas app opens                         |
+| `review_tab_viewed`               | `tab` in review, commits, map, files; `duration_ms`; `reason` in tab_change, visibility_hidden, pagehide, unmount                                              | A tab dwell period ends                      |
+| `review_peek_opened`              | `via` in prose_link, diagram, marker, map, db_lens                                                                                                             | A user opens a code peek                     |
+| `review_peek_resolved`            | `root_kind` in symbol, declaration, range                                                                                                                      | A code peek resolves                         |
+| `review_peek_resolve_failed`      | `root_kind` in symbol, declaration, range                                                                                                                      | A code peek does not resolve                 |
+| `review_tour_started`             | `steps`                                                                                                                                                        | A user starts a tour                         |
+| `review_tour_step_advanced`       | `step`, `steps`                                                                                                                                                | A user moves to the next tour step           |
+| `review_tour_abandoned`           | `step`, `steps`                                                                                                                                                | A user closes an incomplete tour             |
+| `review_tour_completed`           | `steps`                                                                                                                                                        | A user completes a tour                      |
+| `review_map_expanded`             | `level` in system, container, component, code                                                                                                                  | A user expands a map element                 |
+| `review_commit_expanded`          | `expanded`                                                                                                                                                     | A user expands or collapses a commit         |
+| `review_commit_diff_opened`       | `via` in row, file, footer                                                                                                                                     | A user opens a commit diff                   |
+| `review_thread_draft_opened`      | `intent` in comment, ask-agent                                                                                                                                 | A user opens a thread draft                  |
+| `review_threads_opened`           | `thread_count`                                                                                                                                                 | A user opens the Threads panel               |
+| `review_new_ask_opened`           | `via` in topbar, threads_panel                                                                                                                                 | A user opens the new-ask composer            |
+| `review_source_tree_opened`       | `via` in topbar, home                                                                                                                                          | A user opens the source tree                 |
+| `review_comment_created`          | `is_reply`                                                                                                                                                     | A user creates a comment                     |
+| `review_agent_run_started`        | None                                                                                                                                                           | A user starts an agent run                   |
+| `review_thread_resolved`          | `kind: comment`                                                                                                                                                | A user resolves a comment                    |
+| `review_client_error`             | See "Error reports"                                                                                                                                            | A part of Review reports an error            |
+| `review_update_started`           | Random `update_attempt_id`, `target_version`                                                                                                                   | An update is downloaded and ready to install |
+| `review_update_completed`         | Start properties plus `duration_ms`                                                                                                                            | The downloaded target launches after restart |
+| `review_update_failed`            | `phase` in check, download, install; `message_source` in electron, request, shipit, fallback; optional start properties and `duration_ms`; see "Error reports" | An update check, download, or install fails  |
+| `review_bug_report_dialog_opened` | None                                                                                                                                                           | A user opens the bug report dialog           |
+| `review_bug_report_cancelled`     | None                                                                                                                                                           | A user closes the dialog without a report    |
+| `review_bug_report_send_failed`   | Short `error_name`                                                                                                                                             | A bug report request fails                   |
+| `review_setting_changed`          | `setting` in telemetry_enabled, keymap, dismissed_retention_days, software_map_enabled; `enabled`                                                              | A user changes a Review setting              |
+| `review_review_opened`            | `via` in home, cli, other                                                                                                                                      | A user opens a review                        |
+| `review_review_presented`         | `review_id`, `presentation_id`                                                                                                                                 | A visible canvas loads and signals ready     |
+| `review_home_empty_state_viewed`  | None                                                                                                                                                           | The empty Home state opens                   |
 
 The server emits `review_review_submitted` after it stores a submission. Its
 properties are `decision` and `comment_count`. The server emits
@@ -281,15 +281,15 @@ terminal or ready event removes the match automatically.
 
 ### Workbench events
 
-| Event                                           | Additional properties                                                                                                      | When                                        |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `review_lsp_used`                   | `feature` in hover, goto_definition, peek_definition, goto_type_definition, goto_implementation, references, rename, format, code_action, symbol_search; `via` in command, mouse; `language`; `editor_kind` in files_tab, inline_peek, diff | A user invokes an LSP feature               |
-| `review_ls_activated`               | `group` in python, go, rust, swift, csharp; `ok`                                                                            | A language server activation check ends     |
-| `review_extension_installed`        | Allowlisted `extension_id`; `trigger` in user, auto_upgrade, startup_seed, keymap, rollback; `cached`; `duration_ms`         | An optional extension installs              |
-| `review_extension_install_failed`   | Allowlisted `extension_id`; allowlisted `trigger`; `phase` in download, install                                              | An optional extension install fails         |
-| `review_extension_enabled`          | Allowlisted `extension_id`; allowlisted `trigger`                                                                            | Review enables an optional extension        |
-| `review_extension_disabled`         | Allowlisted `extension_id`; allowlisted `trigger`                                                                            | Review disables an optional extension       |
-| `review_extension_uninstalled`      | Allowlisted `extension_id`; allowlisted `trigger`                                                                            | Review uninstalls an optional extension     |
+| Event                             | Additional properties                                                                                                                                                                                                                       | When                                    |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `review_lsp_used`                 | `feature` in hover, goto_definition, peek_definition, goto_type_definition, goto_implementation, references, rename, format, code_action, symbol_search; `via` in command, mouse; `language`; `editor_kind` in files_tab, inline_peek, diff | A user invokes an LSP feature           |
+| `review_ls_activated`             | `group` in python, go, rust, swift, csharp; `ok`                                                                                                                                                                                            | A language server activation check ends |
+| `review_extension_installed`      | Allowlisted `extension_id`; `trigger` in user, auto_upgrade, startup_seed, keymap, rollback; `cached`; `duration_ms`                                                                                                                        | An optional extension installs          |
+| `review_extension_install_failed` | Allowlisted `extension_id`; allowlisted `trigger`; `phase` in download, install                                                                                                                                                             | An optional extension install fails     |
+| `review_extension_enabled`        | Allowlisted `extension_id`; allowlisted `trigger`                                                                                                                                                                                           | Review enables an optional extension    |
+| `review_extension_disabled`       | Allowlisted `extension_id`; allowlisted `trigger`                                                                                                                                                                                           | Review disables an optional extension   |
+| `review_extension_uninstalled`    | Allowlisted `extension_id`; allowlisted `trigger`                                                                                                                                                                                           | Review uninstalls an optional extension |
 
 The `language` property is one of typescript, javascript, python, go, rust,
 swift, csharp, json, css, html, markdown, yaml, toml, shell, sql, or other.
@@ -314,15 +314,15 @@ Install failures read at most 64 KiB appended to ShipIt's stderr log after the
 matching update was staged. Review extracts only the last NSError summary (or
 the fixed retry-exhausted line); it neither stores nor uploads the raw log.
 
-| Property        | Value                                                                                     |
-| --------------- | ----------------------------------------------------------------------------------------- |
-| `error_process` | Which part of Review failed: `main`, `renderer`, `canvas`, or `server`                      |
-| `error_source`  | Which handler caught it, from a closed list                                                 |
-| `error_name`    | The error class name, such as `TypeError`. Identifier characters only, 40 at most           |
-| `component`     | A fixed Review component name, when the reporter has one. Identifier characters only        |
-| `message`       | The error message, cleaned. See below                                                       |
-| `message_hash`  | A fingerprint of the original message. See below                                            |
-| `frames`        | Up to 10 stack lines, all inside the Review program. See below                              |
+| Property        | Value                                                                                |
+| --------------- | ------------------------------------------------------------------------------------ |
+| `error_process` | Which part of Review failed: `main`, `renderer`, `canvas`, or `server`               |
+| `error_source`  | Which handler caught it, from a closed list                                          |
+| `error_name`    | The error class name, such as `TypeError`. Identifier characters only, 40 at most    |
+| `component`     | A fixed Review component name, when the reporter has one. Identifier characters only |
+| `message`       | The error message, cleaned. See below                                                |
+| `message_hash`  | A fingerprint of the original message. See below                                     |
+| `frames`        | Up to 10 stack lines, all inside the Review program. See below                       |
 
 **Review cleans the message before it sends it.** The cleaner replaces each of
 these with a marker that names what it removed, such as

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -374,12 +374,13 @@ frame a second time. Both steps run on your machine, before anything is sent.
 The **Report bug** dialog sends data only after the user selects **Send**. The
 description is optional. It has one **Review** consent control for both the
 current review source and head software map source, plus a separate control for
-changed-file diffs. Both controls are on by default. A third **Agent session
-trace** control attaches the raw local JSONL trace for the session that authored
-the Review and is off by default. Review also captures a screenshot before the
-dialog opens and attaches it by default. The dialog shows a removable preview
-and accepts a replacement image by paste or drag. A selected attachment can be
-unavailable. The report still sends the other available data.
+changed-file diffs. Both controls are on by default. Review also captures a
+screenshot before the dialog opens and attaches it by default. The dialog shows
+a removable preview and accepts a replacement image by paste or drag.
+
+**Agent traces require separate, explicit consent for every report.** The
+**Agent session trace** control is off by default. Review does not attach any
+agent trace unless the user turns on this control before selecting **Send**.
 
 A review does not always have a software map. The report then omits the map and
 records no error, because an absent map is a normal state.
@@ -388,7 +389,7 @@ The report payload contains these fields:
 
 | Field                              | Value                                                                               |
 | ---------------------------------- | ----------------------------------------------------------------------------------- |
-| `schema_version`                   | Payload schema version `3`, or `4` for the separate trace-part transport            |
+| `schema_version`                   | Internal report payload format version                                              |
 | `description`                      | Optional user-entered description, limited to 64 KiB of UTF-8 data                  |
 | `screenshot.mime`                  | `image/jpeg` when a screenshot is attached                                          |
 | `screenshot.base64`                | JPEG screenshot data, limited to 3 MiB decoded                                      |
@@ -429,51 +430,25 @@ The report never sends these review files:
 - the compiled document in `.bundle/`, and the build output in `.build/`
 - `review.db`, which holds the comment threads and the questions
 
-The trace attachment is independent of trace sync. Review finds the source
-session's raw trace directly in the supported harness's local home-directory
-storage, so disabling remote trace storage does not disable this explicit
-attachment.
+Trace attachment consent is independent of passive telemetry and trace sync.
+Neither setting enables trace attachment for a bug report. If the user opts in,
+the report includes the complete source-session JSONL trace and, for a forked
+Codex session, its parent history through the fork point. It can also include
+up to ten of the most recently modified subagent traces.
 
-Before attaching a selected trace, Review replaces recognizable Google API
-keys, JWTs, Slack tokens, GitHub tokens, and Microsoft Entra tokens with labelled
-markers. This secret-format redaction preserves the surrounding JSONL. It does
-not detect every credential or secret format, and it does not anonymize file
-paths, URLs, email addresses, prompts, model output, or source code; those
-values are sent when the user selects the trace checkbox.
+The trace can contain prompts, model output, source code, file paths, URLs, and
+email addresses. Review replaces recognizable Google API keys, JWTs, Slack
+tokens, GitHub tokens, and Microsoft Entra tokens with labelled markers. Other
+credentials or secrets may remain.
 
-Review validates every main-trace JSONL record and sends the complete fixed
-source snapshot as a separate gzip part. For a forked Codex session, it uses the
-recorded parent session ID, exclusive ordinal, and byte offset. It sends the
-complete logical parent history through that boundary as a second gzip part.
-Nested parents are materialized recursively. Review rejects missing parents,
-invalid boundaries, cycles, or more than 32 ancestry levels.
+The Worker stores reports in a private Cloudflare R2 bucket. Only credentialed
+dev.fast operators can read the bucket. Reports are deleted after 90 days.
 
-Review includes the ten most recently modified subagent files in the payload.
-Each keeps at most its newest 1 MiB, and the payload records omitted names. The
-compressed payload remains limited to 10 MiB. The size ladder can drop the diff,
-map, screenshot, and Review source, but it does not drop or shorten a selected
-main trace. The whole request remains subject to the Cloudflare request limit.
-
-The local server sends all current reports to
-`https://bug.dev.fast/api/v2/reports`. Every report has ordered `meta` and
-`payload` parts. A trace report adds `source_trace` and optional `parent_trace`
-parts. The Worker keeps `/api/v1/reports` only for older installed clients.
-
-The Worker stores a schema 2 report below one private R2 prefix. It writes the
-payload and trace objects first, then writes `complete.json` last. A report is
-complete only when this marker exists. Failed uploads have no completion marker
-and the Worker removes any partial objects. Only credentialed dev.fast operators
-can read the bucket. An R2 lifecycle rule deletes objects under `reports/` after
-90 days.
-
-The Worker sends a `review_bug_report` PostHog event only after the completion
-marker exists. The event contains the report ID, UTC report date, description byte
-length, attachment presence flags (including `has_screenshot`), compressed
-payload size, app version, platform, and map, diff, or screenshot truncation
-flags (including `truncated_screenshot`). It also receives `has_trace`,
-`truncated_trace`, the closed `trace_harness` enum, transport schema version,
-compressed source and parent trace sizes, and a completion flag. It does not
-contain the description, attachments, or trace session identifiers.
+After storage completes, the Worker sends a `review_bug_report` PostHog event
+with the report ID, date, app version, platform, sizes, attachment presence, and
+truncation flags. For an explicitly included trace, it also sends the harness
+type and trace sizes. The event does not contain the description, attachments,
+or trace session identifiers.
 
 Cloudflare uses `CF-Connecting-IP` only as the rate-limit key. The Worker does
 not store that value in R2. The Worker does not send it to PostHog as report

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -405,8 +405,6 @@ The report payload contains these fields:
 | `diff.files[].deletions`           | Deleted line count                                                                  |
 | `diff.files[].patch`               | Unified patch used to resolve the review's exact CodePeek ranges                    |
 | `trace.harness`                    | Authoring harness: `claude-code`, `codex`, or `pi`                                  |
-| `trace.session_id`                 | Authoring session identifier from the Review record                                 |
-| `trace.sessions[]`                 | Attached session identifiers and available parent fork points                       |
 | `trace.files["subagents/<name>"]`  | Tail-capped raw JSONL for an included subagent                                      |
 | `trace.omitted_files`              | Subagent trace names omitted because of limits or read failures                     |
 | `trace.truncated`                  | Whether any subagent trace was tail-capped or omitted                               |

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -454,10 +454,10 @@ compressed payload remains limited to 10 MiB. The size ladder can drop the diff,
 map, screenshot, and Review source, but it does not drop or shorten a selected
 main trace. The whole request remains subject to the Cloudflare request limit.
 
-The local server sends reports without a trace to
-`https://bug.dev.fast/api/v1/reports` with the original schema 1 multipart
-request. It sends trace reports to `https://bug.dev.fast/api/v2/reports` with
-ordered `meta`, `payload`, `source_trace`, and optional `parent_trace` parts.
+The local server sends all current reports to
+`https://bug.dev.fast/api/v2/reports`. Every report has ordered `meta` and
+`payload` parts. A trace report adds `source_trace` and optional `parent_trace`
+parts. The Worker keeps `/api/v1/reports` only for older installed clients.
 
 The Worker stores a schema 2 report below one private R2 prefix. It writes the
 payload and trace objects first, then writes `complete.json` last. A report is

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -388,7 +388,7 @@ The report payload contains these fields:
 
 | Field                              | Value                                                                               |
 | ---------------------------------- | ----------------------------------------------------------------------------------- |
-| `schema_version`                   | Payload schema version `3`                                                          |
+| `schema_version`                   | Payload schema version `3`, or `4` for the separate trace-part transport            |
 | `description`                      | Optional user-entered description, limited to 64 KiB of UTF-8 data                  |
 | `screenshot.mime`                  | `image/jpeg` when a screenshot is attached                                          |
 | `screenshot.base64`                | JPEG screenshot data, limited to 3 MiB decoded                                      |
@@ -405,10 +405,10 @@ The report payload contains these fields:
 | `diff.files[].patch`               | Unified patch used to resolve the review's exact CodePeek ranges                    |
 | `trace.harness`                    | Authoring harness: `claude-code`, `codex`, or `pi`                                  |
 | `trace.session_id`                 | Authoring session identifier from the Review record                                 |
-| `trace.files["trace.jsonl"]`       | Tail-capped raw JSONL for the authoring session, when the user opts in              |
+| `trace.parent_session_id`          | Immediate Codex parent session identifier, when the source session is forked        |
 | `trace.files["subagents/<name>"]`  | Tail-capped raw JSONL for an included subagent                                      |
 | `trace.omitted_files`              | Subagent trace names omitted because of limits or read failures                     |
-| `trace.truncated`                  | Whether any trace was tail-capped or omitted                                        |
+| `trace.truncated`                  | Whether any subagent trace was tail-capped or omitted                               |
 | `diagnostics.app_version`          | Review Desktop product version                                                      |
 | `diagnostics.cli_version`          | `@dev.fast/review` package version                                                  |
 | `diagnostics.platform`             | Node platform enum                                                                  |
@@ -441,25 +441,39 @@ not detect every credential or secret format, and it does not anonymize file
 paths, URLs, email addresses, prompts, model output, or source code; those
 values are sent when the user selects the trace checkbox.
 
-The main trace keeps at most its newest 6 MiB on complete JSONL line boundaries.
-Review includes the ten most recently modified subagent files, each keeping at
-most its newest 1 MiB, and records omitted names. If the complete compressed
-multipart report still exceeds 10 MiB, the size ladder drops the whole trace
-first, followed by the diff, map, screenshot, and Review source.
+Review validates every main-trace JSONL record and sends the complete fixed
+source snapshot as a separate gzip part. For a forked Codex session, it uses the
+recorded parent session ID, exclusive ordinal, and byte offset. It sends the
+complete logical parent history through that boundary as a second gzip part.
+Nested parents are materialized recursively. Review rejects missing parents,
+invalid boundaries, cycles, or more than 32 ancestry levels.
 
-The local server compresses the payload and sends it to
-`https://bug.dev.fast/api/v1/reports`. The Worker stores it in the private
-`dev-fast-bug-reports` Cloudflare R2 bucket. Only credentialed dev.fast
-operators can read this bucket. An R2 lifecycle rule deletes objects under
-`reports/` after 90 days.
+Review includes the ten most recently modified subagent files in the payload.
+Each keeps at most its newest 1 MiB, and the payload records omitted names. The
+compressed payload remains limited to 10 MiB. The size ladder can drop the diff,
+map, screenshot, and Review source, but it does not drop or shorten a selected
+main trace. The whole request remains subject to the Cloudflare request limit.
 
-The Worker sends a `review_bug_report` PostHog event after the R2
-write. The event contains the report ID, UTC report date, description byte
+The local server sends reports without a trace to
+`https://bug.dev.fast/api/v1/reports` with the original schema 1 multipart
+request. It sends trace reports to `https://bug.dev.fast/api/v2/reports` with
+ordered `meta`, `payload`, `source_trace`, and optional `parent_trace` parts.
+
+The Worker stores a schema 2 report below one private R2 prefix. It writes the
+payload and trace objects first, then writes `complete.json` last. A report is
+complete only when this marker exists. Failed uploads have no completion marker
+and the Worker removes any partial objects. Only credentialed dev.fast operators
+can read the bucket. An R2 lifecycle rule deletes objects under `reports/` after
+90 days.
+
+The Worker sends a `review_bug_report` PostHog event only after the completion
+marker exists. The event contains the report ID, UTC report date, description byte
 length, attachment presence flags (including `has_screenshot`), compressed
 payload size, app version, platform, and map, diff, or screenshot truncation
 flags (including `truncated_screenshot`). It also receives `has_trace`,
-`truncated_trace`, and, after a trace resolves, the closed `trace_harness` enum.
-It does not contain the description or attachments.
+`truncated_trace`, the closed `trace_harness` enum, transport schema version,
+compressed source and parent trace sizes, and a completion flag. It does not
+contain the description, attachments, or trace session identifiers.
 
 Cloudflare uses `CF-Connecting-IP` only as the rate-limit key. The Worker does
 not store that value in R2. The Worker does not send it to PostHog as report

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -405,15 +405,16 @@ The report payload contains these fields:
 | `diff.files[].deletions`           | Deleted line count                                                                  |
 | `diff.files[].patch`               | Unified patch used to resolve the review's exact CodePeek ranges                    |
 | `trace.harness`                    | Authoring harness: `claude-code`, `codex`, or `pi`                                  |
+| `trace.session_id`                 | Authoring session identifier from the Review record                                 |
 | `trace.files["subagents/<name>"]`  | Tail-capped raw JSONL for an included subagent                                      |
-| `trace.omitted_files`              | Subagent trace names omitted because of limits or read failures                     |
-| `trace.truncated`                  | Whether any subagent trace was tail-capped or omitted                               |
+| `trace.omitted_files`              | Ancestor or subagent trace names omitted because of limits or read failures         |
+| `trace.truncated`                  | Whether any trace record, ancestor, or subagent trace was dropped or tail-capped    |
 | `diagnostics.app_version`          | Review Desktop product version                                                      |
 | `diagnostics.cli_version`          | `@dev.fast/review` package version                                                  |
 | `diagnostics.platform`             | Node platform enum                                                                  |
 | `diagnostics.app_session_id`       | Random identifier for the canvas window                                             |
 | `diagnostics.client_error_names`   | Last 20 sanitized JavaScript error class names from that canvas session             |
-| `diagnostics.attachment_errors`    | Selected attachment names with the value `unavailable`                              |
+| `diagnostics.attachment_errors`    | Selected attachment names with the value `unavailable`, or `too_large` for a trace  |
 | `diagnostics.review_omitted_files` | Names of review source files the report did not send                                |
 
 The `review` field holds a file map. It contains the current review document and
@@ -432,7 +433,10 @@ Trace attachment consent is independent of passive telemetry and trace sync.
 Neither setting enables trace attachment for a bug report. If the user opts in,
 the report includes the complete authoring-session trace and available ancestor
 history through each fork point. It can also include up to ten of the most
-recently modified subagent trace tails.
+recently modified subagent trace tails. Review drops a record the harness has
+not finished writing, an ancestor it cannot read, and, when the compressed
+report would exceed the upload cap, the whole trace; each case is recorded in
+the payload rather than failing the report.
 
 The trace can contain prompts, model output, source code, file paths, URLs, and
 email addresses. Review replaces recognizable Google API keys, JWTs, Slack

--- a/packages/progressive-review/app/src/bug-report-dialog.test.tsx
+++ b/packages/progressive-review/app/src/bug-report-dialog.test.tsx
@@ -118,8 +118,12 @@ describe("BugReportControl", () => {
     expect(privacyButton).not.toBeNull();
     expect(tooltip?.getAttribute("role")).toBe("tooltip");
     expect(tooltip?.textContent).toContain(
-      "Recognizable secrets are redacted, but other secrets may be included. The trace includes your prompts and code and is sent to /dev/fast",
+      "complete, uncapped authoring session trace",
     );
+    expect(tooltip?.textContent).toContain(
+      "each ancestor session up to its fork point",
+    );
+    expect(tooltip?.textContent).toContain("tail-capped subagent traces");
 
     await act(async () => traceCheckbox.click());
 
@@ -130,6 +134,22 @@ describe("BugReportControl", () => {
 
     await act(async () => reportButton().click());
     expect(checkbox("Agent session trace").checked).toBe(false);
+  });
+
+  it("explains how to send when the complete trace is unavailable", async () => {
+    request.mockImplementation(async (url) =>
+      url.includes("/telemetry/bug-report")
+        ? jsonResponse({ error: "Trace unavailable." }, 422)
+        : jsonResponse({ ok: true }),
+    );
+    await renderAndOpen();
+    await act(async () => checkbox("Agent session trace").click());
+
+    await act(async () => sendButton().click());
+
+    expect(container.textContent).toContain(
+      "The complete agent session trace couldn't be read. Uncheck 'Agent session trace' to send the report without it.",
+    );
   });
 
   it("shows an automatic screenshot and omits it after removal", async () => {
@@ -257,9 +277,9 @@ function tutorialBridge(): ReviewCanvasTutorialBridge {
   };
 }
 
-function jsonResponse(body: unknown): Response {
+function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
-    status: 200,
+    status,
     headers: { "content-type": "application/json" },
   });
 }

--- a/packages/progressive-review/app/src/bug-report-dialog.tsx
+++ b/packages/progressive-review/app/src/bug-report-dialog.tsx
@@ -22,7 +22,7 @@ import { captureUiEvent, clientErrorName } from "./ui-telemetry";
 
 const MAX_DESCRIPTION_BYTES = 64 * 1024;
 const TRACE_PRIVACY_COPY =
-  "Recognizable secrets are redacted, but other secrets may be included. The trace includes your prompts and code and is sent to /dev/fast.";
+  "Includes the complete, uncapped authoring session trace. For forked sessions, it also includes each ancestor session up to its fork point, plus up to ten tail-capped subagent traces. Recognizable secrets are redacted, but other secrets may be included; everything is sent to /dev/fast.";
 
 type Toast = { kind: "success" | "error"; text: string };
 
@@ -102,7 +102,9 @@ export function BugReportControl() {
               ? "Too many reports. Try again later."
               : response.status === 413
                 ? "The report is too large. Remove an attachment and try again."
-                : "The report could not be sent. Try again.",
+                : response.status === 422
+                  ? "The complete agent session trace couldn't be read. Uncheck 'Agent session trace' to send the report without it."
+                  : "The report could not be sent. Try again.",
         });
         return;
       }

--- a/packages/progressive-review/src/review-agent-traces.ts
+++ b/packages/progressive-review/src/review-agent-traces.ts
@@ -908,9 +908,7 @@ export async function findLocalTrace(
   const claudeRoot =
     traceEnvValue("TRACE_LOCAL_TRACE_ROOT") ||
     path.join(homedir(), ".claude", "projects");
-  const codexRoot =
-    traceEnvValue("TRACE_CODEX_SESSIONS_ROOT") ||
-    path.join(homedir(), ".codex", "sessions");
+  const codexRoot = codexSessionsRoot();
   const piRoot =
     traceEnvValue("TRACE_PI_SESSIONS_ROOT") ||
     path.join(homedir(), ".pi", "agent", "sessions");
@@ -956,15 +954,33 @@ function findClaudeTrace(root: string, sessionId: string): string | null {
 
 function findCodexTrace(root: string, sessionId: string): string | null {
   if (!existsSync(root)) return null;
+  return findCodexTraceInFiles(listFilesRecursive(root), sessionId);
+}
+
+export function findCodexTraceInFiles(
+  files: string[],
+  sessionId: string,
+): string | null {
   const suffix = `-${sessionId}.jsonl`;
-  const allFiles = listFilesRecursive(root);
-  for (const entry of allFiles.sort()) {
+  return (
+    [...files].sort().find((entry) => {
+      const name = path.basename(entry);
+      return name.startsWith("rollout-") && name.endsWith(suffix);
+    }) ?? null
+  );
+}
+
+export function indexCodexTraceFiles(files: string[]): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const entry of [...files].sort()) {
     const name = path.basename(entry);
-    if (name.startsWith("rollout-") && name.endsWith(suffix)) {
-      return entry;
-    }
+    const match =
+      /^rollout-.*-([0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})\.jsonl$/i.exec(
+        name,
+      );
+    if (match && !index.has(match[1])) index.set(match[1], entry);
   }
-  return null;
+  return index;
 }
 
 function findPiTrace(root: string, sessionId: string): string | null {
@@ -1481,6 +1497,17 @@ function traceEnvFile(): Record<string, string> {
 
 export function traceEnvValue(name: string): string | undefined {
   return process.env[name] ?? traceEnvFile()[name];
+}
+
+export function codexSessionsRoot(): string {
+  const codexHome = traceEnvValue("CODEX_HOME");
+  return (
+    traceEnvValue("TRACE_CODEX_SESSIONS_ROOT") ||
+    path.join(
+      codexHome ? path.resolve(codexHome) : path.join(homedir(), ".codex"),
+      "sessions",
+    )
+  );
 }
 
 export function traceR2Config(): TraceR2Config | null {

--- a/packages/progressive-review/src/review-agent-traces.ts
+++ b/packages/progressive-review/src/review-agent-traces.ts
@@ -954,19 +954,14 @@ function findClaudeTrace(root: string, sessionId: string): string | null {
 
 function findCodexTrace(root: string, sessionId: string): string | null {
   if (!existsSync(root)) return null;
-  return findCodexTraceInFiles(listFilesRecursive(root), sessionId);
-}
-
-export function findCodexTraceInFiles(
-  files: string[],
-  sessionId: string,
-): string | null {
   const suffix = `-${sessionId}.jsonl`;
   return (
-    [...files].sort().find((entry) => {
-      const name = path.basename(entry);
-      return name.startsWith("rollout-") && name.endsWith(suffix);
-    }) ?? null
+    listFilesRecursive(root)
+      .sort()
+      .find((entry) => {
+        const name = path.basename(entry);
+        return name.startsWith("rollout-") && name.endsWith(suffix);
+      }) ?? null
   );
 }
 
@@ -1499,8 +1494,10 @@ export function traceEnvValue(name: string): string | undefined {
   return process.env[name] ?? traceEnvFile()[name];
 }
 
+// Codex reads CODEX_HOME from its own environment only, so this does not
+// consult the trace env file for it.
 export function codexSessionsRoot(): string {
-  const codexHome = traceEnvValue("CODEX_HOME");
+  const codexHome = process.env.CODEX_HOME;
   return (
     traceEnvValue("TRACE_CODEX_SESSIONS_ROOT") ||
     path.join(
@@ -1968,7 +1965,7 @@ function isDirectory(targetPath: string): boolean {
   }
 }
 
-function listFilesRecursive(dirPath: string): string[] {
+export function listFilesRecursive(dirPath: string): string[] {
   const files: string[] = [];
   try {
     const entries = readdirSync(dirPath, { withFileTypes: true });

--- a/packages/progressive-review/src/server/bug-report-trace.test.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.test.ts
@@ -22,7 +22,7 @@ import {
   readAuthoringTraceAttachment,
 } from "./bug-report-trace";
 
-const SUBAGENT_TRACE_CAP_BYTES = 1024 * 1024;
+const SUBAGENT_TRACE_CAP_BYTES = 5 * 1024 * 1024;
 
 describe("readAuthoringTraceAttachment", () => {
   let tempDir: string;

--- a/packages/progressive-review/src/server/bug-report-trace.test.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.test.ts
@@ -1,5 +1,4 @@
 import {
-  appendFileSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -82,6 +81,7 @@ describe("readAuthoringTraceAttachment", () => {
     const attachment = await requiredAttachment();
     expect(attachment.payload).toEqual({
       harness,
+      session_id: id,
       files: {},
       truncated: false,
     });
@@ -192,29 +192,45 @@ describe("readAuthoringTraceAttachment", () => {
     await attachment.cleanup();
   });
 
-  it("rejects an unresolved or malformed declared Codex parent", async () => {
+  it("keeps the source trace and names an unresolved Codex parent", async () => {
     const childId = "44444444-4444-4444-8444-444444444444";
     const parentId = "55555555-5555-4555-8555-555555555555";
-    writeCodexTrace(
+    const child = codexTrace(
       childId,
-      codexTrace(childId, 2, [{ child: true }], historyBase(parentId, 2)),
+      2,
+      [{ child: true }],
+      historyBase(parentId, 2),
     );
+    writeCodexTrace(childId, child);
     writeReview("codex:" + childId);
-    await expect(
-      readAuthoringTraceAttachment({ reviewRootPath }),
-    ).rejects.toThrow("parent could not be resolved");
 
-    writeCodexTrace(
-      parentId,
-      jsonLine({
-        type: "session_meta",
-        payload: { id: parentId },
-        ordinal: 0,
-      }) + "not-json\n",
-    );
-    await expect(
-      readAuthoringTraceAttachment({ reviewRootPath }),
-    ).rejects.toThrow("malformed JSONL");
+    const attachment = await requiredAttachment();
+    expect(attachment.payload).toMatchObject({
+      omitted_files: ["ancestors/" + parentId + ".jsonl"],
+      truncated: true,
+    });
+    expect(readPart(attachment, 0)).toBe(child);
+    expect(attachment.parts).toHaveLength(1);
+    await attachment.cleanup();
+  });
+
+  it("drops malformed and blank lines and marks the trace truncated", async () => {
+    const id = "46464646-4646-4646-8646-464646464646";
+    const first = jsonLine({ first: true });
+    const second = jsonLine({ second: true });
+    writeReview("claude-code:" + id);
+    writeHarnessTrace("claude-code", id, first + "\n" + second);
+
+    const blankOnly = await requiredAttachment();
+    expect(readPart(blankOnly, 0)).toBe(first + second);
+    expect(blankOnly.payload.truncated).toBe(false);
+    await blankOnly.cleanup();
+
+    writeHarnessTrace("claude-code", id, first + "not-json\n" + second);
+    const malformed = await requiredAttachment();
+    expect(readPart(malformed, 0)).toBe(first + second);
+    expect(malformed.payload.truncated).toBe(true);
+    await malformed.cleanup();
   });
 
   it("rejects malformed Codex history metadata", async () => {
@@ -240,7 +256,7 @@ describe("readAuthoringTraceAttachment", () => {
     ).rejects.toThrow("history base is malformed");
   });
 
-  it("rejects Codex ancestry cycles", async () => {
+  it("stops at a Codex ancestry cycle", async () => {
     const childId = "47474747-4747-4747-8747-474747474747";
     const parentId = "58585858-5858-4858-8858-585858585858";
     writeCodexTrace(
@@ -253,12 +269,19 @@ describe("readAuthoringTraceAttachment", () => {
     );
     writeReview("codex:" + childId);
 
-    await expect(
-      readAuthoringTraceAttachment({ reviewRootPath }),
-    ).rejects.toThrow("ancestry contains a cycle");
+    const attachment = await requiredAttachment();
+    expect(attachment.parts.map((part) => part.session_id)).toEqual([
+      childId,
+      parentId,
+    ]);
+    expect(attachment.payload).toMatchObject({
+      omitted_files: ["ancestors/" + childId + ".jsonl"],
+      truncated: true,
+    });
+    await attachment.cleanup();
   });
 
-  it("rejects an ancestor record without an ordinal", async () => {
+  it("omits an ancestor whose records lack ordinals", async () => {
     const childId = "48484848-4848-4848-8848-484848484848";
     const parentId = "59595959-5959-4959-8959-595959595959";
     writeCodexTrace(
@@ -275,9 +298,13 @@ describe("readAuthoringTraceAttachment", () => {
     );
     writeReview("codex:" + childId);
 
-    await expect(
-      readAuthoringTraceAttachment({ reviewRootPath }),
-    ).rejects.toThrow("missing a valid ordinal");
+    const attachment = await requiredAttachment();
+    expect(attachment.parts).toHaveLength(1);
+    expect(attachment.payload).toMatchObject({
+      omitted_files: ["ancestors/" + parentId + ".jsonl"],
+      truncated: true,
+    });
+    await attachment.cleanup();
   });
 
   it("does not require contiguous Codex ordinals", async () => {
@@ -341,7 +368,7 @@ describe("readAuthoringTraceAttachment", () => {
     await attachment.cleanup();
   });
 
-  it("accepts 32 Codex parent levels and rejects 33", async () => {
+  it("accepts 32 Codex parent levels and omits the 33rd", async () => {
     let parentId = codexId(0);
     writeCodexTrace(parentId, codexTrace(parentId, 0, [{ depth: 0 }]));
     for (let depth = 1; depth <= 32; depth++) {
@@ -368,9 +395,13 @@ describe("readAuthoringTraceAttachment", () => {
     );
     writeReview("codex:" + sourceId);
 
-    await expect(
-      readAuthoringTraceAttachment({ reviewRootPath }),
-    ).rejects.toThrow("exceeds the supported depth");
+    const capped = await requiredAttachment();
+    expect(capped.parts).toHaveLength(33);
+    expect(capped.payload).toMatchObject({
+      omitted_files: ["ancestors/" + codexId(0) + ".jsonl"],
+      truncated: true,
+    });
+    await capped.cleanup();
   });
 
   it("keeps a complete main trace that exceeds the old byte cap", async () => {
@@ -385,52 +416,57 @@ describe("readAuthoringTraceAttachment", () => {
     await attachment.cleanup();
   });
 
-  it("rejects an oversized lineage before materializing it", async () => {
+  it("omits an ancestor that would exceed the lineage cap", async () => {
     const parentId = "67676767-6767-4767-8767-676767676767";
     const childId = "68686868-6868-4868-8868-686868686868";
     const parentPath = writeCodexTrace(
       parentId,
       codexTrace(parentId, 0, [{ parent: true }]),
     );
-    const childPath = writeCodexTrace(
+    const child = codexTrace(
       childId,
-      codexTrace(childId, 2, [{ child: true }], historyBase(parentId, 2)),
+      2,
+      [{ child: true }],
+      historyBase(parentId, 2),
     );
-    const halfBudget = Math.floor(MAX_AUTHORING_TRACE_BYTES / 2) + 1;
-    truncateSync(parentPath, halfBudget);
-    truncateSync(childPath, halfBudget);
+    const childPath = writeCodexTrace(childId, child);
+    truncateSync(parentPath, MAX_AUTHORING_TRACE_BYTES + 1);
     writeReview("codex:" + childId);
 
+    const attachment = await requiredAttachment();
+    expect(readPart(attachment, 0)).toBe(child);
+    expect(attachment.payload).toMatchObject({
+      omitted_files: ["ancestors/" + parentId + ".jsonl"],
+      truncated: true,
+    });
+    await attachment.cleanup();
+
+    truncateSync(childPath, MAX_AUTHORING_TRACE_BYTES + 1);
     await expect(
       readAuthoringTraceAttachment({ reviewRootPath }),
     ).rejects.toThrow("exceeds the supported size");
   });
 
-  it("waits for an incomplete final record and then keeps it", async () => {
+  it("drops an incomplete final record and marks the trace truncated", async () => {
     const id = "77777777-7777-4777-8777-777777777777";
     const complete = jsonLine({ complete: true });
     writeReview("claude-code:" + id);
-    const tracePath = writeHarnessTrace(
-      "claude-code",
-      id,
-      complete + '{"later":',
-    );
-    const finish = setTimeout(() => appendFileSync(tracePath, "true}\n"), 60);
+    writeHarnessTrace("claude-code", id, complete + '{"later":');
 
     const attachment = await requiredAttachment();
-    clearTimeout(finish);
-    expect(readPart(attachment, 0)).toBe(complete + jsonLine({ later: true }));
+    expect(readPart(attachment, 0)).toBe(complete);
+    expect(attachment.payload.truncated).toBe(true);
     await attachment.cleanup();
   });
 
-  it("rejects a final record that stays incomplete", async () => {
+  it("rejects a source trace without a complete record", async () => {
     const id = "88888888-8888-4888-8888-888888888888";
     writeReview("claude-code:" + id);
-    writeHarnessTrace("claude-code", id, jsonLine({ complete: true }) + "{");
+    writeHarnessTrace("claude-code", id, "{");
 
     await expect(
       readAuthoringTraceAttachment({ reviewRootPath }),
-    ).rejects.toThrow("incomplete JSONL record");
+    ).rejects.toThrow("Trace file is empty");
   });
 
   it("redacts complete secret values but keeps valid JSONL", async () => {
@@ -476,7 +512,7 @@ describe("readAuthoringTraceAttachment", () => {
     await attachment.cleanup();
   });
 
-  it("keeps the ten newest bounded subagent traces", async () => {
+  it("keeps the ten newest subagent traces and names unreadable or excess files", async () => {
     const id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
     writeReview("claude-code:" + id);
     const tracePath = writeHarnessTrace(
@@ -492,12 +528,16 @@ describe("readAuthoringTraceAttachment", () => {
     for (let index = 0; index < 11; index++) {
       const name = "agent-" + String(index).padStart(2, "0") + ".jsonl";
       const subagentPath = path.join(subagentsDir, name);
-      const contents =
-        index === 10
-          ? jsonLine({ old: "x".repeat(SUBAGENT_TRACE_CAP_BYTES) }) +
-            jsonLine({ recent: true })
-          : jsonLine({ index });
-      writeFileSync(subagentPath, contents);
+      if (index === 9) {
+        mkdirSync(subagentPath);
+      } else {
+        const contents =
+          index === 10
+            ? jsonLine({ old: "x".repeat(SUBAGENT_TRACE_CAP_BYTES) }) +
+              jsonLine({ recent: true })
+            : jsonLine({ index });
+        writeFileSync(subagentPath, contents);
+      }
       const modifiedAt = new Date(1_700_000_000_000 + index * 1000);
       utimesSync(subagentPath, modifiedAt, modifiedAt);
     }
@@ -510,8 +550,12 @@ describe("readAuthoringTraceAttachment", () => {
     expect(attachment.payload.files).not.toHaveProperty(
       "subagents/agent-00.jsonl",
     );
+    expect(attachment.payload.files).not.toHaveProperty(
+      "subagents/agent-09.jsonl",
+    );
     expect(attachment.payload.omitted_files).toEqual([
       "subagents/agent-00.jsonl",
+      "subagents/agent-09.jsonl",
     ]);
     await attachment.cleanup();
   });

--- a/packages/progressive-review/src/server/bug-report-trace.test.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.test.ts
@@ -1,21 +1,26 @@
 import {
+  appendFileSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { gunzipSync } from "node:zlib";
 
 import { REVIEW_SCHEMA_VERSION } from "@dev.fast/review-protocol";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { ReviewAgentHarness } from "../authoring-session";
 import { clearTraceEnvCache } from "../review-agent-traces";
-import { readAuthoringTraceAttachment } from "./bug-report-trace";
+import {
+  type AuthoringTraceAttachment,
+  readAuthoringTraceAttachment,
+} from "./bug-report-trace";
 
-const TRACE_CAP_BYTES = 6 * 1024 * 1024;
 const SUBAGENT_TRACE_CAP_BYTES = 1024 * 1024;
 
 describe("readAuthoringTraceAttachment", () => {
@@ -62,125 +67,187 @@ describe("readAuthoringTraceAttachment", () => {
 
   it.each([
     ["claude-code", "11111111-aaaa-bbbb-cccc-000000000001"],
-    ["codex", "22222222-aaaa-bbbb-cccc-000000000002"],
     ["pi", "33333333-aaaa-bbbb-cccc-000000000003"],
-  ] as const)(
-    "reads a %s trace from its local harness root",
-    async (harness, id) => {
-      writeReview(harness + ":" + id);
-      writeHarnessTrace(harness, id, jsonLine({ harness, id }));
+  ] as const)("stores a complete %s source trace", async (harness, id) => {
+    const source = jsonLine({ harness, id });
+    writeReview(harness + ":" + id);
+    writeHarnessTrace(harness, id, source);
 
-      await expect(
-        readAuthoringTraceAttachment({ reviewRootPath }),
-      ).resolves.toEqual({
-        harness,
-        session_id: id,
-        files: {
-          "trace.jsonl": jsonLine({ harness, id }),
-        },
-        truncated: false,
-      });
-    },
-  );
+    const attachment = await requiredAttachment();
+    expect(attachment.payload).toEqual({
+      harness,
+      session_id: id,
+      files: {},
+      truncated: false,
+    });
+    expect(readPart(attachment, "source_trace")).toBe(source);
+    expect(attachment.parts).toHaveLength(1);
+    await attachment.cleanup();
+  });
 
-  it("redacts complete known-secret values while retaining paths, prompts, and code", async () => {
-    const id = "44444444-aaaa-bbbb-cccc-000000000004";
-    const googleKey = "AIza" + "a".repeat(35);
-    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature";
+  it("stores the physical child and the complete recursive parent history", async () => {
+    const grandparentId = "11111111-1111-4111-8111-111111111111";
+    const parentId = "22222222-2222-4222-8222-222222222222";
+    const childId = "33333333-3333-4333-8333-333333333333";
+    const grandparent = codexTrace(grandparentId, 0, [{ root: true }]);
+    const parentAtFork = codexTrace(
+      parentId,
+      2,
+      [{ parent: true }],
+      historyBase(grandparentId, 2, Buffer.byteLength(grandparent)),
+    );
+    const parent = parentAtFork + jsonLine({ parentLater: true, ordinal: 4 });
+    const child = codexTrace(
+      childId,
+      4,
+      [{ child: true }],
+      historyBase(parentId, 4, Buffer.byteLength(parentAtFork)),
+    );
+    writeCodexTrace(grandparentId, grandparent);
+    writeCodexTrace(parentId, parent);
+    writeCodexTrace(childId, child);
+    writeReview("codex:" + childId);
+
+    const attachment = await requiredAttachment();
+    expect(attachment.payload).toMatchObject({
+      harness: "codex",
+      session_id: childId,
+      parent_session_id: parentId,
+      truncated: false,
+    });
+    expect(readPart(attachment, "source_trace")).toBe(child);
+    expect(readPart(attachment, "parent_trace")).toBe(grandparent + parent);
+    expect(attachment.parts.map((part) => part.field)).toEqual([
+      "source_trace",
+      "parent_trace",
+    ]);
+    await attachment.cleanup();
+  });
+
+  it("rejects an unresolved or malformed declared Codex parent", async () => {
+    const childId = "44444444-4444-4444-8444-444444444444";
+    const parentId = "55555555-5555-4555-8555-555555555555";
+    writeCodexTrace(
+      childId,
+      codexTrace(childId, 2, [{ child: true }], historyBase(parentId, 2, 100)),
+    );
+    writeReview("codex:" + childId);
+    await expect(
+      readAuthoringTraceAttachment({ reviewRootPath }),
+    ).rejects.toThrow("exactly one rollout");
+
+    writeCodexTrace(parentId, '{"ordinal":0}\nnot-json\n');
+    await expect(
+      readAuthoringTraceAttachment({ reviewRootPath }),
+    ).rejects.toThrow("malformed JSONL");
+  });
+
+  it("rejects more than 32 Codex parent levels", async () => {
+    let parentId = codexId(0);
+    let parent = codexTrace(parentId, 0, [{ depth: 0 }]);
+    writeCodexTrace(parentId, parent);
+    let nextOrdinal = 2;
+    for (let depth = 1; depth <= 33; depth++) {
+      const id = codexId(depth);
+      const trace = codexTrace(
+        id,
+        nextOrdinal,
+        [{ depth }],
+        historyBase(parentId, nextOrdinal, Buffer.byteLength(parent)),
+      );
+      writeCodexTrace(id, trace);
+      parentId = id;
+      parent = trace;
+      nextOrdinal += 2;
+    }
+    const sourceId = codexId(34);
+    writeCodexTrace(
+      sourceId,
+      codexTrace(
+        sourceId,
+        nextOrdinal,
+        [{ source: true }],
+        historyBase(parentId, nextOrdinal, Buffer.byteLength(parent)),
+      ),
+    );
+    writeReview("codex:" + sourceId);
+
+    await expect(
+      readAuthoringTraceAttachment({ reviewRootPath }),
+    ).rejects.toThrow("exceeds the supported depth");
+  });
+
+  it("keeps a complete main trace that exceeds the old byte cap", async () => {
+    const id = "66666666-6666-4666-8666-666666666666";
+    const source = jsonLine({ data: "x".repeat(6 * 1024 * 1024 + 1) });
+    writeReview("claude-code:" + id);
+    writeHarnessTrace("claude-code", id, source);
+
+    const attachment = await requiredAttachment();
+    expect(readPart(attachment, "source_trace")).toBe(source);
+    expect(attachment.payload.truncated).toBe(false);
+    await attachment.cleanup();
+  });
+
+  it("waits for an incomplete final record and then keeps it", async () => {
+    const id = "77777777-7777-4777-8777-777777777777";
+    const complete = jsonLine({ complete: true });
+    writeReview("claude-code:" + id);
+    const tracePath = writeHarnessTrace(
+      "claude-code",
+      id,
+      complete + '{"later":',
+    );
+    const finish = setTimeout(() => appendFileSync(tracePath, "true}\n"), 60);
+
+    const attachment = await requiredAttachment();
+    clearTimeout(finish);
+    expect(readPart(attachment, "source_trace")).toBe(
+      complete + jsonLine({ later: true }),
+    );
+    await attachment.cleanup();
+  });
+
+  it("rejects a final record that stays incomplete", async () => {
+    const id = "88888888-8888-4888-8888-888888888888";
+    writeReview("claude-code:" + id);
+    writeHarnessTrace("claude-code", id, jsonLine({ complete: true }) + "{");
+
+    await expect(
+      readAuthoringTraceAttachment({ reviewRootPath }),
+    ).rejects.toThrow("incomplete JSONL record");
+  });
+
+  it("redacts complete secret values but keeps valid JSONL", async () => {
+    const id = "99999999-9999-4999-8999-999999999999";
     const slackToken = [
       "xoxb",
       "123456789012",
       "123456789012",
-      "abcdefghijklmnopqrstuvwx",
+      "abcdefghijklmnop",
     ].join("-");
     const githubToken = "ghp_" + "b".repeat(36);
-    const entraToken =
-      "eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJhcGkifQ.microsoft-signature";
-    const ordinaryBase64Json = "eyJmb28iOiJiYXIifQ==";
-    const source = [
-      {
-        prompt: "Use " + googleKey + " and " + slackToken,
-        path: "/Users/reviewer/project/src/auth.ts",
-        code: "export const answer = 42;",
-        ordinaryBase64Json,
-      },
-      {
-        jwt,
-        githubToken,
-        entraToken,
-      },
-    ]
-      .map(jsonLine)
-      .join("");
+    const source = jsonLine({
+      prompt: "Use " + slackToken,
+      githubToken,
+      path: "/Users/reviewer/project/src/auth.ts",
+    });
     writeReview("claude-code:" + id);
     writeHarnessTrace("claude-code", id, source);
 
-    const attachment = await readAuthoringTraceAttachment({ reviewRootPath });
-    const trace = attachment?.files["trace.jsonl"] ?? "";
-
-    expect(trace).toContain("<REDACTED: Google API Key>");
-    expect(trace).toContain("<REDACTED: Slack Token>");
-    expect(trace).toContain("<REDACTED: JWT>");
-    expect(trace).toContain("<REDACTED: GitHub Token>");
-    expect(trace).not.toContain(googleKey);
-    expect(trace).not.toContain(jwt);
+    const attachment = await requiredAttachment();
+    const trace = readPart(attachment, "source_trace");
     expect(trace).not.toContain(slackToken);
     expect(trace).not.toContain(githubToken);
-    expect(trace).not.toContain(entraToken);
-    expect(trace).toContain(ordinaryBase64Json);
+    expect(trace).toContain("<REDACTED: Slack Token>");
+    expect(trace).toContain("<REDACTED: GitHub Token>");
     expect(trace).toContain("/Users/reviewer/project/src/auth.ts");
-    expect(trace).toContain("export const answer = 42;");
-    for (const line of trace.trimEnd().split("\n")) {
-      expect(() => JSON.parse(line)).not.toThrow();
-    }
+    expect(() => JSON.parse(trace.trim())).not.toThrow();
+    await attachment.cleanup();
   });
 
-  it("keeps the newest complete main-trace lines within the byte cap", async () => {
-    const id = "55555555-aaaa-bbbb-cccc-000000000005";
-    const oversizedOldLine = jsonLine({ old: "x".repeat(TRACE_CAP_BYTES) });
-    const recentLines = [jsonLine({ recent: 1 }), jsonLine({ recent: 2 })].join(
-      "",
-    );
-    writeReview("claude-code:" + id);
-    writeHarnessTrace("claude-code", id, oversizedOldLine + recentLines);
-
-    const attachment = await readAuthoringTraceAttachment({ reviewRootPath });
-
-    expect(attachment?.truncated).toBe(true);
-    expect(attachment?.files["trace.jsonl"]).toBe(recentLines);
-    for (const line of recentLines.trimEnd().split("\n")) {
-      expect(() => JSON.parse(line)).not.toThrow();
-    }
-  });
-
-  it("drops an incomplete final line from a trace being written", async () => {
-    const id = "56565656-aaaa-bbbb-cccc-000000000005";
-    const completeLine = jsonLine({ complete: true });
-    writeReview("claude-code:" + id);
-    writeHarnessTrace("claude-code", id, completeLine + '{"partial":');
-
-    const attachment = await readAuthoringTraceAttachment({ reviewRootPath });
-
-    expect(attachment?.files["trace.jsonl"]).toBe(completeLine);
-    expect(attachment?.truncated).toBe(true);
-  });
-
-  it("treats a capped main trace without a complete line as unavailable", async () => {
-    const id = "57575757-aaaa-bbbb-cccc-000000000005";
-    writeReview("claude-code:" + id);
-    writeHarnessTrace(
-      "claude-code",
-      id,
-      JSON.stringify({ oversized: "x".repeat(TRACE_CAP_BYTES) }),
-    );
-
-    await expect(
-      readAuthoringTraceAttachment({ reviewRootPath }),
-    ).resolves.toBeNull();
-  });
-
-  it("keeps the ten newest subagent traces and names unreadable or excess files as omitted", async () => {
-    const id = "66666666-aaaa-bbbb-cccc-000000000006";
+  it("keeps the ten newest bounded subagent traces", async () => {
+    const id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
     writeReview("claude-code:" + id);
     const tracePath = writeHarnessTrace(
       "claude-code",
@@ -195,33 +262,35 @@ describe("readAuthoringTraceAttachment", () => {
     for (let index = 0; index < 11; index++) {
       const name = "agent-" + String(index).padStart(2, "0") + ".jsonl";
       const subagentPath = path.join(subagentsDir, name);
-      if (index === 9) {
-        mkdirSync(subagentPath);
-      } else {
-        const contents =
-          index === 10
-            ? jsonLine({ old: "x".repeat(SUBAGENT_TRACE_CAP_BYTES) }) +
-              jsonLine({ recent: true })
-            : jsonLine({ index });
-        writeFileSync(subagentPath, contents);
-      }
+      const contents =
+        index === 10
+          ? jsonLine({ old: "x".repeat(SUBAGENT_TRACE_CAP_BYTES) }) +
+            jsonLine({ recent: true })
+          : jsonLine({ index });
+      writeFileSync(subagentPath, contents);
       const modifiedAt = new Date(1_700_000_000_000 + index * 1000);
       utimesSync(subagentPath, modifiedAt, modifiedAt);
     }
 
-    const attachment = await readAuthoringTraceAttachment({ reviewRootPath });
-
-    expect(attachment?.truncated).toBe(true);
-    expect(attachment?.files["subagents/agent-10.jsonl"]).toBe(
+    const attachment = await requiredAttachment();
+    expect(attachment.payload.truncated).toBe(true);
+    expect(attachment.payload.files["subagents/agent-10.jsonl"]).toBe(
       jsonLine({ recent: true }),
     );
-    expect(attachment?.files).not.toHaveProperty("subagents/agent-00.jsonl");
-    expect(attachment?.files).not.toHaveProperty("subagents/agent-09.jsonl");
-    expect(attachment?.omitted_files).toEqual([
+    expect(attachment.payload.files).not.toHaveProperty(
       "subagents/agent-00.jsonl",
-      "subagents/agent-09.jsonl",
+    );
+    expect(attachment.payload.omitted_files).toEqual([
+      "subagents/agent-00.jsonl",
     ]);
+    await attachment.cleanup();
   });
+
+  async function requiredAttachment(): Promise<AuthoringTraceAttachment> {
+    const attachment = await readAuthoringTraceAttachment({ reviewRootPath });
+    if (!attachment) throw new Error("Expected an authoring trace.");
+    return attachment;
+  }
 
   function writeReview(sourceSession: string): void {
     writeFileSync(
@@ -259,12 +328,7 @@ describe("readAuthoringTraceAttachment", () => {
       mkdirSync(projectDir, { recursive: true });
       tracePath = path.join(projectDir, id + ".jsonl");
     } else if (harness === "codex") {
-      const dateDir = path.join(codexRoot, "2026", "08", "31");
-      mkdirSync(dateDir, { recursive: true });
-      tracePath = path.join(
-        dateDir,
-        "rollout-2026-08-31T12-00-00-" + id + ".jsonl",
-      );
+      return writeCodexTrace(id, contents);
     } else {
       const projectDir = path.join(piRoot, "project");
       mkdirSync(projectDir, { recursive: true });
@@ -273,7 +337,67 @@ describe("readAuthoringTraceAttachment", () => {
     writeFileSync(tracePath, contents);
     return tracePath;
   }
+
+  function writeCodexTrace(id: string, contents: string): string {
+    const dateDir = path.join(codexRoot, "2026", "08", "31");
+    mkdirSync(dateDir, { recursive: true });
+    const tracePath = path.join(
+      dateDir,
+      "rollout-2026-08-31T12-00-00-" + id + ".jsonl",
+    );
+    writeFileSync(tracePath, contents);
+    return tracePath;
+  }
 });
+
+function historyBase(
+  parentId: string,
+  endOrdinalExclusive: number,
+  endByteOffset: number,
+): { parentId: string; endOrdinalExclusive: number; endByteOffset: number } {
+  return { parentId, endOrdinalExclusive, endByteOffset };
+}
+
+function codexId(index: number): string {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+}
+
+function codexTrace(
+  id: string,
+  startOrdinal: number,
+  records: Array<Record<string, unknown>>,
+  parent?: ReturnType<typeof historyBase>,
+): string {
+  const metaPayload = {
+    id,
+    ...(parent
+      ? {
+          history_mode: "paginated",
+          forked_from_id: parent.parentId,
+          forked_from_ordinal_exclusive: parent.endOrdinalExclusive,
+          history_base: {
+            thread_id: parent.parentId,
+            end_ordinal_exclusive: parent.endOrdinalExclusive,
+            end_byte_offset: parent.endByteOffset,
+          },
+        }
+      : {}),
+  };
+  return [{ type: "session_meta", payload: metaPayload }, ...records]
+    .map((value, index) =>
+      jsonLine({ ...value, ordinal: startOrdinal + index }),
+    )
+    .join("");
+}
+
+function readPart(
+  attachment: AuthoringTraceAttachment,
+  field: "source_trace" | "parent_trace",
+): string {
+  const part = attachment.parts.find((candidate) => candidate.field === field);
+  if (!part) throw new Error(`Missing ${field}.`);
+  return gunzipSync(readFileSync(part.path)).toString("utf8");
+}
 
 function jsonLine(value: unknown): string {
   return JSON.stringify(value) + "\n";

--- a/packages/progressive-review/src/server/bug-report-trace.test.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.test.ts
@@ -76,14 +76,11 @@ describe("readAuthoringTraceAttachment", () => {
     const attachment = await requiredAttachment();
     expect(attachment.payload).toEqual({
       harness,
-      session_id: id,
-      sessions: [{ session_id: id }],
       files: {},
       truncated: false,
     });
     expect(readPart(attachment, 0)).toBe(source);
     expect(attachment.parts[0]).toMatchObject({
-      field: "trace",
       filename: "trace-0.jsonl.gz",
       session_id: id,
     });
@@ -98,7 +95,7 @@ describe("readAuthoringTraceAttachment", () => {
     writeReview("codex:" + id);
 
     const attachment = await requiredAttachment();
-    expect(attachment.payload.sessions).toEqual([{ session_id: id }]);
+    expect(attachment.payload.harness).toBe("codex");
     expect(readPart(attachment, 0)).toBe(source);
     expect(attachment.parts).toHaveLength(1);
     await attachment.cleanup();
@@ -113,14 +110,14 @@ describe("readAuthoringTraceAttachment", () => {
       parentId,
       2,
       [{ parent: true }],
-      historyBase(grandparentId, 2, 1),
+      historyBase(grandparentId, 2),
     );
     const parent = parentAtFork + jsonLine({ parentLater: true, ordinal: 4 });
     const child = codexTrace(
       childId,
       4,
       [{ child: true }],
-      historyBase(parentId, 4, 1),
+      historyBase(parentId, 4),
     );
     writeCodexTrace(grandparentId, grandparent);
     writeCodexTrace(parentId, parent);
@@ -130,30 +127,11 @@ describe("readAuthoringTraceAttachment", () => {
     const attachment = await requiredAttachment();
     expect(attachment.payload).toMatchObject({
       harness: "codex",
-      session_id: childId,
-      sessions: [
-        {
-          session_id: childId,
-          parent_session_id: parentId,
-          parent_end_ordinal_exclusive: 4,
-        },
-        {
-          session_id: parentId,
-          parent_session_id: grandparentId,
-          parent_end_ordinal_exclusive: 2,
-        },
-        { session_id: grandparentId },
-      ],
       truncated: false,
     });
     expect(readPart(attachment, 0)).toBe(child);
     expect(readPart(attachment, 1)).toBe(parentAtFork);
     expect(readPart(attachment, 2)).toBe(grandparent);
-    expect(attachment.parts.map((part) => part.field)).toEqual([
-      "trace",
-      "trace",
-      "trace",
-    ]);
     expect(attachment.parts.map((part) => part.filename)).toEqual([
       "trace-0.jsonl.gz",
       "trace-1.jsonl.gz",
@@ -167,7 +145,7 @@ describe("readAuthoringTraceAttachment", () => {
     const parentId = "55555555-5555-4555-8555-555555555555";
     writeCodexTrace(
       childId,
-      codexTrace(childId, 2, [{ child: true }], historyBase(parentId, 2, 100)),
+      codexTrace(childId, 2, [{ child: true }], historyBase(parentId, 2)),
     );
     writeReview("codex:" + childId);
     await expect(
@@ -208,11 +186,11 @@ describe("readAuthoringTraceAttachment", () => {
     const parentId = "58585858-5858-4858-8858-585858585858";
     writeCodexTrace(
       childId,
-      codexTrace(childId, 4, [{ child: true }], historyBase(parentId, 4, 1)),
+      codexTrace(childId, 4, [{ child: true }], historyBase(parentId, 4)),
     );
     writeCodexTrace(
       parentId,
-      codexTrace(parentId, 2, [{ parent: true }], historyBase(childId, 2, 1)),
+      codexTrace(parentId, 2, [{ parent: true }], historyBase(childId, 2)),
     );
     writeReview("codex:" + childId);
 
@@ -234,7 +212,7 @@ describe("readAuthoringTraceAttachment", () => {
     );
     writeCodexTrace(
       childId,
-      codexTrace(childId, 2, [{ child: true }], historyBase(parentId, 2, 1)),
+      codexTrace(childId, 2, [{ child: true }], historyBase(parentId, 2)),
     );
     writeReview("codex:" + childId);
 
@@ -255,7 +233,7 @@ describe("readAuthoringTraceAttachment", () => {
     writeCodexTrace(parentId, parent);
     writeCodexTrace(
       childId,
-      codexTrace(childId, 3, [{ child: true }], historyBase(parentId, 3, 1)),
+      codexTrace(childId, 3, [{ child: true }], historyBase(parentId, 3)),
     );
     writeReview("codex:" + childId);
 
@@ -273,7 +251,7 @@ describe("readAuthoringTraceAttachment", () => {
         id,
         depth * 2,
         [{ depth }],
-        historyBase(parentId, depth * 2, 1),
+        historyBase(parentId, depth * 2),
       );
       writeCodexTrace(id, trace);
       parentId = id;
@@ -287,12 +265,7 @@ describe("readAuthoringTraceAttachment", () => {
     const sourceId = codexId(33);
     writeCodexTrace(
       sourceId,
-      codexTrace(
-        sourceId,
-        66,
-        [{ source: true }],
-        historyBase(parentId, 66, 1),
-      ),
+      codexTrace(sourceId, 66, [{ source: true }], historyBase(parentId, 66)),
     );
     writeReview("codex:" + sourceId);
 
@@ -475,9 +448,8 @@ describe("readAuthoringTraceAttachment", () => {
 function historyBase(
   parentId: string,
   endOrdinalExclusive: number,
-  endByteOffset: number,
-): { parentId: string; endOrdinalExclusive: number; endByteOffset: number } {
-  return { parentId, endOrdinalExclusive, endByteOffset };
+): { parentId: string; endOrdinalExclusive: number } {
+  return { parentId, endOrdinalExclusive };
 }
 
 function codexId(index: number): string {
@@ -494,13 +466,9 @@ function codexTrace(
     id,
     ...(parent
       ? {
-          history_mode: "paginated",
-          forked_from_id: parent.parentId,
-          forked_from_ordinal_exclusive: parent.endOrdinalExclusive,
           history_base: {
             thread_id: parent.parentId,
             end_ordinal_exclusive: parent.endOrdinalExclusive,
-            end_byte_offset: parent.endByteOffset,
           },
         }
       : {}),

--- a/packages/progressive-review/src/server/bug-report-trace.test.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.test.ts
@@ -77,15 +77,34 @@ describe("readAuthoringTraceAttachment", () => {
     expect(attachment.payload).toEqual({
       harness,
       session_id: id,
+      sessions: [{ session_id: id }],
       files: {},
       truncated: false,
     });
-    expect(readPart(attachment, "source_trace")).toBe(source);
+    expect(readPart(attachment, 0)).toBe(source);
+    expect(attachment.parts[0]).toMatchObject({
+      field: "trace",
+      filename: "trace-0.jsonl.gz",
+      session_id: id,
+    });
     expect(attachment.parts).toHaveLength(1);
     await attachment.cleanup();
   });
 
-  it("stores the physical child and the complete recursive parent history", async () => {
+  it("stores a standalone Codex trace as one complete source part", async () => {
+    const id = "10101010-1010-4010-8010-101010101010";
+    const source = codexTrace(id, 0, [{ standalone: true }]);
+    writeCodexTrace(id, source);
+    writeReview("codex:" + id);
+
+    const attachment = await requiredAttachment();
+    expect(attachment.payload.sessions).toEqual([{ session_id: id }]);
+    expect(readPart(attachment, 0)).toBe(source);
+    expect(attachment.parts).toHaveLength(1);
+    await attachment.cleanup();
+  });
+
+  it("stores Codex lineage leaf first and excludes post-fork records", async () => {
     const grandparentId = "11111111-1111-4111-8111-111111111111";
     const parentId = "22222222-2222-4222-8222-222222222222";
     const childId = "33333333-3333-4333-8333-333333333333";
@@ -94,14 +113,14 @@ describe("readAuthoringTraceAttachment", () => {
       parentId,
       2,
       [{ parent: true }],
-      historyBase(grandparentId, 2, Buffer.byteLength(grandparent)),
+      historyBase(grandparentId, 2, 1),
     );
     const parent = parentAtFork + jsonLine({ parentLater: true, ordinal: 4 });
     const child = codexTrace(
       childId,
       4,
       [{ child: true }],
-      historyBase(parentId, 4, Buffer.byteLength(parentAtFork)),
+      historyBase(parentId, 4, 1),
     );
     writeCodexTrace(grandparentId, grandparent);
     writeCodexTrace(parentId, parent);
@@ -112,14 +131,33 @@ describe("readAuthoringTraceAttachment", () => {
     expect(attachment.payload).toMatchObject({
       harness: "codex",
       session_id: childId,
-      parent_session_id: parentId,
+      sessions: [
+        {
+          session_id: childId,
+          parent_session_id: parentId,
+          parent_end_ordinal_exclusive: 4,
+        },
+        {
+          session_id: parentId,
+          parent_session_id: grandparentId,
+          parent_end_ordinal_exclusive: 2,
+        },
+        { session_id: grandparentId },
+      ],
       truncated: false,
     });
-    expect(readPart(attachment, "source_trace")).toBe(child);
-    expect(readPart(attachment, "parent_trace")).toBe(grandparent + parent);
+    expect(readPart(attachment, 0)).toBe(child);
+    expect(readPart(attachment, 1)).toBe(parentAtFork);
+    expect(readPart(attachment, 2)).toBe(grandparent);
     expect(attachment.parts.map((part) => part.field)).toEqual([
-      "source_trace",
-      "parent_trace",
+      "trace",
+      "trace",
+      "trace",
+    ]);
+    expect(attachment.parts.map((part) => part.filename)).toEqual([
+      "trace-0.jsonl.gz",
+      "trace-1.jsonl.gz",
+      "trace-2.jsonl.gz",
     ]);
     await attachment.cleanup();
   });
@@ -142,32 +180,118 @@ describe("readAuthoringTraceAttachment", () => {
     ).rejects.toThrow("malformed JSONL");
   });
 
-  it("rejects more than 32 Codex parent levels", async () => {
-    let parentId = codexId(0);
-    let parent = codexTrace(parentId, 0, [{ depth: 0 }]);
+  it("rejects malformed Codex history metadata", async () => {
+    const childId = "45454545-4545-4545-8545-454545454545";
+    const parentId = "56565656-5656-4656-8656-565656565656";
+    writeCodexTrace(
+      childId,
+      [
+        {
+          type: "session_meta",
+          payload: { id: childId, history_base: { thread_id: parentId } },
+          ordinal: 2,
+        },
+        { child: true, ordinal: 3 },
+      ]
+        .map(jsonLine)
+        .join(""),
+    );
+    writeReview("codex:" + childId);
+
+    await expect(
+      readAuthoringTraceAttachment({ reviewRootPath }),
+    ).rejects.toThrow("history base is malformed");
+  });
+
+  it("rejects Codex ancestry cycles", async () => {
+    const childId = "47474747-4747-4747-8747-474747474747";
+    const parentId = "58585858-5858-4858-8858-585858585858";
+    writeCodexTrace(
+      childId,
+      codexTrace(childId, 4, [{ child: true }], historyBase(parentId, 4, 1)),
+    );
+    writeCodexTrace(
+      parentId,
+      codexTrace(parentId, 2, [{ parent: true }], historyBase(childId, 2, 1)),
+    );
+    writeReview("codex:" + childId);
+
+    await expect(
+      readAuthoringTraceAttachment({ reviewRootPath }),
+    ).rejects.toThrow("ancestry contains a cycle");
+  });
+
+  it("rejects an ancestor record without an ordinal", async () => {
+    const childId = "48484848-4848-4848-8848-484848484848";
+    const parentId = "59595959-5959-4959-8959-595959595959";
+    writeCodexTrace(
+      parentId,
+      jsonLine({
+        type: "session_meta",
+        payload: { id: parentId },
+        ordinal: 0,
+      }) + jsonLine({ missing: "ordinal" }),
+    );
+    writeCodexTrace(
+      childId,
+      codexTrace(childId, 2, [{ child: true }], historyBase(parentId, 2, 1)),
+    );
+    writeReview("codex:" + childId);
+
+    await expect(
+      readAuthoringTraceAttachment({ reviewRootPath }),
+    ).rejects.toThrow("missing a valid ordinal");
+  });
+
+  it("does not require contiguous Codex ordinals", async () => {
+    const childId = "49494949-4949-4949-8949-494949494949";
+    const parentId = "60606060-6060-4060-8060-606060606060";
+    const parent =
+      jsonLine({
+        type: "session_meta",
+        payload: { id: parentId },
+        ordinal: 0,
+      }) + jsonLine({ gap: true, ordinal: 2 });
     writeCodexTrace(parentId, parent);
-    let nextOrdinal = 2;
-    for (let depth = 1; depth <= 33; depth++) {
+    writeCodexTrace(
+      childId,
+      codexTrace(childId, 3, [{ child: true }], historyBase(parentId, 3, 1)),
+    );
+    writeReview("codex:" + childId);
+
+    const attachment = await requiredAttachment();
+    expect(readPart(attachment, 1)).toBe(parent);
+    await attachment.cleanup();
+  });
+
+  it("accepts 32 Codex parent levels and rejects 33", async () => {
+    let parentId = codexId(0);
+    writeCodexTrace(parentId, codexTrace(parentId, 0, [{ depth: 0 }]));
+    for (let depth = 1; depth <= 32; depth++) {
       const id = codexId(depth);
       const trace = codexTrace(
         id,
-        nextOrdinal,
+        depth * 2,
         [{ depth }],
-        historyBase(parentId, nextOrdinal, Buffer.byteLength(parent)),
+        historyBase(parentId, depth * 2, 1),
       );
       writeCodexTrace(id, trace);
       parentId = id;
-      parent = trace;
-      nextOrdinal += 2;
     }
-    const sourceId = codexId(34);
+    writeReview("codex:" + parentId);
+
+    const accepted = await requiredAttachment();
+    expect(accepted.parts).toHaveLength(33);
+    await accepted.cleanup();
+
+    const sourceId = codexId(33);
     writeCodexTrace(
       sourceId,
       codexTrace(
         sourceId,
-        nextOrdinal,
+        66,
         [{ source: true }],
-        historyBase(parentId, nextOrdinal, Buffer.byteLength(parent)),
+        historyBase(parentId, 66, 1),
       ),
     );
     writeReview("codex:" + sourceId);
@@ -184,7 +308,7 @@ describe("readAuthoringTraceAttachment", () => {
     writeHarnessTrace("claude-code", id, source);
 
     const attachment = await requiredAttachment();
-    expect(readPart(attachment, "source_trace")).toBe(source);
+    expect(readPart(attachment, 0)).toBe(source);
     expect(attachment.payload.truncated).toBe(false);
     await attachment.cleanup();
   });
@@ -202,9 +326,7 @@ describe("readAuthoringTraceAttachment", () => {
 
     const attachment = await requiredAttachment();
     clearTimeout(finish);
-    expect(readPart(attachment, "source_trace")).toBe(
-      complete + jsonLine({ later: true }),
-    );
+    expect(readPart(attachment, 0)).toBe(complete + jsonLine({ later: true }));
     await attachment.cleanup();
   });
 
@@ -236,7 +358,7 @@ describe("readAuthoringTraceAttachment", () => {
     writeHarnessTrace("claude-code", id, source);
 
     const attachment = await requiredAttachment();
-    const trace = readPart(attachment, "source_trace");
+    const trace = readPart(attachment, 0);
     expect(trace).not.toContain(slackToken);
     expect(trace).not.toContain(githubToken);
     expect(trace).toContain("<REDACTED: Slack Token>");
@@ -390,12 +512,9 @@ function codexTrace(
     .join("");
 }
 
-function readPart(
-  attachment: AuthoringTraceAttachment,
-  field: "source_trace" | "parent_trace",
-): string {
-  const part = attachment.parts.find((candidate) => candidate.field === field);
-  if (!part) throw new Error(`Missing ${field}.`);
+function readPart(attachment: AuthoringTraceAttachment, index: number): string {
+  const part = attachment.parts[index];
+  if (!part) throw new Error(`Missing trace part ${index}.`);
   return gunzipSync(readFileSync(part.path)).toString("utf8");
 }
 

--- a/packages/progressive-review/src/server/bug-report-trace.test.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.test.ts
@@ -4,6 +4,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  truncateSync,
   utimesSync,
   writeFileSync,
 } from "node:fs";
@@ -18,6 +19,7 @@ import type { ReviewAgentHarness } from "../authoring-session";
 import { clearTraceEnvCache } from "../review-agent-traces";
 import {
   type AuthoringTraceAttachment,
+  MAX_AUTHORING_TRACE_BYTES,
   readAuthoringTraceAttachment,
 } from "./bug-report-trace";
 
@@ -29,6 +31,7 @@ describe("readAuthoringTraceAttachment", () => {
   let claudeRoot: string;
   let codexRoot: string;
   let piRoot: string;
+  let originalCodexHome: string | undefined;
 
   beforeEach(() => {
     tempDir = mkdtempSync(path.join(tmpdir(), "bug-report-trace-"));
@@ -36,6 +39,7 @@ describe("readAuthoringTraceAttachment", () => {
     claudeRoot = path.join(tempDir, "claude");
     codexRoot = path.join(tempDir, "codex");
     piRoot = path.join(tempDir, "pi");
+    originalCodexHome = process.env.CODEX_HOME;
     for (const directory of [reviewRootPath, claudeRoot, codexRoot, piRoot]) {
       mkdirSync(directory, { recursive: true });
     }
@@ -49,6 +53,8 @@ describe("readAuthoringTraceAttachment", () => {
     delete process.env.TRACE_LOCAL_TRACE_ROOT;
     delete process.env.TRACE_CODEX_SESSIONS_ROOT;
     delete process.env.TRACE_PI_SESSIONS_ROOT;
+    if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = originalCodexHome;
     clearTraceEnvCache();
     rmSync(tempDir, { recursive: true, force: true });
   });
@@ -101,6 +107,52 @@ describe("readAuthoringTraceAttachment", () => {
     await attachment.cleanup();
   });
 
+  it("does not require ordinals on an untrimmed Codex source", async () => {
+    const id = "10201020-1020-4020-8020-102010201020";
+    const source =
+      jsonLine({ type: "session_meta", payload: { id } }) +
+      jsonLine({ standalone: true });
+    writeCodexTrace(id, source);
+    writeReview("codex:" + id);
+
+    const attachment = await requiredAttachment();
+    expect(readPart(attachment, 0)).toBe(source);
+    expect(attachment.parts).toHaveLength(1);
+    await attachment.cleanup();
+  });
+
+  it("uses the first sorted Codex rollout when duplicate files exist", async () => {
+    const id = "10301030-1030-4030-8030-103010301030";
+    const first = codexTrace(id, 0, [{ selected: true }]);
+    writeCodexTrace(id, first);
+    const duplicateDir = path.join(codexRoot, "2027", "01", "01");
+    mkdirSync(duplicateDir, { recursive: true });
+    writeFileSync(
+      path.join(duplicateDir, "rollout-2027-01-01T00-00-00-" + id + ".jsonl"),
+      codexTrace(id, 0, [{ selected: false }]),
+    );
+    writeReview("codex:" + id);
+
+    const attachment = await requiredAttachment();
+    expect(readPart(attachment, 0)).toBe(first);
+    await attachment.cleanup();
+  });
+
+  it("discovers Codex rollouts under CODEX_HOME", async () => {
+    const id = "10401040-1040-4040-8040-104010401040";
+    const source = codexTrace(id, 0, [{ customHome: true }]);
+    delete process.env.TRACE_CODEX_SESSIONS_ROOT;
+    process.env.CODEX_HOME = path.join(tempDir, "custom-codex-home");
+    codexRoot = path.join(process.env.CODEX_HOME, "sessions");
+    clearTraceEnvCache();
+    writeCodexTrace(id, source);
+    writeReview("codex:" + id);
+
+    const attachment = await requiredAttachment();
+    expect(readPart(attachment, 0)).toBe(source);
+    await attachment.cleanup();
+  });
+
   it("stores Codex lineage leaf first and excludes post-fork records", async () => {
     const grandparentId = "11111111-1111-4111-8111-111111111111";
     const parentId = "22222222-2222-4222-8222-222222222222";
@@ -150,9 +202,16 @@ describe("readAuthoringTraceAttachment", () => {
     writeReview("codex:" + childId);
     await expect(
       readAuthoringTraceAttachment({ reviewRootPath }),
-    ).rejects.toThrow("exactly one rollout");
+    ).rejects.toThrow("parent could not be resolved");
 
-    writeCodexTrace(parentId, '{"ordinal":0}\nnot-json\n');
+    writeCodexTrace(
+      parentId,
+      jsonLine({
+        type: "session_meta",
+        payload: { id: parentId },
+        ordinal: 0,
+      }) + "not-json\n",
+    );
     await expect(
       readAuthoringTraceAttachment({ reviewRootPath }),
     ).rejects.toThrow("malformed JSONL");
@@ -242,6 +301,46 @@ describe("readAuthoringTraceAttachment", () => {
     await attachment.cleanup();
   });
 
+  it("propagates the earliest fork boundary and skips an empty parent part", async () => {
+    const grandparentId = "61616161-6161-4161-8161-616161616161";
+    const parentId = "62626262-6262-4262-8262-626262626262";
+    const childId = "63636363-6363-4363-8363-636363636363";
+    const grandparentAtLeafFork = codexTrace(grandparentId, 0, [
+      { inherited: 1 },
+      { inherited: 2 },
+    ]);
+    writeCodexTrace(
+      grandparentId,
+      grandparentAtLeafFork + jsonLine({ unseen: true, ordinal: 3 }),
+    );
+    writeCodexTrace(
+      parentId,
+      codexTrace(
+        parentId,
+        6,
+        [{ parentOwnRecord: true }],
+        historyBase(grandparentId, 6),
+      ),
+    );
+    const child = codexTrace(
+      childId,
+      3,
+      [{ child: true }],
+      historyBase(parentId, 3),
+    );
+    writeCodexTrace(childId, child);
+    writeReview("codex:" + childId);
+
+    const attachment = await requiredAttachment();
+    expect(attachment.parts.map((part) => part.session_id)).toEqual([
+      childId,
+      grandparentId,
+    ]);
+    expect(readPart(attachment, 0)).toBe(child);
+    expect(readPart(attachment, 1)).toBe(grandparentAtLeafFork);
+    await attachment.cleanup();
+  });
+
   it("accepts 32 Codex parent levels and rejects 33", async () => {
     let parentId = codexId(0);
     writeCodexTrace(parentId, codexTrace(parentId, 0, [{ depth: 0 }]));
@@ -286,6 +385,27 @@ describe("readAuthoringTraceAttachment", () => {
     await attachment.cleanup();
   });
 
+  it("rejects an oversized lineage before materializing it", async () => {
+    const parentId = "67676767-6767-4767-8767-676767676767";
+    const childId = "68686868-6868-4868-8868-686868686868";
+    const parentPath = writeCodexTrace(
+      parentId,
+      codexTrace(parentId, 0, [{ parent: true }]),
+    );
+    const childPath = writeCodexTrace(
+      childId,
+      codexTrace(childId, 2, [{ child: true }], historyBase(parentId, 2)),
+    );
+    const halfBudget = Math.floor(MAX_AUTHORING_TRACE_BYTES / 2) + 1;
+    truncateSync(parentPath, halfBudget);
+    truncateSync(childPath, halfBudget);
+    writeReview("codex:" + childId);
+
+    await expect(
+      readAuthoringTraceAttachment({ reviewRootPath }),
+    ).rejects.toThrow("exceeds the supported size");
+  });
+
   it("waits for an incomplete final record and then keeps it", async () => {
     const id = "77777777-7777-4777-8777-777777777777";
     const complete = jsonLine({ complete: true });
@@ -315,6 +435,9 @@ describe("readAuthoringTraceAttachment", () => {
 
   it("redacts complete secret values but keeps valid JSONL", async () => {
     const id = "99999999-9999-4999-8999-999999999999";
+    const googleApiKey = "AIza" + "a".repeat(35);
+    const entraToken = "eyJ0eXAiOiJKV1Qi.abc.def";
+    const jwt = "eyJzdWIiOiIxMjM0NTY3ODkw.abc.def";
     const slackToken = [
       "xoxb",
       "123456789012",
@@ -322,9 +445,14 @@ describe("readAuthoringTraceAttachment", () => {
       "abcdefghijklmnop",
     ].join("-");
     const githubToken = "ghp_" + "b".repeat(36);
+    const ordinaryBase64 = "U29tZUJhc2U2NERhdGFXaXRob3V0U2VjcmV0";
     const source = jsonLine({
       prompt: "Use " + slackToken,
+      googleApiKey,
+      entraToken,
+      jwt,
       githubToken,
+      ordinaryBase64,
       path: "/Users/reviewer/project/src/auth.ts",
     });
     writeReview("claude-code:" + id);
@@ -332,10 +460,17 @@ describe("readAuthoringTraceAttachment", () => {
 
     const attachment = await requiredAttachment();
     const trace = readPart(attachment, 0);
-    expect(trace).not.toContain(slackToken);
-    expect(trace).not.toContain(githubToken);
-    expect(trace).toContain("<REDACTED: Slack Token>");
-    expect(trace).toContain("<REDACTED: GitHub Token>");
+    for (const [secret, label] of [
+      [googleApiKey, "Google API Key"],
+      [entraToken, "Microsoft Entra ID"],
+      [jwt, "JWT"],
+      [slackToken, "Slack Token"],
+      [githubToken, "GitHub Token"],
+    ]) {
+      expect(trace).not.toContain(secret);
+      expect(trace).toContain(`<REDACTED: ${label}>`);
+    }
+    expect(trace).toContain(ordinaryBase64);
     expect(trace).toContain("/Users/reviewer/project/src/auth.ts");
     expect(() => JSON.parse(trace.trim())).not.toThrow();
     await attachment.cleanup();

--- a/packages/progressive-review/src/server/bug-report-trace.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { createReadStream, createWriteStream } from "node:fs";
 import { mkdtemp, open, readdir, rm, stat } from "node:fs/promises";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -12,13 +12,21 @@ import {
   type ReviewAgentHarness,
   parseAuthoringSessionKey,
 } from "../authoring-session";
-import { findLocalTrace, traceEnvValue } from "../review-agent-traces";
+import {
+  codexSessionsRoot,
+  findCodexTraceInFiles,
+  findLocalTrace,
+  indexCodexTraceFiles,
+} from "../review-agent-traces";
 import { readReviewStoreRecord } from "../review-worktree-target";
 import { USER_DATA_REGEXES } from "../telemetry-clean-text";
 
 const MAX_SUBAGENT_TRACE_BYTES = 1024 * 1024;
 const MAX_SUBAGENT_TRACES = 10;
 const MAX_CODEX_ANCESTRY_DEPTH = 32;
+export const MAX_AUTHORING_TRACE_BYTES = 256 * 1024 * 1024;
+const MAX_CODEX_METADATA_BYTES = 1024 * 1024;
+const MAX_JSONL_RECORD_COMPLETION_BYTES = 1024 * 1024;
 const INCOMPLETE_FINAL_LINE_RETRIES = 3;
 const INCOMPLETE_FINAL_LINE_RETRY_MS = 50;
 
@@ -64,41 +72,48 @@ interface CodexHistoryBase {
   endOrdinalExclusive: number;
 }
 
-interface CodexSnapshot extends JsonlSnapshot {
+interface CodexMetadata {
   sessionId: string;
   historyBase?: CodexHistoryBase;
 }
 
 interface ResolvedTraceFile {
   sessionId: string;
-  snapshot: JsonlSnapshot;
+  path: string;
+  snapshotBytes: number;
   endOrdinalExclusive?: number;
 }
 
-const TRACE_SECRET_LABELS = new Set([
+const TRACE_SECRET_LABELS = [
   "Google API Key",
+  "Microsoft Entra ID",
   "JWT",
   "Slack Token",
   "GitHub Token",
-  "Microsoft Entra ID",
-]);
+] as const;
 
-const TRACE_SECRET_REGEXES = USER_DATA_REGEXES.filter(({ label }) =>
-  TRACE_SECRET_LABELS.has(label),
-).map(({ label, regex }) => ({
-  label,
-  // Shared telemetry only needs to detect these values. Trace reports retain
-  // their lines, so these expressions must consume the complete secret.
-  regex:
-    label === "Slack Token"
-      ? /xox[pbar]-[A-Za-z0-9-]+/g
-      : label === "Microsoft Entra ID"
-        ? /eyJ(?:0eXAiOiJKV1Qi|hbGci)[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g
-        : new RegExp(
-            regex.source,
-            regex.flags.includes("g") ? regex.flags : `${regex.flags}g`,
-          ),
-}));
+const TRACE_SECRET_REGEXES = TRACE_SECRET_LABELS.map((label) => {
+  const entry = USER_DATA_REGEXES.find(
+    (candidate) => candidate.label === label,
+  );
+  if (!entry) throw new Error(`Missing trace secret redaction for ${label}.`);
+  return {
+    label,
+    // Shared telemetry only needs to detect these values. Trace reports retain
+    // their lines, so these expressions must consume the complete secret.
+    regex:
+      label === "Slack Token"
+        ? /xox[pbar]-[A-Za-z0-9-]+/g
+        : label === "Microsoft Entra ID"
+          ? /eyJ(?:0eXAiOiJKV1Qi|hbGci)[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g
+          : new RegExp(
+              entry.regex.source,
+              entry.regex.flags.includes("g")
+                ? entry.regex.flags
+                : `${entry.regex.flags}g`,
+            ),
+  };
+});
 
 export async function readAuthoringTraceAttachment(input: {
   reviewRootPath: string;
@@ -117,19 +132,20 @@ export async function readAuthoringTraceAttachment(input: {
       sourceSession.sessionId,
       localTrace.tracePath,
     );
-    const parts = await Promise.all(
-      lineage.map((entry, index) =>
-        writeTracePart({
-          index,
-          sessionId: entry.sessionId,
-          outputPath: path.join(tempRoot, `trace-${index}.jsonl.gz`),
-          snapshot: entry.snapshot,
-          ...(entry.endOrdinalExclusive !== undefined
-            ? { endOrdinalExclusive: entry.endOrdinalExclusive }
-            : {}),
-        }),
-      ),
-    );
+    const parts: AuthoringTraceUploadPart[] = [];
+    for (const entry of lineage) {
+      const snapshot = await readJsonlSnapshot(entry.path, entry.snapshotBytes);
+      const part = await writeTracePart({
+        index: parts.length,
+        sessionId: entry.sessionId,
+        outputPath: path.join(tempRoot, `trace-${parts.length}.jsonl.gz`),
+        snapshot,
+        ...(entry.endOrdinalExclusive !== undefined
+          ? { endOrdinalExclusive: entry.endOrdinalExclusive }
+          : {}),
+      });
+      if (part) parts.push(part);
+    }
 
     const subagents = await readSubagentAttachments(localTrace.subagentPaths);
     return {
@@ -145,7 +161,7 @@ export async function readAuthoringTraceAttachment(input: {
       cleanup: () => rm(tempRoot, { recursive: true, force: true }),
     };
   } catch (error) {
-    await rm(tempRoot, { recursive: true, force: true });
+    await rm(tempRoot, { recursive: true, force: true }).catch(() => {});
     throw error;
   }
 }
@@ -156,61 +172,68 @@ async function resolveTraceLineage(
   tracePath: string,
 ): Promise<ResolvedTraceFile[]> {
   if (harness !== "codex") {
-    return [{ sessionId, snapshot: await readJsonlSnapshot(tracePath) }];
+    const snapshotBytes = await traceFileSize(tracePath);
+    return [{ sessionId, path: tracePath, snapshotBytes }];
   }
 
+  const rollouts = await listFilesRecursive(codexSessionsRoot());
+  const rolloutIndex = indexCodexTraceFiles(rollouts);
+  const resolvePath = (targetSessionId: string): string => {
+    if (targetSessionId === sessionId) return tracePath;
+    const resolved =
+      rolloutIndex.get(targetSessionId) ??
+      findCodexTraceInFiles(rollouts, targetSessionId);
+    if (!resolved) throw new Error("Codex trace parent could not be resolved.");
+    return resolved;
+  };
   const chain: ResolvedTraceFile[] = [];
   const seen = new Set<string>();
-  let current = await resolveCodexSnapshot(sessionId);
-  if (path.resolve(current.path) !== path.resolve(tracePath)) {
-    throw new Error("Codex source trace resolution is ambiguous.");
-  }
+  let currentSessionId = sessionId;
   let endOrdinalExclusive: number | undefined;
   while (true) {
-    if (seen.has(current.sessionId)) {
+    if (seen.has(currentSessionId)) {
       throw new Error("Codex trace ancestry contains a cycle.");
     }
     if (seen.size >= MAX_CODEX_ANCESTRY_DEPTH + 1) {
       throw new Error("Codex trace ancestry exceeds the supported depth.");
     }
-    seen.add(current.sessionId);
+    seen.add(currentSessionId);
+    const currentPath = resolvePath(currentSessionId);
+    const current = await readCodexMetadata(currentPath, currentSessionId);
     chain.push({
       sessionId: current.sessionId,
-      snapshot: current,
+      path: currentPath,
+      snapshotBytes: await traceFileSize(currentPath),
       ...(endOrdinalExclusive !== undefined ? { endOrdinalExclusive } : {}),
     });
-    if (!current.historyBase) return chain;
-    endOrdinalExclusive = current.historyBase.endOrdinalExclusive;
-    current = await resolveCodexSnapshot(current.historyBase.threadId);
+    if (!current.historyBase) break;
+    endOrdinalExclusive = Math.min(
+      endOrdinalExclusive ?? Number.POSITIVE_INFINITY,
+      current.historyBase.endOrdinalExclusive,
+    );
+    currentSessionId = current.historyBase.threadId;
   }
+  const lineageBytes = chain.reduce(
+    (total, entry) => total + entry.snapshotBytes,
+    0,
+  );
+  if (lineageBytes > MAX_AUTHORING_TRACE_BYTES) {
+    throw new Error("Trace lineage exceeds the supported size.");
+  }
+  return chain;
 }
 
-async function resolveCodexSnapshot(sessionId: string): Promise<CodexSnapshot> {
-  const codexRoot =
-    traceEnvValue("TRACE_CODEX_SESSIONS_ROOT") ||
-    path.join(homedir(), ".codex", "sessions");
-  const suffix = `-${sessionId}.jsonl`;
-  const candidates = (await listFilesRecursive(codexRoot)).filter((entry) => {
-    const name = path.basename(entry);
-    return name.startsWith("rollout-") && name.endsWith(suffix);
-  });
-  if (candidates.length !== 1) {
-    throw new Error("Codex trace resolution requires exactly one rollout.");
-  }
-
-  const snapshot = await readJsonlSnapshot(candidates[0]);
-  const first = snapshot.records[0];
-  if (first?.value.type !== "session_meta") {
+async function readCodexMetadata(
+  filePath: string,
+  sessionId: string,
+): Promise<CodexMetadata> {
+  const first = await readFirstJsonlRecord(filePath);
+  if (first.type !== "session_meta") {
     throw new Error("Codex trace does not start with session metadata.");
   }
-  const payload = objectValue(first.value.payload);
+  const payload = objectValue(first.payload);
   if (payload?.id !== sessionId) {
     throw new Error("Codex trace metadata does not match its session id.");
-  }
-  for (const record of snapshot.records) {
-    if (!Number.isSafeInteger(record.ordinal) || (record.ordinal ?? -1) < 0) {
-      throw new Error("Codex trace record is missing a valid ordinal.");
-    }
   }
   const historyBaseValue = objectValue(payload.history_base);
   let historyBase: CodexHistoryBase | undefined;
@@ -229,10 +252,38 @@ async function resolveCodexSnapshot(sessionId: string): Promise<CodexSnapshot> {
   }
 
   return {
-    ...snapshot,
     sessionId,
     ...(historyBase ? { historyBase } : {}),
   };
+}
+
+async function readFirstJsonlRecord(filePath: string): Promise<JsonObject> {
+  const handle = await open(filePath, "r");
+  try {
+    const { size } = await handle.stat();
+    if (size <= 0) throw new Error("Trace file is empty.");
+    const length = Math.min(size, MAX_CODEX_METADATA_BYTES);
+    const bytes = await readBytes(handle, 0, length);
+    const newline = bytes.indexOf(0x0a);
+    if (newline === -1 && size > length) {
+      throw new Error("Codex session metadata is too large.");
+    }
+    const record = parseJsonl(
+      newline === -1 ? bytes : bytes.subarray(0, newline + 1),
+    );
+    return record[0].value;
+  } finally {
+    await handle.close();
+  }
+}
+
+async function traceFileSize(filePath: string): Promise<number> {
+  const { size } = await stat(filePath);
+  if (size <= 0) throw new Error("Trace file is empty.");
+  if (size > MAX_AUTHORING_TRACE_BYTES) {
+    throw new Error("Trace lineage exceeds the supported size.");
+  }
+  return size;
 }
 
 async function listFilesRecursive(root: string): Promise<string[]> {
@@ -249,28 +300,36 @@ async function listFilesRecursive(root: string): Promise<string[]> {
   return results.sort();
 }
 
-async function readJsonlSnapshot(filePath: string): Promise<JsonlSnapshot> {
+async function readJsonlSnapshot(
+  filePath: string,
+  snapshotBytes: number,
+): Promise<JsonlSnapshot> {
   const handle = await open(filePath, "r");
   try {
-    const initialSize = (await handle.stat()).size;
-    if (initialSize <= 0) throw new Error("Trace file is empty.");
-    let bytes = await readBytes(handle, initialSize);
-    try {
-      return { path: filePath, records: parseJsonl(bytes) };
-    } catch (error) {
-      if (!(error instanceof IncompleteFinalRecordError)) throw error;
-    }
-
-    for (let attempt = 0; attempt < INCOMPLETE_FINAL_LINE_RETRIES; attempt++) {
-      await delay(INCOMPLETE_FINAL_LINE_RETRY_MS);
-      const currentSize = (await handle.stat()).size;
-      if (currentSize <= initialSize) continue;
-      const currentBytes = await readBytes(handle, currentSize);
-      const completionEnd = currentBytes.indexOf(0x0a, initialSize);
-      bytes =
-        completionEnd === -1
-          ? currentBytes
-          : currentBytes.subarray(0, completionEnd + 1);
+    let bytes = await readBytes(handle, 0, snapshotBytes);
+    for (let attempt = 0; attempt <= INCOMPLETE_FINAL_LINE_RETRIES; attempt++) {
+      if (attempt > 0) {
+        await delay(INCOMPLETE_FINAL_LINE_RETRY_MS);
+        const currentSize = (await handle.stat()).size;
+        if (currentSize > bytes.length) {
+          const nextSize = Math.min(
+            currentSize,
+            bytes.length + MAX_JSONL_RECORD_COMPLETION_BYTES,
+          );
+          const appended = await readBytes(
+            handle,
+            bytes.length,
+            nextSize - bytes.length,
+          );
+          const completionEnd = appended.indexOf(0x0a);
+          bytes = Buffer.concat([
+            bytes,
+            completionEnd === -1
+              ? appended
+              : appended.subarray(0, completionEnd + 1),
+          ]);
+        }
+      }
       try {
         return { path: filePath, records: parseJsonl(bytes) };
       } catch (error) {
@@ -285,12 +344,18 @@ async function readJsonlSnapshot(filePath: string): Promise<JsonlSnapshot> {
 
 async function readBytes(
   handle: Awaited<ReturnType<typeof open>>,
+  position: number,
   size: number,
 ): Promise<Buffer> {
   const bytes = Buffer.alloc(size);
   let offset = 0;
   while (offset < size) {
-    const result = await handle.read(bytes, offset, size - offset, offset);
+    const result = await handle.read(
+      bytes,
+      offset,
+      size - offset,
+      position + offset,
+    );
     if (result.bytesRead === 0) break;
     offset += result.bytesRead;
   }
@@ -344,19 +409,17 @@ async function writeTracePart(input: {
   outputPath: string;
   snapshot: JsonlSnapshot;
   endOrdinalExclusive?: number;
-}): Promise<AuthoringTraceUploadPart> {
+}): Promise<AuthoringTraceUploadPart | null> {
   const records =
     input.endOrdinalExclusive === undefined
       ? input.snapshot.records
       : input.snapshot.records.filter((record) => {
-          if (record.ordinal === undefined) {
-            throw new Error("Codex trace record is missing an ordinal.");
+          if (record.ordinal === undefined || record.ordinal < 0) {
+            throw new Error("Codex trace record is missing a valid ordinal.");
           }
           return record.ordinal < input.endOrdinalExclusive!;
         });
-  if (records.length === 0) {
-    throw new Error("Trace part has no records before the fork point.");
-  }
+  if (records.length === 0) return null;
   const source = Readable.from(
     (async function* () {
       for (const record of records) {

--- a/packages/progressive-review/src/server/bug-report-trace.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.ts
@@ -61,14 +61,11 @@ interface JsonlRecord {
   value: JsonObject;
   raw: string;
   terminator: string;
-  start: number;
-  end: number;
   ordinal?: number;
 }
 
 interface JsonlSnapshot {
   path: string;
-  bytes: Buffer;
   records: JsonlRecord[];
   sessionId?: string;
 }
@@ -290,7 +287,7 @@ async function readJsonlSnapshot(filePath: string): Promise<JsonlSnapshot> {
     if (initialSize <= 0) throw new Error("Trace file is empty.");
     let bytes = await readBytes(handle, initialSize);
     try {
-      return { path: filePath, bytes, records: parseJsonl(bytes) };
+      return { path: filePath, records: parseJsonl(bytes) };
     } catch (error) {
       if (!(error instanceof IncompleteFinalRecordError)) throw error;
     }
@@ -306,7 +303,7 @@ async function readJsonlSnapshot(filePath: string): Promise<JsonlSnapshot> {
           ? currentBytes
           : currentBytes.subarray(0, completionEnd + 1);
       try {
-        return { path: filePath, bytes, records: parseJsonl(bytes) };
+        return { path: filePath, records: parseJsonl(bytes) };
       } catch (error) {
         if (!(error instanceof IncompleteFinalRecordError)) throw error;
       }
@@ -362,8 +359,6 @@ function parseJsonl(bytes: Buffer): JsonlRecord[] {
       value,
       raw,
       terminator: lineFeed === -1 ? "" : "\n",
-      start,
-      end,
       ...(Number.isSafeInteger(value.ordinal)
         ? { ordinal: value.ordinal as number }
         : {}),

--- a/packages/progressive-review/src/server/bug-report-trace.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.ts
@@ -1,11 +1,10 @@
 import { createHash } from "node:crypto";
-import { createReadStream, createWriteStream } from "node:fs";
-import { mkdtemp, open, readdir, rm, stat } from "node:fs/promises";
+import { createWriteStream } from "node:fs";
+import { mkdtemp, open, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { Readable } from "node:stream";
+import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import { setTimeout as delay } from "node:timers/promises";
 import { createGzip } from "node:zlib";
 
 import {
@@ -14,9 +13,9 @@ import {
 } from "../authoring-session";
 import {
   codexSessionsRoot,
-  findCodexTraceInFiles,
   findLocalTrace,
   indexCodexTraceFiles,
+  listFilesRecursive,
 } from "../review-agent-traces";
 import { readReviewStoreRecord } from "../review-worktree-target";
 import { USER_DATA_REGEXES } from "../telemetry-clean-text";
@@ -26,12 +25,11 @@ const MAX_SUBAGENT_TRACES = 10;
 const MAX_CODEX_ANCESTRY_DEPTH = 32;
 export const MAX_AUTHORING_TRACE_BYTES = 256 * 1024 * 1024;
 const MAX_CODEX_METADATA_BYTES = 1024 * 1024;
-const MAX_JSONL_RECORD_COMPLETION_BYTES = 1024 * 1024;
-const INCOMPLETE_FINAL_LINE_RETRIES = 3;
-const INCOMPLETE_FINAL_LINE_RETRY_MS = 50;
+const TRACE_READ_CHUNK_BYTES = 1024 * 1024;
 
 export interface AuthoringTracePayload {
   harness: ReviewAgentHarness;
+  session_id: string;
   files: Record<string, string>;
   omitted_files?: string[];
   truncated: boolean;
@@ -55,18 +53,6 @@ interface JsonObject {
   [key: string]: unknown;
 }
 
-interface JsonlRecord {
-  value: JsonObject;
-  raw: string;
-  terminator: string;
-  ordinal?: number;
-}
-
-interface JsonlSnapshot {
-  path: string;
-  records: JsonlRecord[];
-}
-
 interface CodexHistoryBase {
   threadId: string;
   endOrdinalExclusive: number;
@@ -75,13 +61,6 @@ interface CodexHistoryBase {
 interface CodexMetadata {
   sessionId: string;
   historyBase?: CodexHistoryBase;
-}
-
-interface ResolvedTraceFile {
-  sessionId: string;
-  path: string;
-  snapshotBytes: number;
-  endOrdinalExclusive?: number;
 }
 
 const TRACE_SECRET_LABELS = [
@@ -127,37 +106,26 @@ export async function readAuthoringTraceAttachment(input: {
 
   const tempRoot = await mkdtemp(path.join(tmpdir(), "review-bug-trace-"));
   try {
-    const lineage = await resolveTraceLineage(
-      sourceSession.harness,
-      sourceSession.sessionId,
-      localTrace.tracePath,
-    );
-    const parts: AuthoringTraceUploadPart[] = [];
-    for (const entry of lineage) {
-      const snapshot = await readJsonlSnapshot(entry.path, entry.snapshotBytes);
-      const part = await writeTracePart({
-        index: parts.length,
-        sessionId: entry.sessionId,
-        outputPath: path.join(tempRoot, `trace-${parts.length}.jsonl.gz`),
-        snapshot,
-        ...(entry.endOrdinalExclusive !== undefined
-          ? { endOrdinalExclusive: entry.endOrdinalExclusive }
-          : {}),
-      });
-      if (part) parts.push(part);
-    }
-
+    const lineage = await writeTraceLineage({
+      harness: sourceSession.harness,
+      sessionId: sourceSession.sessionId,
+      tracePath: localTrace.tracePath,
+      tempRoot,
+    });
     const subagents = await readSubagentAttachments(localTrace.subagentPaths);
+    const omittedFiles = [
+      ...lineage.omittedFiles,
+      ...subagents.omittedFiles,
+    ].sort();
     return {
       payload: {
         harness: sourceSession.harness,
+        session_id: sourceSession.sessionId,
         files: subagents.files,
-        ...(subagents.omittedFiles.length > 0
-          ? { omitted_files: subagents.omittedFiles }
-          : {}),
-        truncated: subagents.truncated,
+        ...(omittedFiles.length > 0 ? { omitted_files: omittedFiles } : {}),
+        truncated: lineage.truncated || subagents.truncated,
       },
-      parts,
+      parts: lineage.parts,
       cleanup: () => rm(tempRoot, { recursive: true, force: true }),
     };
   } catch (error) {
@@ -166,61 +134,91 @@ export async function readAuthoringTraceAttachment(input: {
   }
 }
 
-async function resolveTraceLineage(
-  harness: ReviewAgentHarness,
+// The source session's own trace is required: a report that opted into the
+// trace fails without it. Ancestors are best effort. The report keeps the
+// parts it has written and names the first ancestor it could not include.
+async function writeTraceLineage(input: {
+  harness: ReviewAgentHarness;
+  sessionId: string;
+  tracePath: string;
+  tempRoot: string;
+}): Promise<{
+  parts: AuthoringTraceUploadPart[];
+  omittedFiles: string[];
+  truncated: boolean;
+}> {
+  const parts: AuthoringTraceUploadPart[] = [];
+  const omittedFiles: string[] = [];
+  let truncated = false;
+  const resolveRollout =
+    input.harness === "codex"
+      ? codexRolloutResolver(input.sessionId, input.tracePath)
+      : undefined;
+  const seen = new Set<string>();
+  let sessionId = input.sessionId;
+  let lineageBytes = 0;
+  let endOrdinalExclusive: number | undefined;
+  while (true) {
+    let historyBase: CodexHistoryBase | undefined;
+    try {
+      if (seen.has(sessionId)) {
+        throw new Error("Codex trace ancestry contains a cycle.");
+      }
+      if (seen.size > MAX_CODEX_ANCESTRY_DEPTH) {
+        throw new Error("Codex trace ancestry exceeds the supported depth.");
+      }
+      seen.add(sessionId);
+      const sourcePath = resolveRollout
+        ? resolveRollout(sessionId)
+        : input.tracePath;
+      const snapshotBytes = await traceFileSize(sourcePath);
+      lineageBytes += snapshotBytes;
+      if (lineageBytes > MAX_AUTHORING_TRACE_BYTES) {
+        throw new Error("Trace lineage exceeds the supported size.");
+      }
+      if (resolveRollout) {
+        historyBase = (await readCodexMetadata(sourcePath, sessionId))
+          .historyBase;
+      }
+      const written = await writeTracePart({
+        index: parts.length,
+        sessionId,
+        sourcePath,
+        snapshotBytes,
+        outputPath: path.join(input.tempRoot, `trace-${parts.length}.jsonl.gz`),
+        ...(endOrdinalExclusive !== undefined ? { endOrdinalExclusive } : {}),
+      });
+      truncated ||= written.truncated;
+      if (written.part) parts.push(written.part);
+      else if (parts.length === 0) throw new Error("Trace file is empty.");
+    } catch (error) {
+      if (parts.length === 0) throw error;
+      omittedFiles.push(`ancestors/${sessionId}.jsonl`);
+      truncated = true;
+      break;
+    }
+    if (!historyBase) break;
+    endOrdinalExclusive = Math.min(
+      endOrdinalExclusive ?? Number.POSITIVE_INFINITY,
+      historyBase.endOrdinalExclusive,
+    );
+    sessionId = historyBase.threadId;
+  }
+  return { parts, omittedFiles, truncated };
+}
+
+function codexRolloutResolver(
   sessionId: string,
   tracePath: string,
-): Promise<ResolvedTraceFile[]> {
-  if (harness !== "codex") {
-    const snapshotBytes = await traceFileSize(tracePath);
-    return [{ sessionId, path: tracePath, snapshotBytes }];
-  }
-
-  const rollouts = await listFilesRecursive(codexSessionsRoot());
-  const rolloutIndex = indexCodexTraceFiles(rollouts);
-  const resolvePath = (targetSessionId: string): string => {
+): (targetSessionId: string) => string {
+  let index: Map<string, string> | undefined;
+  return (targetSessionId) => {
     if (targetSessionId === sessionId) return tracePath;
-    const resolved =
-      rolloutIndex.get(targetSessionId) ??
-      findCodexTraceInFiles(rollouts, targetSessionId);
+    index ??= indexCodexTraceFiles(listFilesRecursive(codexSessionsRoot()));
+    const resolved = index.get(targetSessionId);
     if (!resolved) throw new Error("Codex trace parent could not be resolved.");
     return resolved;
   };
-  const chain: ResolvedTraceFile[] = [];
-  const seen = new Set<string>();
-  let currentSessionId = sessionId;
-  let endOrdinalExclusive: number | undefined;
-  while (true) {
-    if (seen.has(currentSessionId)) {
-      throw new Error("Codex trace ancestry contains a cycle.");
-    }
-    if (seen.size >= MAX_CODEX_ANCESTRY_DEPTH + 1) {
-      throw new Error("Codex trace ancestry exceeds the supported depth.");
-    }
-    seen.add(currentSessionId);
-    const currentPath = resolvePath(currentSessionId);
-    const current = await readCodexMetadata(currentPath, currentSessionId);
-    chain.push({
-      sessionId: current.sessionId,
-      path: currentPath,
-      snapshotBytes: await traceFileSize(currentPath),
-      ...(endOrdinalExclusive !== undefined ? { endOrdinalExclusive } : {}),
-    });
-    if (!current.historyBase) break;
-    endOrdinalExclusive = Math.min(
-      endOrdinalExclusive ?? Number.POSITIVE_INFINITY,
-      current.historyBase.endOrdinalExclusive,
-    );
-    currentSessionId = current.historyBase.threadId;
-  }
-  const lineageBytes = chain.reduce(
-    (total, entry) => total + entry.snapshotBytes,
-    0,
-  );
-  if (lineageBytes > MAX_AUTHORING_TRACE_BYTES) {
-    throw new Error("Trace lineage exceeds the supported size.");
-  }
-  return chain;
 }
 
 async function readCodexMetadata(
@@ -258,23 +256,13 @@ async function readCodexMetadata(
 }
 
 async function readFirstJsonlRecord(filePath: string): Promise<JsonObject> {
-  const handle = await open(filePath, "r");
-  try {
-    const { size } = await handle.stat();
-    if (size <= 0) throw new Error("Trace file is empty.");
-    const length = Math.min(size, MAX_CODEX_METADATA_BYTES);
-    const bytes = await readBytes(handle, 0, length);
-    const newline = bytes.indexOf(0x0a);
-    if (newline === -1 && size > length) {
-      throw new Error("Codex session metadata is too large.");
-    }
-    const record = parseJsonl(
-      newline === -1 ? bytes : bytes.subarray(0, newline + 1),
-    );
-    return record[0].value;
-  } finally {
-    await handle.close();
+  for await (const line of readJsonlLines(filePath, MAX_CODEX_METADATA_BYTES)) {
+    if (line.trim() === "") continue;
+    const value = parseJsonObject(line);
+    if (!value) throw new Error("Codex session metadata is malformed.");
+    return value;
   }
+  throw new Error("Trace file is empty.");
 }
 
 async function traceFileSize(filePath: string): Promise<number> {
@@ -286,167 +274,103 @@ async function traceFileSize(filePath: string): Promise<number> {
   return size;
 }
 
-async function listFilesRecursive(root: string): Promise<string[]> {
-  const results: string[] = [];
-  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
-  for (const entry of entries) {
-    const entryPath = path.join(root, entry.name);
-    if (entry.isDirectory()) {
-      results.push(...(await listFilesRecursive(entryPath)));
-    } else if (entry.isFile()) {
-      results.push(entryPath);
-    }
-  }
-  return results.sort();
-}
-
-async function readJsonlSnapshot(
+// Yields each line without its line feed. Reads at most `byteLimit` bytes, so
+// a trace that grows during the read stays at its measured snapshot. A final
+// line cut by that limit, or one the harness is still writing, is yielded
+// as-is and fails to parse.
+async function* readJsonlLines(
   filePath: string,
-  snapshotBytes: number,
-): Promise<JsonlSnapshot> {
+  byteLimit: number,
+): AsyncGenerator<string> {
   const handle = await open(filePath, "r");
   try {
-    let bytes = await readBytes(handle, 0, snapshotBytes);
-    for (let attempt = 0; attempt <= INCOMPLETE_FINAL_LINE_RETRIES; attempt++) {
-      if (attempt > 0) {
-        await delay(INCOMPLETE_FINAL_LINE_RETRY_MS);
-        const currentSize = (await handle.stat()).size;
-        if (currentSize > bytes.length) {
-          const nextSize = Math.min(
-            currentSize,
-            bytes.length + MAX_JSONL_RECORD_COMPLETION_BYTES,
-          );
-          const appended = await readBytes(
-            handle,
-            bytes.length,
-            nextSize - bytes.length,
-          );
-          const completionEnd = appended.indexOf(0x0a);
-          bytes = Buffer.concat([
-            bytes,
-            completionEnd === -1
-              ? appended
-              : appended.subarray(0, completionEnd + 1),
-          ]);
-        }
+    let carry = Buffer.alloc(0);
+    let position = 0;
+    while (position < byteLimit) {
+      const chunk = Buffer.alloc(
+        Math.min(TRACE_READ_CHUNK_BYTES, byteLimit - position),
+      );
+      const { bytesRead } = await handle.read(chunk, 0, chunk.length, position);
+      if (bytesRead === 0) break;
+      position += bytesRead;
+      const buffer = Buffer.concat([carry, chunk.subarray(0, bytesRead)]);
+      let start = 0;
+      while (true) {
+        const lineFeed = buffer.indexOf(0x0a, start);
+        if (lineFeed === -1) break;
+        yield buffer.subarray(start, lineFeed).toString("utf8");
+        start = lineFeed + 1;
       }
-      try {
-        return { path: filePath, records: parseJsonl(bytes) };
-      } catch (error) {
-        if (!(error instanceof IncompleteFinalRecordError)) throw error;
-      }
+      carry = buffer.subarray(start);
     }
-    throw new Error("Trace file ends with an incomplete JSONL record.");
+    if (carry.length > 0) yield carry.toString("utf8");
   } finally {
     await handle.close();
   }
 }
 
-async function readBytes(
-  handle: Awaited<ReturnType<typeof open>>,
-  position: number,
-  size: number,
-): Promise<Buffer> {
-  const bytes = Buffer.alloc(size);
-  let offset = 0;
-  while (offset < size) {
-    const result = await handle.read(
-      bytes,
-      offset,
-      size - offset,
-      position + offset,
-    );
-    if (result.bytesRead === 0) break;
-    offset += result.bytesRead;
-  }
-  if (offset !== size) throw new Error("Trace snapshot changed while reading.");
-  return bytes;
-}
-
-class IncompleteFinalRecordError extends Error {}
-
-function parseJsonl(bytes: Buffer): JsonlRecord[] {
-  const records: JsonlRecord[] = [];
-  let start = 0;
-  while (start < bytes.length) {
-    const lineFeed = bytes.indexOf(0x0a, start);
-    const end = lineFeed === -1 ? bytes.length : lineFeed + 1;
-    const contentEnd = lineFeed === -1 ? end : lineFeed;
-    const rawBytes = bytes.subarray(start, contentEnd);
-    let raw: string;
-    try {
-      raw = new TextDecoder("utf-8", { fatal: true }).decode(rawBytes);
-    } catch {
-      throw new Error("Trace file contains invalid UTF-8.");
-    }
-    let value: unknown;
-    try {
-      value = JSON.parse(raw);
-    } catch {
-      if (lineFeed === -1) throw new IncompleteFinalRecordError();
-      throw new Error("Trace file contains malformed JSONL.");
-    }
-    if (!isJsonObject(value)) {
-      throw new Error("Trace JSONL records must be objects.");
-    }
-    records.push({
-      value,
-      raw,
-      terminator: lineFeed === -1 ? "" : "\n",
-      ...(Number.isSafeInteger(value.ordinal)
-        ? { ordinal: value.ordinal as number }
-        : {}),
-    });
-    start = end;
-  }
-  if (records.length === 0) throw new Error("Trace file is empty.");
-  return records;
-}
-
 async function writeTracePart(input: {
   index: number;
   sessionId: string;
+  sourcePath: string;
+  snapshotBytes: number;
   outputPath: string;
-  snapshot: JsonlSnapshot;
   endOrdinalExclusive?: number;
-}): Promise<AuthoringTraceUploadPart | null> {
-  const records =
-    input.endOrdinalExclusive === undefined
-      ? input.snapshot.records
-      : input.snapshot.records.filter((record) => {
-          if (record.ordinal === undefined || record.ordinal < 0) {
-            throw new Error("Codex trace record is missing a valid ordinal.");
-          }
-          return record.ordinal < input.endOrdinalExclusive!;
-        });
-  if (records.length === 0) return null;
+}): Promise<{ part: AuthoringTraceUploadPart | null; truncated: boolean }> {
+  let records = 0;
+  let truncated = false;
   const source = Readable.from(
     (async function* () {
-      for (const record of records) {
-        const redacted = redactTraceText(record.raw) + record.terminator;
-        yield Buffer.from(redacted);
+      for await (const line of readJsonlLines(
+        input.sourcePath,
+        input.snapshotBytes,
+      )) {
+        if (line.trim() === "") continue;
+        const value = parseJsonObject(line);
+        if (!value) {
+          // A record the harness has not finished writing, or one a crash cut
+          // short. The report drops it and says so instead of failing.
+          truncated = true;
+          continue;
+        }
+        if (input.endOrdinalExclusive !== undefined) {
+          const ordinal = integerValue(value.ordinal);
+          if (ordinal === undefined) {
+            throw new Error("Codex trace record is missing a valid ordinal.");
+          }
+          // Ordinals only grow, so the first post-fork record ends the part.
+          if (ordinal >= input.endOrdinalExclusive) break;
+        }
+        records += 1;
+        yield Buffer.from(redactTraceText(line) + "\n");
       }
     })(),
   );
+  const hash = createHash("sha256");
+  let bytes = 0;
   await pipeline(
     source,
     createGzip({ level: 9 }),
+    new Transform({
+      transform(chunk: Buffer, _encoding, callback) {
+        hash.update(chunk);
+        bytes += chunk.length;
+        callback(null, chunk);
+      },
+    }),
     createWriteStream(input.outputPath, { mode: 0o600 }),
   );
-  const fileStat = await stat(input.outputPath);
+  if (records === 0) return { part: null, truncated };
   return {
-    filename: `trace-${input.index}.jsonl.gz`,
-    session_id: input.sessionId,
-    path: input.outputPath,
-    bytes: fileStat.size,
-    sha256: await sha256File(input.outputPath),
+    part: {
+      filename: `trace-${input.index}.jsonl.gz`,
+      session_id: input.sessionId,
+      path: input.outputPath,
+      bytes,
+      sha256: hash.digest("hex"),
+    },
+    truncated,
   };
-}
-
-async function sha256File(filePath: string): Promise<string> {
-  const hash = createHash("sha256");
-  for await (const chunk of createReadStream(filePath)) hash.update(chunk);
-  return hash.digest("hex");
 }
 
 async function readSubagentAttachments(
@@ -558,6 +482,14 @@ function redactTraceText(contents: string): string {
     redacted = redacted.replace(regex, `<REDACTED: ${label}>`);
   }
   return redacted;
+}
+
+function parseJsonObject(line: string): JsonObject | undefined {
+  try {
+    return objectValue(JSON.parse(line));
+  } catch {
+    return undefined;
+  }
 }
 
 function isJsonObject(value: unknown): value is JsonObject {

--- a/packages/progressive-review/src/server/bug-report-trace.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.ts
@@ -20,7 +20,7 @@ import {
 import { readReviewStoreRecord } from "../review-worktree-target";
 import { USER_DATA_REGEXES } from "../telemetry-clean-text";
 
-const MAX_SUBAGENT_TRACE_BYTES = 1024 * 1024;
+const MAX_SUBAGENT_TRACE_BYTES = 5 * 1024 * 1024;
 const MAX_SUBAGENT_TRACES = 10;
 const MAX_CODEX_ANCESTRY_DEPTH = 32;
 export const MAX_AUTHORING_TRACE_BYTES = 256 * 1024 * 1024;

--- a/packages/progressive-review/src/server/bug-report-trace.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.ts
@@ -22,29 +22,19 @@ const MAX_CODEX_ANCESTRY_DEPTH = 32;
 const INCOMPLETE_FINAL_LINE_RETRIES = 3;
 const INCOMPLETE_FINAL_LINE_RETRY_MS = 50;
 
-export interface AuthoringTraceSessionRef {
-  session_id: string;
-  parent_session_id?: string;
-  parent_end_ordinal_exclusive?: number;
-}
-
 export interface AuthoringTracePayload {
   harness: ReviewAgentHarness;
-  session_id: string;
-  sessions: AuthoringTraceSessionRef[];
   files: Record<string, string>;
   omitted_files?: string[];
   truncated: boolean;
 }
 
 export interface AuthoringTraceUploadPart {
-  field: "trace";
   filename: string;
   session_id: string;
   path: string;
   bytes: number;
   sha256: string;
-  uncompressed_bytes: number;
 }
 
 export interface AuthoringTraceAttachment {
@@ -67,7 +57,6 @@ interface JsonlRecord {
 interface JsonlSnapshot {
   path: string;
   records: JsonlRecord[];
-  sessionId?: string;
 }
 
 interface CodexHistoryBase {
@@ -84,8 +73,6 @@ interface ResolvedTraceFile {
   sessionId: string;
   snapshot: JsonlSnapshot;
   endOrdinalExclusive?: number;
-  parentSessionId?: string;
-  parentEndOrdinalExclusive?: number;
 }
 
 const TRACE_SECRET_LABELS = new Set([
@@ -148,18 +135,6 @@ export async function readAuthoringTraceAttachment(input: {
     return {
       payload: {
         harness: sourceSession.harness,
-        session_id: sourceSession.sessionId,
-        sessions: lineage.map((entry) => ({
-          session_id: entry.sessionId,
-          ...(entry.parentSessionId
-            ? { parent_session_id: entry.parentSessionId }
-            : {}),
-          ...(entry.parentEndOrdinalExclusive !== undefined
-            ? {
-                parent_end_ordinal_exclusive: entry.parentEndOrdinalExclusive,
-              }
-            : {}),
-        })),
         files: subagents.files,
         ...(subagents.omittedFiles.length > 0
           ? { omitted_files: subagents.omittedFiles }
@@ -203,12 +178,6 @@ async function resolveTraceLineage(
       sessionId: current.sessionId,
       snapshot: current,
       ...(endOrdinalExclusive !== undefined ? { endOrdinalExclusive } : {}),
-      ...(current.historyBase
-        ? {
-            parentSessionId: current.historyBase.threadId,
-            parentEndOrdinalExclusive: current.historyBase.endOrdinalExclusive,
-          }
-        : {}),
     });
     if (!current.historyBase) return chain;
     endOrdinalExclusive = current.historyBase.endOrdinalExclusive;
@@ -376,7 +345,6 @@ async function writeTracePart(input: {
   snapshot: JsonlSnapshot;
   endOrdinalExclusive?: number;
 }): Promise<AuthoringTraceUploadPart> {
-  let uncompressedBytes = 0;
   const records =
     input.endOrdinalExclusive === undefined
       ? input.snapshot.records
@@ -393,7 +361,6 @@ async function writeTracePart(input: {
     (async function* () {
       for (const record of records) {
         const redacted = redactTraceText(record.raw) + record.terminator;
-        uncompressedBytes += Buffer.byteLength(redacted);
         yield Buffer.from(redacted);
       }
     })(),
@@ -405,13 +372,11 @@ async function writeTracePart(input: {
   );
   const fileStat = await stat(input.outputPath);
   return {
-    field: "trace",
     filename: `trace-${input.index}.jsonl.gz`,
     session_id: input.sessionId,
     path: input.outputPath,
     bytes: fileStat.size,
     sha256: await sha256File(input.outputPath),
-    uncompressed_bytes: uncompressedBytes,
   };
 }
 

--- a/packages/progressive-review/src/server/bug-report-trace.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.ts
@@ -22,18 +22,24 @@ const MAX_CODEX_ANCESTRY_DEPTH = 32;
 const INCOMPLETE_FINAL_LINE_RETRIES = 3;
 const INCOMPLETE_FINAL_LINE_RETRY_MS = 50;
 
+export interface AuthoringTraceSessionRef {
+  session_id: string;
+  parent_session_id?: string;
+  parent_end_ordinal_exclusive?: number;
+}
+
 export interface AuthoringTracePayload {
   harness: ReviewAgentHarness;
   session_id: string;
-  parent_session_id?: string;
+  sessions: AuthoringTraceSessionRef[];
   files: Record<string, string>;
   omitted_files?: string[];
   truncated: boolean;
 }
 
 export interface AuthoringTraceUploadPart {
-  field: "source_trace" | "parent_trace";
-  filename: "source.jsonl.gz" | "parent.jsonl.gz";
+  field: "trace";
+  filename: string;
   session_id: string;
   path: string;
   bytes: number;
@@ -70,19 +76,19 @@ interface JsonlSnapshot {
 interface CodexHistoryBase {
   threadId: string;
   endOrdinalExclusive: number;
-  endByteOffset: number;
 }
 
 interface CodexSnapshot extends JsonlSnapshot {
   sessionId: string;
-  forkedFromId?: string;
-  forkedFromOrdinalExclusive?: number;
   historyBase?: CodexHistoryBase;
 }
 
-interface SnapshotSegment {
+interface ResolvedTraceFile {
+  sessionId: string;
   snapshot: JsonlSnapshot;
-  endByteOffset: number;
+  endOrdinalExclusive?: number;
+  parentSessionId?: string;
+  parentEndOrdinalExclusive?: number;
 }
 
 const TRACE_SECRET_LABELS = new Set([
@@ -122,66 +128,41 @@ export async function readAuthoringTraceAttachment(input: {
 
   const tempRoot = await mkdtemp(path.join(tmpdir(), "review-bug-trace-"));
   try {
-    const parts: AuthoringTraceUploadPart[] = [];
-    let parentSessionId: string | undefined;
-
-    if (sourceSession.harness === "codex") {
-      const source = await resolveCodexSnapshot(sourceSession.sessionId);
-      if (path.resolve(source.path) !== path.resolve(localTrace.tracePath)) {
-        throw new Error("Codex source trace resolution is ambiguous.");
-      }
-      parts.push(
-        await writeTracePart({
-          field: "source_trace",
-          filename: "source.jsonl.gz",
-          sessionId: source.sessionId,
-          outputPath: path.join(tempRoot, "source.jsonl.gz"),
-          segments: [{ snapshot: source, endByteOffset: source.bytes.length }],
-          requireContiguousOrdinals: true,
+    const lineage = await resolveTraceLineage(
+      sourceSession.harness,
+      sourceSession.sessionId,
+      localTrace.tracePath,
+    );
+    const parts = await Promise.all(
+      lineage.map((entry, index) =>
+        writeTracePart({
+          index,
+          sessionId: entry.sessionId,
+          outputPath: path.join(tempRoot, `trace-${index}.jsonl.gz`),
+          snapshot: entry.snapshot,
+          ...(entry.endOrdinalExclusive !== undefined
+            ? { endOrdinalExclusive: entry.endOrdinalExclusive }
+            : {}),
         }),
-      );
-
-      if (source.historyBase) {
-        validateForkMetadata(source);
-        parentSessionId = source.historyBase.threadId;
-        const parent = await resolveCodexSnapshot(parentSessionId);
-        validateHistoryBoundary(source, parent);
-        const parentSegments = await materializeCodexHistory(
-          parent,
-          new Set([source.sessionId]),
-          1,
-        );
-        parts.push(
-          await writeTracePart({
-            field: "parent_trace",
-            filename: "parent.jsonl.gz",
-            sessionId: parent.sessionId,
-            outputPath: path.join(tempRoot, "parent.jsonl.gz"),
-            segments: parentSegments,
-            requireContiguousOrdinals: true,
-          }),
-        );
-      }
-    } else {
-      const source = await readJsonlSnapshot(localTrace.tracePath);
-      parts.push(
-        await writeTracePart({
-          field: "source_trace",
-          filename: "source.jsonl.gz",
-          sessionId: sourceSession.sessionId,
-          outputPath: path.join(tempRoot, "source.jsonl.gz"),
-          segments: [{ snapshot: source, endByteOffset: source.bytes.length }],
-          requireContiguousOrdinals: false,
-        }),
-      );
-    }
+      ),
+    );
 
     const subagents = await readSubagentAttachments(localTrace.subagentPaths);
     return {
       payload: {
         harness: sourceSession.harness,
         session_id: sourceSession.sessionId,
-        ...(parentSessionId ? { parent_session_id: parentSessionId } : {}),
+        sessions: lineage.map((entry) => ({
+          session_id: entry.sessionId,
+          ...(entry.parentSessionId
+            ? { parent_session_id: entry.parentSessionId }
+            : {}),
+          ...(entry.parentEndOrdinalExclusive !== undefined
+            ? {
+                parent_end_ordinal_exclusive: entry.parentEndOrdinalExclusive,
+              }
+            : {}),
+        })),
         files: subagents.files,
         ...(subagents.omittedFiles.length > 0
           ? { omitted_files: subagents.omittedFiles }
@@ -197,68 +178,44 @@ export async function readAuthoringTraceAttachment(input: {
   }
 }
 
-async function materializeCodexHistory(
-  snapshot: CodexSnapshot,
-  seen: Set<string>,
-  depth: number,
-): Promise<SnapshotSegment[]> {
-  if (depth > MAX_CODEX_ANCESTRY_DEPTH) {
-    throw new Error("Codex trace ancestry exceeds the supported depth.");
+async function resolveTraceLineage(
+  harness: ReviewAgentHarness,
+  sessionId: string,
+  tracePath: string,
+): Promise<ResolvedTraceFile[]> {
+  if (harness !== "codex") {
+    return [{ sessionId, snapshot: await readJsonlSnapshot(tracePath) }];
   }
-  if (seen.has(snapshot.sessionId)) {
-    throw new Error("Codex trace ancestry contains a cycle.");
+
+  const chain: ResolvedTraceFile[] = [];
+  const seen = new Set<string>();
+  let current = await resolveCodexSnapshot(sessionId);
+  if (path.resolve(current.path) !== path.resolve(tracePath)) {
+    throw new Error("Codex source trace resolution is ambiguous.");
   }
-  const nextSeen = new Set(seen).add(snapshot.sessionId);
-  const segments: SnapshotSegment[] = [];
-  if (snapshot.historyBase) {
-    validateForkMetadata(snapshot);
-    const parent = await resolveCodexSnapshot(snapshot.historyBase.threadId);
-    validateHistoryBoundary(snapshot, parent);
-    segments.push(
-      ...(await materializeCodexHistory(parent, nextSeen, depth + 1)),
-    );
-    const baseSegment = segments.at(-1);
-    if (!baseSegment || baseSegment.snapshot.sessionId !== parent.sessionId) {
-      throw new Error("Codex parent history did not materialize correctly.");
+  let endOrdinalExclusive: number | undefined;
+  while (true) {
+    if (seen.has(current.sessionId)) {
+      throw new Error("Codex trace ancestry contains a cycle.");
     }
-    baseSegment.endByteOffset = snapshot.historyBase.endByteOffset;
-  }
-  segments.push({ snapshot, endByteOffset: snapshot.bytes.length });
-  return segments;
-}
-
-function validateForkMetadata(snapshot: CodexSnapshot): void {
-  const base = snapshot.historyBase;
-  if (!base) return;
-  if (
-    snapshot.forkedFromId !== base.threadId ||
-    snapshot.forkedFromOrdinalExclusive !== base.endOrdinalExclusive
-  ) {
-    throw new Error("Codex fork metadata does not match its history base.");
-  }
-  if (snapshot.records[0]?.ordinal !== base.endOrdinalExclusive) {
-    throw new Error("Codex child trace starts at the wrong ordinal.");
-  }
-}
-
-function validateHistoryBoundary(
-  child: CodexSnapshot,
-  parent: CodexSnapshot,
-): void {
-  const base = child.historyBase;
-  if (!base) return;
-  if (base.endByteOffset <= 0 || base.endByteOffset > parent.bytes.length) {
-    throw new Error("Codex parent byte offset is outside the trace snapshot.");
-  }
-  const boundaryRecord = parent.records.find(
-    (record) => record.end === base.endByteOffset,
-  );
-  if (
-    !boundaryRecord ||
-    boundaryRecord.terminator !== "\n" ||
-    boundaryRecord.ordinal !== base.endOrdinalExclusive - 1
-  ) {
-    throw new Error("Codex parent byte offset is not an ordinal boundary.");
+    if (seen.size >= MAX_CODEX_ANCESTRY_DEPTH + 1) {
+      throw new Error("Codex trace ancestry exceeds the supported depth.");
+    }
+    seen.add(current.sessionId);
+    chain.push({
+      sessionId: current.sessionId,
+      snapshot: current,
+      ...(endOrdinalExclusive !== undefined ? { endOrdinalExclusive } : {}),
+      ...(current.historyBase
+        ? {
+            parentSessionId: current.historyBase.threadId,
+            parentEndOrdinalExclusive: current.historyBase.endOrdinalExclusive,
+          }
+        : {}),
+    });
+    if (!current.historyBase) return chain;
+    endOrdinalExclusive = current.historyBase.endOrdinalExclusive;
+    current = await resolveCodexSnapshot(current.historyBase.threadId);
   }
 }
 
@@ -289,47 +246,25 @@ async function resolveCodexSnapshot(sessionId: string): Promise<CodexSnapshot> {
       throw new Error("Codex trace record is missing a valid ordinal.");
     }
   }
-  validateContiguousOrdinals(snapshot.records);
-
   const historyBaseValue = objectValue(payload.history_base);
-  const forkedFromId = stringValue(payload.forked_from_id);
-  const forkedFromOrdinalExclusive = integerValue(
-    payload.forked_from_ordinal_exclusive,
-  );
   let historyBase: CodexHistoryBase | undefined;
-  if (historyBaseValue) {
+  if (payload.history_base !== undefined) {
+    if (!historyBaseValue) {
+      throw new Error("Codex history base is malformed.");
+    }
     const threadId = stringValue(historyBaseValue.thread_id);
     const endOrdinalExclusive = integerValue(
       historyBaseValue.end_ordinal_exclusive,
     );
-    const endByteOffset = integerValue(historyBaseValue.end_byte_offset);
-    if (
-      !threadId ||
-      endOrdinalExclusive === undefined ||
-      endByteOffset === undefined
-    ) {
+    if (!threadId || endOrdinalExclusive === undefined) {
       throw new Error("Codex history base is malformed.");
     }
-    historyBase = { threadId, endOrdinalExclusive, endByteOffset };
-  }
-  const hasPartialForkMetadata =
-    historyBase !== undefined ||
-    forkedFromId !== undefined ||
-    forkedFromOrdinalExclusive !== undefined;
-  if (
-    hasPartialForkMetadata &&
-    (!historyBase || !forkedFromId || forkedFromOrdinalExclusive === undefined)
-  ) {
-    throw new Error("Codex fork metadata is incomplete.");
+    historyBase = { threadId, endOrdinalExclusive };
   }
 
   return {
     ...snapshot,
     sessionId,
-    ...(forkedFromId ? { forkedFromId } : {}),
-    ...(forkedFromOrdinalExclusive !== undefined
-      ? { forkedFromOrdinalExclusive }
-      : {}),
     ...(historyBase ? { historyBase } : {}),
   };
 }
@@ -440,41 +375,31 @@ function parseJsonl(bytes: Buffer): JsonlRecord[] {
 }
 
 async function writeTracePart(input: {
-  field: AuthoringTraceUploadPart["field"];
-  filename: AuthoringTraceUploadPart["filename"];
+  index: number;
   sessionId: string;
   outputPath: string;
-  segments: SnapshotSegment[];
-  requireContiguousOrdinals: boolean;
+  snapshot: JsonlSnapshot;
+  endOrdinalExclusive?: number;
 }): Promise<AuthoringTraceUploadPart> {
   let uncompressedBytes = 0;
-  let previousOrdinal: number | undefined;
+  const records =
+    input.endOrdinalExclusive === undefined
+      ? input.snapshot.records
+      : input.snapshot.records.filter((record) => {
+          if (record.ordinal === undefined) {
+            throw new Error("Codex trace record is missing an ordinal.");
+          }
+          return record.ordinal < input.endOrdinalExclusive!;
+        });
+  if (records.length === 0) {
+    throw new Error("Trace part has no records before the fork point.");
+  }
   const source = Readable.from(
     (async function* () {
-      for (const segment of input.segments) {
-        const records = segment.snapshot.records.filter(
-          (record) => record.end <= segment.endByteOffset,
-        );
-        if (records.at(-1)?.end !== segment.endByteOffset) {
-          throw new Error("Trace segment does not end on a record boundary.");
-        }
-        for (const record of records) {
-          if (input.requireContiguousOrdinals) {
-            if (record.ordinal === undefined) {
-              throw new Error("Codex trace record is missing an ordinal.");
-            }
-            if (
-              previousOrdinal !== undefined &&
-              record.ordinal !== previousOrdinal + 1
-            ) {
-              throw new Error("Codex trace ordinals are not contiguous.");
-            }
-            previousOrdinal = record.ordinal;
-          }
-          const redacted = redactTraceText(record.raw) + record.terminator;
-          uncompressedBytes += Buffer.byteLength(redacted);
-          yield Buffer.from(redacted);
-        }
+      for (const record of records) {
+        const redacted = redactTraceText(record.raw) + record.terminator;
+        uncompressedBytes += Buffer.byteLength(redacted);
+        yield Buffer.from(redacted);
       }
     })(),
   );
@@ -485,8 +410,8 @@ async function writeTracePart(input: {
   );
   const fileStat = await stat(input.outputPath);
   return {
-    field: input.field,
-    filename: input.filename,
+    field: "trace",
+    filename: `trace-${input.index}.jsonl.gz`,
     session_id: input.sessionId,
     path: input.outputPath,
     bytes: fileStat.size,
@@ -601,14 +526,6 @@ function retainCompleteJsonlLines(contents: string): string {
     return contents;
   } catch {
     return lastLineBreak === -1 ? "" : contents.slice(0, lastLineBreak + 1);
-  }
-}
-
-function validateContiguousOrdinals(records: JsonlRecord[]): void {
-  for (let index = 1; index < records.length; index++) {
-    if (records[index].ordinal !== (records[index - 1].ordinal ?? -2) + 1) {
-      throw new Error("Codex trace ordinals are not contiguous.");
-    }
   }
 }
 

--- a/packages/progressive-review/src/server/bug-report-trace.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.ts
@@ -1,23 +1,88 @@
-import { open, stat } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { createReadStream, createWriteStream } from "node:fs";
+import { mkdtemp, open, readdir, rm, stat } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { setTimeout as delay } from "node:timers/promises";
+import { createGzip } from "node:zlib";
 
 import {
   type ReviewAgentHarness,
   parseAuthoringSessionKey,
 } from "../authoring-session";
-import { findLocalTrace } from "../review-agent-traces";
+import { findLocalTrace, traceEnvValue } from "../review-agent-traces";
 import { readReviewStoreRecord } from "../review-worktree-target";
 import { USER_DATA_REGEXES } from "../telemetry-clean-text";
 
-const MAX_TRACE_BYTES = 6 * 1024 * 1024;
 const MAX_SUBAGENT_TRACE_BYTES = 1024 * 1024;
 const MAX_SUBAGENT_TRACES = 10;
+const MAX_CODEX_ANCESTRY_DEPTH = 32;
+const INCOMPLETE_FINAL_LINE_RETRIES = 3;
+const INCOMPLETE_FINAL_LINE_RETRY_MS = 50;
 
-export interface AuthoringTraceAttachment {
+export interface AuthoringTracePayload {
   harness: ReviewAgentHarness;
   session_id: string;
+  parent_session_id?: string;
   files: Record<string, string>;
   omitted_files?: string[];
   truncated: boolean;
+}
+
+export interface AuthoringTraceUploadPart {
+  field: "source_trace" | "parent_trace";
+  filename: "source.jsonl.gz" | "parent.jsonl.gz";
+  session_id: string;
+  path: string;
+  bytes: number;
+  sha256: string;
+  uncompressed_bytes: number;
+}
+
+export interface AuthoringTraceAttachment {
+  payload: AuthoringTracePayload;
+  parts: AuthoringTraceUploadPart[];
+  cleanup: () => Promise<void>;
+}
+
+interface JsonObject {
+  [key: string]: unknown;
+}
+
+interface JsonlRecord {
+  value: JsonObject;
+  raw: string;
+  terminator: string;
+  start: number;
+  end: number;
+  ordinal?: number;
+}
+
+interface JsonlSnapshot {
+  path: string;
+  bytes: Buffer;
+  records: JsonlRecord[];
+  sessionId?: string;
+}
+
+interface CodexHistoryBase {
+  threadId: string;
+  endOrdinalExclusive: number;
+  endByteOffset: number;
+}
+
+interface CodexSnapshot extends JsonlSnapshot {
+  sessionId: string;
+  forkedFromId?: string;
+  forkedFromOrdinalExclusive?: number;
+  historyBase?: CodexHistoryBase;
+}
+
+interface SnapshotSegment {
+  snapshot: JsonlSnapshot;
+  endByteOffset: number;
 }
 
 const TRACE_SECRET_LABELS = new Set([
@@ -32,10 +97,8 @@ const TRACE_SECRET_REGEXES = USER_DATA_REGEXES.filter(({ label }) =>
   TRACE_SECRET_LABELS.has(label),
 ).map(({ label, regex }) => ({
   label,
-  // The shared Slack and Entra expressions detect that a line should be
-  // discarded by telemetry, so they only need to match a token prefix. Bug
-  // report traces preserve the rest of the line, which requires consuming the
-  // complete token instead.
+  // Shared telemetry only needs to detect these values. Trace reports retain
+  // their lines, so these expressions must consume the complete secret.
   regex:
     label === "Slack Token"
       ? /xox[pbar]-[A-Za-z0-9-]+/g
@@ -57,17 +120,396 @@ export async function readAuthoringTraceAttachment(input: {
   const localTrace = await findLocalTrace(sourceSession.sessionId);
   if (!localTrace) return null;
 
-  const mainTrace = await readTailTraceFile(
-    localTrace.tracePath,
-    MAX_TRACE_BYTES,
-  );
-  if (!mainTrace.contents) return null;
+  const tempRoot = await mkdtemp(path.join(tmpdir(), "review-bug-trace-"));
+  try {
+    const parts: AuthoringTraceUploadPart[] = [];
+    let parentSessionId: string | undefined;
 
-  const files: Record<string, string> = {
-    "trace.jsonl": mainTrace.contents,
+    if (sourceSession.harness === "codex") {
+      const source = await resolveCodexSnapshot(sourceSession.sessionId);
+      if (path.resolve(source.path) !== path.resolve(localTrace.tracePath)) {
+        throw new Error("Codex source trace resolution is ambiguous.");
+      }
+      parts.push(
+        await writeTracePart({
+          field: "source_trace",
+          filename: "source.jsonl.gz",
+          sessionId: source.sessionId,
+          outputPath: path.join(tempRoot, "source.jsonl.gz"),
+          segments: [{ snapshot: source, endByteOffset: source.bytes.length }],
+          requireContiguousOrdinals: true,
+        }),
+      );
+
+      if (source.historyBase) {
+        validateForkMetadata(source);
+        parentSessionId = source.historyBase.threadId;
+        const parent = await resolveCodexSnapshot(parentSessionId);
+        validateHistoryBoundary(source, parent);
+        const parentSegments = await materializeCodexHistory(
+          parent,
+          new Set([source.sessionId]),
+          1,
+        );
+        parts.push(
+          await writeTracePart({
+            field: "parent_trace",
+            filename: "parent.jsonl.gz",
+            sessionId: parent.sessionId,
+            outputPath: path.join(tempRoot, "parent.jsonl.gz"),
+            segments: parentSegments,
+            requireContiguousOrdinals: true,
+          }),
+        );
+      }
+    } else {
+      const source = await readJsonlSnapshot(localTrace.tracePath);
+      parts.push(
+        await writeTracePart({
+          field: "source_trace",
+          filename: "source.jsonl.gz",
+          sessionId: sourceSession.sessionId,
+          outputPath: path.join(tempRoot, "source.jsonl.gz"),
+          segments: [{ snapshot: source, endByteOffset: source.bytes.length }],
+          requireContiguousOrdinals: false,
+        }),
+      );
+    }
+
+    const subagents = await readSubagentAttachments(localTrace.subagentPaths);
+    return {
+      payload: {
+        harness: sourceSession.harness,
+        session_id: sourceSession.sessionId,
+        ...(parentSessionId ? { parent_session_id: parentSessionId } : {}),
+        files: subagents.files,
+        ...(subagents.omittedFiles.length > 0
+          ? { omitted_files: subagents.omittedFiles }
+          : {}),
+        truncated: subagents.truncated,
+      },
+      parts,
+      cleanup: () => rm(tempRoot, { recursive: true, force: true }),
+    };
+  } catch (error) {
+    await rm(tempRoot, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function materializeCodexHistory(
+  snapshot: CodexSnapshot,
+  seen: Set<string>,
+  depth: number,
+): Promise<SnapshotSegment[]> {
+  if (depth > MAX_CODEX_ANCESTRY_DEPTH) {
+    throw new Error("Codex trace ancestry exceeds the supported depth.");
+  }
+  if (seen.has(snapshot.sessionId)) {
+    throw new Error("Codex trace ancestry contains a cycle.");
+  }
+  const nextSeen = new Set(seen).add(snapshot.sessionId);
+  const segments: SnapshotSegment[] = [];
+  if (snapshot.historyBase) {
+    validateForkMetadata(snapshot);
+    const parent = await resolveCodexSnapshot(snapshot.historyBase.threadId);
+    validateHistoryBoundary(snapshot, parent);
+    segments.push(
+      ...(await materializeCodexHistory(parent, nextSeen, depth + 1)),
+    );
+    const baseSegment = segments.at(-1);
+    if (!baseSegment || baseSegment.snapshot.sessionId !== parent.sessionId) {
+      throw new Error("Codex parent history did not materialize correctly.");
+    }
+    baseSegment.endByteOffset = snapshot.historyBase.endByteOffset;
+  }
+  segments.push({ snapshot, endByteOffset: snapshot.bytes.length });
+  return segments;
+}
+
+function validateForkMetadata(snapshot: CodexSnapshot): void {
+  const base = snapshot.historyBase;
+  if (!base) return;
+  if (
+    snapshot.forkedFromId !== base.threadId ||
+    snapshot.forkedFromOrdinalExclusive !== base.endOrdinalExclusive
+  ) {
+    throw new Error("Codex fork metadata does not match its history base.");
+  }
+  if (snapshot.records[0]?.ordinal !== base.endOrdinalExclusive) {
+    throw new Error("Codex child trace starts at the wrong ordinal.");
+  }
+}
+
+function validateHistoryBoundary(
+  child: CodexSnapshot,
+  parent: CodexSnapshot,
+): void {
+  const base = child.historyBase;
+  if (!base) return;
+  if (base.endByteOffset <= 0 || base.endByteOffset > parent.bytes.length) {
+    throw new Error("Codex parent byte offset is outside the trace snapshot.");
+  }
+  const boundaryRecord = parent.records.find(
+    (record) => record.end === base.endByteOffset,
+  );
+  if (
+    !boundaryRecord ||
+    boundaryRecord.terminator !== "\n" ||
+    boundaryRecord.ordinal !== base.endOrdinalExclusive - 1
+  ) {
+    throw new Error("Codex parent byte offset is not an ordinal boundary.");
+  }
+}
+
+async function resolveCodexSnapshot(sessionId: string): Promise<CodexSnapshot> {
+  const codexRoot =
+    traceEnvValue("TRACE_CODEX_SESSIONS_ROOT") ||
+    path.join(homedir(), ".codex", "sessions");
+  const suffix = `-${sessionId}.jsonl`;
+  const candidates = (await listFilesRecursive(codexRoot)).filter((entry) => {
+    const name = path.basename(entry);
+    return name.startsWith("rollout-") && name.endsWith(suffix);
+  });
+  if (candidates.length !== 1) {
+    throw new Error("Codex trace resolution requires exactly one rollout.");
+  }
+
+  const snapshot = await readJsonlSnapshot(candidates[0]);
+  const first = snapshot.records[0];
+  if (first?.value.type !== "session_meta") {
+    throw new Error("Codex trace does not start with session metadata.");
+  }
+  const payload = objectValue(first.value.payload);
+  if (payload?.id !== sessionId) {
+    throw new Error("Codex trace metadata does not match its session id.");
+  }
+  for (const record of snapshot.records) {
+    if (!Number.isSafeInteger(record.ordinal) || (record.ordinal ?? -1) < 0) {
+      throw new Error("Codex trace record is missing a valid ordinal.");
+    }
+  }
+  validateContiguousOrdinals(snapshot.records);
+
+  const historyBaseValue = objectValue(payload.history_base);
+  const forkedFromId = stringValue(payload.forked_from_id);
+  const forkedFromOrdinalExclusive = integerValue(
+    payload.forked_from_ordinal_exclusive,
+  );
+  let historyBase: CodexHistoryBase | undefined;
+  if (historyBaseValue) {
+    const threadId = stringValue(historyBaseValue.thread_id);
+    const endOrdinalExclusive = integerValue(
+      historyBaseValue.end_ordinal_exclusive,
+    );
+    const endByteOffset = integerValue(historyBaseValue.end_byte_offset);
+    if (
+      !threadId ||
+      endOrdinalExclusive === undefined ||
+      endByteOffset === undefined
+    ) {
+      throw new Error("Codex history base is malformed.");
+    }
+    historyBase = { threadId, endOrdinalExclusive, endByteOffset };
+  }
+  const hasPartialForkMetadata =
+    historyBase !== undefined ||
+    forkedFromId !== undefined ||
+    forkedFromOrdinalExclusive !== undefined;
+  if (
+    hasPartialForkMetadata &&
+    (!historyBase || !forkedFromId || forkedFromOrdinalExclusive === undefined)
+  ) {
+    throw new Error("Codex fork metadata is incomplete.");
+  }
+
+  return {
+    ...snapshot,
+    sessionId,
+    ...(forkedFromId ? { forkedFromId } : {}),
+    ...(forkedFromOrdinalExclusive !== undefined
+      ? { forkedFromOrdinalExclusive }
+      : {}),
+    ...(historyBase ? { historyBase } : {}),
   };
-  const subagentPaths = await Promise.all(
-    localTrace.subagentPaths.map(async (subagent) => ({
+}
+
+async function listFilesRecursive(root: string): Promise<string[]> {
+  const results: string[] = [];
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await listFilesRecursive(entryPath)));
+    } else if (entry.isFile()) {
+      results.push(entryPath);
+    }
+  }
+  return results.sort();
+}
+
+async function readJsonlSnapshot(filePath: string): Promise<JsonlSnapshot> {
+  const handle = await open(filePath, "r");
+  try {
+    const initialSize = (await handle.stat()).size;
+    if (initialSize <= 0) throw new Error("Trace file is empty.");
+    let bytes = await readBytes(handle, initialSize);
+    try {
+      return { path: filePath, bytes, records: parseJsonl(bytes) };
+    } catch (error) {
+      if (!(error instanceof IncompleteFinalRecordError)) throw error;
+    }
+
+    for (let attempt = 0; attempt < INCOMPLETE_FINAL_LINE_RETRIES; attempt++) {
+      await delay(INCOMPLETE_FINAL_LINE_RETRY_MS);
+      const currentSize = (await handle.stat()).size;
+      if (currentSize <= initialSize) continue;
+      const currentBytes = await readBytes(handle, currentSize);
+      const completionEnd = currentBytes.indexOf(0x0a, initialSize);
+      bytes =
+        completionEnd === -1
+          ? currentBytes
+          : currentBytes.subarray(0, completionEnd + 1);
+      try {
+        return { path: filePath, bytes, records: parseJsonl(bytes) };
+      } catch (error) {
+        if (!(error instanceof IncompleteFinalRecordError)) throw error;
+      }
+    }
+    throw new Error("Trace file ends with an incomplete JSONL record.");
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readBytes(
+  handle: Awaited<ReturnType<typeof open>>,
+  size: number,
+): Promise<Buffer> {
+  const bytes = Buffer.alloc(size);
+  let offset = 0;
+  while (offset < size) {
+    const result = await handle.read(bytes, offset, size - offset, offset);
+    if (result.bytesRead === 0) break;
+    offset += result.bytesRead;
+  }
+  if (offset !== size) throw new Error("Trace snapshot changed while reading.");
+  return bytes;
+}
+
+class IncompleteFinalRecordError extends Error {}
+
+function parseJsonl(bytes: Buffer): JsonlRecord[] {
+  const records: JsonlRecord[] = [];
+  let start = 0;
+  while (start < bytes.length) {
+    const lineFeed = bytes.indexOf(0x0a, start);
+    const end = lineFeed === -1 ? bytes.length : lineFeed + 1;
+    const contentEnd = lineFeed === -1 ? end : lineFeed;
+    const rawBytes = bytes.subarray(start, contentEnd);
+    let raw: string;
+    try {
+      raw = new TextDecoder("utf-8", { fatal: true }).decode(rawBytes);
+    } catch {
+      throw new Error("Trace file contains invalid UTF-8.");
+    }
+    let value: unknown;
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      if (lineFeed === -1) throw new IncompleteFinalRecordError();
+      throw new Error("Trace file contains malformed JSONL.");
+    }
+    if (!isJsonObject(value)) {
+      throw new Error("Trace JSONL records must be objects.");
+    }
+    records.push({
+      value,
+      raw,
+      terminator: lineFeed === -1 ? "" : "\n",
+      start,
+      end,
+      ...(Number.isSafeInteger(value.ordinal)
+        ? { ordinal: value.ordinal as number }
+        : {}),
+    });
+    start = end;
+  }
+  if (records.length === 0) throw new Error("Trace file is empty.");
+  return records;
+}
+
+async function writeTracePart(input: {
+  field: AuthoringTraceUploadPart["field"];
+  filename: AuthoringTraceUploadPart["filename"];
+  sessionId: string;
+  outputPath: string;
+  segments: SnapshotSegment[];
+  requireContiguousOrdinals: boolean;
+}): Promise<AuthoringTraceUploadPart> {
+  let uncompressedBytes = 0;
+  let previousOrdinal: number | undefined;
+  const source = Readable.from(
+    (async function* () {
+      for (const segment of input.segments) {
+        const records = segment.snapshot.records.filter(
+          (record) => record.end <= segment.endByteOffset,
+        );
+        if (records.at(-1)?.end !== segment.endByteOffset) {
+          throw new Error("Trace segment does not end on a record boundary.");
+        }
+        for (const record of records) {
+          if (input.requireContiguousOrdinals) {
+            if (record.ordinal === undefined) {
+              throw new Error("Codex trace record is missing an ordinal.");
+            }
+            if (
+              previousOrdinal !== undefined &&
+              record.ordinal !== previousOrdinal + 1
+            ) {
+              throw new Error("Codex trace ordinals are not contiguous.");
+            }
+            previousOrdinal = record.ordinal;
+          }
+          const redacted = redactTraceText(record.raw) + record.terminator;
+          uncompressedBytes += Buffer.byteLength(redacted);
+          yield Buffer.from(redacted);
+        }
+      }
+    })(),
+  );
+  await pipeline(
+    source,
+    createGzip({ level: 9 }),
+    createWriteStream(input.outputPath, { mode: 0o600 }),
+  );
+  const fileStat = await stat(input.outputPath);
+  return {
+    field: input.field,
+    filename: input.filename,
+    session_id: input.sessionId,
+    path: input.outputPath,
+    bytes: fileStat.size,
+    sha256: await sha256File(input.outputPath),
+    uncompressed_bytes: uncompressedBytes,
+  };
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(filePath)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+async function readSubagentAttachments(
+  paths: Array<{ name: string; path: string }>,
+): Promise<{
+  files: Record<string, string>;
+  omittedFiles: string[];
+  truncated: boolean;
+}> {
+  const candidates = await Promise.all(
+    paths.map(async (subagent) => ({
       ...subagent,
       modifiedAt: await stat(subagent.path).then(
         ({ mtimeMs }) => mtimeMs,
@@ -75,17 +517,17 @@ export async function readAuthoringTraceAttachment(input: {
       ),
     })),
   );
-  subagentPaths.sort(
+  candidates.sort(
     (left, right) =>
       right.modifiedAt - left.modifiedAt || left.name.localeCompare(right.name),
   );
-  const omittedFiles = subagentPaths
+  const omittedFiles = candidates
     .slice(MAX_SUBAGENT_TRACES)
     .map(({ name }) => `subagents/${name}`);
-  let truncated = mainTrace.truncated || omittedFiles.length > 0;
-
-  const subagentResults = await Promise.all(
-    subagentPaths.slice(0, MAX_SUBAGENT_TRACES).map(async ({ name, path }) => {
+  const files: Record<string, string> = {};
+  let truncated = omittedFiles.length > 0;
+  const results = await Promise.all(
+    candidates.slice(0, MAX_SUBAGENT_TRACES).map(async ({ name, path }) => {
       const attachmentName = `subagents/${name}`;
       try {
         return {
@@ -97,7 +539,7 @@ export async function readAuthoringTraceAttachment(input: {
       }
     }),
   );
-  for (const result of subagentResults) {
+  for (const result of results) {
     if (!result.trace) {
       omittedFiles.push(result.attachmentName);
       truncated = true;
@@ -106,14 +548,7 @@ export async function readAuthoringTraceAttachment(input: {
     files[result.attachmentName] = result.trace.contents;
     truncated ||= result.trace.truncated;
   }
-
-  return {
-    harness: sourceSession.harness,
-    session_id: sourceSession.sessionId,
-    files,
-    ...(omittedFiles.length > 0 ? { omitted_files: omittedFiles.sort() } : {}),
-    truncated,
-  };
+  return { files, omittedFiles: omittedFiles.sort(), truncated };
 }
 
 async function readTailTraceFile(
@@ -149,7 +584,7 @@ async function readTailTraceFile(
     const decoded = tail.toString("utf8");
     const completeJsonl = retainCompleteJsonlLines(decoded);
     return {
-      contents: redactTraceJsonl(completeJsonl),
+      contents: redactTraceText(completeJsonl),
       truncated: truncated || completeJsonl.length < decoded.length,
     };
   } finally {
@@ -169,10 +604,36 @@ function retainCompleteJsonlLines(contents: string): string {
   }
 }
 
-function redactTraceJsonl(contents: string): string {
+function validateContiguousOrdinals(records: JsonlRecord[]): void {
+  for (let index = 1; index < records.length; index++) {
+    if (records[index].ordinal !== (records[index - 1].ordinal ?? -2) + 1) {
+      throw new Error("Codex trace ordinals are not contiguous.");
+    }
+  }
+}
+
+function redactTraceText(contents: string): string {
   let redacted = contents;
   for (const { label, regex } of TRACE_SECRET_REGEXES) {
     redacted = redacted.replace(regex, `<REDACTED: ${label}>`);
   }
   return redacted;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function objectValue(value: unknown): JsonObject | undefined {
+  return isJsonObject(value) ? value : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function integerValue(value: unknown): number | undefined {
+  return Number.isSafeInteger(value) && (value as number) >= 0
+    ? (value as number)
+    : undefined;
 }

--- a/packages/progressive-review/src/server/bug-report.test.ts
+++ b/packages/progressive-review/src/server/bug-report.test.ts
@@ -227,31 +227,35 @@ describe("submitReviewBugReport", () => {
     expect(meta.parts[0].sha256).toBe(sha256(payloadBytes));
   });
 
-  it("does not retry a failed schema 2 report through schema 1", async () => {
-    writeReview("disabled:review");
-    const fetchImpl = vi.fn<typeof fetch>(async () =>
-      Response.json({ ok: false, error: "Unavailable." }, { status: 503 }),
-    );
+  it.each([503, 422])(
+    "reports an upstream %s as a service failure without retrying",
+    async (status) => {
+      writeReview("disabled:review");
+      const fetchImpl = vi.fn<typeof fetch>(async () =>
+        Response.json({ ok: false, error: "Rejected." }, { status }),
+      );
 
-    await expect(
-      submitReviewBugReport({
-        report: report(),
-        reviewDocumentPath: path.join(reviewRootPath, "review.mdx"),
-        reviewRootPath,
-        clientErrorNames: [],
-        fetchImpl,
-      }),
-    ).rejects.toMatchObject({ status: 502 });
-    expect(fetchImpl).toHaveBeenCalledOnce();
-    expect(fetchImpl.mock.calls[0][0].toString()).toBe(
-      "https://bug.dev.fast/api/v2/reports",
-    );
-  });
+      await expect(
+        submitReviewBugReport({
+          report: report(),
+          reviewDocumentPath: path.join(reviewRootPath, "review.mdx"),
+          reviewRootPath,
+          clientErrorNames: [],
+          fetchImpl,
+        }),
+      ).rejects.toMatchObject({ status: 502 });
+      expect(fetchImpl).toHaveBeenCalledOnce();
+      expect(fetchImpl.mock.calls[0][0].toString()).toBe(
+        "https://bug.dev.fast/api/v2/reports",
+      );
+    },
+  );
 
   it("drops subagent trace files before a changed-file diff", async () => {
     const trace: AuthoringTraceAttachment = {
       payload: {
         harness: "claude-code",
+        session_id: "11111111-1111-4111-8111-111111111111",
         files: {
           "subagents/agent.jsonl": randomBytes(2048).toString("base64"),
         },
@@ -294,6 +298,7 @@ describe("submitReviewBugReport", () => {
 
     expect(fitted.trace).toEqual({
       harness: "claude-code",
+      session_id: "11111111-1111-4111-8111-111111111111",
       files: {},
       omitted_files: ["subagents/agent.jsonl"],
       truncated: true,
@@ -304,6 +309,58 @@ describe("submitReviewBugReport", () => {
       truncated_diff: false,
       truncated_trace: true,
     });
+    expect(trace.payload.truncated).toBe(false);
+  });
+
+  it("drops trace parts that exceed the upload cap instead of the report", async () => {
+    const trace: AuthoringTraceAttachment = {
+      payload: {
+        harness: "codex",
+        session_id: "22222222-2222-4222-8222-222222222222",
+        files: {},
+        truncated: false,
+      },
+      parts: [
+        {
+          filename: "trace-0.jsonl.gz",
+          session_id: "22222222-2222-4222-8222-222222222222",
+          path: path.join(tempDir, "missing-trace-0.jsonl.gz"),
+          bytes: 99_000_001,
+          sha256: "0".repeat(64),
+        },
+      ],
+      cleanup: async () => {},
+    };
+    const payload: BugReportPayload = {
+      schema_version: 4,
+      description: "",
+      trace: trace.payload,
+      diagnostics: {
+        ...diagnostics(),
+        attachment_errors: [{ attachment: "review", error: "unavailable" }],
+      },
+    };
+
+    const request = await buildBugReportRequest(payload, trace, {
+      appVersion: "1.2.3",
+      cliVersion: "0.0.1",
+    });
+    const formPayload = request.body.get("payload");
+    if (!(formPayload instanceof Blob)) throw new Error("Missing payload.");
+    const fitted = JSON.parse(
+      gunzipSync(Buffer.from(await formPayload.arrayBuffer())).toString("utf8"),
+    );
+    const meta = JSON.parse(String(request.body.get("meta")));
+
+    expect(request.body.getAll("trace")).toEqual([]);
+    expect(fitted).not.toHaveProperty("trace");
+    expect(fitted.diagnostics.attachment_errors).toEqual([
+      { attachment: "review", error: "unavailable" },
+      { attachment: "trace", error: "too_large" },
+    ]);
+    expect(meta).toMatchObject({ has_trace: false, truncated_trace: false });
+    expect(meta).not.toHaveProperty("trace_harness");
+    expect(meta.parts).toHaveLength(1);
   });
 
   it("does not replace a successful submit when trace cleanup fails", async () => {
@@ -312,7 +369,12 @@ describe("submitReviewBugReport", () => {
       throw new Error("busy");
     });
     const trace: AuthoringTraceAttachment = {
-      payload: { harness: "claude-code", files: {}, truncated: false },
+      payload: {
+        harness: "claude-code",
+        session_id: "cleanup-test",
+        files: {},
+        truncated: false,
+      },
       parts: [],
       cleanup,
     };

--- a/packages/progressive-review/src/server/bug-report.test.ts
+++ b/packages/progressive-review/src/server/bug-report.test.ts
@@ -52,7 +52,6 @@ describe("submitReviewBugReport", () => {
     const child = codexTrace(childId, 2, [{ child: true }], {
       parentId,
       endOrdinalExclusive: 2,
-      endByteOffset: Buffer.byteLength(parentAtFork),
     });
     writeCodexTrace(parentId, parent);
     writeCodexTrace(childId, child);
@@ -103,15 +102,6 @@ describe("submitReviewBugReport", () => {
       schema_version: 4,
       trace: {
         harness: "codex",
-        session_id: childId,
-        sessions: [
-          {
-            session_id: childId,
-            parent_session_id: parentId,
-            parent_end_ordinal_exclusive: 2,
-          },
-          { session_id: parentId },
-        ],
         truncated: false,
       },
     });
@@ -170,8 +160,6 @@ describe("submitReviewBugReport", () => {
       );
       expect(payload.trace).toMatchObject({
         harness,
-        session_id: id,
-        sessions: [{ session_id: id }],
       });
       expect(gunzipSync(capture.filePart("trace")).toString("utf8")).toBe(
         source,
@@ -226,7 +214,7 @@ describe("submitReviewBugReport", () => {
     const payloadBytes = capture.filePart("payload");
     expect(JSON.parse(gunzipSync(payloadBytes).toString("utf8"))).toMatchObject(
       {
-        schema_version: 3,
+        schema_version: 4,
         description: "",
       },
     );
@@ -413,20 +401,15 @@ function codexTrace(
   parent?: {
     parentId: string;
     endOrdinalExclusive: number;
-    endByteOffset: number;
   },
 ): string {
   const payload = {
     id,
     ...(parent
       ? {
-          history_mode: "paginated",
-          forked_from_id: parent.parentId,
-          forked_from_ordinal_exclusive: parent.endOrdinalExclusive,
           history_base: {
             thread_id: parent.parentId,
             end_ordinal_exclusive: parent.endOrdinalExclusive,
-            end_byte_offset: parent.endByteOffset,
           },
         }
       : {}),

--- a/packages/progressive-review/src/server/bug-report.test.ts
+++ b/packages/progressive-review/src/server/bug-report.test.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -11,7 +11,12 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { clearTraceEnvCache } from "../review-agent-traces";
-import { submitReviewBugReport } from "./bug-report";
+import {
+  type BugReportPayload,
+  buildBugReportRequest,
+  submitReviewBugReport,
+} from "./bug-report";
+import type { AuthoringTraceAttachment } from "./bug-report-trace";
 
 describe("submitReviewBugReport", () => {
   let tempDir: string;
@@ -243,6 +248,89 @@ describe("submitReviewBugReport", () => {
     );
   });
 
+  it("drops subagent trace files before a changed-file diff", async () => {
+    const trace: AuthoringTraceAttachment = {
+      payload: {
+        harness: "claude-code",
+        files: {
+          "subagents/agent.jsonl": randomBytes(2048).toString("base64"),
+        },
+        truncated: false,
+      },
+      parts: [],
+      cleanup: async () => {},
+    };
+    const payload: BugReportPayload = {
+      schema_version: 4,
+      description: "",
+      trace: trace.payload,
+      diff: {
+        baseRef: "base",
+        headRef: "head",
+        files: [
+          {
+            path: "src/example.ts",
+            status: "modified",
+            additions: 1,
+            deletions: 1,
+            patch: "@@ -1 +1 @@\n-old\n+new",
+          },
+        ],
+      },
+      diagnostics: diagnostics(),
+    };
+
+    const request = await buildBugReportRequest(payload, trace, {
+      appVersion: "1.2.3",
+      cliVersion: "0.0.1",
+      maxPayloadBytes: 1024,
+    });
+    const formPayload = request.body.get("payload");
+    if (!(formPayload instanceof Blob)) throw new Error("Missing payload.");
+    const fitted = JSON.parse(
+      gunzipSync(Buffer.from(await formPayload.arrayBuffer())).toString("utf8"),
+    );
+    const meta = JSON.parse(String(request.body.get("meta")));
+
+    expect(fitted.trace).toEqual({
+      harness: "claude-code",
+      files: {},
+      omitted_files: ["subagents/agent.jsonl"],
+      truncated: true,
+    });
+    expect(fitted).toHaveProperty("diff.files.0.path", "src/example.ts");
+    expect(meta).toMatchObject({
+      has_diff: true,
+      truncated_diff: false,
+      truncated_trace: true,
+    });
+  });
+
+  it("does not replace a successful submit when trace cleanup fails", async () => {
+    writeReview("claude-code:cleanup-test");
+    const cleanup = vi.fn<() => Promise<void>>(async () => {
+      throw new Error("busy");
+    });
+    const trace: AuthoringTraceAttachment = {
+      payload: { harness: "claude-code", files: {}, truncated: false },
+      parts: [],
+      cleanup,
+    };
+    const capture = captureFetch();
+
+    await expect(
+      submitReviewBugReport({
+        report: report({ include_trace: true }),
+        reviewDocumentPath: path.join(reviewRootPath, "review.mdx"),
+        reviewRootPath,
+        clientErrorNames: [],
+        fetchImpl: capture.fetchImpl,
+        readTraceAttachment: async () => trace,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
   function writeReview(sourceSession: string): void {
     writeFileSync(
       path.join(reviewRootPath, "review.json"),
@@ -311,6 +399,16 @@ function report(
     app_session_id: "session-1234567890",
     app_version: "1.2.3",
     ...overrides,
+  };
+}
+
+function diagnostics(): BugReportPayload["diagnostics"] {
+  return {
+    app_version: "1.2.3",
+    cli_version: "0.0.1",
+    platform: process.platform,
+    app_session_id: "session-1234567890",
+    client_error_names: [],
   };
 }
 

--- a/packages/progressive-review/src/server/bug-report.test.ts
+++ b/packages/progressive-review/src/server/bug-report.test.ts
@@ -16,14 +16,16 @@ import { submitReviewBugReport } from "./bug-report";
 describe("submitReviewBugReport", () => {
   let tempDir: string;
   let reviewRootPath: string;
+  let claudeRoot: string;
   let codexRoot: string;
+  let piRoot: string;
 
   beforeEach(() => {
     tempDir = mkdtempSync(path.join(tmpdir(), "bug-report-submit-"));
     reviewRootPath = path.join(tempDir, "review");
     codexRoot = path.join(tempDir, "codex");
-    const claudeRoot = path.join(tempDir, "claude");
-    const piRoot = path.join(tempDir, "pi");
+    claudeRoot = path.join(tempDir, "claude");
+    piRoot = path.join(tempDir, "pi");
     for (const directory of [reviewRootPath, codexRoot, claudeRoot, piRoot]) {
       mkdirSync(directory, { recursive: true });
     }
@@ -41,7 +43,7 @@ describe("submitReviewBugReport", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("sends ordered schema 2 parts for the complete child and parent traces", async () => {
+  it("sends ordered generic parts for a complete Codex lineage", async () => {
     const parentId = "11111111-1111-4111-8111-111111111111";
     const childId = "22222222-2222-4222-8222-222222222222";
     const parentAtFork = codexTrace(parentId, 0, [{ parent: true }]);
@@ -70,19 +72,29 @@ describe("submitReviewBugReport", () => {
     expect(capture.parts().map((part) => part.name)).toEqual([
       "meta",
       "payload",
-      "source_trace",
-      "parent_trace",
+      "trace",
+      "trace",
     ]);
     const meta = JSON.parse(capture.textPart("meta")) as {
       schema_version: number;
       payload_bytes: number;
-      parts: Array<{ field: string; bytes: number; sha256: string }>;
+      parts: Array<{
+        field: string;
+        filename: string;
+        bytes: number;
+        sha256: string;
+      }>;
     };
     expect(meta.schema_version).toBe(2);
     expect(meta.parts.map((part) => part.field)).toEqual([
       "payload",
-      "source_trace",
-      "parent_trace",
+      "trace",
+      "trace",
+    ]);
+    expect(meta.parts.map((part) => part.filename)).toEqual([
+      "payload.json.gz",
+      "trace-0.jsonl.gz",
+      "trace-1.jsonl.gz",
     ]);
 
     const payloadBytes = capture.filePart("payload");
@@ -92,23 +104,80 @@ describe("submitReviewBugReport", () => {
       trace: {
         harness: "codex",
         session_id: childId,
-        parent_session_id: parentId,
+        sessions: [
+          {
+            session_id: childId,
+            parent_session_id: parentId,
+            parent_end_ordinal_exclusive: 2,
+          },
+          { session_id: parentId },
+        ],
         truncated: false,
       },
     });
-    expect(gunzipSync(capture.filePart("source_trace")).toString("utf8")).toBe(
-      child,
-    );
-    expect(gunzipSync(capture.filePart("parent_trace")).toString("utf8")).toBe(
-      parent,
-    );
+    const traceFiles = capture.fileParts("trace");
+    expect(traceFiles).toHaveLength(2);
+    expect(gunzipSync(traceFiles[0]).toString("utf8")).toBe(child);
+    expect(gunzipSync(traceFiles[1]).toString("utf8")).toBe(parentAtFork);
     expect(meta.payload_bytes).toBe(payloadBytes.byteLength);
-    for (const part of meta.parts) {
-      const bytes = capture.filePart(part.field);
+    const files = [payloadBytes, ...traceFiles];
+    for (const [index, part] of meta.parts.entries()) {
+      const bytes = files[index];
       expect(part.bytes).toBe(bytes.byteLength);
       expect(part.sha256).toBe(sha256(bytes));
     }
   });
+
+  it.each([
+    ["claude-code", "33333333-3333-4333-8333-333333333333"],
+    ["pi", "44444444-4444-4444-8444-444444444444"],
+  ] as const)(
+    "sends an opted-in %s trace through the generic field",
+    async (harness, id) => {
+      const source = JSON.stringify({ harness, id }) + "\n";
+      writeReview(harness + ":" + id);
+      writeHarnessTrace(harness, id, source);
+      const capture = captureFetch();
+
+      await submitReviewBugReport({
+        report: report({ include_trace: true }),
+        reviewDocumentPath: path.join(reviewRootPath, "review.mdx"),
+        reviewRootPath,
+        clientErrorNames: [],
+        fetchImpl: capture.fetchImpl,
+      });
+
+      expect(capture.parts().map((part) => part.name)).toEqual([
+        "meta",
+        "payload",
+        "trace",
+      ]);
+      const meta = JSON.parse(capture.textPart("meta"));
+      expect(meta).toMatchObject({
+        has_trace: true,
+        trace_harness: harness,
+        parts: [
+          { field: "payload", filename: "payload.json.gz" },
+          {
+            field: "trace",
+            filename: "trace-0.jsonl.gz",
+            session_id: id,
+          },
+        ],
+      });
+      const payload = JSON.parse(
+        gunzipSync(capture.filePart("payload")).toString("utf8"),
+      );
+      expect(payload.trace).toMatchObject({
+        harness,
+        session_id: id,
+        sessions: [{ session_id: id }],
+      });
+      expect(gunzipSync(capture.filePart("trace")).toString("utf8")).toBe(
+        source,
+      );
+    },
+  );
 
   it("fails instead of omitting a selected trace", async () => {
     writeReview("codex:missing-session");
@@ -219,6 +288,27 @@ describe("submitReviewBugReport", () => {
       contents,
     );
   }
+
+  function writeHarnessTrace(
+    harness: "claude-code" | "pi",
+    id: string,
+    contents: string,
+  ): void {
+    const directory = path.join(
+      harness === "claude-code" ? claudeRoot : piRoot,
+      "project",
+    );
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(
+      path.join(
+        directory,
+        harness === "claude-code"
+          ? id + ".jsonl"
+          : "2026-08-31T12-00-00_" + id + ".jsonl",
+      ),
+      contents,
+    );
+  }
 });
 
 function report(
@@ -248,6 +338,7 @@ function captureFetch(): {
   parts: () => CapturedPart[];
   textPart: (name: string) => string;
   filePart: (name: string) => Buffer;
+  fileParts: (name: string) => Buffer[];
 } {
   let url: string | undefined;
   let headers: Headers | undefined;
@@ -292,6 +383,15 @@ function captureFetch(): {
       if (typeof value === "string") throw new Error(`${name} is not a file.`);
       return value.bytes;
     },
+    fileParts: (name) =>
+      capturedParts
+        .filter((candidate) => candidate.name === name)
+        .map((candidate) => {
+          if (typeof candidate.value === "string") {
+            throw new Error(`${name} is not a file.`);
+          }
+          return candidate.value.bytes;
+        }),
   };
 }
 

--- a/packages/progressive-review/src/server/bug-report.test.ts
+++ b/packages/progressive-review/src/server/bug-report.test.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -8,14 +8,10 @@ import {
   REVIEW_SCHEMA_VERSION,
   type ReviewBugReportRequest,
 } from "@dev.fast/review-protocol";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { clearTraceEnvCache } from "../review-agent-traces";
-import {
-  buildSizedBugReportRequest,
-  submitReviewBugReport,
-} from "./bug-report";
-import type { AuthoringTraceAttachment } from "./bug-report-trace";
+import { submitReviewBugReport } from "./bug-report";
 
 describe("submitReviewBugReport", () => {
   let tempDir: string;
@@ -45,15 +41,20 @@ describe("submitReviewBugReport", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("attaches the resolved authoring trace and exposes filterable metadata", async () => {
-    const sessionId = "77777777-aaaa-bbbb-cccc-000000000007";
-    writeReview("codex:" + sessionId);
-    const dateDir = path.join(codexRoot, "2026", "08", "31");
-    mkdirSync(dateDir, { recursive: true });
-    writeFileSync(
-      path.join(dateDir, "rollout-2026-08-31T12-00-00-" + sessionId + ".jsonl"),
-      JSON.stringify({ prompt: "Fix the bug" }) + "\n",
-    );
+  it("sends ordered schema 2 parts for the complete child and parent traces", async () => {
+    const parentId = "11111111-1111-4111-8111-111111111111";
+    const childId = "22222222-2222-4222-8222-222222222222";
+    const parentAtFork = codexTrace(parentId, 0, [{ parent: true }]);
+    const parent =
+      parentAtFork + JSON.stringify({ parentLater: true, ordinal: 2 }) + "\n";
+    const child = codexTrace(childId, 2, [{ child: true }], {
+      parentId,
+      endOrdinalExclusive: 2,
+      endByteOffset: Buffer.byteLength(parentAtFork),
+    });
+    writeCodexTrace(parentId, parent);
+    writeCodexTrace(childId, child);
+    writeReview("codex:" + childId);
     const capture = captureFetch();
 
     await submitReviewBugReport({
@@ -64,64 +65,96 @@ describe("submitReviewBugReport", () => {
       fetchImpl: capture.fetchImpl,
     });
 
-    const { meta, payload } = parseMultipart(capture.body());
-    expect(meta).toMatchObject({
-      has_trace: true,
-      trace_harness: "codex",
-      truncated_trace: false,
-    });
+    expect(capture.url()).toBe("https://bug.dev.fast/api/v2/reports");
+    expect(capture.headers().get("X-Review-Bug-Report-Schema")).toBeNull();
+    expect(capture.parts().map((part) => part.name)).toEqual([
+      "meta",
+      "payload",
+      "source_trace",
+      "parent_trace",
+    ]);
+    const meta = JSON.parse(capture.textPart("meta")) as {
+      schema_version: number;
+      payload_bytes: number;
+      parts: Array<{ field: string; bytes: number; sha256: string }>;
+    };
+    expect(meta.schema_version).toBe(2);
+    expect(meta.parts.map((part) => part.field)).toEqual([
+      "payload",
+      "source_trace",
+      "parent_trace",
+    ]);
+
+    const payloadBytes = capture.filePart("payload");
+    const payload = JSON.parse(gunzipSync(payloadBytes).toString("utf8"));
     expect(payload).toMatchObject({
-      schema_version: 3,
+      schema_version: 4,
       trace: {
         harness: "codex",
-        session_id: sessionId,
+        session_id: childId,
+        parent_session_id: parentId,
         truncated: false,
       },
     });
+    expect(gunzipSync(capture.filePart("source_trace")).toString("utf8")).toBe(
+      child,
+    );
+    expect(gunzipSync(capture.filePart("parent_trace")).toString("utf8")).toBe(
+      parent,
+    );
+    expect(meta.payload_bytes).toBe(payloadBytes.byteLength);
+    for (const part of meta.parts) {
+      const bytes = capture.filePart(part.field);
+      expect(part.bytes).toBe(bytes.byteLength);
+      expect(part.sha256).toBe(sha256(bytes));
+    }
   });
 
-  it("records an unavailable trace without failing the report", async () => {
+  it("fails instead of omitting a selected trace", async () => {
     writeReview("codex:missing-session");
-    const capture = captureFetch();
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await expect(
+      submitReviewBugReport({
+        report: report({ include_trace: true }),
+        reviewDocumentPath: path.join(reviewRootPath, "review.mdx"),
+        reviewRootPath,
+        clientErrorNames: [],
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("keeps the schema 1 multipart path for reports without traces", async () => {
+    writeReview("disabled:review");
+    let url: string | undefined;
+    let headers: Headers | undefined;
+    let body: Buffer | undefined;
+    const fetchImpl: typeof fetch = async (input, init) => {
+      url = input.toString();
+      headers = new Headers(init?.headers);
+      body = Buffer.from(init?.body as Buffer);
+      return successResponse();
+    };
 
     await submitReviewBugReport({
-      report: report({ include_trace: true }),
+      report: report(),
       reviewDocumentPath: path.join(reviewRootPath, "review.mdx"),
       reviewRootPath,
       clientErrorNames: [],
-      fetchImpl: capture.fetchImpl,
+      fetchImpl,
     });
 
-    const { meta, payload } = parseMultipart(capture.body());
-    expect(meta).not.toHaveProperty("has_trace");
-    expect(meta).not.toHaveProperty("trace_harness");
-    expect(meta).not.toHaveProperty("truncated_trace");
-    expect(payload).not.toHaveProperty("trace");
-    expect(payload).toMatchObject({
-      diagnostics: {
-        attachment_errors: [{ attachment: "trace", error: "unavailable" }],
-      },
+    expect(url).toBe("https://bug.dev.fast/api/v1/reports");
+    expect(headers?.get("X-Review-Bug-Report-Schema")).toBeNull();
+    expect(headers?.get("content-type")).toContain(
+      "boundary=dev-fast-review-bug-report-v1",
+    );
+    expect(parseV1Multipart(body ?? Buffer.alloc(0)).payload).toMatchObject({
+      schema_version: 3,
+      description: "",
     });
-  });
-
-  it("drops an oversized trace before a changed-file diff", () => {
-    const payload = bugReportPayload(largeTraceAttachment());
-
-    const request = buildSizedBugReportRequest(payload, {
-      appVersion: "1.2.3",
-      cliVersion: "0.0.1",
-    });
-
-    const { meta, payload: fittedPayload } = parseMultipart(request.body);
-    expect(meta).toMatchObject({
-      has_trace: false,
-      has_diff: true,
-      trace_harness: "claude-code",
-      truncated_trace: true,
-      truncated_diff: false,
-    });
-    expect(fittedPayload).not.toHaveProperty("trace");
-    expect(fittedPayload).toHaveProperty("diff.files.0.path", "src/example.ts");
   });
 
   function writeReview(sourceSession: string): void {
@@ -148,6 +181,15 @@ describe("submitReviewBugReport", () => {
       }),
     );
   }
+
+  function writeCodexTrace(id: string, contents: string): void {
+    const dateDir = path.join(codexRoot, "2026", "08", "31");
+    mkdirSync(dateDir, { recursive: true });
+    writeFileSync(
+      path.join(dateDir, "rollout-2026-08-31T12-00-00-" + id + ".jsonl"),
+      contents,
+    );
+  }
 });
 
 function report(
@@ -165,32 +207,114 @@ function report(
   };
 }
 
+interface CapturedPart {
+  name: string;
+  value: string | { filename: string; type: string; bytes: Buffer };
+}
+
 function captureFetch(): {
   fetchImpl: typeof fetch;
-  body: () => Buffer;
+  url: () => string;
+  headers: () => Headers;
+  parts: () => CapturedPart[];
+  textPart: (name: string) => string;
+  filePart: (name: string) => Buffer;
 } {
-  let body: Buffer | undefined;
-  const fetchImpl: typeof fetch = async (_input, init) => {
-    body = Buffer.from(init?.body as Buffer);
-    return new Response(
-      JSON.stringify({
-        ok: true,
-        report_id: "00000000-0000-4000-8000-000000000000",
-        short_id: "123456789012",
-      }),
-      { status: 200, headers: { "content-type": "application/json" } },
-    );
+  let url: string | undefined;
+  let headers: Headers | undefined;
+  const capturedParts: CapturedPart[] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    url = input.toString();
+    headers = new Headers(init?.headers);
+    const form = init?.body;
+    if (!(form instanceof FormData)) throw new Error("Expected FormData.");
+    for (const [name, value] of form.entries()) {
+      capturedParts.push({
+        name,
+        value:
+          typeof value === "string"
+            ? value
+            : {
+                filename: value.name,
+                type: value.type,
+                bytes: Buffer.from(await value.arrayBuffer()),
+              },
+      });
+    }
+    return successResponse();
+  };
+  const part = (name: string) => {
+    const result = capturedParts.find((candidate) => candidate.name === name);
+    if (!result) throw new Error(`Missing captured ${name} part.`);
+    return result.value;
   };
   return {
     fetchImpl,
-    body: () => {
-      if (!body) throw new Error("Bug-report body was not captured");
-      return body;
+    url: () => url ?? "",
+    headers: () => headers ?? new Headers(),
+    parts: () => capturedParts,
+    textPart: (name) => {
+      const value = part(name);
+      if (typeof value !== "string") throw new Error(`${name} is not text.`);
+      return value;
+    },
+    filePart: (name) => {
+      const value = part(name);
+      if (typeof value === "string") throw new Error(`${name} is not a file.`);
+      return value.bytes;
     },
   };
 }
 
-function parseMultipart(body: Buffer): {
+function successResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      report_id: "00000000-0000-4000-8000-000000000000",
+      short_id: "123456789012",
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function codexTrace(
+  id: string,
+  startOrdinal: number,
+  records: Array<Record<string, unknown>>,
+  parent?: {
+    parentId: string;
+    endOrdinalExclusive: number;
+    endByteOffset: number;
+  },
+): string {
+  const payload = {
+    id,
+    ...(parent
+      ? {
+          history_mode: "paginated",
+          forked_from_id: parent.parentId,
+          forked_from_ordinal_exclusive: parent.endOrdinalExclusive,
+          history_base: {
+            thread_id: parent.parentId,
+            end_ordinal_exclusive: parent.endOrdinalExclusive,
+            end_byte_offset: parent.endByteOffset,
+          },
+        }
+      : {}),
+  };
+  return [{ type: "session_meta", payload }, ...records]
+    .map(
+      (value, index) =>
+        JSON.stringify({ ...value, ordinal: startOrdinal + index }) + "\n",
+    )
+    .join("");
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function parseV1Multipart(body: Buffer): {
   meta: Record<string, unknown>;
   payload: Record<string, unknown>;
 } {
@@ -210,63 +334,4 @@ function parseMultipart(body: Buffer): {
       gunzipSync(body.subarray(payloadStart, payloadEnd)).toString("utf8"),
     ),
   };
-}
-
-function bugReportPayload(
-  trace: AuthoringTraceAttachment,
-): Parameters<typeof buildSizedBugReportRequest>[0] {
-  return {
-    schema_version: 3,
-    description: "",
-    trace,
-    diff: {
-      baseRef: "base",
-      headRef: "head",
-      files: [
-        {
-          path: "src/example.ts",
-          status: "modified",
-          additions: 1,
-          deletions: 1,
-          patch: "@@ -1 +1 @@\n-old\n+new",
-        },
-      ],
-    },
-    diagnostics: {
-      app_version: "1.2.3",
-      cli_version: "0.0.1",
-      platform: process.platform,
-      app_session_id: "session-1234567890",
-      client_error_names: [],
-    },
-  };
-}
-
-function largeTraceAttachment(): AuthoringTraceAttachment {
-  const files: Record<string, string> = {
-    "trace.jsonl": incompressibleJsonl(6 * 1024 * 1024),
-  };
-  for (let index = 0; index < 10; index++) {
-    files["subagents/agent-" + index + ".jsonl"] = incompressibleJsonl(
-      1024 * 1024,
-    );
-  }
-  return {
-    harness: "claude-code",
-    session_id: "session-oversized",
-    files,
-    truncated: false,
-  };
-}
-
-function incompressibleJsonl(targetBytes: number): string {
-  const lines: string[] = [];
-  let bytes = 0;
-  while (bytes < targetBytes) {
-    const line =
-      JSON.stringify({ data: randomBytes(768).toString("base64") }) + "\n";
-    lines.push(line);
-    bytes += Buffer.byteLength(line);
-  }
-  return lines.join("");
 }

--- a/packages/progressive-review/src/server/bug-report.test.ts
+++ b/packages/progressive-review/src/server/bug-report.test.ts
@@ -126,35 +126,64 @@ describe("submitReviewBugReport", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it("keeps the schema 1 multipart path for reports without traces", async () => {
+  it("sends schema 2 payload parts for reports without traces", async () => {
     writeReview("disabled:review");
-    let url: string | undefined;
-    let headers: Headers | undefined;
-    let body: Buffer | undefined;
-    const fetchImpl: typeof fetch = async (input, init) => {
-      url = input.toString();
-      headers = new Headers(init?.headers);
-      body = Buffer.from(init?.body as Buffer);
-      return successResponse();
-    };
+    const capture = captureFetch();
 
     await submitReviewBugReport({
       report: report(),
       reviewDocumentPath: path.join(reviewRootPath, "review.mdx"),
       reviewRootPath,
       clientErrorNames: [],
-      fetchImpl,
+      fetchImpl: capture.fetchImpl,
     });
 
-    expect(url).toBe("https://bug.dev.fast/api/v1/reports");
-    expect(headers?.get("X-Review-Bug-Report-Schema")).toBeNull();
-    expect(headers?.get("content-type")).toContain(
-      "boundary=dev-fast-review-bug-report-v1",
-    );
-    expect(parseV1Multipart(body ?? Buffer.alloc(0)).payload).toMatchObject({
-      schema_version: 3,
-      description: "",
+    expect(capture.url()).toBe("https://bug.dev.fast/api/v2/reports");
+    expect(capture.headers().get("X-Review-Bug-Report-Schema")).toBeNull();
+    expect(capture.parts().map((part) => part.name)).toEqual([
+      "meta",
+      "payload",
+    ]);
+    const meta = JSON.parse(capture.textPart("meta")) as {
+      schema_version: number;
+      has_trace: boolean;
+      parts: Array<{ field: string; bytes: number; sha256: string }>;
+    };
+    expect(meta).toMatchObject({
+      schema_version: 2,
+      has_trace: false,
+      parts: [{ field: "payload" }],
     });
+    const payloadBytes = capture.filePart("payload");
+    expect(JSON.parse(gunzipSync(payloadBytes).toString("utf8"))).toMatchObject(
+      {
+        schema_version: 3,
+        description: "",
+      },
+    );
+    expect(meta.parts[0].bytes).toBe(payloadBytes.byteLength);
+    expect(meta.parts[0].sha256).toBe(sha256(payloadBytes));
+  });
+
+  it("does not retry a failed schema 2 report through schema 1", async () => {
+    writeReview("disabled:review");
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      Response.json({ ok: false, error: "Unavailable." }, { status: 503 }),
+    );
+
+    await expect(
+      submitReviewBugReport({
+        report: report(),
+        reviewDocumentPath: path.join(reviewRootPath, "review.mdx"),
+        reviewRootPath,
+        clientErrorNames: [],
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({ status: 502 });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(fetchImpl.mock.calls[0][0].toString()).toBe(
+      "https://bug.dev.fast/api/v2/reports",
+    );
   });
 
   function writeReview(sourceSession: string): void {
@@ -312,26 +341,4 @@ function codexTrace(
 
 function sha256(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
-}
-
-function parseV1Multipart(body: Buffer): {
-  meta: Record<string, unknown>;
-  payload: Record<string, unknown>;
-} {
-  const metaHeader = Buffer.from('Content-Disposition: form-data; name="meta"');
-  const payloadHeader = Buffer.from(
-    'Content-Disposition: form-data; name="payload"',
-  );
-  const metaPart = body.indexOf(metaHeader);
-  const metaStart = body.indexOf(Buffer.from("\r\n\r\n"), metaPart) + 4;
-  const metaEnd = body.indexOf(Buffer.from("\r\n--"), metaStart);
-  const payloadPart = body.indexOf(payloadHeader);
-  const payloadStart = body.indexOf(Buffer.from("\r\n\r\n"), payloadPart) + 4;
-  const payloadEnd = body.lastIndexOf(Buffer.from("\r\n--"));
-  return {
-    meta: JSON.parse(body.subarray(metaStart, metaEnd).toString("utf8")),
-    payload: JSON.parse(
-      gunzipSync(body.subarray(payloadStart, payloadEnd)).toString("utf8"),
-    ),
-  };
 }

--- a/packages/progressive-review/src/server/bug-report.ts
+++ b/packages/progressive-review/src/server/bug-report.ts
@@ -54,7 +54,7 @@ type AttachmentError = {
   error: "unavailable";
 };
 
-interface BugReportPayload {
+export interface BugReportPayload {
   schema_version: 4;
   description: string;
   screenshot?: { mime: "image/jpeg"; base64: string };
@@ -93,6 +93,7 @@ export async function submitReviewBugReport(input: {
   reviewRootPath: string;
   clientErrorNames: string[];
   fetchImpl?: typeof fetch;
+  readTraceAttachment?: typeof readAuthoringTraceAttachment;
 }) {
   const cliVersion = readProgressiveReviewPackageVersion();
   const attachmentErrors: AttachmentError[] = [];
@@ -167,7 +168,7 @@ export async function submitReviewBugReport(input: {
   }
   if (input.report.include_trace) {
     tasks.push(
-      readAuthoringTraceAttachment({
+      (input.readTraceAttachment ?? readAuthoringTraceAttachment)({
         reviewRootPath: input.reviewRootPath,
       }).then(
         (trace) => {
@@ -225,54 +226,79 @@ export async function submitReviewBugReport(input: {
     const responseBody = await response.json().catch(() => null);
     if (!response.ok) {
       throw new BugReportUpstreamError(
-        response.status === 429 || response.status === 413
+        response.status === 429 ||
+          response.status === 413 ||
+          response.status === 422
           ? response.status
           : 502,
         response.status === 429
           ? "Too many reports. Try again later."
           : response.status === 413
             ? "Bug report is too large."
-            : "Bug report service failed.",
+            : response.status === 422
+              ? "The complete authoring trace is unavailable."
+              : "Bug report service failed.",
       );
     }
     const result = parseReviewBugReportResponse(responseBody);
     if (!result.ok) throw new BugReportUpstreamError(502, result.error);
     return result;
   } finally {
-    await traceAttachment?.cleanup();
+    await traceAttachment?.cleanup().catch(() => {});
   }
 }
 
-async function buildBugReportRequest(
+export async function buildBugReportRequest(
   payload: BugReportPayload,
   trace: AuthoringTraceAttachment | undefined,
-  input: { appVersion: string; cliVersion: string },
+  input: {
+    appVersion: string;
+    cliVersion: string;
+    maxPayloadBytes?: number;
+  },
 ): Promise<{ body: FormData }> {
+  const maxPayloadBytes = input.maxPayloadBytes ?? MAX_PAYLOAD_BYTES;
   let truncatedDiff = false;
   let truncatedMap = false;
   let truncatedScreenshot = false;
   let payloadBytes = gzipPayload(payload);
 
-  if (payloadBytes.byteLength > MAX_PAYLOAD_BYTES && payload.diff) {
+  if (
+    payloadBytes.byteLength > maxPayloadBytes &&
+    payload.trace &&
+    Object.keys(payload.trace.files).length > 0
+  ) {
+    payload.trace.omitted_files = [
+      ...new Set([
+        ...(payload.trace.omitted_files ?? []),
+        ...Object.keys(payload.trace.files),
+      ]),
+    ].sort();
+    payload.trace.files = {};
+    payload.trace.truncated = true;
+    payloadBytes = gzipPayload(payload);
+  }
+
+  if (payloadBytes.byteLength > maxPayloadBytes && payload.diff) {
     delete payload.diff;
     truncatedDiff = true;
     payloadBytes = gzipPayload(payload);
   }
-  if (payloadBytes.byteLength > MAX_PAYLOAD_BYTES && payload.map) {
+  if (payloadBytes.byteLength > maxPayloadBytes && payload.map) {
     delete payload.map;
     truncatedMap = true;
     payloadBytes = gzipPayload(payload);
   }
-  if (payloadBytes.byteLength > MAX_PAYLOAD_BYTES && payload.screenshot) {
+  if (payloadBytes.byteLength > maxPayloadBytes && payload.screenshot) {
     delete payload.screenshot;
     truncatedScreenshot = true;
     payloadBytes = gzipPayload(payload);
   }
-  if (payloadBytes.byteLength > MAX_PAYLOAD_BYTES && payload.review) {
+  if (payloadBytes.byteLength > maxPayloadBytes && payload.review) {
     delete payload.review;
     payloadBytes = gzipPayload(payload);
   }
-  if (payloadBytes.byteLength > MAX_PAYLOAD_BYTES) {
+  if (payloadBytes.byteLength > maxPayloadBytes) {
     throw new BugReportUpstreamError(413, "Bug report is too large.");
   }
 

--- a/packages/progressive-review/src/server/bug-report.ts
+++ b/packages/progressive-review/src/server/bug-report.ts
@@ -1,9 +1,12 @@
+import { createHash } from "node:crypto";
+import { openAsBlob } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
 
 import {
-  type ReviewBugReportMeta,
+  type ReviewBugReportMetaV1,
+  type ReviewBugReportMetaV2,
   type ReviewBugReportRequest,
   parseReviewBugReportResponse,
 } from "@dev.fast/review-protocol";
@@ -20,13 +23,19 @@ import {
 import { readSoftwareMapSourceForRef } from "../software-map-artifact";
 import {
   type AuthoringTraceAttachment,
+  type AuthoringTracePayload,
   readAuthoringTraceAttachment,
 } from "./bug-report-trace";
 
-const BUG_REPORT_URL = "https://bug.dev.fast/api/v1/reports";
+const BUG_REPORT_V1_URL = "https://bug.dev.fast/api/v1/reports";
+const BUG_REPORT_V2_URL = "https://bug.dev.fast/api/v2/reports";
 const MAX_MULTIPART_BYTES = 10 * 1024 * 1024;
 const MULTIPART_BOUNDARY = "dev-fast-review-bug-report-v1";
 const UPSTREAM_TIMEOUT_MS = 20_000;
+const TRACE_UPSTREAM_TIMEOUT_MS = 5 * 60_000;
+const MAX_TRACE_MULTIPART_PART_BYTES = 100_000_000;
+// Keep room for multipart headers and boundaries below the Worker request cap.
+const MAX_TRACE_MULTIPART_CONTENT_BYTES = 99_000_000;
 // The review directory is a git repo, but its tracked set also holds
 // `review.json` (an absolute home path, the repo key, the pull request URL) and
 // the compiled `.bundle/` output. So the report attaches an explicit source set
@@ -49,7 +58,7 @@ type AttachmentError = {
 };
 
 interface BugReportPayload {
-  schema_version: 3;
+  schema_version: 3 | 4;
   description: string;
   screenshot?: { mime: "image/jpeg"; base64: string };
   // File name to text. The document alone cannot render: every anchor lives in
@@ -57,7 +66,7 @@ interface BugReportPayload {
   review?: Record<string, string>;
   map?: string;
   diff?: ReviewDiffFilesResult;
-  trace?: AuthoringTraceAttachment;
+  trace?: AuthoringTracePayload;
   diagnostics: {
     app_version: string;
     cli_version: string;
@@ -166,13 +175,18 @@ export async function submitReviewBugReport(input: {
       }).then(
         (trace) => {
           if (trace === null) {
-            attachmentErrors.push(unavailable("trace"));
-            return;
+            throw new BugReportUpstreamError(
+              422,
+              "The complete authoring trace is unavailable.",
+            );
           }
           traceAttachment = trace;
         },
         () => {
-          attachmentErrors.push(unavailable("trace"));
+          throw new BugReportUpstreamError(
+            422,
+            "The complete authoring trace is unavailable.",
+          );
         },
       ),
     );
@@ -184,45 +198,62 @@ export async function submitReviewBugReport(input: {
   }
   if (mapSource !== undefined) payload.map = mapSource;
   if (changedFileDiffs !== undefined) payload.diff = changedFileDiffs;
-  if (traceAttachment !== undefined) payload.trace = traceAttachment;
+  if (traceAttachment !== undefined) {
+    payload.schema_version = 4;
+    payload.trace = traceAttachment.payload;
+  }
   if (attachmentErrors.length > 0) {
     payload.diagnostics.attachment_errors = attachmentErrors.sort(
       (left, right) => left.attachment.localeCompare(right.attachment),
     );
   }
 
-  const request = buildSizedBugReportRequest(payload, {
-    appVersion: input.report.app_version,
-    cliVersion,
-  });
+  try {
+    const request = traceAttachment
+      ? await buildTraceBugReportRequest(payload, traceAttachment, {
+          appVersion: input.report.app_version,
+          cliVersion,
+        })
+      : buildSizedBugReportRequest(payload, {
+          appVersion: input.report.app_version,
+          cliVersion,
+        });
 
-  const response = await (input.fetchImpl ?? fetch)(BUG_REPORT_URL, {
-    method: "POST",
-    headers: { "content-type": request.contentType },
-    body: request.body,
-    signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
-  }).catch((error) => {
-    throw new BugReportUpstreamError(
-      502,
-      error instanceof Error ? error.message : "Bug report service failed.",
-    );
-  });
-  const responseBody = await response.json().catch(() => null);
-  if (!response.ok) {
-    throw new BugReportUpstreamError(
-      response.status === 429 || response.status === 413
-        ? response.status
-        : 502,
-      response.status === 429
-        ? "Too many reports. Try again later."
-        : response.status === 413
-          ? "Bug report is too large."
-          : "Bug report service failed.",
-    );
+    const response = await (input.fetchImpl ?? fetch)(
+      traceAttachment ? BUG_REPORT_V2_URL : BUG_REPORT_V1_URL,
+      {
+        method: "POST",
+        headers: request.headers,
+        body: request.body,
+        signal: AbortSignal.timeout(
+          traceAttachment ? TRACE_UPSTREAM_TIMEOUT_MS : UPSTREAM_TIMEOUT_MS,
+        ),
+      },
+    ).catch((error) => {
+      throw new BugReportUpstreamError(
+        502,
+        error instanceof Error ? error.message : "Bug report service failed.",
+      );
+    });
+    const responseBody = await response.json().catch(() => null);
+    if (!response.ok) {
+      throw new BugReportUpstreamError(
+        response.status === 429 || response.status === 413
+          ? response.status
+          : 502,
+        response.status === 429
+          ? "Too many reports. Try again later."
+          : response.status === 413
+            ? "Bug report is too large."
+            : "Bug report service failed.",
+      );
+    }
+    const result = parseReviewBugReportResponse(responseBody);
+    if (!result.ok) throw new BugReportUpstreamError(502, result.error);
+    return result;
+  } finally {
+    await traceAttachment?.cleanup();
   }
-  const result = parseReviewBugReportResponse(responseBody);
-  if (!result.ok) throw new BugReportUpstreamError(502, result.error);
-  return result;
 }
 
 export function buildSizedBugReportRequest(
@@ -232,27 +263,24 @@ export function buildSizedBugReportRequest(
     cliVersion: string;
   },
 ) {
+  if (payload.trace) {
+    throw new BugReportUpstreamError(
+      400,
+      "Trace reports require the v2 transport.",
+    );
+  }
   let truncatedDiff = false;
   let truncatedMap = false;
   let truncatedScreenshot = false;
-  let truncatedTrace = payload.trace?.truncated ?? false;
-  const traceHarness = payload.trace?.harness;
   const build = () =>
     buildBugReportRequest(payload, {
       ...input,
       truncatedDiff,
       truncatedMap,
       truncatedScreenshot,
-      truncatedTrace,
-      traceHarness,
     });
 
   let request = build();
-  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.trace) {
-    delete payload.trace;
-    truncatedTrace = true;
-    request = build();
-  }
   if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.diff) {
     delete payload.diff;
     truncatedDiff = true;
@@ -276,6 +304,120 @@ export function buildSizedBugReportRequest(
     throw new BugReportUpstreamError(413, "Bug report is too large.");
   }
   return request;
+}
+
+async function buildTraceBugReportRequest(
+  payload: BugReportPayload,
+  trace: AuthoringTraceAttachment,
+  input: { appVersion: string; cliVersion: string },
+): Promise<{ body: FormData; headers: HeadersInit }> {
+  let truncatedDiff = false;
+  let truncatedMap = false;
+  let truncatedScreenshot = false;
+  let payloadBytes = gzipPayload(payload);
+
+  if (payloadBytes.byteLength > MAX_MULTIPART_BYTES && payload.diff) {
+    delete payload.diff;
+    truncatedDiff = true;
+    payloadBytes = gzipPayload(payload);
+  }
+  if (payloadBytes.byteLength > MAX_MULTIPART_BYTES && payload.map) {
+    delete payload.map;
+    truncatedMap = true;
+    payloadBytes = gzipPayload(payload);
+  }
+  if (payloadBytes.byteLength > MAX_MULTIPART_BYTES && payload.screenshot) {
+    delete payload.screenshot;
+    truncatedScreenshot = true;
+    payloadBytes = gzipPayload(payload);
+  }
+  if (payloadBytes.byteLength > MAX_MULTIPART_BYTES && payload.review) {
+    delete payload.review;
+    payloadBytes = gzipPayload(payload);
+  }
+  if (payloadBytes.byteLength > MAX_MULTIPART_BYTES) {
+    throw new BugReportUpstreamError(413, "Bug report is too large.");
+  }
+
+  const traceParts: ReviewBugReportMetaV2["parts"] = trace.parts.map((part) =>
+    part.field === "source_trace"
+      ? {
+          field: "source_trace",
+          filename: "source.jsonl.gz",
+          session_id: part.session_id,
+          bytes: part.bytes,
+          sha256: part.sha256,
+        }
+      : {
+          field: "parent_trace",
+          filename: "parent.jsonl.gz",
+          session_id: part.session_id,
+          bytes: part.bytes,
+          sha256: part.sha256,
+        },
+  );
+  const parts: ReviewBugReportMetaV2["parts"] = [
+    {
+      field: "payload",
+      filename: "payload.json.gz",
+      bytes: payloadBytes.byteLength,
+      sha256: sha256Bytes(payloadBytes),
+    },
+    ...traceParts,
+  ];
+  const contentBytes = parts.reduce((total, part) => total + part.bytes, 0);
+  if (
+    parts.some((part) => part.bytes > MAX_TRACE_MULTIPART_PART_BYTES) ||
+    contentBytes > MAX_TRACE_MULTIPART_CONTENT_BYTES
+  ) {
+    throw new BugReportUpstreamError(413, "Bug report is too large.");
+  }
+
+  const meta: ReviewBugReportMetaV2 = {
+    schema_version: 2,
+    description_length: Buffer.byteLength(payload.description),
+    has_review: payload.review !== undefined,
+    has_map: payload.map !== undefined,
+    has_diff: payload.diff !== undefined,
+    has_screenshot: payload.screenshot !== undefined,
+    has_trace: true,
+    trace_harness: trace.payload.harness,
+    payload_bytes: payloadBytes.byteLength,
+    app_version: input.appVersion,
+    cli_version: input.cliVersion,
+    platform: process.platform,
+    truncated_diff: truncatedDiff,
+    truncated_map: truncatedMap,
+    truncated_screenshot: truncatedScreenshot,
+    truncated_trace: trace.payload.truncated,
+    parts,
+  };
+  const form = new FormData();
+  form.append("meta", JSON.stringify(meta));
+  form.append(
+    "payload",
+    new Blob([Uint8Array.from(payloadBytes)], { type: "application/gzip" }),
+    "payload.json.gz",
+  );
+  for (const part of trace.parts) {
+    form.append(
+      part.field,
+      await openAsBlob(part.path, { type: "application/gzip" }),
+      part.filename,
+    );
+  }
+  return {
+    body: form,
+    headers: {},
+  };
+}
+
+function gzipPayload(payload: BugReportPayload): Buffer {
+  return gzipSync(Buffer.from(JSON.stringify(payload)), { level: 9 });
+}
+
+function sha256Bytes(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
 }
 
 // The document is required: a failure to read it makes the attachment
@@ -357,27 +499,19 @@ function buildBugReportRequest(
     truncatedDiff: boolean;
     truncatedMap: boolean;
     truncatedScreenshot: boolean;
-    truncatedTrace: boolean;
-    traceHarness?: AuthoringTraceAttachment["harness"];
   },
 ) {
   const payloadBytes = gzipSync(Buffer.from(JSON.stringify(payload)), {
     level: 9,
   });
-  const meta: ReviewBugReportMeta = {
+  const meta: ReviewBugReportMetaV1 = {
     schema_version: 1,
     description_length: Buffer.byteLength(payload.description),
     has_review: payload.review !== undefined,
     has_map: payload.map !== undefined,
     has_diff: payload.diff !== undefined,
     has_screenshot: payload.screenshot !== undefined,
-    ...(input.traceHarness
-      ? {
-          has_trace: payload.trace !== undefined,
-          trace_harness: input.traceHarness,
-          truncated_trace: input.truncatedTrace,
-        }
-      : {}),
+    has_trace: false,
     payload_bytes: payloadBytes.byteLength,
     app_version: input.appVersion,
     cli_version: input.cliVersion,
@@ -385,6 +519,7 @@ function buildBugReportRequest(
     truncated_diff: input.truncatedDiff,
     truncated_map: input.truncatedMap,
     truncated_screenshot: input.truncatedScreenshot,
+    truncated_trace: false,
   };
   const body = Buffer.concat([
     Buffer.from(
@@ -398,7 +533,9 @@ function buildBugReportRequest(
   ]);
   return {
     body,
-    contentType: `multipart/form-data; boundary=${MULTIPART_BOUNDARY}`,
+    headers: {
+      "content-type": `multipart/form-data; boundary=${MULTIPART_BOUNDARY}`,
+    },
   };
 }
 

--- a/packages/progressive-review/src/server/bug-report.ts
+++ b/packages/progressive-review/src/server/bug-report.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import { gzipSync } from "node:zlib";
 
 import {
-  type ReviewBugReportMetaV1,
   type ReviewBugReportMetaV2,
   type ReviewBugReportRequest,
   parseReviewBugReportResponse,
@@ -27,15 +26,13 @@ import {
   readAuthoringTraceAttachment,
 } from "./bug-report-trace";
 
-const BUG_REPORT_V1_URL = "https://bug.dev.fast/api/v1/reports";
-const BUG_REPORT_V2_URL = "https://bug.dev.fast/api/v2/reports";
-const MAX_MULTIPART_BYTES = 10 * 1024 * 1024;
-const MULTIPART_BOUNDARY = "dev-fast-review-bug-report-v1";
+const BUG_REPORT_URL = "https://bug.dev.fast/api/v2/reports";
+const MAX_PAYLOAD_BYTES = 10 * 1024 * 1024;
 const UPSTREAM_TIMEOUT_MS = 20_000;
 const TRACE_UPSTREAM_TIMEOUT_MS = 5 * 60_000;
-const MAX_TRACE_MULTIPART_PART_BYTES = 100_000_000;
+const MAX_MULTIPART_PART_BYTES = 100_000_000;
 // Keep room for multipart headers and boundaries below the Worker request cap.
-const MAX_TRACE_MULTIPART_CONTENT_BYTES = 99_000_000;
+const MAX_MULTIPART_CONTENT_BYTES = 99_000_000;
 // The review directory is a git repo, but its tracked set also holds
 // `review.json` (an absolute home path, the repo key, the pull request URL) and
 // the compiled `.bundle/` output. So the report attaches an explicit source set
@@ -44,7 +41,7 @@ const MAX_TRACE_MULTIPART_CONTENT_BYTES = 99_000_000;
 // `.build/<revision>/` holds a second copy of every source file.
 const REVIEW_SOURCE_MODULE_RE = /\.tsx?$/;
 const MAX_REVIEW_SOURCE_FILES = 20;
-// Not a transfer limit: `MAX_MULTIPART_BYTES` already bounds what reaches the
+// Not a transfer limit: `MAX_PAYLOAD_BYTES` already bounds what reaches the
 // Worker. This bounds one file, because the size ladder below drops the whole
 // review attachment rather than one module. So a single huge file would cost
 // the report its entire review. Authored modules run to a few kilobytes, and
@@ -209,27 +206,18 @@ export async function submitReviewBugReport(input: {
   }
 
   try {
-    const request = traceAttachment
-      ? await buildTraceBugReportRequest(payload, traceAttachment, {
-          appVersion: input.report.app_version,
-          cliVersion,
-        })
-      : buildSizedBugReportRequest(payload, {
-          appVersion: input.report.app_version,
-          cliVersion,
-        });
+    const request = await buildBugReportRequest(payload, traceAttachment, {
+      appVersion: input.report.app_version,
+      cliVersion,
+    });
 
-    const response = await (input.fetchImpl ?? fetch)(
-      traceAttachment ? BUG_REPORT_V2_URL : BUG_REPORT_V1_URL,
-      {
-        method: "POST",
-        headers: request.headers,
-        body: request.body,
-        signal: AbortSignal.timeout(
-          traceAttachment ? TRACE_UPSTREAM_TIMEOUT_MS : UPSTREAM_TIMEOUT_MS,
-        ),
-      },
-    ).catch((error) => {
+    const response = await (input.fetchImpl ?? fetch)(BUG_REPORT_URL, {
+      method: "POST",
+      body: request.body,
+      signal: AbortSignal.timeout(
+        traceAttachment ? TRACE_UPSTREAM_TIMEOUT_MS : UPSTREAM_TIMEOUT_MS,
+      ),
+    }).catch((error) => {
       throw new BugReportUpstreamError(
         502,
         error instanceof Error ? error.message : "Bug report service failed.",
@@ -256,106 +244,57 @@ export async function submitReviewBugReport(input: {
   }
 }
 
-export function buildSizedBugReportRequest(
+async function buildBugReportRequest(
   payload: BugReportPayload,
-  input: {
-    appVersion: string;
-    cliVersion: string;
-  },
-) {
-  if (payload.trace) {
-    throw new BugReportUpstreamError(
-      400,
-      "Trace reports require the v2 transport.",
-    );
-  }
-  let truncatedDiff = false;
-  let truncatedMap = false;
-  let truncatedScreenshot = false;
-  const build = () =>
-    buildBugReportRequest(payload, {
-      ...input,
-      truncatedDiff,
-      truncatedMap,
-      truncatedScreenshot,
-    });
-
-  let request = build();
-  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.diff) {
-    delete payload.diff;
-    truncatedDiff = true;
-    request = build();
-  }
-  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.map) {
-    delete payload.map;
-    truncatedMap = true;
-    request = build();
-  }
-  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.screenshot) {
-    delete payload.screenshot;
-    truncatedScreenshot = true;
-    request = build();
-  }
-  if (request.body.byteLength > MAX_MULTIPART_BYTES && payload.review) {
-    delete payload.review;
-    request = build();
-  }
-  if (request.body.byteLength > MAX_MULTIPART_BYTES) {
-    throw new BugReportUpstreamError(413, "Bug report is too large.");
-  }
-  return request;
-}
-
-async function buildTraceBugReportRequest(
-  payload: BugReportPayload,
-  trace: AuthoringTraceAttachment,
+  trace: AuthoringTraceAttachment | undefined,
   input: { appVersion: string; cliVersion: string },
-): Promise<{ body: FormData; headers: HeadersInit }> {
+): Promise<{ body: FormData }> {
   let truncatedDiff = false;
   let truncatedMap = false;
   let truncatedScreenshot = false;
   let payloadBytes = gzipPayload(payload);
 
-  if (payloadBytes.byteLength > MAX_MULTIPART_BYTES && payload.diff) {
+  if (payloadBytes.byteLength > MAX_PAYLOAD_BYTES && payload.diff) {
     delete payload.diff;
     truncatedDiff = true;
     payloadBytes = gzipPayload(payload);
   }
-  if (payloadBytes.byteLength > MAX_MULTIPART_BYTES && payload.map) {
+  if (payloadBytes.byteLength > MAX_PAYLOAD_BYTES && payload.map) {
     delete payload.map;
     truncatedMap = true;
     payloadBytes = gzipPayload(payload);
   }
-  if (payloadBytes.byteLength > MAX_MULTIPART_BYTES && payload.screenshot) {
+  if (payloadBytes.byteLength > MAX_PAYLOAD_BYTES && payload.screenshot) {
     delete payload.screenshot;
     truncatedScreenshot = true;
     payloadBytes = gzipPayload(payload);
   }
-  if (payloadBytes.byteLength > MAX_MULTIPART_BYTES && payload.review) {
+  if (payloadBytes.byteLength > MAX_PAYLOAD_BYTES && payload.review) {
     delete payload.review;
     payloadBytes = gzipPayload(payload);
   }
-  if (payloadBytes.byteLength > MAX_MULTIPART_BYTES) {
+  if (payloadBytes.byteLength > MAX_PAYLOAD_BYTES) {
     throw new BugReportUpstreamError(413, "Bug report is too large.");
   }
 
-  const traceParts: ReviewBugReportMetaV2["parts"] = trace.parts.map((part) =>
-    part.field === "source_trace"
-      ? {
-          field: "source_trace",
-          filename: "source.jsonl.gz",
-          session_id: part.session_id,
-          bytes: part.bytes,
-          sha256: part.sha256,
-        }
-      : {
-          field: "parent_trace",
-          filename: "parent.jsonl.gz",
-          session_id: part.session_id,
-          bytes: part.bytes,
-          sha256: part.sha256,
-        },
-  );
+  const traceParts: ReviewBugReportMetaV2["parts"] =
+    trace?.parts.map((part) =>
+      part.field === "source_trace"
+        ? {
+            field: "source_trace",
+            filename: "source.jsonl.gz",
+            session_id: part.session_id,
+            bytes: part.bytes,
+            sha256: part.sha256,
+          }
+        : {
+            field: "parent_trace",
+            filename: "parent.jsonl.gz",
+            session_id: part.session_id,
+            bytes: part.bytes,
+            sha256: part.sha256,
+          },
+    ) ?? [];
   const parts: ReviewBugReportMetaV2["parts"] = [
     {
       field: "payload",
@@ -367,8 +306,8 @@ async function buildTraceBugReportRequest(
   ];
   const contentBytes = parts.reduce((total, part) => total + part.bytes, 0);
   if (
-    parts.some((part) => part.bytes > MAX_TRACE_MULTIPART_PART_BYTES) ||
-    contentBytes > MAX_TRACE_MULTIPART_CONTENT_BYTES
+    parts.some((part) => part.bytes > MAX_MULTIPART_PART_BYTES) ||
+    contentBytes > MAX_MULTIPART_CONTENT_BYTES
   ) {
     throw new BugReportUpstreamError(413, "Bug report is too large.");
   }
@@ -380,8 +319,8 @@ async function buildTraceBugReportRequest(
     has_map: payload.map !== undefined,
     has_diff: payload.diff !== undefined,
     has_screenshot: payload.screenshot !== undefined,
-    has_trace: true,
-    trace_harness: trace.payload.harness,
+    has_trace: trace !== undefined,
+    ...(trace ? { trace_harness: trace.payload.harness } : {}),
     payload_bytes: payloadBytes.byteLength,
     app_version: input.appVersion,
     cli_version: input.cliVersion,
@@ -389,7 +328,7 @@ async function buildTraceBugReportRequest(
     truncated_diff: truncatedDiff,
     truncated_map: truncatedMap,
     truncated_screenshot: truncatedScreenshot,
-    truncated_trace: trace.payload.truncated,
+    truncated_trace: trace?.payload.truncated ?? false,
     parts,
   };
   const form = new FormData();
@@ -399,17 +338,14 @@ async function buildTraceBugReportRequest(
     new Blob([Uint8Array.from(payloadBytes)], { type: "application/gzip" }),
     "payload.json.gz",
   );
-  for (const part of trace.parts) {
+  for (const part of trace?.parts ?? []) {
     form.append(
       part.field,
       await openAsBlob(part.path, { type: "application/gzip" }),
       part.filename,
     );
   }
-  return {
-    body: form,
-    headers: {},
-  };
+  return { body: form };
 }
 
 function gzipPayload(payload: BugReportPayload): Buffer {
@@ -489,54 +425,6 @@ async function readChangedFileDiffs(
     headRef: target.headRef,
     includePatch: true,
   });
-}
-
-function buildBugReportRequest(
-  payload: BugReportPayload,
-  input: {
-    appVersion: string;
-    cliVersion: string;
-    truncatedDiff: boolean;
-    truncatedMap: boolean;
-    truncatedScreenshot: boolean;
-  },
-) {
-  const payloadBytes = gzipSync(Buffer.from(JSON.stringify(payload)), {
-    level: 9,
-  });
-  const meta: ReviewBugReportMetaV1 = {
-    schema_version: 1,
-    description_length: Buffer.byteLength(payload.description),
-    has_review: payload.review !== undefined,
-    has_map: payload.map !== undefined,
-    has_diff: payload.diff !== undefined,
-    has_screenshot: payload.screenshot !== undefined,
-    has_trace: false,
-    payload_bytes: payloadBytes.byteLength,
-    app_version: input.appVersion,
-    cli_version: input.cliVersion,
-    platform: process.platform,
-    truncated_diff: input.truncatedDiff,
-    truncated_map: input.truncatedMap,
-    truncated_screenshot: input.truncatedScreenshot,
-    truncated_trace: false,
-  };
-  const body = Buffer.concat([
-    Buffer.from(
-      `--${MULTIPART_BOUNDARY}\r\nContent-Disposition: form-data; name="meta"\r\nContent-Type: application/json\r\n\r\n${JSON.stringify(meta)}\r\n`,
-    ),
-    Buffer.from(
-      `--${MULTIPART_BOUNDARY}\r\nContent-Disposition: form-data; name="payload"; filename="payload.json.gz"\r\nContent-Type: application/gzip\r\n\r\n`,
-    ),
-    payloadBytes,
-    Buffer.from(`\r\n--${MULTIPART_BOUNDARY}--\r\n`),
-  ]);
-  return {
-    body,
-    headers: {
-      "content-type": `multipart/form-data; boundary=${MULTIPART_BOUNDARY}`,
-    },
-  };
 }
 
 function unavailable(attachment: AttachmentName): AttachmentError {

--- a/packages/progressive-review/src/server/bug-report.ts
+++ b/packages/progressive-review/src/server/bug-report.ts
@@ -278,23 +278,13 @@ async function buildBugReportRequest(
   }
 
   const traceParts: ReviewBugReportMetaV2["parts"] =
-    trace?.parts.map((part) =>
-      part.field === "source_trace"
-        ? {
-            field: "source_trace",
-            filename: "source.jsonl.gz",
-            session_id: part.session_id,
-            bytes: part.bytes,
-            sha256: part.sha256,
-          }
-        : {
-            field: "parent_trace",
-            filename: "parent.jsonl.gz",
-            session_id: part.session_id,
-            bytes: part.bytes,
-            sha256: part.sha256,
-          },
-    ) ?? [];
+    trace?.parts.map((part) => ({
+      field: "trace",
+      filename: part.filename,
+      session_id: part.session_id,
+      bytes: part.bytes,
+      sha256: part.sha256,
+    })) ?? [];
   const parts: ReviewBugReportMetaV2["parts"] = [
     {
       field: "payload",

--- a/packages/progressive-review/src/server/bug-report.ts
+++ b/packages/progressive-review/src/server/bug-report.ts
@@ -55,7 +55,7 @@ type AttachmentError = {
 };
 
 interface BugReportPayload {
-  schema_version: 3 | 4;
+  schema_version: 4;
   description: string;
   screenshot?: { mime: "image/jpeg"; base64: string };
   // File name to text. The document alone cannot render: every anchor lives in
@@ -97,7 +97,7 @@ export async function submitReviewBugReport(input: {
   const cliVersion = readProgressiveReviewPackageVersion();
   const attachmentErrors: AttachmentError[] = [];
   const payload: BugReportPayload = {
-    schema_version: 3,
+    schema_version: 4,
     description: input.report.description,
     ...(input.report.screenshot ? { screenshot: input.report.screenshot } : {}),
     diagnostics: {
@@ -196,7 +196,6 @@ export async function submitReviewBugReport(input: {
   if (mapSource !== undefined) payload.map = mapSource;
   if (changedFileDiffs !== undefined) payload.diff = changedFileDiffs;
   if (traceAttachment !== undefined) {
-    payload.schema_version = 4;
     payload.trace = traceAttachment.payload;
   }
   if (attachmentErrors.length > 0) {
@@ -330,7 +329,7 @@ async function buildBugReportRequest(
   );
   for (const part of trace?.parts ?? []) {
     form.append(
-      part.field,
+      "trace",
       await openAsBlob(part.path, { type: "application/gzip" }),
       part.filename,
     );

--- a/packages/progressive-review/src/server/bug-report.ts
+++ b/packages/progressive-review/src/server/bug-report.ts
@@ -30,7 +30,6 @@ const BUG_REPORT_URL = "https://bug.dev.fast/api/v2/reports";
 const MAX_PAYLOAD_BYTES = 10 * 1024 * 1024;
 const UPSTREAM_TIMEOUT_MS = 20_000;
 const TRACE_UPSTREAM_TIMEOUT_MS = 5 * 60_000;
-const MAX_MULTIPART_PART_BYTES = 100_000_000;
 // Keep room for multipart headers and boundaries below the Worker request cap.
 const MAX_MULTIPART_CONTENT_BYTES = 99_000_000;
 // The review directory is a git repo, but its tracked set also holds
@@ -51,7 +50,7 @@ const MAX_REVIEW_SOURCE_FILE_BYTES = 2 * 1024 * 1024;
 type AttachmentName = "review" | "map" | "diff" | "trace";
 type AttachmentError = {
   attachment: AttachmentName;
-  error: "unavailable";
+  error: "unavailable" | "too_large";
 };
 
 export interface BugReportPayload {
@@ -200,9 +199,7 @@ export async function submitReviewBugReport(input: {
     payload.trace = traceAttachment.payload;
   }
   if (attachmentErrors.length > 0) {
-    payload.diagnostics.attachment_errors = attachmentErrors.sort(
-      (left, right) => left.attachment.localeCompare(right.attachment),
-    );
+    payload.diagnostics.attachment_errors = attachmentErrors.sort(byAttachment);
   }
 
   try {
@@ -226,18 +223,14 @@ export async function submitReviewBugReport(input: {
     const responseBody = await response.json().catch(() => null);
     if (!response.ok) {
       throw new BugReportUpstreamError(
-        response.status === 429 ||
-          response.status === 413 ||
-          response.status === 422
+        response.status === 429 || response.status === 413
           ? response.status
           : 502,
         response.status === 429
           ? "Too many reports. Try again later."
           : response.status === 413
             ? "Bug report is too large."
-            : response.status === 422
-              ? "The complete authoring trace is unavailable."
-              : "Bug report service failed.",
+            : "Bug report service failed.",
       );
     }
     const result = parseReviewBugReportResponse(responseBody);
@@ -261,6 +254,7 @@ export async function buildBugReportRequest(
   let truncatedDiff = false;
   let truncatedMap = false;
   let truncatedScreenshot = false;
+  let traceParts = trace?.parts ?? [];
   let payloadBytes = gzipPayload(payload);
 
   if (
@@ -268,14 +262,17 @@ export async function buildBugReportRequest(
     payload.trace &&
     Object.keys(payload.trace.files).length > 0
   ) {
-    payload.trace.omitted_files = [
-      ...new Set([
-        ...(payload.trace.omitted_files ?? []),
-        ...Object.keys(payload.trace.files),
-      ]),
-    ].sort();
-    payload.trace.files = {};
-    payload.trace.truncated = true;
+    payload.trace = {
+      ...payload.trace,
+      files: {},
+      omitted_files: [
+        ...new Set([
+          ...(payload.trace.omitted_files ?? []),
+          ...Object.keys(payload.trace.files),
+        ]),
+      ].sort(),
+      truncated: true,
+    };
     payloadBytes = gzipPayload(payload);
   }
 
@@ -302,28 +299,28 @@ export async function buildBugReportRequest(
     throw new BugReportUpstreamError(413, "Bug report is too large.");
   }
 
-  const traceParts: ReviewBugReportMetaV2["parts"] =
-    trace?.parts.map((part) => ({
-      field: "trace",
-      filename: part.filename,
-      session_id: part.session_id,
-      bytes: part.bytes,
-      sha256: part.sha256,
-    })) ?? [];
-  const parts: ReviewBugReportMetaV2["parts"] = [
-    {
-      field: "payload",
-      filename: "payload.json.gz",
-      bytes: payloadBytes.byteLength,
-      sha256: sha256Bytes(payloadBytes),
-    },
-    ...traceParts,
-  ];
-  const contentBytes = parts.reduce((total, part) => total + part.bytes, 0);
-  if (
-    parts.some((part) => part.bytes > MAX_MULTIPART_PART_BYTES) ||
-    contentBytes > MAX_MULTIPART_CONTENT_BYTES
-  ) {
+  // The trace parts are the only attachment that can outgrow the Worker's
+  // request cap on their own. The rest of the report still helps triage, so
+  // it goes without the trace instead of being refused.
+  const contentBytes = () =>
+    traceParts.reduce(
+      (total, part) => total + part.bytes,
+      payloadBytes.byteLength,
+    );
+  if (contentBytes() > MAX_MULTIPART_CONTENT_BYTES && payload.trace) {
+    traceParts = [];
+    delete payload.trace;
+    const tooLarge: AttachmentError = {
+      attachment: "trace",
+      error: "too_large",
+    };
+    payload.diagnostics.attachment_errors = [
+      ...(payload.diagnostics.attachment_errors ?? []),
+      tooLarge,
+    ].sort(byAttachment);
+    payloadBytes = gzipPayload(payload);
+  }
+  if (contentBytes() > MAX_MULTIPART_CONTENT_BYTES) {
     throw new BugReportUpstreamError(413, "Bug report is too large.");
   }
 
@@ -334,8 +331,8 @@ export async function buildBugReportRequest(
     has_map: payload.map !== undefined,
     has_diff: payload.diff !== undefined,
     has_screenshot: payload.screenshot !== undefined,
-    has_trace: trace !== undefined,
-    ...(trace ? { trace_harness: trace.payload.harness } : {}),
+    has_trace: payload.trace !== undefined,
+    ...(payload.trace ? { trace_harness: payload.trace.harness } : {}),
     payload_bytes: payloadBytes.byteLength,
     app_version: input.appVersion,
     cli_version: input.cliVersion,
@@ -343,8 +340,22 @@ export async function buildBugReportRequest(
     truncated_diff: truncatedDiff,
     truncated_map: truncatedMap,
     truncated_screenshot: truncatedScreenshot,
-    truncated_trace: trace?.payload.truncated ?? false,
-    parts,
+    truncated_trace: payload.trace?.truncated ?? false,
+    parts: [
+      {
+        field: "payload",
+        filename: "payload.json.gz",
+        bytes: payloadBytes.byteLength,
+        sha256: sha256Bytes(payloadBytes),
+      },
+      ...traceParts.map((part) => ({
+        field: "trace" as const,
+        filename: part.filename,
+        session_id: part.session_id,
+        bytes: part.bytes,
+        sha256: part.sha256,
+      })),
+    ],
   };
   const form = new FormData();
   form.append("meta", JSON.stringify(meta));
@@ -353,7 +364,7 @@ export async function buildBugReportRequest(
     new Blob([Uint8Array.from(payloadBytes)], { type: "application/gzip" }),
     "payload.json.gz",
   );
-  for (const part of trace?.parts ?? []) {
+  for (const part of traceParts) {
     form.append(
       "trace",
       await openAsBlob(part.path, { type: "application/gzip" }),
@@ -444,4 +455,8 @@ async function readChangedFileDiffs(
 
 function unavailable(attachment: AttachmentName): AttachmentError {
   return { attachment, error: "unavailable" };
+}
+
+function byAttachment(left: AttachmentError, right: AttachmentError): number {
+  return left.attachment.localeCompare(right.attachment);
 }

--- a/packages/review-protocol/src/bug-report.test.ts
+++ b/packages/review-protocol/src/bug-report.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  parseReviewBugReportMeta,
+  ReviewBugReportMetaV2Schema,
   parseReviewBugReportRequest,
 } from "./bug-report.js";
 
@@ -21,41 +21,6 @@ describe("bug report protocol", () => {
 
     const { include_trace: _includeTrace, ...withoutTraceConsent } = request;
     expect(parseReviewBugReportRequest(withoutTraceConsent)).toEqual(request);
-  });
-
-  it("round-trips trace metadata and defaults new fields for older senders", () => {
-    const meta = {
-      schema_version: 1,
-      description_length: 0,
-      has_review: true,
-      has_map: true,
-      has_diff: true,
-      has_screenshot: false,
-      has_trace: true,
-      trace_harness: "codex" as const,
-      payload_bytes: 1024,
-      app_version: "1.2.3",
-      cli_version: "0.0.1",
-      platform: "darwin",
-      truncated_diff: false,
-      truncated_map: false,
-      truncated_screenshot: false,
-      truncated_trace: true,
-    };
-
-    expect(parseReviewBugReportMeta(meta)).toEqual(meta);
-
-    const {
-      has_trace: _hasTrace,
-      trace_harness: _traceHarness,
-      truncated_trace: _truncatedTrace,
-      ...olderMeta
-    } = meta;
-    expect(parseReviewBugReportMeta(olderMeta)).toEqual({
-      ...olderMeta,
-      has_trace: false,
-      truncated_trace: false,
-    });
   });
 
   it("accepts ordered schema 2 trace parts and rejects reordered parts", () => {
@@ -100,9 +65,9 @@ describe("bug report protocol", () => {
       ],
     };
 
-    expect(parseReviewBugReportMeta(meta)).toEqual(meta);
+    expect(ReviewBugReportMetaV2Schema.parse(meta)).toEqual(meta);
     expect(() =>
-      parseReviewBugReportMeta({
+      ReviewBugReportMetaV2Schema.parse({
         ...meta,
         parts: [meta.parts[0], meta.parts[2], meta.parts[1]],
       }),
@@ -136,9 +101,9 @@ describe("bug report protocol", () => {
       ],
     };
 
-    expect(parseReviewBugReportMeta(meta)).toEqual(meta);
+    expect(ReviewBugReportMetaV2Schema.parse(meta)).toEqual(meta);
     expect(() =>
-      parseReviewBugReportMeta({ ...meta, trace_harness: "codex" }),
+      ReviewBugReportMetaV2Schema.parse({ ...meta, trace_harness: "codex" }),
     ).toThrow(/present only when the report has a trace/);
   });
 });

--- a/packages/review-protocol/src/bug-report.test.ts
+++ b/packages/review-protocol/src/bug-report.test.ts
@@ -23,55 +23,88 @@ describe("bug report protocol", () => {
     expect(parseReviewBugReportRequest(withoutTraceConsent)).toEqual(request);
   });
 
-  it("accepts ordered schema 2 trace parts and rejects reordered parts", () => {
-    const meta = {
-      schema_version: 2,
-      description_length: 12,
-      has_review: false,
-      has_map: false,
-      has_diff: false,
-      has_screenshot: false,
-      has_trace: true,
-      trace_harness: "codex" as const,
-      payload_bytes: 100,
-      app_version: "1.2.3",
-      cli_version: "0.0.1",
-      platform: "darwin",
-      truncated_diff: false,
-      truncated_map: false,
-      truncated_screenshot: false,
-      truncated_trace: false,
-      parts: [
-        {
-          field: "payload",
-          filename: "payload.json.gz",
-          bytes: 100,
-          sha256: "a".repeat(64),
-        },
-        {
-          field: "source_trace",
-          filename: "source.jsonl.gz",
-          session_id: "11111111-1111-4111-8111-111111111111",
-          bytes: 200,
-          sha256: "b".repeat(64),
-        },
-        {
-          field: "parent_trace",
-          filename: "parent.jsonl.gz",
-          session_id: "22222222-2222-4222-8222-222222222222",
-          bytes: 300,
-          sha256: "c".repeat(64),
-        },
-      ],
-    };
+  const payloadPart = {
+    field: "payload" as const,
+    filename: "payload.json.gz" as const,
+    bytes: 100,
+    sha256: "a".repeat(64),
+  };
 
-    expect(ReviewBugReportMetaV2Schema.parse(meta)).toEqual(meta);
+  const tracePart = (index: number, sessionId = `session-${index}`) => ({
+    field: "trace" as const,
+    filename: `trace-${index}.jsonl.gz`,
+    session_id: sessionId,
+    bytes: 200 + index,
+    sha256: "b".repeat(64),
+  });
+
+  const baseMeta = {
+    schema_version: 2,
+    description_length: 12,
+    has_review: false,
+    has_map: false,
+    has_diff: false,
+    has_screenshot: false,
+    has_trace: true,
+    trace_harness: "codex" as const,
+    payload_bytes: 100,
+    app_version: "1.2.3",
+    cli_version: "0.0.1",
+    platform: "darwin",
+    truncated_diff: false,
+    truncated_map: false,
+    truncated_screenshot: false,
+    truncated_trace: false,
+    parts: [payloadPart, tracePart(0), tracePart(1)],
+  } as const;
+
+  it("accepts ordered schema 2 trace parts", () => {
+    expect(ReviewBugReportMetaV2Schema.parse(baseMeta)).toEqual(baseMeta);
+  });
+
+  it("rejects skipped or reordered trace filenames", () => {
     expect(() =>
       ReviewBugReportMetaV2Schema.parse({
-        ...meta,
-        parts: [meta.parts[0], meta.parts[2], meta.parts[1]],
+        ...baseMeta,
+        parts: [payloadPart, tracePart(1), tracePart(0)],
       }),
-    ).toThrow(/must list payload/);
+    ).toThrow(/trace-<n>/);
+    expect(() =>
+      ReviewBugReportMetaV2Schema.parse({
+        ...baseMeta,
+        parts: [payloadPart, tracePart(0), tracePart(2)],
+      }),
+    ).toThrow(/trace-<n>/);
+  });
+
+  it("rejects duplicate trace session ids", () => {
+    expect(() =>
+      ReviewBugReportMetaV2Schema.parse({
+        ...baseMeta,
+        parts: [
+          payloadPart,
+          tracePart(0, "duplicate"),
+          tracePart(1, "duplicate"),
+        ],
+      }),
+    ).toThrow(/trace-<n>/);
+  });
+
+  it("rejects trace presence that disagrees with has_trace", () => {
+    expect(() =>
+      ReviewBugReportMetaV2Schema.parse({
+        ...baseMeta,
+        has_trace: false,
+        trace_harness: undefined,
+      }),
+    ).toThrow(/presence of trace parts/);
+    expect(() =>
+      ReviewBugReportMetaV2Schema.parse({
+        ...baseMeta,
+        has_trace: true,
+        parts: [payloadPart],
+      }),
+    ).toThrow(/presence of trace parts/);
   });
 
   it("accepts a schema 2 report without a trace", () => {
@@ -91,14 +124,7 @@ describe("bug report protocol", () => {
       truncated_map: false,
       truncated_screenshot: false,
       truncated_trace: false,
-      parts: [
-        {
-          field: "payload",
-          filename: "payload.json.gz",
-          bytes: 100,
-          sha256: "a".repeat(64),
-        },
-      ],
+      parts: [payloadPart],
     };
 
     expect(ReviewBugReportMetaV2Schema.parse(meta)).toEqual(meta);

--- a/packages/review-protocol/src/bug-report.test.ts
+++ b/packages/review-protocol/src/bug-report.test.ts
@@ -57,4 +57,55 @@ describe("bug report protocol", () => {
       truncated_trace: false,
     });
   });
+
+  it("accepts ordered schema 2 trace parts and rejects reordered parts", () => {
+    const meta = {
+      schema_version: 2,
+      description_length: 12,
+      has_review: false,
+      has_map: false,
+      has_diff: false,
+      has_screenshot: false,
+      has_trace: true,
+      trace_harness: "codex" as const,
+      payload_bytes: 100,
+      app_version: "1.2.3",
+      cli_version: "0.0.1",
+      platform: "darwin",
+      truncated_diff: false,
+      truncated_map: false,
+      truncated_screenshot: false,
+      truncated_trace: false,
+      parts: [
+        {
+          field: "payload",
+          filename: "payload.json.gz",
+          bytes: 100,
+          sha256: "a".repeat(64),
+        },
+        {
+          field: "source_trace",
+          filename: "source.jsonl.gz",
+          session_id: "11111111-1111-4111-8111-111111111111",
+          bytes: 200,
+          sha256: "b".repeat(64),
+        },
+        {
+          field: "parent_trace",
+          filename: "parent.jsonl.gz",
+          session_id: "22222222-2222-4222-8222-222222222222",
+          bytes: 300,
+          sha256: "c".repeat(64),
+        },
+      ],
+    };
+
+    expect(parseReviewBugReportMeta(meta)).toEqual(meta);
+    expect(() =>
+      parseReviewBugReportMeta({
+        ...meta,
+        parts: [meta.parts[0], meta.parts[2], meta.parts[1]],
+      }),
+    ).toThrow(/must list payload/);
+  });
 });

--- a/packages/review-protocol/src/bug-report.test.ts
+++ b/packages/review-protocol/src/bug-report.test.ts
@@ -108,4 +108,37 @@ describe("bug report protocol", () => {
       }),
     ).toThrow(/must list payload/);
   });
+
+  it("accepts a schema 2 report without a trace", () => {
+    const meta = {
+      schema_version: 2,
+      description_length: 12,
+      has_review: false,
+      has_map: false,
+      has_diff: false,
+      has_screenshot: false,
+      has_trace: false,
+      payload_bytes: 100,
+      app_version: "1.2.3",
+      cli_version: "0.0.1",
+      platform: "darwin",
+      truncated_diff: false,
+      truncated_map: false,
+      truncated_screenshot: false,
+      truncated_trace: false,
+      parts: [
+        {
+          field: "payload",
+          filename: "payload.json.gz",
+          bytes: 100,
+          sha256: "a".repeat(64),
+        },
+      ],
+    };
+
+    expect(parseReviewBugReportMeta(meta)).toEqual(meta);
+    expect(() =>
+      parseReviewBugReportMeta({ ...meta, trace_harness: "codex" }),
+    ).toThrow(/present only when the report has a trace/);
+  });
 });

--- a/packages/review-protocol/src/bug-report.ts
+++ b/packages/review-protocol/src/bug-report.ts
@@ -26,42 +26,6 @@ export type ReviewBugReportRequest = z.infer<
   typeof ReviewBugReportRequestSchema
 >;
 
-export const ReviewBugReportMetaV1Schema = z.strictObject({
-  schema_version: z.literal(1),
-  description_length: z.number().int().nonnegative().max(65_536),
-  has_review: z.boolean(),
-  has_map: z.boolean(),
-  has_diff: z.boolean(),
-  has_screenshot: z.boolean(),
-  has_trace: z.boolean().default(false),
-  trace_harness: z.enum(["claude-code", "codex", "pi"]).optional(),
-  payload_bytes: z
-    .number()
-    .int()
-    .positive()
-    .max(10 * 1024 * 1024),
-  app_version: requiredString.max(100),
-  cli_version: requiredString.max(100),
-  platform: z.enum([
-    "aix",
-    "android",
-    "darwin",
-    "freebsd",
-    "haiku",
-    "linux",
-    "openbsd",
-    "sunos",
-    "win32",
-    "cygwin",
-    "netbsd",
-  ]),
-  truncated_diff: z.boolean(),
-  truncated_map: z.boolean(),
-  truncated_screenshot: z.boolean(),
-  truncated_trace: z.boolean().default(false),
-});
-export type ReviewBugReportMetaV1 = z.infer<typeof ReviewBugReportMetaV1Schema>;
-
 const compressedPartBytes = z.number().int().positive().max(100_000_000);
 const compressedSha256 = z.string().regex(/^[a-f0-9]{64}$/);
 
@@ -168,12 +132,6 @@ export const ReviewBugReportMetaV2Schema = z
   });
 export type ReviewBugReportMetaV2 = z.infer<typeof ReviewBugReportMetaV2Schema>;
 
-export const ReviewBugReportMetaSchema = z.discriminatedUnion(
-  "schema_version",
-  [ReviewBugReportMetaV1Schema, ReviewBugReportMetaV2Schema],
-);
-export type ReviewBugReportMeta = z.infer<typeof ReviewBugReportMetaSchema>;
-
 export const ReviewBugReportResponseSchema = z.discriminatedUnion("ok", [
   z.strictObject({
     ok: z.literal(true),
@@ -193,10 +151,6 @@ export function parseReviewBugReportRequest(
   value: unknown,
 ): ReviewBugReportRequest {
   return ReviewBugReportRequestSchema.parse(value);
-}
-
-export function parseReviewBugReportMeta(value: unknown): ReviewBugReportMeta {
-  return ReviewBugReportMetaSchema.parse(value);
 }
 
 export function parseReviewBugReportResponse(

--- a/packages/review-protocol/src/bug-report.ts
+++ b/packages/review-protocol/src/bug-report.ts
@@ -26,7 +26,7 @@ export type ReviewBugReportRequest = z.infer<
   typeof ReviewBugReportRequestSchema
 >;
 
-export const ReviewBugReportMetaSchema = z.strictObject({
+export const ReviewBugReportMetaV1Schema = z.strictObject({
   schema_version: z.literal(1),
   description_length: z.number().int().nonnegative().max(65_536),
   has_review: z.boolean(),
@@ -60,6 +60,99 @@ export const ReviewBugReportMetaSchema = z.strictObject({
   truncated_screenshot: z.boolean(),
   truncated_trace: z.boolean().default(false),
 });
+export type ReviewBugReportMetaV1 = z.infer<typeof ReviewBugReportMetaV1Schema>;
+
+const compressedPartBytes = z.number().int().positive().max(100_000_000);
+const compressedSha256 = z.string().regex(/^[a-f0-9]{64}$/);
+
+export const ReviewBugReportPartSchema = z.discriminatedUnion("field", [
+  z.strictObject({
+    field: z.literal("payload"),
+    filename: z.literal("payload.json.gz"),
+    bytes: compressedPartBytes,
+    sha256: compressedSha256,
+  }),
+  z.strictObject({
+    field: z.literal("source_trace"),
+    filename: z.literal("source.jsonl.gz"),
+    bytes: compressedPartBytes,
+    sha256: compressedSha256,
+    session_id: requiredString.max(128),
+  }),
+  z.strictObject({
+    field: z.literal("parent_trace"),
+    filename: z.literal("parent.jsonl.gz"),
+    bytes: compressedPartBytes,
+    sha256: compressedSha256,
+    session_id: requiredString.max(128),
+  }),
+]);
+export type ReviewBugReportPart = z.infer<typeof ReviewBugReportPartSchema>;
+
+export const ReviewBugReportMetaV2Schema = z
+  .strictObject({
+    schema_version: z.literal(2),
+    description_length: z.number().int().nonnegative().max(65_536),
+    has_review: z.boolean(),
+    has_map: z.boolean(),
+    has_diff: z.boolean(),
+    has_screenshot: z.boolean(),
+    has_trace: z.literal(true),
+    trace_harness: z.enum(["claude-code", "codex", "pi"]),
+    payload_bytes: z
+      .number()
+      .int()
+      .positive()
+      .max(10 * 1024 * 1024),
+    app_version: requiredString.max(100),
+    cli_version: requiredString.max(100),
+    platform: z.enum([
+      "aix",
+      "android",
+      "darwin",
+      "freebsd",
+      "haiku",
+      "linux",
+      "openbsd",
+      "sunos",
+      "win32",
+      "cygwin",
+      "netbsd",
+    ]),
+    truncated_diff: z.boolean(),
+    truncated_map: z.boolean(),
+    truncated_screenshot: z.boolean(),
+    truncated_trace: z.boolean(),
+    parts: z.array(ReviewBugReportPartSchema).min(2).max(3),
+  })
+  .superRefine((meta, context) => {
+    const fields = meta.parts.map((part) => part.field);
+    const expected =
+      meta.parts.length === 2
+        ? ["payload", "source_trace"]
+        : ["payload", "source_trace", "parent_trace"];
+    if (fields.some((field, index) => field !== expected[index])) {
+      context.addIssue({
+        code: "custom",
+        path: ["parts"],
+        message:
+          "must list payload, source trace, and optional parent trace in order",
+      });
+    }
+    if (meta.parts[0]?.bytes !== meta.payload_bytes) {
+      context.addIssue({
+        code: "custom",
+        path: ["payload_bytes"],
+        message: "must match the payload part size",
+      });
+    }
+  });
+export type ReviewBugReportMetaV2 = z.infer<typeof ReviewBugReportMetaV2Schema>;
+
+export const ReviewBugReportMetaSchema = z.discriminatedUnion(
+  "schema_version",
+  [ReviewBugReportMetaV1Schema, ReviewBugReportMetaV2Schema],
+);
 export type ReviewBugReportMeta = z.infer<typeof ReviewBugReportMetaSchema>;
 
 export const ReviewBugReportResponseSchema = z.discriminatedUnion("ok", [

--- a/packages/review-protocol/src/bug-report.ts
+++ b/packages/review-protocol/src/bug-report.ts
@@ -37,15 +37,8 @@ export const ReviewBugReportPartSchema = z.discriminatedUnion("field", [
     sha256: compressedSha256,
   }),
   z.strictObject({
-    field: z.literal("source_trace"),
-    filename: z.literal("source.jsonl.gz"),
-    bytes: compressedPartBytes,
-    sha256: compressedSha256,
-    session_id: requiredString.max(128),
-  }),
-  z.strictObject({
-    field: z.literal("parent_trace"),
-    filename: z.literal("parent.jsonl.gz"),
+    field: z.literal("trace"),
+    filename: z.string().regex(/^trace-(0|[1-9]\d?)\.jsonl\.gz$/),
     bytes: compressedPartBytes,
     sha256: compressedSha256,
     session_id: requiredString.max(128),
@@ -87,25 +80,31 @@ export const ReviewBugReportMetaV2Schema = z
     truncated_map: z.boolean(),
     truncated_screenshot: z.boolean(),
     truncated_trace: z.boolean(),
-    parts: z.array(ReviewBugReportPartSchema).min(1).max(3),
+    parts: z.array(ReviewBugReportPartSchema).min(1).max(34),
   })
   .superRefine((meta, context) => {
-    const fields = meta.parts.map((part) => part.field);
-    const hasParent = fields.includes("parent_trace");
-    const expected = meta.has_trace
-      ? hasParent
-        ? ["payload", "source_trace", "parent_trace"]
-        : ["payload", "source_trace"]
-      : ["payload"];
-    if (
-      fields.length !== expected.length ||
-      fields.some((field, index) => field !== expected[index])
-    ) {
+    const [first, ...traces] = meta.parts;
+    const validOrder =
+      first?.field === "payload" &&
+      traces.every(
+        (part, index) =>
+          part.field === "trace" && part.filename === `trace-${index}.jsonl.gz`,
+      );
+    const sessionIds = traces.map((part) =>
+      part.field === "trace" ? part.session_id : "",
+    );
+    if (!validOrder || new Set(sessionIds).size !== sessionIds.length) {
       context.addIssue({
         code: "custom",
         path: ["parts"],
-        message:
-          "must list payload and the optional source and parent traces in order",
+        message: "must list the payload then trace-<n> parts in order",
+      });
+    }
+    if (meta.has_trace !== traces.length > 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["has_trace"],
+        message: "must match the presence of trace parts",
       });
     }
     if (meta.has_trace !== (meta.trace_harness !== undefined)) {

--- a/packages/review-protocol/src/bug-report.ts
+++ b/packages/review-protocol/src/bug-report.ts
@@ -97,8 +97,8 @@ export const ReviewBugReportMetaV2Schema = z
     has_map: z.boolean(),
     has_diff: z.boolean(),
     has_screenshot: z.boolean(),
-    has_trace: z.literal(true),
-    trace_harness: z.enum(["claude-code", "codex", "pi"]),
+    has_trace: z.boolean(),
+    trace_harness: z.enum(["claude-code", "codex", "pi"]).optional(),
     payload_bytes: z
       .number()
       .int()
@@ -123,20 +123,39 @@ export const ReviewBugReportMetaV2Schema = z
     truncated_map: z.boolean(),
     truncated_screenshot: z.boolean(),
     truncated_trace: z.boolean(),
-    parts: z.array(ReviewBugReportPartSchema).min(2).max(3),
+    parts: z.array(ReviewBugReportPartSchema).min(1).max(3),
   })
   .superRefine((meta, context) => {
     const fields = meta.parts.map((part) => part.field);
-    const expected =
-      meta.parts.length === 2
-        ? ["payload", "source_trace"]
-        : ["payload", "source_trace", "parent_trace"];
-    if (fields.some((field, index) => field !== expected[index])) {
+    const hasParent = fields.includes("parent_trace");
+    const expected = meta.has_trace
+      ? hasParent
+        ? ["payload", "source_trace", "parent_trace"]
+        : ["payload", "source_trace"]
+      : ["payload"];
+    if (
+      fields.length !== expected.length ||
+      fields.some((field, index) => field !== expected[index])
+    ) {
       context.addIssue({
         code: "custom",
         path: ["parts"],
         message:
-          "must list payload, source trace, and optional parent trace in order",
+          "must list payload and the optional source and parent traces in order",
+      });
+    }
+    if (meta.has_trace !== (meta.trace_harness !== undefined)) {
+      context.addIssue({
+        code: "custom",
+        path: ["trace_harness"],
+        message: "must be present only when the report has a trace",
+      });
+    }
+    if (!meta.has_trace && meta.truncated_trace) {
+      context.addIssue({
+        code: "custom",
+        path: ["truncated_trace"],
+        message: "must be false when the report has no trace",
       });
     }
     if (meta.parts[0]?.bytes !== meta.payload_bytes) {


### PR DESCRIPTION
## Summary

- send every Desktop bug report through `/api/v2/reports`, with trace attachment still off by default
- upload an opted-in authoring trace as ordered, generic `trace-0..N` gzip parts
- keep Claude Code and Pi source-only, and resolve Codex ancestry recursively from `history_base`
- preserve the complete child snapshot while bounding each ancestor at its record-level fork ordinal
- reject malformed or unresolved Codex ancestry instead of silently omitting it
- keep privacy and telemetry docs focused on the data collected after explicit opt-in

## Validation

- Review protocol: 110 tests passed; typecheck passed
- Review package: 1,163 tests passed
- focused trace/sender coverage: 22 tests passed
- Review Desktop test gate passed after installing its locked Code OSS dependencies
- Worker protocol: 103 tests passed; typecheck passed
- bug Worker: 27 tests passed; typecheck passed
- format check, lint, and diff check passed
- shared V2 protocol definitions match the deployed Worker copy
- production Codex report `0b00b25d-442d-4d20-a501-c0b59bb337d7`: payload plus two ordered trace parts read back from R2 with matching byte counts and SHA-256 hashes; child and pre-fork parent records were intact and the synthetic post-fork parent record was absent
- production Claude Code report `ef07f5ce-a7b4-4ac1-bd82-f6eb4aa2e38e`: payload plus one trace part read back from R2 with matching byte count, SHA-256 hash, and two valid JSONL records

Root `pnpm typecheck` still reaches the existing error in unchanged `packages/progressive-review/scripts/check-tutorial.ts:136`: `unknown` is not assignable to `unknown[] | undefined`; it reports no new trace-related errors.