### PR TITLE
Update Discord invite link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ directory as a reference.
 
 - [GitHub Issues](https://github.com/devdotfast/review/issues) — bugs and feature
   requests.
-- [Discord](https://discord.gg/FmrJraNvN) — setup questions and community help.
+- [Discord](https://discord.gg/wYvd2cpMQg) — setup questions and community help.
 - [Contributing](https://github.com/devdotfast/review/blob/main/CONTRIBUTING.md)
 - [Security policy](https://github.com/devdotfast/review/blob/main/SECURITY.md)
 - [Desktop build and release guide](https://github.com/devdotfast/review/blob/main/apps/review-desktop/README.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -168,4 +168,4 @@ or exploit details.
 
 Use [GitHub Issues](https://github.com/devdotfast/review/issues) for
 reproducible bugs and feature requests. For setup questions and community help,
-join the [dev.fast Discord](https://discord.gg/FmrJraNvN).
+join the [dev.fast Discord](https://discord.gg/wYvd2cpMQg).


### PR DESCRIPTION
## Summary
- replace the outdated Discord invite in the documentation index
- update the matching troubleshooting link

## Validation
- `git diff --check origin/main...HEAD`
- confirmed no tracked references remain to the previous invite URL