### PR TITLE
Add Review view selection

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
@@ -24,6 +24,14 @@ const nonNegativeInteger = z
 const reviewDiffSideSchema = z.enum(["base", "head"], {
   error: "must be base or head",
 });
+export const reviewViewSchema = z.enum([
+  "review",
+  "commits",
+  "diff",
+  "map",
+  "trace",
+]);
+export type ReviewView = z.infer<typeof reviewViewSchema>;
 const reviewThemeSchema = z.enum(["light", "dark"], {
   error: "must be light or dark",
 });
@@ -1466,6 +1474,7 @@ export const ReviewPublishReadyRequestSchema = z.strictObject({
     .string({ error: "must be a 40-hex revision" })
     .regex(/^[0-9a-f]{40}$/i, "must be a 40-hex revision"),
   agent: AuthoringAgentSessionSchema.optional(),
+  view: reviewViewSchema.optional(),
 });
 export type ReviewPublishReadyRequest = z.infer<
   typeof ReviewPublishReadyRequestSchema
@@ -1914,7 +1923,10 @@ const revealArgsSchema = z
 
 export const ReviewVerbRequestSchema = z.discriminatedUnion("name", [
   z.strictObject({ name: z.literal("openFile"), args: openFileArgsSchema }),
-  z.strictObject({ name: z.literal("openFiles"), args: z.strictObject({}) }),
+  z.strictObject({
+    name: z.literal("showReviewView"),
+    args: z.strictObject({ view: reviewViewSchema }),
+  }),
   z.strictObject({
     name: z.literal("openSourceTree"),
     args: z.strictObject({}),
@@ -2034,7 +2046,8 @@ export const ReviewSurfaceEventSchema = z.discriminatedUnion("event", [
     theme: reviewThemeSchema,
   }),
   z.strictObject({
-    event: z.literal("showDiffView"),
+    event: z.literal("showReviewView"),
+    view: reviewViewSchema,
   }),
 ]);
 export type ReviewSurfaceEvent = z.infer<typeof ReviewSurfaceEventSchema>;

--- a/apps/review-desktop/code-oss/src/vs/review/contrib/verbs/reviewVerbs.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/verbs/reviewVerbs.ts
@@ -47,6 +47,7 @@ import {
   type ReviewSurfaceEvent,
   type ReviewVerbRequest,
   type ReviewVerbResponse,
+  type ReviewView,
   parseReviewVerbRequest,
 } from "../../common/reviewProtocol.js";
 import {
@@ -165,8 +166,8 @@ export class ReviewVerbsService
         case "openFile":
           await this.openFile(request.args);
           break;
-        case "openFiles":
-          await this.openFiles();
+        case "showReviewView":
+          await this.showReviewView(request.args.view);
           break;
         case "openSourceTree":
           // Bind the tab to the active review so a later re-activation can
@@ -424,14 +425,12 @@ export class ReviewVerbsService
   }
 
   /**
-   * The diff is a view inside the Review tab, not a separate editor. The
-   * dispatcher reveals that tab before this runs, so the verb only has to
-   * focus the canvas and ask the app to show the Diff view.
+   * The dispatcher reveals the Review tab before asking the app to show a view.
    */
-  private async openFiles(): Promise<void> {
+  private async showReviewView(view: ReviewView): Promise<void> {
     this.requireSession();
     this._onDidRequestCanvasFocus.fire();
-    this._onDidEmitSurfaceEvent.fire({ event: "showDiffView" });
+    this._onDidEmitSurfaceEvent.fire({ event: "showReviewView", view });
   }
 
   private async openDiffEditor(args: {

--- a/apps/review-desktop/scripts/files-multidiff-contract.test.mjs
+++ b/apps/review-desktop/scripts/files-multidiff-contract.test.mjs
@@ -92,6 +92,14 @@ test("Diff is a Review-tab view with a native changed-files tree beside one scro
   assert.match(reviewVerbs, /event: "showReviewView", view/);
   assert.doesNotMatch(reviewVerbs, /ReviewFilesEditorInput/);
   assert.match(reviewApp, /event\.event === "showReviewView"/);
+  assert.match(
+    reviewApp,
+    /useLayoutEffect\(\(\) => \{\s*return session\.surface\.subscribe/,
+  );
+  assert.doesNotMatch(
+    reviewCanvasPart,
+    /pendingReviewViews|surfaceSubscriptionCounts/,
+  );
 
   assert.match(reviewCanvasPart, /diffView: this\.diffViews/);
   assert.match(reviewCanvasPart, /this\.diffViews\.reset\(\)/);

--- a/apps/review-desktop/scripts/files-multidiff-contract.test.mjs
+++ b/apps/review-desktop/scripts/files-multidiff-contract.test.mjs
@@ -87,12 +87,11 @@ test("Diff is a Review-tab view with a native changed-files tree beside one scro
   assert.match(reviewDiffView, /create\(\{ container, scope \}\)/);
   assert.match(reviewDiffView, /review-diff-view-host/);
 
-  // The openFiles verb survives for server and CLI callers; it now switches
-  // the Review tab to the Diff view instead of opening an editor.
-  assert.match(reviewVerbs, /case "openFiles"/);
-  assert.match(reviewVerbs, /event: "showDiffView"/);
+  // Server and CLI callers use one typed verb to select any Review-tab view.
+  assert.match(reviewVerbs, /case "showReviewView"/);
+  assert.match(reviewVerbs, /event: "showReviewView", view/);
   assert.doesNotMatch(reviewVerbs, /ReviewFilesEditorInput/);
-  assert.match(reviewApp, /event\.event === "showDiffView"/);
+  assert.match(reviewApp, /event\.event === "showReviewView"/);
 
   assert.match(reviewCanvasPart, /diffView: this\.diffViews/);
   assert.match(reviewCanvasPart, /this\.diffViews\.reset\(\)/);

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -68,10 +68,10 @@ $ review version --json
 | --- | --- |
 | `review app` | Start Review Desktop. Bare `review app` aliases `app launch`. |
 | `review app launch` | Start or activate Review Desktop. |
-| `review app pick` | Select a published Review, interactively or by UUID. |
+| `review app pick` | Select a published Review and optionally choose its opened view. |
 | `review info` | List Reviews associated with the current checkout. |
 | `review scaffold` | Create or update a pinned UUID Review. |
-| `review publish` | Validate and publish the Review document. |
+| `review publish` | Validate and publish the Review document, optionally opening a chosen view. |
 | `review rebind` | Move a Review to another branch, bookmark, or change ID. |
 | `review wait` | Wait for reviewer activity or an agent-action state. |
 | `review threads` | Read, reply to, and resolve Review threads. |
@@ -85,7 +85,7 @@ $ review version --json
 ```sh
 review app launch
 review app pick
-review app pick --review <uuid>
+review app pick --review <uuid> --view diff
 review info
 review info --all
 ```
@@ -97,6 +97,9 @@ active Reviews for every worktree in the current repository.
 
 The legacy `review app --review <uuid>` form remains a compatibility alias for
 `review app pick --review <uuid>`.
+
+Both `review app pick` and `review publish` accept `--view` with one of
+`review`, `commits`, `diff`, `map`, or `trace`.
 
 ## Scaffold and update
 
@@ -120,7 +123,7 @@ moves the pins automatically.
 ## Publish, rebind, and wait
 
 ```sh
-review publish --review <uuid>
+review publish --review <uuid> --view diff
 review rebind <branch-bookmark-or-change> --review <uuid>
 review wait --review <uuid>
 review wait --timeout <seconds> --review <uuid>

--- a/packages/progressive-review/app/src/App.tsx
+++ b/packages/progressive-review/app/src/App.tsx
@@ -9,6 +9,7 @@ import {
   type ReactNode,
   type RefObject,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -420,8 +421,9 @@ function ReviewLayoutContent({
   }, [review.softwareMapFocusRequest, softwareMapEnabled]);
   const applyReviewViewRef = useRef(applyReviewView);
   applyReviewViewRef.current = applyReviewView;
-  // The workbench emits this event after it reveals the Review tab.
-  useEffect(() => {
+  // Subscribe before the canvas signals ready so a reveal immediately after
+  // mounting cannot outrun the listener.
+  useLayoutEffect(() => {
     return session.surface.subscribe((event) => {
       if (
         event.event === "showReviewView" &&

--- a/packages/progressive-review/app/src/App.tsx
+++ b/packages/progressive-review/app/src/App.tsx
@@ -364,6 +364,8 @@ function ReviewLayoutContent({
     ...(softwareMapEnabled ? (["map"] as const) : []),
     ...(hasTraceSessions ? (["trace"] as const) : []),
   ];
+  const reviewViewsRef = useRef(reviewViews);
+  reviewViewsRef.current = reviewViews;
   const applyReviewView = (view: ReviewView) => {
     const normalizedView = normalizeReviewView(
       view,
@@ -418,11 +420,15 @@ function ReviewLayoutContent({
   }, [review.softwareMapFocusRequest, softwareMapEnabled]);
   const applyReviewViewRef = useRef(applyReviewView);
   applyReviewViewRef.current = applyReviewView;
-  // The server and the CLI still send the openFiles verb. The workbench turns
-  // it into this event once it reveals the Review tab.
+  // The workbench emits this event after it reveals the Review tab.
   useEffect(() => {
     return session.surface.subscribe((event) => {
-      if (event.event === "showDiffView") applyReviewViewRef.current("diff");
+      if (
+        event.event === "showReviewView" &&
+        reviewViewsRef.current.includes(event.view)
+      ) {
+        applyReviewViewRef.current(event.view);
+      }
     });
   }, [session.surface]);
   const activeSoftwareMapSource = useMemo(

--- a/packages/progressive-review/app/src/host/review-session.test.tsx
+++ b/packages/progressive-review/app/src/host/review-session.test.tsx
@@ -116,7 +116,9 @@ describe("ReviewSessionProvider", () => {
     await sessionB.fetch("/session");
 
     expect(postedA).toEqual([]);
-    expect(postedB).toEqual([{ name: "openFiles", args: {} }]);
+    expect(postedB).toEqual([
+      { name: "showReviewView", args: { view: "diff" } },
+    ]);
     expect(fetchMock).toHaveBeenCalledWith(
       "http://127.0.0.1:5570/sessions/b/__progressive-review/session?document=%2Fb.mdx",
       expect.objectContaining({
@@ -139,7 +141,10 @@ function SessionProbe() {
       <button
         type="button"
         onClick={() => {
-          session.surface.post({ name: "openFiles", args: {} });
+          session.surface.post({
+            name: "showReviewView",
+            args: { view: "diff" },
+          });
           setClicks((current) => current + 1);
         }}
       >

--- a/packages/progressive-review/app/src/review-view-route.ts
+++ b/packages/progressive-review/app/src/review-view-route.ts
@@ -1,4 +1,6 @@
-export type ReviewView = "review" | "commits" | "map" | "diff" | "trace";
+import type { ReviewView } from "@dev.fast/review-protocol";
+
+export type { ReviewView } from "@dev.fast/review-protocol";
 
 export function normalizeReviewView(
   view: ReviewView,

--- a/packages/progressive-review/skills/dev-review/SKILL.md
+++ b/packages/progressive-review/skills/dev-review/SKILL.md
@@ -66,7 +66,17 @@ Read the scaffold JSON event and `<review-dir>/review.json`. Together they carry
 
 `inSync: false` in `review info` means only that the source worktree does not sit on the pinned commit. That alone requires no action. Use `review scaffold --update --review <uuid>` only when the bound branch or pull request gained commits past the pin. Re-read each file whose anchored range changed after the update.
 
-### 2. Dispatch the map worker
+### 2. Show small changes immediately
+
+Measure the change from the source worktree: `git diff --shortstat <baseCommit> <sourceCommit>`. When insertions plus deletions total under 300, publish the untouched scaffolded stub at once and land the reader on the diff:
+
+```sh
+review publish --review <uuid> --view diff --json
+```
+
+Then write a short document (a few sentences with `AnchorLink`s; no diagrams unless one claim needs one), publish again, and continue with the normal steps. Larger changes skip this step.
+
+### 3. Dispatch the map worker
 
 Use the current harness sub-agent facility. Dispatch one worker after Review resolution provides the UUID and pinned commits. The worker must follow the dev-review-map skill.
 
@@ -92,7 +102,7 @@ Continue document work while the worker runs. Do not author the map in the main-
 
 If no sub-agent facility exists, publish the document. Report that the map is not published. Do not silently author it in the main-agent context.
 
-### 3. Author the document
+### 4. Author the document
 
 Read [Document authoring](references/document-authoring.md) before you edit `review.mdx` or `data.ts`.
 
@@ -102,13 +112,15 @@ Use the smallest document that explains the important change. Default to `Anchor
 
 Read every referenced range from the correct pinned checkout before you add it. Use the `checkouts` paths from the scaffold event: the head checkout for a head range, the base checkout for a base range.
 
-### 4. Publish the document
+### 5. Publish the document
 
 Run:
 
 ```sh
 review publish --review <uuid> --json
 ```
+
+Both `review publish` and `review app pick` accept `--view <review|commits|diff|map|trace>` to choose the tab the reader lands on. Without `--view`, the Review tab remains the default.
 
 Read each NDJSON error event. Correct all document errors and publish again. A missing software map is not a document error.
 
@@ -120,7 +132,7 @@ Show the published document immediately:
 review app pick --review <uuid> --json
 ```
 
-### 5. Publish the map
+### 6. Publish the map
 
 Join the map worker after document publication. If the Review became terminal, report the valid unpublished-map state and do not retry.
 
@@ -136,7 +148,7 @@ This command updates only `presentedSoftwareMapRevision`. It preserves the docum
 
 If the worker fails, keep the valid document publication. Report the map failure and the smallest next action.
 
-### 6. Handle feedback
+### 7. Handle feedback
 
 Wait for a status that requires agent action. Use the command for the current harness:
 

--- a/packages/progressive-review/src/cli-runner.ts
+++ b/packages/progressive-review/src/cli-runner.ts
@@ -2,6 +2,7 @@ import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 
 import { devfastPrepareCommands } from "@dev.fast/local-vcs";
+import type { ReviewView } from "@dev.fast/review-protocol";
 import { Argument, Command, CommanderError, Option } from "commander";
 
 import { humanStream, jsonRequestedInArgv } from "./cli-output";
@@ -216,6 +217,14 @@ export async function runProgressiveReviewCli(
     configureOutput(command, surface).addOption(
       new Option("--json", "print machine-readable JSON events on stdout"),
     );
+  const viewOption = () =>
+    new Option("--view <view>", "view to show after opening").choices([
+      "review",
+      "commits",
+      "diff",
+      "map",
+      "trace",
+    ]);
 
   const executeMap = async (mapArgs: string[]) => {
     const parsed = parseSoftwareMapCliArgs(mapArgs);
@@ -279,10 +288,15 @@ export async function runProgressiveReviewCli(
       input.stdout.write(`Review Desktop is showing "${event.title}".\n`);
     }
   };
-  const pickReview = async (options: { review?: string; json?: boolean }) => {
+  const pickReview = async (options: {
+    review?: string;
+    view?: ReviewView;
+    json?: boolean;
+  }) => {
     const event = await runtime.runReviewAppPick({
       cwd,
       reviewUuid: options.review,
+      view: options.view,
       stdin: (input.stdin ?? process.stdin) as NodeJS.ReadStream,
       // This stream carries only the interactive picker. Under --json it must
       // not be stdout: the picker's ANSI frames would corrupt the event line.
@@ -316,12 +330,15 @@ export async function runProgressiveReviewCli(
     program
       .command("app")
       .description("Start or activate Review Desktop")
-      .option("--review <uuid>", "compatibility alias for app pick --review"),
+      .option("--review <uuid>", "compatibility alias for app pick --review")
+      .addOption(viewOption()),
     "plain",
-  ).action(async (options: { review?: string; json?: boolean }) => {
-    if (options.review) return pickReview(options);
-    return launchApp(options);
-  });
+  ).action(
+    async (options: { review?: string; view?: ReviewView; json?: boolean }) => {
+      if (options.review) return pickReview(options);
+      return launchApp(options);
+    },
+  );
   configureJsonOutput(
     app.command("launch").description("Start or activate Review Desktop"),
     "plain",
@@ -332,7 +349,8 @@ export async function runProgressiveReviewCli(
       .description(
         "Select a published Review (interactive picker without --review)",
       )
-      .option("--review <uuid>", "review UUID"),
+      .option("--review <uuid>", "review UUID")
+      .addOption(viewOption()),
     "plain",
   ).action(pickReview);
 
@@ -362,20 +380,24 @@ export async function runProgressiveReviewCli(
       .description(
         "Present the Review document in the local Review Desktop app",
       )
-      .option("--review <uuid>", "review UUID"),
+      .option("--review <uuid>", "review UUID")
+      .addOption(viewOption()),
     "plain",
-  ).action(async (options: { review?: string; json?: boolean }) => {
-    state.exitCode = await runtime.runReviewPublish({
-      cwd,
-      reviewUuid: options.review,
-      json: options.json,
-      toolingRoot: env.DEV_FAST_REVIEW_TOOLING_ROOT || undefined,
-      stdout: input.stdout,
-      stderr: input.stderr,
-      env,
-      onReviewBound: bindActiveReview,
-    });
-  });
+  ).action(
+    async (options: { review?: string; view?: ReviewView; json?: boolean }) => {
+      state.exitCode = await runtime.runReviewPublish({
+        cwd,
+        reviewUuid: options.review,
+        view: options.view,
+        json: options.json,
+        toolingRoot: env.DEV_FAST_REVIEW_TOOLING_ROOT || undefined,
+        stdout: input.stdout,
+        stderr: input.stderr,
+        env,
+        onReviewBound: bindActiveReview,
+      });
+    },
+  );
 
   configureJsonOutput(
     program
@@ -1289,6 +1311,7 @@ function progressiveReviewTopLevelHelp(): string {
     "Edit the returned review.mdx and data.ts files, then use `review present` (alias of `review publish`). It validates in the CLI before contacting Review Desktop.",
     "The CLI validates before publishing; Review Desktop promotes the revision before mounting it.",
     "Use `review app launch` to start Review Desktop. Use `review app pick --review <uuid>` after publication.",
+    "Use `--view <review|commits|diff|map|trace>` with `review publish` or `review app pick` to choose the opened tab.",
     "",
     "Every command accepts --json. Stdout then carries only JSON events, one per line,",
     "human progress moves to stderr, and a failure prints a JSON error event too.",

--- a/packages/progressive-review/src/cli.test.ts
+++ b/packages/progressive-review/src/cli.test.ts
@@ -577,8 +577,14 @@ describe("Review CLI", () => {
   });
 
   it.each([
-    ["pick subcommand", ["app", "pick", "--review", "review-uuid"]],
-    ["compatibility alias", ["app", "--review", "review-uuid"]],
+    [
+      "pick subcommand",
+      ["app", "pick", "--review", "review-uuid", "--view", "diff"],
+    ],
+    [
+      "compatibility alias",
+      ["app", "--review", "review-uuid", "--view", "diff"],
+    ],
   ])("supports the app %s", async (_label, argv) => {
     const runReviewAppPick = vi.fn<typeof runReviewAppActual>(async () => ({
       event: "app",
@@ -599,13 +605,44 @@ describe("Review CLI", () => {
       }),
     ).resolves.toBe(0);
     expect(runReviewAppPick).toHaveBeenCalledWith(
-      expect.objectContaining({ reviewUuid: "review-uuid" }),
+      expect.objectContaining({ reviewUuid: "review-uuid", view: "diff" }),
     );
     expect(JSON.parse(output)).toMatchObject({
       event: "app",
       action: "pick",
       reviewUuid: "review-uuid",
     });
+  });
+
+  it("forwards the selected view when publishing", async () => {
+    const runReviewPublish = vi.fn<typeof runReviewPublishActual>(
+      async () => 0,
+    );
+
+    await expect(
+      runProgressiveReviewCli({
+        argv: ["publish", "--review", "review-uuid", "--view", "diff"],
+        stdout: outputStream(),
+        stderr: outputStream(),
+        runtime: { runReviewPublish },
+      }),
+    ).resolves.toBe(0);
+    expect(runReviewPublish).toHaveBeenCalledWith(
+      expect.objectContaining({ reviewUuid: "review-uuid", view: "diff" }),
+    );
+  });
+
+  it.each([
+    ["app pick", ["app", "pick", "--review", "review-uuid"]],
+    ["publish", ["publish", "--review", "review-uuid"]],
+  ])("rejects an invalid --view for %s", async (_label, argv) => {
+    await expect(
+      runProgressiveReviewCli({
+        argv: [...argv, "--view", "files"],
+        stdout: outputStream(),
+        stderr: outputStream(),
+      }),
+    ).resolves.toBe(1);
   });
 
   it("accepts --json on scaffold and keeps stdout to one JSON line", async () => {

--- a/packages/progressive-review/src/review-app.test.ts
+++ b/packages/progressive-review/src/review-app.test.ts
@@ -85,6 +85,7 @@ describe("review app", () => {
           stdin: fakeTty(),
           stdout: process.stdout,
           reviewUuid: selected.review.uuid,
+          view: "diff",
         },
         {
           launch: async () => ({
@@ -108,6 +109,17 @@ describe("review app", () => {
       reviewUuid: selected.review.uuid,
       title: selected.review.title,
     });
+    expect(fetch).toHaveBeenCalledWith(
+      `${discovery.url}/reviews/${selected.review.uuid}/open`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-review-token": discovery.token,
+        },
+        body: JSON.stringify({ view: "diff" }),
+      },
+    );
   });
 
   it("requires a TTY only for the interactive picker", async () => {

--- a/packages/progressive-review/src/review-app.ts
+++ b/packages/progressive-review/src/review-app.ts
@@ -1,3 +1,5 @@
+import type { ReviewView } from "@dev.fast/review-protocol";
+
 import { readReviewDesktopDiscovery } from "./desktop-discovery";
 import { runReviewAppLaunch } from "./review-app-launcher";
 import { type ReviewPickerItem, pickReview } from "./review-app-picker";
@@ -17,6 +19,7 @@ interface ReviewAppRuntime {
 export interface RunReviewAppInput {
   cwd: string;
   reviewUuid?: string;
+  view?: ReviewView;
   stdin: NodeJS.ReadStream;
   stdout: NodeJS.WriteStream;
 }
@@ -68,7 +71,11 @@ export async function runReviewAppPick(
     `${discovery.url}/reviews/${encodeURIComponent(review.review.uuid)}/open`,
     {
       method: "POST",
-      headers: { "x-review-token": discovery.token },
+      headers: {
+        "x-review-token": discovery.token,
+        ...(input.view ? { "content-type": "application/json" } : {}),
+      },
+      ...(input.view ? { body: JSON.stringify({ view: input.view }) } : {}),
     },
   );
   const payload: unknown = await response.json();

--- a/packages/progressive-review/src/review-publish.ts
+++ b/packages/progressive-review/src/review-publish.ts
@@ -1,3 +1,5 @@
+import type { ReviewView } from "@dev.fast/review-protocol";
+
 import { resolveAuthoringSessionRef } from "./authoring-session";
 import { emitJsonEvent } from "./cli-output";
 import type { ReviewDocumentDiagnostic } from "./compiler/review-document-compiler";
@@ -17,6 +19,7 @@ import { prepareReviewPublish } from "./server/publish-preparation";
 export async function runReviewPublish(input: {
   cwd: string;
   reviewUuid?: string;
+  view?: ReviewView;
   json?: boolean;
   toolingRoot?: string;
   stdout: NodeJS.WriteStream;
@@ -43,6 +46,7 @@ async function publish(
   input: {
     cwd: string;
     reviewUuid?: string;
+    view?: ReviewView;
     toolingRoot?: string;
     env?: NodeJS.ProcessEnv;
     onReviewBound?: (uuid: string) => void | Promise<void>;
@@ -105,6 +109,7 @@ async function publish(
       reviewUuid: prepared.uuid,
       revision,
       agent: resolveAuthoringSessionRef(input.env ?? process.env),
+      ...(input.view ? { view: input.view } : {}),
     }),
   });
   const result = (await response.json().catch(() => null)) as {

--- a/packages/progressive-review/src/server/desktop-server.test.ts
+++ b/packages/progressive-review/src/server/desktop-server.test.ts
@@ -1,14 +1,19 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import type { ReviewRecord } from "@dev.fast/review-protocol";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { reviewTitleFromDocument } from "../review-home";
-import { reviewAgentKind } from "./desktop-server";
+import { createGlobalReviewServer, reviewAgentKind } from "./desktop-server";
 
 let directory: string | undefined;
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
 
 afterEach(async () => {
   if (directory) await rm(directory, { recursive: true, force: true });
@@ -74,5 +79,43 @@ describe("reviewAgentKind", () => {
         agentSessions: undefined,
       }),
     ).toBe("pi");
+  });
+});
+
+describe("Review Desktop open requests", () => {
+  it("rejects an unknown Review view before opening a session", async () => {
+    directory = await mkdtemp(path.join(tmpdir(), "review-view-server-"));
+    const token = "review-view-test-token";
+    const server = createGlobalReviewServer({
+      appPid: process.pid,
+      packageRoot,
+      toolingRoot: packageRoot,
+      port: 0,
+      token,
+      discoveryPath: path.join(directory, "desktop.json"),
+    });
+
+    try {
+      await server.listen();
+      const response = await fetch(
+        `${server.url}/reviews/11111111-1111-4111-8111-111111111111/open`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-review-token": token,
+          },
+          body: JSON.stringify({ view: "files" }),
+        },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        ok: false,
+        code: "invalid_view",
+      });
+    } finally {
+      await server.close();
+    }
   });
 });

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -16,8 +16,10 @@ import {
   type ReviewSessionWire,
   type ReviewTutorialOpenResponse,
   type ReviewVerbRequest,
+  type ReviewView,
   parseReviewCliInstallApplyRequest,
   parseReviewPublishReadyRequest,
+  reviewViewSchema,
 } from "@dev.fast/review-protocol";
 import { type Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
@@ -159,6 +161,7 @@ interface RegisterSessionInput {
   promoted: boolean;
   announce?: boolean;
   focusCanvas?: boolean;
+  view?: ReviewView;
   // True when opened for a non-document surface (the Source tab). Stamped on
   // the session-registered broadcast so the app suppresses the document tab.
   background?: boolean;
@@ -172,6 +175,12 @@ interface RegisterSessionInput {
 interface ReviewCheckoutRoots {
   baseRootPath: string;
   headRootPath: string;
+}
+
+function revealVerb(view?: ReviewView): ReviewVerbRequest {
+  return view
+    ? { name: "showReviewView", args: { view } }
+    : { name: "focusCanvas", args: {} };
 }
 
 interface PreparedTutorial {
@@ -442,8 +451,18 @@ export function createGlobalReviewServer(
     const openBody = (await context.req.json().catch(() => null)) as {
       background?: unknown;
       revision?: unknown;
+      view?: unknown;
     } | null;
     const background = openBody?.background === true;
+    const parsedView = reviewViewSchema.safeParse(openBody?.view);
+    if (openBody?.view !== undefined && !parsedView.success) {
+      throw new ReviewServerError(
+        "Review view must be one of review, commits, diff, map, or trace.",
+        400,
+        "invalid_view",
+      );
+    }
+    const view = parsedView.success ? parsedView.data : undefined;
     const review = await findReview(uuid);
     if (!review) {
       throw new ReviewServerError("Review not found.", 404);
@@ -489,6 +508,7 @@ export function createGlobalReviewServer(
         requestedRevision,
         appSessionId,
         descriptor,
+        view,
       );
     }
     const documentRevision = review.review.presentedDocumentRevision;
@@ -518,10 +538,7 @@ export function createGlobalReviewServer(
     if (existing) {
       existing.appSessionId ??= appSessionId;
       if (!background) {
-        void relay.dispatch(existing.descriptor.sessionId, {
-          name: "focusCanvas",
-          args: {},
-        });
+        void relay.dispatch(existing.descriptor.sessionId, revealVerb(view));
       }
       return globalJson(200, {
         sessionId: existing.descriptor.sessionId,
@@ -551,6 +568,7 @@ export function createGlobalReviewServer(
       promoted: true,
       announce: true,
       focusCanvas: !background,
+      view,
       background,
       appSessionId,
     });
@@ -567,6 +585,7 @@ export function createGlobalReviewServer(
     revision: string,
     appSessionId: string | undefined,
     homeReview: ReviewDescriptor,
+    view: ReviewView | undefined,
   ): Promise<Response> {
     const existing = [...sessions.values()].find(
       (session) =>
@@ -575,10 +594,7 @@ export function createGlobalReviewServer(
     );
     if (existing) {
       existing.appSessionId ??= appSessionId;
-      void relay.dispatch(existing.descriptor.sessionId, {
-        name: "focusCanvas",
-        args: {},
-      });
+      void relay.dispatch(existing.descriptor.sessionId, revealVerb(view));
       return globalJson(200, {
         sessionId: existing.descriptor.sessionId,
         url: existing.descriptor.sessionUrl,
@@ -622,6 +638,7 @@ export function createGlobalReviewServer(
       historicalRevision: revision,
       announce: true,
       focusCanvas: true,
+      view,
       appSessionId,
     });
     return globalJson(201, {
@@ -786,7 +803,7 @@ export function createGlobalReviewServer(
       }
       return globalJson(
         201,
-        await mountPublishedDocument(review, request.revision),
+        await mountPublishedDocument(review, request.revision, request.view),
       );
     } catch (error) {
       await telemetry.capturePublishGateRejected({ gate: "publish_ready" });
@@ -952,6 +969,7 @@ export function createGlobalReviewServer(
   async function mountPublishedDocument(
     review: StoredReview,
     revision: string,
+    view?: ReviewView,
   ): Promise<{
     ok: true;
     revision: string;
@@ -1057,10 +1075,10 @@ export function createGlobalReviewServer(
     // Promotion already happened: from here on nothing can fail the publish.
     // A focus failure is a warning — the promoted revision is live either
     // way — and a prune failure is ignored.
-    const focus = await relay.dispatch(successor.descriptor.sessionId, {
-      name: "focusCanvas",
-      args: {},
-    });
+    const focus = await relay.dispatch(
+      successor.descriptor.sessionId,
+      revealVerb(view),
+    );
     await pruneReviewBuilds(review.dir, [
       revision,
       ...(successor.review.review.presentedSoftwareMapRevision
@@ -1765,7 +1783,7 @@ export function createGlobalReviewServer(
       });
     }
     if (registration.focusCanvas) {
-      void relay.dispatch(sessionId, { name: "focusCanvas", args: {} });
+      void relay.dispatch(sessionId, revealVerb(registration.view));
     }
     return active;
   }

--- a/packages/review-protocol/src/contracts.test.ts
+++ b/packages/review-protocol/src/contracts.test.ts
@@ -47,6 +47,7 @@ import {
   ReviewVerbResponseSchema,
   ThreadTargetSchema,
   createGitLabTextDiffPosition,
+  reviewViewSchema,
   summarizeReviewDiffFiles,
 } from "./contracts.js";
 
@@ -188,6 +189,7 @@ const contracts: Array<[string, ZodType, Record<string, unknown>]> = [
       reviewUuid: reviewRecord.uuid,
       revision: "a".repeat(40),
       agent: { harness: "codex", sessionId: "session-1" },
+      view: "diff",
     },
   ],
   ["session descriptor", ReviewSessionDescriptorSchema, descriptor],
@@ -404,6 +406,29 @@ describe("Review protocol Zod contracts", () => {
     expect(schema.safeParse({ ...value, unexpected: true }).success).toBe(
       tolerantContracts.has(name),
     );
+  });
+});
+
+describe("review views", () => {
+  it("accepts the five shared views and rejects unknown values", () => {
+    expect(
+      ["review", "commits", "diff", "map", "trace"].every(
+        (view) => reviewViewSchema.safeParse(view).success,
+      ),
+    ).toBe(true);
+    expect(reviewViewSchema.safeParse("files").success).toBe(false);
+    expect(
+      ReviewVerbRequestSchema.safeParse({
+        name: "showReviewView",
+        args: { view: "diff" },
+      }).success,
+    ).toBe(true);
+    expect(
+      ReviewSurfaceEventSchema.safeParse({
+        event: "showReviewView",
+        view: "map",
+      }).success,
+    ).toBe(true);
   });
 });
 

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -21,6 +21,14 @@ const nonNegativeInteger = z
 const reviewDiffSideSchema = z.enum(["base", "head"], {
   error: "must be base or head",
 });
+export const reviewViewSchema = z.enum([
+  "review",
+  "commits",
+  "diff",
+  "map",
+  "trace",
+]);
+export type ReviewView = z.infer<typeof reviewViewSchema>;
 const reviewThemeSchema = z.enum(["light", "dark"], {
   error: "must be light or dark",
 });
@@ -1463,6 +1471,7 @@ export const ReviewPublishReadyRequestSchema = z.strictObject({
     .string({ error: "must be a 40-hex revision" })
     .regex(/^[0-9a-f]{40}$/i, "must be a 40-hex revision"),
   agent: AuthoringAgentSessionSchema.optional(),
+  view: reviewViewSchema.optional(),
 });
 export type ReviewPublishReadyRequest = z.infer<
   typeof ReviewPublishReadyRequestSchema
@@ -1911,7 +1920,10 @@ const revealArgsSchema = z
 
 export const ReviewVerbRequestSchema = z.discriminatedUnion("name", [
   z.strictObject({ name: z.literal("openFile"), args: openFileArgsSchema }),
-  z.strictObject({ name: z.literal("openFiles"), args: z.strictObject({}) }),
+  z.strictObject({
+    name: z.literal("showReviewView"),
+    args: z.strictObject({ view: reviewViewSchema }),
+  }),
   z.strictObject({
     name: z.literal("openSourceTree"),
     args: z.strictObject({}),
@@ -2031,7 +2043,8 @@ export const ReviewSurfaceEventSchema = z.discriminatedUnion("event", [
     theme: reviewThemeSchema,
   }),
   z.strictObject({
-    event: z.literal("showDiffView"),
+    event: z.literal("showReviewView"),
+    view: reviewViewSchema,
   }),
 ]);
 export type ReviewSurfaceEvent = z.infer<typeof ReviewSurfaceEventSchema>;


### PR DESCRIPTION
## Summary

- add a shared Review view protocol and `--view` support to `review publish` and `review app pick`
- route the requested view through the Desktop server, workbench, and Review canvas
- update the dev-review skill to publish small-change scaffolds directly into Diff before writing the short review

## Testing

- `pnpm --filter @dev.fast/review-protocol build`
- `pnpm --filter @dev-fast/review-desktop protocol:sync`
- `pnpm --filter @dev-fast/review-desktop protocol:check`
- `pnpm --filter @dev.fast/review test` (1,157 passed)
- `pnpm --filter @dev-fast/review-desktop test` (199 passed, 1 expected skip)
- `pnpm format:check`
- `pnpm lint`
- `pnpm desktop:build`

## Manual smoke

- fresh `review publish --review <uuid> --view diff --json` mounted the Review successfully
- `review app pick --review <uuid> --view map` and `--view trace` succeeded
- `--view bogus` failed through Commander choices validation