### PR TITLE
Add anti-slop Oxlint rules and enforce lint/format in CI

### DIFF
--- a/.github/workflows/review-desktop-ci.yml
+++ b/.github/workflows/review-desktop-ci.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Install monorepo dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Lint
+        run: pnpm lint
+
+      - name: Check formatting
+        run: pnpm format:check
+
       # Headers for the Code OSS native modules npm ci builds from source:
       # native-keymap needs x11/xkbfile, kerberos needs krb5, and the secret
       # storage bindings need libsecret.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -30,6 +30,18 @@
     "**/routeTree.gen.ts",
     "**/worker-configuration.d.ts",
     "packages/code-graph/fixtures/indexing/**/malformed.js",
-    "packages/code-graph/fixtures/indexing/**/malformed.ts"
+    "packages/code-graph/fixtures/indexing/**/malformed.ts",
+    ".agent/**",
+    ".agents/**",
+    ".claude/**",
+    ".codex/**",
+    ".continue/**",
+    ".cursor/**",
+    ".gemini/**",
+    ".opencode/**",
+    ".pi/**",
+    ".roo/**",
+    ".windsurf/**",
+    "tools/oxlint/anti-slop/**"
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -29,7 +29,19 @@
     "**/routeTree.gen.ts",
     "**/worker-configuration.d.ts",
     "packages/code-graph/fixtures/indexing/**/malformed.js",
-    "packages/code-graph/fixtures/indexing/**/malformed.ts"
+    "packages/code-graph/fixtures/indexing/**/malformed.ts",
+    ".agent/**",
+    ".agents/**",
+    ".claude/**",
+    ".codex/**",
+    ".continue/**",
+    ".cursor/**",
+    ".gemini/**",
+    ".opencode/**",
+    ".pi/**",
+    ".roo/**",
+    ".windsurf/**",
+    "tools/oxlint/anti-slop/**"
   ],
   "rules": {
     "sort-imports": [
@@ -72,6 +84,27 @@
     "jest/valid-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-disabled-tests": "off",
-    "no-unmodified-loop-condition": "off"
-  }
+    "no-unmodified-loop-condition": "off",
+    "anti-slop/no-chained-type-assertions": "error",
+    "anti-slop/no-conditional-empty-object-spread": "warn",
+    "anti-slop/no-known-value-widening": "warn",
+    "anti-slop/no-module-mocking": "warn",
+    "anti-slop/no-object-parameters": "error",
+    "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-reflect-get": "error",
+    "anti-slop/no-runtime-typeof": "warn",
+    "anti-slop/no-shape-in-symbol-names": "warn",
+    "anti-slop/no-unknown-parameters": "warn",
+    "anti-slop/no-unknown-returns": "warn",
+    "anti-slop/no-unknown-type-aliases": "error",
+    "anti-slop/no-unsafe-dictionary-type": "warn",
+    "anti-slop/no-widen-then-assert": "error",
+    "anti-slop/require-safety-comment-for-type-assertion": "warn"
+  },
+  "jsPlugins": [
+    {
+      "name": "anti-slop",
+      "specifier": "./tools/oxlint/anti-slop/index.ts"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build": "pnpm -r --if-present build"
   },
   "devDependencies": {
+    "@oxlint/plugins": "1.63.0",
     "@types/node": "24.12.2",
     "oxfmt": "0.48.0",
     "oxlint": "1.63.0",

--- a/packages/progressive-review/app/desktop-trusted-types.test.ts
+++ b/packages/progressive-review/app/desktop-trusted-types.test.ts
@@ -54,10 +54,16 @@ describe("libavoid Trusted Types hardening", () => {
       return (...values: unknown[]) =>
         body.trustedScript === "return value + 1" ? Number(values[0]) + 1 : 7;
     });
-    const canvasGlobal = {
+    interface LibavoidCanvasGlobal {
+      Function: typeof functionConstructor;
+      trustedTypes: { createPolicy: typeof createPolicy };
+      first?: number;
+      second?: number;
+    }
+    const canvasGlobal: LibavoidCanvasGlobal = {
       Function: functionConstructor,
       trustedTypes: { createPolicy },
-    } as unknown as typeof globalThis;
+    };
 
     Function("globalThis", transformed)(canvasGlobal);
 

--- a/packages/progressive-review/app/src/InlineCodeEditor.test.tsx
+++ b/packages/progressive-review/app/src/InlineCodeEditor.test.tsx
@@ -13,9 +13,13 @@ import {
   testReviewSession,
 } from "./review-session-test-utils";
 
-class FakeIntersectionObserver {
+class FakeIntersectionObserver implements IntersectionObserver {
   static instances: FakeIntersectionObserver[] = [];
   observed: Element[] = [];
+  readonly root = null;
+  readonly rootMargin = "";
+  readonly scrollMargin = "";
+  readonly thresholds: readonly number[] = [];
 
   constructor(private readonly callback: IntersectionObserverCallback) {
     FakeIntersectionObserver.instances.push(this);
@@ -41,7 +45,7 @@ class FakeIntersectionObserver {
         (target) =>
           ({ isIntersecting: true, target }) as IntersectionObserverEntry,
       ),
-      this as unknown as IntersectionObserver,
+      this,
     );
   }
 }

--- a/packages/progressive-review/app/src/diagrams.tsx
+++ b/packages/progressive-review/app/src/diagrams.tsx
@@ -55,6 +55,19 @@ import { captureUiEvent } from "./ui-telemetry";
 
 import "@xyflow/react/dist/style.css";
 
+type SequenceParticipantNodeData = {
+  participant: ActorRef;
+  diagram: string;
+  height: number;
+  messages: SequenceMessage[];
+  messageGap: number;
+  messageTop: number;
+};
+type SequenceParticipantFlowNode = ReactFlowNode<
+  SequenceParticipantNodeData,
+  "sequenceParticipant"
+>;
+
 const sequenceNodeTypes = { sequenceParticipant: SequenceParticipantNode };
 const sequenceEdgeTypes = { sequenceMessage: SequenceMessageEdge };
 
@@ -515,7 +528,7 @@ function SequenceDiagramFigure({
   const messageGap = 76;
   const width = Math.max(320, sequence.participants.length * laneWidth);
   const height = messageTop + sequence.messages.length * messageGap + 42;
-  const reactFlowNodes: ReactFlowNode[] = useMemo(
+  const reactFlowNodes: SequenceParticipantFlowNode[] = useMemo(
     () =>
       sequence.participants.map((participant, index) => ({
         id: participant.id,
@@ -774,17 +787,12 @@ function DiagramHeader({
   );
 }
 
-function SequenceParticipantNode({ data }: ReactFlowNodeProps) {
+function SequenceParticipantNode({
+  data,
+}: ReactFlowNodeProps<SequenceParticipantFlowNode>) {
   const review = useReview();
   const { participant, diagram, height, messages, messageGap, messageTop } =
-    data as unknown as {
-      participant: ActorRef;
-      diagram: string;
-      height: number;
-      messages: SequenceMessage[];
-      messageGap: number;
-      messageTop: number;
-    };
+    data;
   const target = buildGraphTarget({
     diagram,
     type: "node",

--- a/packages/progressive-review/app/src/review-view-state.test.tsx
+++ b/packages/progressive-review/app/src/review-view-state.test.tsx
@@ -45,16 +45,17 @@ beforeEach(() => {
   vi.stubGlobal("cancelAnimationFrame", (frame: number) => {
     frames.delete(frame);
   });
-  class TestResizeObserver {
+  class TestResizeObserver implements ResizeObserver {
     constructor(private readonly callback: ResizeObserverCallback) {
       resizeObservers.add(this);
     }
     observe(): void {}
+    unobserve(): void {}
     disconnect(): void {
       resizeObservers.delete(this);
     }
     trigger(): void {
-      this.callback([], this as unknown as ResizeObserver);
+      this.callback([], this);
     }
   }
   vi.stubGlobal("ResizeObserver", TestResizeObserver);

--- a/packages/progressive-review/app/src/software-map/SoftwareMap.tsx
+++ b/packages/progressive-review/app/src/software-map/SoftwareMap.tsx
@@ -20,7 +20,7 @@ import {
   type NodeProps as ReactFlowNodeProps,
   type Viewport,
 } from "@xyflow/react";
-import ELK from "elkjs/lib/elk.bundled.js";
+import ELK, { type ElkNode } from "elkjs/lib/elk.bundled.js";
 import {
   type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
@@ -1314,9 +1314,11 @@ const SOFTWARE_MAP_KEYBOARD_NODE_SELECTOR = `[${SOFTWARE_MAP_KEYBOARD_NODE_ID_AT
 function softwareMapKeyboardNodeDomAttributes(
   nodeId: string,
 ): C4MapAnyFlowNode["domAttributes"] {
+  // SAFETY: React types data-* attributes only in JSX. React Flow spreads
+  // domAttributes onto the node wrapper, so this attribute reaches the DOM.
   return {
     [SOFTWARE_MAP_KEYBOARD_NODE_ID_ATTRIBUTE]: nodeId,
-  } as unknown as C4MapAnyFlowNode["domAttributes"];
+  } as C4MapAnyFlowNode["domAttributes"];
 }
 
 function softwareMapEventTargetNodeId(
@@ -5050,7 +5052,7 @@ async function runC4ElkLayout(
         : undefined,
     };
   });
-  const result = (await c4Elk.layout({
+  const result: C4ElkLayoutGraph = await c4Elk.layout({
     id: "software-map-c4",
     layoutOptions: {
       "elk.algorithm": "layered",
@@ -5090,7 +5092,7 @@ async function runC4ElkLayout(
       }),
     ),
     edges: elkEdges,
-  } as never)) as unknown as C4ElkLayoutGraph;
+  });
 
   const nodeOffsets = new Map<string, C4ElkPoint>([
     [result.id, { x: 0, y: 0 }],
@@ -5203,7 +5205,7 @@ function c4ElkNodeForSnapshot(
     portsByNodeId?: ReadonlyMap<string, C4ElkPort[]>;
   },
   parentOffset: C4ElkPoint = { x: 0, y: 0 },
-): C4ElkLayoutNode {
+): ElkNode {
   const hint = context.layoutHints?.get(node.id);
   const nodeOffset = hint ? { x: hint.x, y: hint.y } : parentOffset;
   const dimensions = c4MeasuredNodeDimensions(node, context.nodeDimensions);

--- a/packages/progressive-review/app/src/thread-annotations.test.ts
+++ b/packages/progressive-review/app/src/thread-annotations.test.ts
@@ -12,6 +12,13 @@ import {
   threadFitsExpandedCard,
 } from "./thread-annotations";
 
+/** A DOMRectList backed by the given rects, for stubbing Range.getClientRects. */
+function domRectList(...rects: DOMRect[]): DOMRectList {
+  return Object.assign(rects, {
+    item: (index: number) => rects[index] ?? null,
+  });
+}
+
 describe("annotationForThread", () => {
   it("places a cross-paragraph comment pin in the selected prose margin", () => {
     const article = document.createElement("article");
@@ -40,9 +47,9 @@ describe("annotationForThread", () => {
     Object.defineProperty(rangePrototype, "getClientRects", {
       configurable: true,
       value: vi.fn<() => DOMRectList>(function (this: Range): DOMRectList {
-        return [
+        return domRectList(
           this.startContainer === headingText ? headingLine : paragraphLine,
-        ] as unknown as DOMRectList;
+        );
       }),
     });
 
@@ -116,15 +123,15 @@ describe("textNodeClientRects", () => {
       function (this: Range): DOMRectList {
         measuredRanges.push(this);
         if (this === selection) {
-          return [enclosingParagraph] as unknown as DOMRectList;
+          return domRectList(enclosingParagraph);
         }
         if (this.startContainer === headingText) {
-          return [headingLine] as unknown as DOMRectList;
+          return domRectList(headingLine);
         }
         if (this.startContainer === firstParagraphText) {
-          return [firstParagraphLine] as unknown as DOMRectList;
+          return domRectList(firstParagraphLine);
         }
-        return [secondParagraphLine] as unknown as DOMRectList;
+        return domRectList(secondParagraphLine);
       },
     );
     Object.defineProperty(rangePrototype, "getClientRects", {

--- a/packages/progressive-review/app/src/thread-card.test.tsx
+++ b/packages/progressive-review/app/src/thread-card.test.tsx
@@ -7,11 +7,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // jsdom does not implement ResizeObserver, which ThreadCard uses to re-measure
 // clamped message bodies. These tests assert markup, not layout, so a stub that
 // never fires is enough — the observer's real behaviour is verified in a browser.
-globalThis.ResizeObserver ??= class {
+class StubResizeObserver implements ResizeObserver {
   observe(): void {}
   unobserve(): void {}
   disconnect(): void {}
-} as unknown as typeof ResizeObserver;
+}
+globalThis.ResizeObserver ??= StubResizeObserver;
 
 import type { ThreadView } from "./review-threads";
 import { readReviewUiState, writeReviewUiState } from "./review-ui-state";

--- a/packages/progressive-review/package.json
+++ b/packages/progressive-review/package.json
@@ -114,6 +114,7 @@
     "@types/write-file-atomic": "4.0.3",
     "@vitejs/plugin-react": "6.0.1",
     "jsdom": "29.1.1",
+    "mdast-util-mdx-jsx": "3.2.0",
     "tsdown": "^0.22.3",
     "tsx": "4.21.0",
     "typescript-7": "npm:typescript@7.0.1-rc",

--- a/packages/progressive-review/scripts/scroll-eval.ts
+++ b/packages/progressive-review/scripts/scroll-eval.ts
@@ -695,13 +695,16 @@ function summarizeTrace(trace: { traceEvents?: unknown[] }) {
   };
 }
 
+/** What the stop probe script reports back from the page. */
+type ScrollEvalPageSummary = {
+  frameGapMs: Stats;
+  longTaskMs: Stats;
+  activeLongTaskMs?: Stats;
+  viewportsPerSecond: number | null;
+};
+
 function passFail(summary: {
-  pageSummary: {
-    frameGapMs: Stats;
-    longTaskMs: Stats;
-    activeLongTaskMs?: Stats;
-    viewportsPerSecond: number | null;
-  };
+  pageSummary: ScrollEvalPageSummary;
   traceSummary: ReturnType<typeof summarizeTrace> | null;
 }) {
   const failures: string[] = [];
@@ -943,7 +946,7 @@ async function main() {
       }
     }
 
-    const pageSummary = await evaluate<Record<string, Json>>(
+    const pageSummary = await evaluate<ScrollEvalPageSummary>(
       client,
       buildStopProbeScript(),
     );
@@ -962,14 +965,7 @@ async function main() {
       },
       pageSummary,
       traceSummary,
-      result: passFail({
-        pageSummary: pageSummary as unknown as {
-          frameGapMs: Stats;
-          longTaskMs: Stats;
-          viewportsPerSecond: number | null;
-        },
-        traceSummary,
-      }),
+      result: passFail({ pageSummary, traceSummary }),
       artifacts: {
         summary: summaryPath,
         trace: opts.noTrace ? null : tracePath,

--- a/packages/progressive-review/src/cli-output.ts
+++ b/packages/progressive-review/src/cli-output.ts
@@ -4,14 +4,32 @@
 // carries only JSON events, one per line, and the human report moves to
 // stderr, so a caller can parse stdout without stripping prose out of it.
 
+import { type Readable, Writable } from "node:stream";
+
+/** Standard input for a command: `process.stdin`, or any Readable in tests. */
+export interface CliInputStream extends Readable {
+  readonly isTTY?: boolean;
+}
+
+/** A Writable that appends every chunk to `chunks`, for captured CLI output. */
+export function collectingWritable(chunks: string[]): Writable {
+  return new Writable({
+    decodeStrings: false,
+    write(chunk, _encoding, callback) {
+      chunks.push(String(chunk));
+      callback();
+    },
+  });
+}
+
 export interface CliJsonOutput {
   json?: boolean;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
 }
 
 /** The stream a human report belongs on. */
-export function humanStream(output: CliJsonOutput): NodeJS.WriteStream {
+export function humanStream(output: CliJsonOutput): Writable {
   return output.json ? output.stderr : output.stdout;
 }
 

--- a/packages/progressive-review/src/cli-runner.ts
+++ b/packages/progressive-review/src/cli-runner.ts
@@ -1,11 +1,16 @@
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
+import type { Writable } from "node:stream";
 
 import { devfastPrepareCommands } from "@dev.fast/local-vcs";
 import type { ReviewView } from "@dev.fast/review-protocol";
 import { Argument, Command, CommanderError, Option } from "commander";
 
-import { humanStream, jsonRequestedInArgv } from "./cli-output";
+import {
+  type CliInputStream,
+  humanStream,
+  jsonRequestedInArgv,
+} from "./cli-output";
 import {
   type CodexWaitProcessInput,
   requireCodexThreadId,
@@ -24,6 +29,7 @@ import { readProgressiveReviewPackageVersion } from "./package-paths";
 import {
   type ProgressiveReviewCommand,
   type ProgressiveReviewCommandPath,
+  type ProgressiveReviewCommandTelemetry,
   ProgressiveReviewTelemetry,
   type ProgressiveReviewTelemetryErrorCategory,
   type ProgressiveReviewTelemetryErrorName,
@@ -120,10 +126,10 @@ export interface ProgressiveReviewCliInput {
   cliVersion?: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
-  stdin?: NodeJS.ReadableStream;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
-  telemetry?: ProgressiveReviewTelemetry;
+  stdin?: CliInputStream;
+  stdout: Writable;
+  stderr: Writable;
+  telemetry?: ProgressiveReviewCommandTelemetry;
   runtime?: Partial<ProgressiveReviewCliRuntime>;
 }
 
@@ -1021,7 +1027,7 @@ export async function runProgressiveReviewCli(
         cwd,
         event,
         sessionId: options.session,
-        stdin: input.stdin as NodeJS.ReadStream | undefined,
+        stdin: input.stdin,
       });
     },
   );
@@ -1182,7 +1188,7 @@ async function readStopHookPayload(
   input: ProgressiveReviewCliInput,
 ): Promise<{ cwd?: string; transcriptPath?: string }> {
   const stdin = input.stdin ?? process.stdin;
-  if ((stdin as NodeJS.ReadStream).isTTY) return {};
+  if (stdin.isTTY) return {};
   try {
     const chunks: Buffer[] = [];
     for await (const chunk of stdin) {
@@ -1471,7 +1477,7 @@ function normalizeMapTelemetrySubcommand(
 }
 
 async function finishActiveTelemetry(
-  telemetry: ProgressiveReviewTelemetry,
+  telemetry: ProgressiveReviewCommandTelemetry,
   active:
     | {
         command: ProgressiveReviewCommandPath;
@@ -1511,7 +1517,7 @@ async function finishActiveTelemetry(
 }
 
 async function captureOneOffCommand(
-  telemetry: ProgressiveReviewTelemetry,
+  telemetry: ProgressiveReviewCommandTelemetry,
   command: ProgressiveReviewCommandPath,
   exitCode: number,
   error?: unknown,

--- a/packages/progressive-review/src/cli.test.ts
+++ b/packages/progressive-review/src/cli.test.ts
@@ -8,7 +8,7 @@ import {
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { PassThrough } from "node:stream";
+import { PassThrough, Readable } from "node:stream";
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -16,7 +16,10 @@ import { runProgressiveReviewCli } from "./cli-runner";
 import { runInstall as runInstallActual } from "./install";
 import { runReviewMigration as runReviewMigrationActual } from "./migrate";
 import { PostHogCaptureClient } from "./posthog-capture-client";
-import { ProgressiveReviewTelemetry } from "./progressive-review-telemetry";
+import {
+  type ProgressiveReviewCommandTelemetry,
+  ProgressiveReviewTelemetry,
+} from "./progressive-review-telemetry";
 import { runReviewApp as runReviewAppActual } from "./review-app";
 import { runReviewAppLaunch as runReviewAppLaunchActual } from "./review-app-launcher";
 import {
@@ -308,7 +311,7 @@ describe("Review CLI", () => {
         runProgressiveReviewCli({
           argv: [...argv, "--json"],
           cwd: "/outside-a-repository",
-          stdin: { isTTY: false } as NodeJS.ReadStream,
+          stdin: Readable.from([]),
           stdout,
           stderr: outputStream(),
           runtime: { runReviewAppLaunch },
@@ -351,7 +354,7 @@ describe("Review CLI", () => {
         async () => undefined,
       ),
       shutdown: vi.fn<() => Promise<undefined>>(async () => undefined),
-    } as unknown as ProgressiveReviewTelemetry;
+    } satisfies ProgressiveReviewCommandTelemetry;
 
     await expect(
       runProgressiveReviewCli({
@@ -491,7 +494,7 @@ describe("Review CLI", () => {
       shutdown: vi.fn<ProgressiveReviewTelemetry["shutdown"]>(
         async () => undefined,
       ),
-    } as unknown as ProgressiveReviewTelemetry;
+    } satisfies ProgressiveReviewCommandTelemetry;
 
     await expect(
       runProgressiveReviewCli({
@@ -544,7 +547,7 @@ describe("Review CLI", () => {
       shutdown: vi.fn<ProgressiveReviewTelemetry["shutdown"]>(
         async () => undefined,
       ),
-    } as unknown as ProgressiveReviewTelemetry;
+    } satisfies ProgressiveReviewCommandTelemetry;
     const runReviewScaffold = vi.fn<typeof runReviewScaffoldActual>(
       async (input) => {
         await input.onReviewBound?.(reviewUuid);
@@ -958,6 +961,6 @@ function emptyScaffoldEvent(): Awaited<
   };
 }
 
-function outputStream(): NodeJS.WriteStream {
-  return new PassThrough() as unknown as NodeJS.WriteStream;
+function outputStream(): PassThrough {
+  return new PassThrough();
 }

--- a/packages/progressive-review/src/compiler/remark-review-sections.ts
+++ b/packages/progressive-review/src/compiler/remark-review-sections.ts
@@ -1,19 +1,13 @@
-import type { Heading, Root, RootContent } from "mdast";
+import type {
+  BlockContent,
+  DefinitionContent,
+  Heading,
+  Root,
+  RootContent,
+} from "mdast";
+import type { MdxJsxAttribute, MdxJsxFlowElement } from "mdast-util-mdx-jsx";
 
 const COLLAPSED_MARKER = /\s*\[collapsed\]\s*$/i;
-
-interface MdxJsxAttribute {
-  type: "mdxJsxAttribute";
-  name: string;
-  value?: string | null;
-}
-
-interface MdxJsxFlowElement {
-  type: "mdxJsxFlowElement";
-  name: string;
-  attributes: MdxJsxAttribute[];
-  children: RootContent[];
-}
 
 /**
  * Wraps every `##` heading and the content that follows it (up to the next
@@ -32,7 +26,7 @@ export function remarkReviewSections() {
     let section: MdxJsxFlowElement | null = null;
 
     const closeSection = () => {
-      if (section) next.push(section as unknown as RootContent);
+      if (section) next.push(section);
       section = null;
     };
 
@@ -51,7 +45,9 @@ export function remarkReviewSections() {
         continue;
       }
       if (section) {
-        section.children.push(node);
+        // SAFETY: remark-parse only emits flow content as root children, and
+        // ESM nodes are hoisted above; mdast types Root.children more loosely.
+        section.children.push(node as BlockContent | DefinitionContent);
         continue;
       }
       next.push(node);

--- a/packages/progressive-review/src/install.test.ts
+++ b/packages/progressive-review/src/install.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { collectingWritable } from "./cli-output";
 import { runInstall } from "./install";
 
 const REQUIRED_SKILLS = ["dev-review", "dev-review-map"] as const;
@@ -49,8 +50,8 @@ function silentStreams() {
   return {
     out,
     err,
-    stdout: { write: (s: string) => (out.push(s), true) } as NodeJS.WriteStream,
-    stderr: { write: (s: string) => (err.push(s), true) } as NodeJS.WriteStream,
+    stdout: collectingWritable(out),
+    stderr: collectingWritable(err),
   };
 }
 

--- a/packages/progressive-review/src/install.ts
+++ b/packages/progressive-review/src/install.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
 
 import { ensureNotesConfig, gitCommonDir } from "@dev.fast/local-vcs";
@@ -65,8 +66,8 @@ export async function runInstall(input: {
     verify?: boolean;
   };
   json?: boolean;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
 }): Promise<number> {
   const homeDir = input.homeDir ?? os.homedir();
   const packageRoot = input.packageRoot ?? defaultPackageRoot();

--- a/packages/progressive-review/src/map-cli-entry.test.ts
+++ b/packages/progressive-review/src/map-cli-entry.test.ts
@@ -1,8 +1,11 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { Writable } from "node:stream";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { collectingWritable } from "./cli-output";
 
 const mapMocks = vi.hoisted(() => ({
   runSoftwareMapCli: vi.fn<typeof import("./map-cli").runSoftwareMapCli>(),
@@ -133,13 +136,8 @@ function stubPostHog() {
   return fetchMock;
 }
 
-function writableOutput(output: string[]): NodeJS.WriteStream {
-  return {
-    write: (chunk: string) => {
-      output.push(chunk);
-      return true;
-    },
-  } as NodeJS.WriteStream;
+function writableOutput(output: string[]): Writable {
+  return collectingWritable(output);
 }
 
 function lastCaptureBody(fetchMock: {

--- a/packages/progressive-review/src/map-cli-entry.ts
+++ b/packages/progressive-review/src/map-cli-entry.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import path from "node:path";
+import type { Writable } from "node:stream";
 import { pathToFileURL } from "node:url";
 
 import { runProgressiveReviewCli } from "./cli-runner";
@@ -9,8 +10,8 @@ export interface SoftwareMapCliEntryInput {
   args: string[];
   cwd: string;
   env: NodeJS.ProcessEnv;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
   runSoftwareMapCli?: typeof runSoftwareMapCli;
 }
 

--- a/packages/progressive-review/src/map-cli.test.ts
+++ b/packages/progressive-review/src/map-cli.test.ts
@@ -10,6 +10,7 @@ import {
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { Writable } from "node:stream";
 
 import {
   listNoteCommits,
@@ -19,6 +20,7 @@ import {
 } from "@dev.fast/local-vcs";
 import { describe, expect, it } from "vitest";
 
+import { collectingWritable } from "./cli-output";
 import { parseSoftwareMapCliArgs, runSoftwareMapCli } from "./map-cli";
 import { createReviewDir } from "./review-home";
 import { SOFTWARE_MAP_NOTES_REF } from "./review-storage";
@@ -1323,13 +1325,8 @@ describe("review map push / fetch", () => {
   });
 });
 
-function writable(chunks: string[]): NodeJS.WriteStream {
-  return {
-    write: (chunk: string) => {
-      chunks.push(chunk);
-      return true;
-    },
-  } as NodeJS.WriteStream;
+function writable(chunks: string[]): Writable {
+  return collectingWritable(chunks);
 }
 
 function authoredMapSource(label: string): string {

--- a/packages/progressive-review/src/map-cli.ts
+++ b/packages/progressive-review/src/map-cli.ts
@@ -1,5 +1,6 @@
 import { readFileSync, readdirSync, rmSync } from "node:fs";
 import path from "node:path";
+import type { Writable } from "node:stream";
 
 import {
   currentHead,
@@ -52,8 +53,8 @@ import type {
 export interface SoftwareMapCliInput {
   args: string[];
   cwd: string;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
   env?: NodeJS.ProcessEnv;
 }
 
@@ -684,7 +685,7 @@ async function pruneSoftwareMapNotes(
 async function sweepFlushedScratches(input: {
   rootPath: string;
   gitDir: string;
-  stdout: NodeJS.WriteStream;
+  stdout: Writable;
 }): Promise<{ deleted: number; kept: number }> {
   const scratchRoot = path.join(devFastGitDir(input.gitDir), "scratch");
   let commits: string[] = [];

--- a/packages/progressive-review/src/migrate.test.ts
+++ b/packages/progressive-review/src/migrate.test.ts
@@ -10,10 +10,12 @@ import {
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { Writable } from "node:stream";
 
 import * as git from "isomorphic-git";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { collectingWritable } from "./cli-output";
 import {
   type ReviewPackageManager,
   migrateJjReviewRepositories,
@@ -33,8 +35,8 @@ type TestRunProcess = (input: {
   command: string;
   args: string[];
   env: NodeJS.ProcessEnv;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
 }) => Promise<number>;
 
 afterEach(async () => {
@@ -494,11 +496,7 @@ function streams() {
   return {
     out,
     err,
-    stdout: {
-      write: (value: string) => (out.push(value), true),
-    } as NodeJS.WriteStream,
-    stderr: {
-      write: (value: string) => (err.push(value), true),
-    } as NodeJS.WriteStream,
+    stdout: collectingWritable(out),
+    stderr: collectingWritable(err),
   };
 }

--- a/packages/progressive-review/src/migrate.ts
+++ b/packages/progressive-review/src/migrate.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { Writable } from "node:stream";
 import { promisify } from "node:util";
 
 import { emitJsonEvent, humanStream } from "./cli-output";
@@ -87,8 +88,8 @@ export async function runReviewMigration(input: {
   json?: boolean;
   homeDir?: string;
   packageRoot?: string;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
   runtime?: Partial<RunReviewMigrationRuntime>;
 }): Promise<number> {
   const human = humanStream(input);
@@ -622,8 +623,8 @@ type RunProcess = (input: {
   command: string;
   args: string[];
   env: NodeJS.ProcessEnv;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
 }) => Promise<number>;
 
 export async function removeLegacyGlobalReviewInstalls(input: {
@@ -631,8 +632,8 @@ export async function removeLegacyGlobalReviewInstalls(input: {
   homeDir: string;
   env: NodeJS.ProcessEnv;
   desktopManagedCli: boolean;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
   runCommand?: RunCommand;
   runProcess?: RunProcess;
 }): Promise<CleanupResult> {
@@ -754,8 +755,8 @@ function spawnProcess(input: {
   command: string;
   args: string[];
   env: NodeJS.ProcessEnv;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
 }): Promise<number> {
   return new Promise((resolve, reject) => {
     const child = spawn(input.command, input.args, {

--- a/packages/progressive-review/src/progressive-review-telemetry.ts
+++ b/packages/progressive-review/src/progressive-review-telemetry.ts
@@ -193,6 +193,18 @@ export function createLogger(_scope: string): Logger {
   return noopLogger;
 }
 
+/** The telemetry surface a CLI command run drives; tests fake this contract. */
+export type ProgressiveReviewCommandTelemetry = Pick<
+  ProgressiveReviewTelemetry,
+  | "createCommandRunId"
+  | "captureInstallationCreated"
+  | "captureCommandStarted"
+  | "captureCommandBound"
+  | "captureCommandSucceeded"
+  | "captureCommandFailed"
+  | "shutdown"
+>;
+
 export class ProgressiveReviewTelemetry {
   private readonly captureClient: ProgressiveReviewTelemetryCaptureClient;
   private readonly env: NodeJS.ProcessEnv;

--- a/packages/progressive-review/src/review-app-picker.ts
+++ b/packages/progressive-review/src/review-app-picker.ts
@@ -1,4 +1,5 @@
 import { emitKeypressEvents } from "node:readline";
+import type { Writable } from "node:stream";
 
 import { fuzzyRank } from "./fuzzy-match";
 
@@ -18,7 +19,7 @@ const MAX_VISIBLE_ROWS = 10;
  */
 export function pickReview(
   items: readonly ReviewPickerItem[],
-  io: { stdin: NodeJS.ReadStream; stdout: NodeJS.WriteStream },
+  io: { stdin: NodeJS.ReadStream; stdout: Writable },
 ): Promise<ReviewPickerItem | null> {
   const { stdin, stdout } = io;
   return new Promise((resolve, reject) => {

--- a/packages/progressive-review/src/review-app.ts
+++ b/packages/progressive-review/src/review-app.ts
@@ -1,3 +1,5 @@
+import type { Writable } from "node:stream";
+
 import type { ReviewView } from "@dev.fast/review-protocol";
 
 import { readReviewDesktopDiscovery } from "./desktop-discovery";
@@ -21,7 +23,7 @@ export interface RunReviewAppInput {
   reviewUuid?: string;
   view?: ReviewView;
   stdin: NodeJS.ReadStream;
-  stdout: NodeJS.WriteStream;
+  stdout: Writable;
 }
 
 export interface ReviewAppEvent {

--- a/packages/progressive-review/src/review-info.test.ts
+++ b/packages/progressive-review/src/review-info.test.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Writable } from "node:stream";
 import { promisify } from "node:util";
 
 import { describe, expect, it, vi } from "vitest";
@@ -1020,8 +1021,12 @@ async function git(root: string, args: string[]): Promise<string> {
   return stdout.trim();
 }
 
-function nullStream(): NodeJS.WriteStream {
-  return { write: () => true } as unknown as NodeJS.WriteStream;
+function nullStream(): Writable {
+  return new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
 }
 
 async function jj(root: string, args: string[]): Promise<string> {

--- a/packages/progressive-review/src/review-map-publish.ts
+++ b/packages/progressive-review/src/review-map-publish.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import type { Writable } from "node:stream";
 
 import {
   authoringSessionKey,
@@ -29,8 +30,8 @@ export async function runReviewMapPublish(input: {
   cwd: string;
   reviewUuid?: string;
   json?: boolean;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
   env?: NodeJS.ProcessEnv;
 }): Promise<number> {
   const report = mapPublishReporter(input);
@@ -160,8 +161,8 @@ interface MapPublishReporter {
 
 function mapPublishReporter(input: {
   json?: boolean;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
 }): MapPublishReporter {
   if (input.json) {
     const emit = (event: Record<string, unknown>) =>

--- a/packages/progressive-review/src/review-mdx-ast.ts
+++ b/packages/progressive-review/src/review-mdx-ast.ts
@@ -207,9 +207,8 @@ export function walkEstree(
   visit: (node: EstreeNode) => void,
 ): void {
   visit(node);
-  for (const value of Object.values(
-    node as unknown as Record<string, unknown>,
-  )) {
+  const fields: unknown[] = Object.values(node);
+  for (const value of fields) {
     if (Array.isArray(value)) {
       for (const item of value) {
         if (isEstreeNode(item)) walkEstree(item, visit);

--- a/packages/progressive-review/src/review-mdx-typescript-parser.ts
+++ b/packages/progressive-review/src/review-mdx-typescript-parser.ts
@@ -1,8 +1,18 @@
 import type { ParserOptions } from "@babel/parser";
 import { parse, parseExpression } from "@babel/parser";
+import type { Comment, Expression, Program } from "estree";
 
 interface EstreeNode extends Record<string, unknown> {
   type?: string;
+}
+
+/**
+ * What `@babel/parser` returns under the "estree" plugin. Its typings describe
+ * the Babel AST, but the plugin rewrites nodes and comments into ESTree form.
+ */
+interface EstreeParseResult {
+  program: Program;
+  comments: Comment[] | null;
 }
 
 const parserOptions = {
@@ -14,23 +24,30 @@ const parserOptions = {
 
 /** Acorn-compatible syntax adapter used by MDX's micromark extensions. */
 export const reviewTypescriptEstreeParser = {
-  parse(value: string, options?: { sourceType?: "script" | "module" }) {
+  parse(
+    value: string,
+    options?: { sourceType?: "script" | "module" },
+  ): Program {
     return withAcornCompatibleError(() => {
+      // SAFETY: parserOptions enables the "estree" plugin, so the returned
+      // program and comments are ESTree nodes despite Babel's declared types.
       const file = parse(value, {
         ...parserOptions,
         sourceType: options?.sourceType ?? "module",
-      });
-      const program = file.program as unknown as EstreeNode;
+      }) as EstreeParseResult;
+      const program = file.program;
       program.comments = file.comments ?? [];
       return program;
     });
   },
-  parseExpressionAt(value: string, offset: number) {
+  parseExpressionAt(value: string, offset: number): Expression {
     return withAcornCompatibleError(() => {
+      // SAFETY: parserOptions enables the "estree" plugin, so the returned
+      // expression is an ESTree node despite Babel's declared type.
       const expression = parseExpression(
         value.slice(offset),
         parserOptions,
-      ) as unknown as EstreeNode;
+      ) as Expression;
       if (offset > 0) offsetEstreeNode(expression, offset);
       return expression;
     });

--- a/packages/progressive-review/src/review-publish-thread-gate.test.ts
+++ b/packages/progressive-review/src/review-publish-thread-gate.test.ts
@@ -102,7 +102,7 @@ describe("requireClosedThreadsForRepublish", () => {
         cwd: review.review.worktreePath,
         reviewUuid: review.review.uuid,
         json: true,
-        stdout: stdout as unknown as NodeJS.WriteStream,
+        stdout,
         onReviewBound,
       }),
     ).resolves.toBe(1);

--- a/packages/progressive-review/src/review-publish.ts
+++ b/packages/progressive-review/src/review-publish.ts
@@ -1,3 +1,5 @@
+import type { Writable } from "node:stream";
+
 import type { ReviewView } from "@dev.fast/review-protocol";
 
 import { resolveAuthoringSessionRef } from "./authoring-session";
@@ -22,8 +24,8 @@ export async function runReviewPublish(input: {
   view?: ReviewView;
   json?: boolean;
   toolingRoot?: string;
-  stdout: NodeJS.WriteStream;
-  stderr?: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr?: Writable;
   env?: NodeJS.ProcessEnv;
   onReviewBound?: (uuid: string) => void | Promise<void>;
 }): Promise<number> {
@@ -163,8 +165,8 @@ const STAGE_LABELS: Record<string, string> = {
 
 function createPublishReporter(input: {
   json: boolean;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
 }): PublishReporter {
   const emit = (event: Record<string, unknown>) => emitJsonEvent(input, event);
   if (input.json) {

--- a/packages/progressive-review/src/review-rebind.ts
+++ b/packages/progressive-review/src/review-rebind.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import type { Writable } from "node:stream";
 
 import {
   changeIdentityForRevision,
@@ -23,7 +24,7 @@ export async function runReviewRebind(input: {
   toolingRoot?: string;
   progress?: (message: string) => void;
   env?: NodeJS.ProcessEnv;
-  stdout: NodeJS.WriteStream;
+  stdout: Writable;
 }): Promise<number> {
   const reviewRoot = await resolveReviewRoot(input.cwd);
   const review = await resolvePublishReview(reviewRoot, input.reviewUuid);

--- a/packages/progressive-review/src/review-wait.test.ts
+++ b/packages/progressive-review/src/review-wait.test.ts
@@ -284,6 +284,6 @@ The review and its threads no longer exist. Do not wait on or publish to this re
   });
 });
 
-function outputStream(): NodeJS.WriteStream {
-  return new PassThrough() as unknown as NodeJS.WriteStream;
+function outputStream(): PassThrough {
+  return new PassThrough();
 }

--- a/packages/progressive-review/src/review-wait.ts
+++ b/packages/progressive-review/src/review-wait.ts
@@ -1,3 +1,5 @@
+import type { Writable } from "node:stream";
+
 import {
   type ReviewDesktopGlobalEvent,
   ReviewDesktopGlobalEventSchema,
@@ -86,7 +88,7 @@ export async function runReviewWait(
     reviewUuid?: string;
     requiresAgent?: boolean;
     timeoutSeconds?: number;
-    stdout: NodeJS.WriteStream;
+    stdout: Writable;
   },
   dependencies: ReviewWaitDependencies = defaultReviewWaitDependencies,
 ): Promise<number> {
@@ -225,10 +227,7 @@ function reviewWaitRequiresAgentStatus(status: ReviewStatus): boolean {
   );
 }
 
-function writeWaitResult(
-  stdout: NodeJS.WriteStream,
-  result: ReviewWaitResult,
-): void {
+function writeWaitResult(stdout: Writable, result: ReviewWaitResult): void {
   if (result.event === "timeout") {
     stdout.write(
       `${JSON.stringify({

--- a/packages/progressive-review/src/server/cli-install.ts
+++ b/packages/progressive-review/src/server/cli-install.ts
@@ -35,6 +35,7 @@ import {
   removeFffRegistration,
 } from "../agent-fff";
 import { removeAgentTraceHook } from "../agent-trace-hooks";
+import { collectingWritable } from "../cli-output";
 import {
   ALL_INSTALL_TARGETS,
   type InstallTarget,
@@ -180,9 +181,7 @@ export async function applyCliInstall(input: {
   const env = input.env ?? process.env;
   const wantShim = input.shim ?? input.targets.length > 0;
   const chunks: string[] = [];
-  const sink = {
-    write: (chunk: string) => (chunks.push(chunk), true),
-  } as NodeJS.WriteStream;
+  const sink = collectingWritable(chunks);
   const fffTargets = input.fff ? input.targets.filter(isFffTarget) : [];
   const fffPresentBefore = new Map(
     await Promise.all(

--- a/packages/progressive-review/src/server/desktop-server.test.ts
+++ b/packages/progressive-review/src/server/desktop-server.test.ts
@@ -3,11 +3,14 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import type { ReviewRecord } from "@dev.fast/review-protocol";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { reviewTitleFromDocument } from "../review-home";
-import { createGlobalReviewServer, reviewAgentKind } from "./desktop-server";
+import {
+  type ReviewAgentSessionSource,
+  createGlobalReviewServer,
+  reviewAgentKind,
+} from "./desktop-server";
 
 let directory: string | undefined;
 const packageRoot = path.resolve(
@@ -47,7 +50,7 @@ describe("reviewTitleFromDocument", () => {
 
 describe("reviewAgentKind", () => {
   it("uses the latest publisher, then author, then legacy creator", () => {
-    const review = {
+    const review: ReviewAgentSessionSource = {
       sourceSession: "pi:legacy",
       agentSessions: {
         "codex:author": {
@@ -61,7 +64,7 @@ describe("reviewAgentKind", () => {
           lastSeenAt: "2026-08-12T10:00:00.000Z",
         },
       },
-    } as unknown as ReviewRecord;
+    };
     expect(reviewAgentKind(review)).toBe("claude");
     expect(
       reviewAgentKind({

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -2209,8 +2209,14 @@ function reviewSourceKind(review: ReviewRecord): ProgressiveReviewSourceKind {
   return "git_branch";
 }
 
+/** The review fields that identify which agent a review belongs to. */
+export type ReviewAgentSessionSource = Pick<
+  ReviewRecord,
+  "sourceSession" | "agentSessions"
+>;
+
 export function reviewAgentKind(
-  review: ReviewRecord,
+  review: ReviewAgentSessionSource,
 ): ProgressiveReviewSessionAgent {
   const sessionKey =
     latestAgentSessionWithRole(review, "publisher") ??
@@ -2228,7 +2234,7 @@ export function reviewAgentKind(
 }
 
 function latestAgentSessionWithRole(
-  review: ReviewRecord,
+  review: ReviewAgentSessionSource,
   role: "publisher" | "author",
 ): string | undefined {
   return Object.entries(review.agentSessions ?? {})

--- a/packages/progressive-review/src/server/session-handler.test.ts
+++ b/packages/progressive-review/src/server/session-handler.test.ts
@@ -2,7 +2,10 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import type { ReviewThreadsCommit } from "@dev.fast/review-protocol";
+import type {
+  CreateReviewCommentInput,
+  ReviewThreadsCommit,
+} from "@dev.fast/review-protocol";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { PostHogCaptureInput } from "../posthog-capture-client";
@@ -283,7 +286,11 @@ describe("createReviewSessionHandler", () => {
       },
     });
 
-    const request = (path: string, method: "POST" | "DELETE", body?: object) =>
+    const request = (
+      path: string,
+      method: "POST" | "DELETE",
+      body?: CreateReviewCommentInput,
+    ) =>
       handler.handle(
         new Request(new URL(`/__progressive-review${path}`, sessionUrl), {
           method,

--- a/packages/progressive-review/src/server/session-handler.ts
+++ b/packages/progressive-review/src/server/session-handler.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
+import type { Writable } from "node:stream";
 
 import {
   type ReviewDocumentVersionWire,
@@ -61,7 +62,7 @@ export interface ReviewSessionHandlerInput {
   historicalRevision?: string;
   listDocumentVersions?: () => Promise<ReviewDocumentVersionWire[]>;
   session: ReviewSessionWire;
-  stderr?: NodeJS.WriteStream;
+  stderr?: Writable;
   getReviewStatus?: () => ReviewRecord["status"];
   onSubmission?: (event: ReviewSubmissionEvent) => void | Promise<void>;
   onReviewDismiss?: () => void | Promise<void>;

--- a/packages/progressive-review/src/stored-review-migration.ts
+++ b/packages/progressive-review/src/stored-review-migration.ts
@@ -712,7 +712,7 @@ async function removedCodePeekKeys(reviewDir: string): Promise<string[]> {
 
   let program: Program;
   try {
-    program = reviewTypescriptEstreeParser.parse(source) as unknown as Program;
+    program = reviewTypescriptEstreeParser.parse(source);
   } catch {
     return [];
   }

--- a/packages/progressive-review/src/threads-cli.test.ts
+++ b/packages/progressive-review/src/threads-cli.test.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { PassThrough } from "node:stream";
+import { PassThrough, type Writable } from "node:stream";
 import { promisify } from "node:util";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -163,15 +163,15 @@ async function git(root: string, args: string[]): Promise<string> {
 }
 
 async function captureOutput(
-  run: (stdout: NodeJS.WriteStream) => Promise<number>,
+  run: (stdout: Writable) => Promise<number>,
 ): Promise<string> {
   const stream = new PassThrough();
   let output = "";
   stream.on("data", (chunk) => (output += String(chunk)));
-  await expect(run(stream as unknown as NodeJS.WriteStream)).resolves.toBe(0);
+  await expect(run(stream)).resolves.toBe(0);
   return output;
 }
 
-function outputStream(): NodeJS.WriteStream {
-  return new PassThrough() as unknown as NodeJS.WriteStream;
+function outputStream(): PassThrough {
+  return new PassThrough();
 }

--- a/packages/progressive-review/src/threads-cli.ts
+++ b/packages/progressive-review/src/threads-cli.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
+import type { Writable } from "node:stream";
 
 import { ReviewCommentThreadRecordSchema } from "./review-comment-schema";
 import { reviewUuidForManagedCheckout } from "./review-head-checkout";
@@ -22,7 +23,7 @@ const REVIEW_AGENT_THREAD_URL_ENV = "DEV_FAST_REVIEW_AGENT_THREAD_URL";
 const REVIEW_AGENT_HOOK_TOKEN_ENV = "DEV_FAST_REVIEW_AGENT_HOOK_TOKEN";
 
 export async function runReviewThreadsList(
-  input: ReviewThreadsTarget & { json?: boolean; stdout: NodeJS.WriteStream },
+  input: ReviewThreadsTarget & { json?: boolean; stdout: Writable },
 ): Promise<number> {
   const review = await resolveThreadsReview(input.cwd, input.reviewUuid);
   const document = reviewDocumentPath(review);
@@ -44,7 +45,7 @@ export async function runReviewThreadsGet(
   input: ReviewThreadsTarget & {
     env?: NodeJS.ProcessEnv;
     threadId: string;
-    stdout: NodeJS.WriteStream;
+    stdout: Writable;
   },
 ): Promise<number> {
   const thread = await readAttachedReviewThread(input);
@@ -114,7 +115,7 @@ async function readAttachedReviewThread(input: {
 export async function runReviewThreadsResolve(
   input: ReviewThreadsTarget & {
     threadId: string;
-    stdout: NodeJS.WriteStream;
+    stdout: Writable;
   },
 ): Promise<number> {
   const review = await resolveThreadsReview(input.cwd, input.reviewUuid);
@@ -137,7 +138,7 @@ export async function runReviewThreadsReply(
     threadId: string;
     body: string;
     author?: string;
-    stdout: NodeJS.WriteStream;
+    stdout: Writable;
   },
 ): Promise<number> {
   const body = input.body.trim();

--- a/packages/progressive-review/src/trace-cli.ts
+++ b/packages/progressive-review/src/trace-cli.ts
@@ -1,3 +1,5 @@
+import type { Writable } from "node:stream";
+
 import {
   type AgentTraceEvent,
   extractTraceEventText,
@@ -36,8 +38,8 @@ export { runReviewTraceGitHook, runReviewTraceHook };
 
 export async function runReviewTraceStatus(input: {
   cwd: string;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
 }): Promise<number> {
   const machine = await traceMachineStatus();
   const repository = await traceRepositoryStatus(input.cwd);
@@ -80,8 +82,8 @@ export async function runReviewTraceStatus(input: {
 
 export async function runReviewTraceEnable(input: {
   cwd: string;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
 }): Promise<number> {
   if (!(await traceMachineStatus()).enabled) {
     input.stderr.write(
@@ -96,7 +98,7 @@ export async function runReviewTraceEnable(input: {
 
 export async function runReviewTraceDisable(input: {
   cwd: string;
-  stdout: NodeJS.WriteStream;
+  stdout: Writable;
 }): Promise<number> {
   const result = await disableTraceRepository({ cwd: input.cwd });
   input.stdout.write(`${result.message}\n`);
@@ -105,8 +107,8 @@ export async function runReviewTraceDisable(input: {
 
 export async function runReviewTraceRepair(input: {
   cwd: string;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
 }): Promise<number> {
   if (!(await traceMachineStatus()).enabled) {
     input.stderr.write(
@@ -137,7 +139,7 @@ export async function runReviewTraceList(input: {
   reviewUuid?: string;
   commitSha?: string;
   json?: boolean;
-  stdout: NodeJS.WriteStream;
+  stdout: Writable;
 }): Promise<number> {
   let scope: { review: string } | { commit: string };
   let sessions: ReviewTraceSessionDescriptor[];
@@ -207,8 +209,8 @@ export async function runReviewTraceShow(input: {
   eventIndex?: number;
   kind?: string;
   json?: boolean;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
 }): Promise<number> {
   const traceName = input.trace === "main" ? undefined : input.trace;
   const loaded = await loadReviewAgentTrace({
@@ -291,8 +293,8 @@ export async function runReviewTracePull(input: {
   session?: string;
   mainOnly?: boolean;
   json?: boolean;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
 }): Promise<number> {
   try {
     let scope: Record<string, string>;
@@ -375,7 +377,7 @@ export async function runReviewTraceLookupCommit(input: {
   cwd: string;
   sha: string;
   json?: boolean;
-  stdout: NodeJS.WriteStream;
+  stdout: Writable;
 }): Promise<number> {
   const result = await lookupReviewTraceCommit({
     cwd: input.cwd,
@@ -397,8 +399,8 @@ export async function runReviewTraceBlame(input: {
   lines?: string;
   history?: boolean;
   json?: boolean;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdout: Writable;
+  stderr: Writable;
 }): Promise<number> {
   let result: ReviewTraceBlameLookupResult;
   try {
@@ -442,7 +444,7 @@ export async function runReviewTraceLookupSession(input: {
   cwd: string;
   sessionId: string;
   json?: boolean;
-  stdout: NodeJS.WriteStream;
+  stdout: Writable;
 }): Promise<number> {
   const result = await lookupReviewTraceSession({
     sessionId: input.sessionId,
@@ -477,7 +479,7 @@ export async function runReviewTraceLookupSession(input: {
 
 function printCommitResolution(
   resolution: ReviewTraceCommitLookupResult,
-  stdout: NodeJS.WriteStream,
+  stdout: Writable,
 ): void {
   const shortCommit = resolution.commit.slice(0, 12);
   if (resolution.sessions.length === 0) {
@@ -509,7 +511,7 @@ export async function runReviewTraceSync(input: {
   sessionId: string;
   repo?: string;
   json?: boolean;
-  stdout: NodeJS.WriteStream;
+  stdout: Writable;
 }): Promise<number> {
   const result = await syncReviewTrace({
     sessionId: input.sessionId,

--- a/packages/progressive-review/src/trace-git-hook-runner.ts
+++ b/packages/progressive-review/src/trace-git-hook-runner.ts
@@ -1,3 +1,5 @@
+import type { Writable } from "node:stream";
+
 import { sessionIdSchema } from "@dev-fast/trace-shared";
 import { git } from "@dev.fast/local-vcs";
 
@@ -18,7 +20,7 @@ export async function runReviewTraceGitHook(input: {
   hook: string;
   args: string[];
   stdin?: NodeJS.ReadableStream;
-  stderr: NodeJS.WriteStream;
+  stderr: Writable;
 }): Promise<number> {
   if (process.env.TRACE_DISABLE === "1") return 0;
   try {
@@ -82,7 +84,7 @@ async function activeSessions(cwd: string): Promise<string[]> {
 async function runPrePush(input: {
   cwd: string;
   stdin?: NodeJS.ReadableStream;
-  stderr: NodeJS.WriteStream;
+  stderr: Writable;
 }): Promise<void> {
   const raw = await readStdin(input.stdin);
   const commits = new Map<
@@ -166,7 +168,7 @@ async function readStdin(
   return Buffer.concat(chunks).toString("utf8");
 }
 
-function warn(stderr: NodeJS.WriteStream, cause: unknown): void {
+function warn(stderr: Writable, cause: unknown): void {
   stderr.write(
     `trace-sync: warning: ${cause instanceof Error ? cause.message : String(cause)}\n`,
   );

--- a/packages/progressive-review/src/trace-hook-runner.test.ts
+++ b/packages/progressive-review/src/trace-hook-runner.test.ts
@@ -131,9 +131,7 @@ describe("runReviewTraceHook", () => {
       hook_event_name: "SessionStart",
       session_id: sessionId,
     });
-    const stdinStart = Readable.from([
-      startPayload,
-    ]) as unknown as NodeJS.ReadStream;
+    const stdinStart = Readable.from([startPayload]);
 
     await runReviewTraceHook({
       cwd: repo,
@@ -153,9 +151,7 @@ describe("runReviewTraceHook", () => {
       hook_event_name: "SessionEnd",
       session_id: sessionId,
     });
-    const stdinEnd = Readable.from([
-      endPayload,
-    ]) as unknown as NodeJS.ReadStream;
+    const stdinEnd = Readable.from([endPayload]);
 
     await runReviewTraceHook({
       cwd: repo,

--- a/packages/progressive-review/src/trace-hook-runner.ts
+++ b/packages/progressive-review/src/trace-hook-runner.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 
 import { git } from "@dev.fast/local-vcs";
 
+import type { CliInputStream } from "./cli-output";
 import {
   readActiveTraceSessions,
   writeTraceSessions,
@@ -21,7 +22,7 @@ export interface RunReviewTraceHookInput {
   cwd: string;
   event: string;
   sessionId?: string;
-  stdin?: NodeJS.ReadStream;
+  stdin?: CliInputStream;
   homeDir?: string;
   env?: NodeJS.ProcessEnv;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   .:
     devDependencies:
+      '@oxlint/plugins':
+        specifier: 1.63.0
+        version: 1.63.0
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
@@ -90,7 +93,7 @@ importers:
         version: typescript@7.0.1-rc
       vitest:
         specifier: ^4.1.5
-        version: 4.1.10(@types/node@24.12.2)(esbuild@0.28.1)(jsdom@29.1.1)(tsx@4.21.0)
+        version: 4.1.10(@types/node@24.12.2)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.21.0))
 
   packages/progressive-review:
     dependencies:
@@ -230,6 +233,9 @@ importers:
       jsdom:
         specifier: 29.1.1
         version: 29.1.1
+      mdast-util-mdx-jsx:
+        specifier: 3.2.0
+        version: 3.2.0
       tsdown:
         specifier: ^0.22.3
         version: 0.22.14(tsx@4.21.0)(typescript@6.0.3)
@@ -247,7 +253,7 @@ importers:
         version: 8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.21.0)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.10(@types/node@24.12.2)(esbuild@0.28.1)(jsdom@29.1.1)(tsx@4.21.0)
+        version: 4.1.10(@types/node@24.12.2)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.21.0))
 
   packages/review-protocol:
     dependencies:
@@ -266,7 +272,7 @@ importers:
         version: typescript@7.0.1-rc
       vitest:
         specifier: ^4.1.5
-        version: 4.1.10(@types/node@24.12.2)(esbuild@0.28.1)(jsdom@29.1.1)(tsx@4.21.0)
+        version: 4.1.10(@types/node@24.12.2)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.21.0))
 
   packages/trace-shared:
     dependencies:
@@ -282,7 +288,7 @@ importers:
         version: typescript@7.0.1-rc
       vitest:
         specifier: ^4.1.5
-        version: 4.1.10(@types/node@24.12.2)(esbuild@0.28.1)(jsdom@29.1.1)(tsx@4.21.0)
+        version: 4.1.10(@types/node@24.12.2)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.21.0))
 
 packages:
 
@@ -809,6 +815,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@oxlint/plugins@1.63.0':
+    resolution: {integrity: sha512-vZAzaUQkwgdN62RHgPFzfCsiBI6SDJMUdUlBGpJK0V++UHCMUk7UeJseygOhE/wOUSgV3ccE4ORkgab3C3MC6g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -2688,6 +2698,7 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
+      vite: 8.0.16
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -3106,6 +3117,8 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.63.0':
     optional: true
+
+  '@oxlint/plugins@1.63.0': {}
 
   '@pinojs/redact@0.4.0': {}
 
@@ -5180,7 +5193,7 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vitest@4.1.10(@types/node@24.12.2)(esbuild@0.28.1)(jsdom@29.1.1)(tsx@4.21.0):
+  vitest@4.1.10(@types/node@24.12.2)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.21.0))
@@ -5206,18 +5219,7 @@ snapshots:
       '@types/node': 24.12.2
       jsdom: 29.1.1
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/tools/oxlint/anti-slop/effect/index.ts
+++ b/tools/oxlint/anti-slop/effect/index.ts
@@ -1,0 +1,13 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { noServiceConstructorImportsRule } from "./rules/no-service-constructor-imports.ts";
+
+/** Opt-in Oxlint rules for Effect service and Layer architecture. */
+const antiSlopEffectPlugin = eslintCompatPlugin({
+	meta: { name: "anti-slop-effect" },
+	rules: {
+		"no-service-constructor-imports": noServiceConstructorImportsRule,
+	},
+});
+
+export default antiSlopEffectPlugin;

--- a/tools/oxlint/anti-slop/effect/rules/no-service-constructor-imports.ts
+++ b/tools/oxlint/anti-slop/effect/rules/no-service-constructor-imports.ts
@@ -1,0 +1,52 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+const SERVICE_CONSTRUCTOR_NAME = /^make[A-Z]/u;
+const TEST_FILE = /\.(?:test|spec)\.[cm]?[jt]sx?$/u;
+
+function isProjectLocalImport(source: string): boolean {
+	return source.startsWith("./") || source.startsWith("../");
+}
+
+function getImportedName(specifier: ESTree.ImportSpecifier): string {
+	if (specifier.imported.type === "Identifier") return specifier.imported.name;
+	return specifier.imported.value;
+}
+
+/** Keep dependency-bearing Effect service constructors local to their owning capability modules. */
+export const noServiceConstructorImportsRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow project-local make<CapabilityName> imports outside test and spec files.",
+		},
+		messages: {
+			serviceConstructorImport:
+				'Do not import Effect service constructor "{{name}}" into runtime code. Import the owning Layer, yield the contextual service, and allow its requirements to propagate to the composition root.',
+		},
+	},
+	create(context) {
+		const isTestFile = TEST_FILE.test(context.filename.replaceAll("\\", "/"));
+
+		return {
+			ImportDeclaration(node) {
+				if (isTestFile || !isProjectLocalImport(node.source.value)) return;
+
+				for (const specifier of node.specifiers) {
+					if (specifier.type !== "ImportSpecifier") continue;
+
+					const importedName = getImportedName(specifier);
+					if (!SERVICE_CONSTRUCTOR_NAME.test(importedName)) continue;
+
+					context.report({
+						node: specifier,
+						messageId: "serviceConstructorImport",
+						data: { name: importedName },
+					});
+				}
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/index.ts
+++ b/tools/oxlint/anti-slop/index.ts
@@ -1,0 +1,41 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { noChainedTypeAssertionsRule } from "./rules/no-chained-type-assertions.ts";
+import { noConditionalEmptyObjectSpreadRule } from "./rules/no-conditional-empty-object-spread.ts";
+import { noKnownValueWideningRule } from "./rules/no-known-value-widening.ts";
+import { noModuleMockingRule } from "./rules/no-module-mocking.ts";
+import { noObjectParametersRule } from "./rules/no-object-parameters.ts";
+import { noReflectApplyRule } from "./rules/no-reflect-apply.ts";
+import { noReflectGetRule } from "./rules/no-reflect-get.ts";
+import { noRuntimeTypeofRule } from "./rules/no-runtime-typeof.ts";
+import { noForbiddenTermInSymbolNamesRule } from "./rules/no-shape-in-symbol-names.ts";
+import { noUnknownParametersRule } from "./rules/no-unknown-parameters.ts";
+import { noUnknownReturnsRule } from "./rules/no-unknown-returns.ts";
+import { noUnknownTypeAliasesRule } from "./rules/no-unknown-type-aliases.ts";
+import { noUnsafeDictionaryTypeRule } from "./rules/no-unsafe-dictionary-type.ts";
+import { noWidenThenAssertRule } from "./rules/no-widen-then-assert.ts";
+import { requireSafetyCommentForTypeAssertionRule } from "./rules/require-safety-comment-for-type-assertion.ts";
+
+/** Generic Oxlint rules that reject low-evidence and low-signal implementation patterns. */
+const antiSlopPlugin = eslintCompatPlugin({
+	meta: { name: "anti-slop" },
+	rules: {
+		"no-chained-type-assertions": noChainedTypeAssertionsRule,
+		"no-conditional-empty-object-spread": noConditionalEmptyObjectSpreadRule,
+		"no-known-value-widening": noKnownValueWideningRule,
+		"no-module-mocking": noModuleMockingRule,
+		"no-object-parameters": noObjectParametersRule,
+		"no-reflect-apply": noReflectApplyRule,
+		"no-reflect-get": noReflectGetRule,
+		"no-runtime-typeof": noRuntimeTypeofRule,
+		"no-unsafe-dictionary-type": noUnsafeDictionaryTypeRule,
+		"no-shape-in-symbol-names": noForbiddenTermInSymbolNamesRule,
+		"no-unknown-parameters": noUnknownParametersRule,
+		"no-unknown-returns": noUnknownReturnsRule,
+		"no-unknown-type-aliases": noUnknownTypeAliasesRule,
+		"no-widen-then-assert": noWidenThenAssertRule,
+		"require-safety-comment-for-type-assertion": requireSafetyCommentForTypeAssertionRule,
+	},
+});
+
+export default antiSlopPlugin;

--- a/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
+++ b/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
@@ -1,0 +1,77 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+type TypeAssertionExpression = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+function isTypeAssertionExpression(node: ESTree.Node): node is TypeAssertionExpression {
+  return node.type === "TSAsExpression" || node.type === "TSTypeAssertion";
+}
+
+function unwrapParenthesizedExpression(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isConstAssertion(node: TypeAssertionExpression): boolean {
+  const { typeAnnotation } = node;
+  return (
+    typeAnnotation.type === "TSTypeReference" &&
+    typeAnnotation.typeName.type === "Identifier" &&
+    typeAnnotation.typeName.name === "const"
+  );
+}
+
+function isOutermostAssertionInChain(node: TypeAssertionExpression): boolean {
+  let current: ESTree.Expression = node;
+  let parent = node.parent;
+
+  while (parent.type === "ParenthesizedExpression" && parent.expression === current) {
+    current = parent;
+    parent = parent.parent;
+  }
+
+  return !isTypeAssertionExpression(parent) || parent.expression !== current;
+}
+
+function isForbiddenAssertionChain(node: TypeAssertionExpression): boolean {
+  let assertionCount = 0;
+  let hasNonConstAssertion = false;
+  let current: ESTree.Expression = node;
+
+  while (isTypeAssertionExpression(current)) {
+    assertionCount += 1;
+    hasNonConstAssertion ||= !isConstAssertion(current);
+    current = unwrapParenthesizedExpression(current.expression);
+  }
+
+  return assertionCount > 1 && hasNonConstAssertion;
+}
+
+/** Disallow nested TypeScript type assertions, while permitting chains made only of const assertions. */
+export const noChainedTypeAssertionsRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow chained TypeScript as and angle-bracket assertions, including parenthesized chains.",
+    },
+    messages: {
+      chained:
+        "This assertion chain discards type evidence. Keep the original precise type, or parse untrusted input at its boundary before narrowing it.",
+    },
+  },
+  createOnce(context) {
+    const checkTypeAssertion = (node: TypeAssertionExpression) => {
+      if (!isOutermostAssertionInChain(node) || !isForbiddenAssertionChain(node)) return;
+      context.report({ node, messageId: "chained" });
+    };
+
+    return {
+      TSAsExpression: checkTypeAssertion,
+      TSTypeAssertion: checkTypeAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
+++ b/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
@@ -1,0 +1,49 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+function unwrapParentheses(node: ESTree.Expression): ESTree.Expression {
+  let current = node;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isEmptyObjectExpression(node: ESTree.Expression): boolean {
+  return node.type === "ObjectExpression" && node.properties.length === 0;
+}
+
+function isConditionalEmptyObjectSpread(node: ESTree.Expression): boolean {
+  const conditional = unwrapParentheses(node);
+  return (
+    conditional.type === "ConditionalExpression" &&
+    (isEmptyObjectExpression(conditional.consequent) ||
+      isEmptyObjectExpression(conditional.alternate))
+  );
+}
+
+/** Ban conditional empty-object spreads without changing their omission semantics. */
+export const noConditionalEmptyObjectSpreadRule = defineRule({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow object spreads that conditionally spread an empty object to omit fields.",
+    },
+    messages: {
+      avoid:
+        "This conditional spread hides property omission behind an empty object. Build the object in separate statements and add the property only when present.",
+    },
+  },
+  createOnce(context) {
+    return {
+      SpreadElement(node) {
+        if (node.parent.type !== "ObjectExpression") return;
+
+        if (isConditionalEmptyObjectSpread(node.argument)) {
+          context.report({ node, messageId: "avoid" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
+++ b/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
@@ -1,0 +1,427 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	classifyUnsafeDictionaryValue,
+	classifyWideningTarget,
+	createTypeEnvironment,
+	isKnownEvidenceExpression,
+	type TypeEnvironment,
+	type WideningTarget,
+} from "../shared/dictionary-types.ts";
+import {
+	containsUnknownType,
+	functionParameterBindingName,
+	functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
+
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+type FunctionExpression = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function unwrapExpression(expression: ESTree.Expression): ESTree.Expression {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSSatisfiesExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression"
+	) {
+		current = current.expression;
+	}
+	return current;
+}
+
+function resolveVariable(
+	sourceCode: SourceCode,
+	identifier: ESTree.IdentifierReference,
+): Variable | null {
+	let scope: Scope | null = sourceCode.getScope(identifier);
+	while (scope !== null) {
+		const variable = scope.set.get(identifier.name);
+		if (variable !== undefined) return variable;
+		scope = scope.upper;
+	}
+	return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+	if (variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	return definition?.type === "Variable" && definition.node.type === "VariableDeclarator"
+		? definition.node
+		: null;
+}
+
+function isStableConstVariable(variable: Variable, declarator: ESTree.VariableDeclarator): boolean {
+	return (
+		declarator.parent.type === "VariableDeclaration" &&
+		declarator.parent.kind === "const" &&
+		variable.references.every((reference) => reference.init || !reference.isWrite())
+	);
+}
+
+function hasKnownEvidence(
+	sourceCode: SourceCode,
+	expression: ESTree.Expression,
+	visitedVariables = new Set<Variable>(),
+): boolean {
+	if (isKnownEvidenceExpression(expression)) return true;
+	const unwrapped = unwrapExpression(expression);
+	if (unwrapped.type !== "Identifier") return false;
+	const variable = resolveVariable(sourceCode, unwrapped);
+	if (variable === null || visitedVariables.has(variable)) return false;
+	const declarator = variableDeclarator(variable);
+	if (
+		declarator === null ||
+		declarator.init === null ||
+		!isStableConstVariable(variable, declarator)
+	) {
+		return false;
+	}
+	visitedVariables.add(variable);
+	return hasKnownEvidence(sourceCode, declarator.init, visitedVariables);
+}
+
+function isFunctionExpression(node: ESTree.Node): node is FunctionExpression {
+	return (
+		node.type === "ArrowFunctionExpression" ||
+		node.type === "FunctionDeclaration" ||
+		node.type === "FunctionExpression" ||
+		node.type === "TSDeclareFunction" ||
+		node.type === "TSEmptyBodyFunctionExpression"
+	);
+}
+
+function localFunctionForCall(
+	sourceCode: SourceCode,
+	callee: ESTree.Expression,
+): FunctionExpression | null {
+	const unwrapped = unwrapExpression(callee);
+	if (isFunctionExpression(unwrapped)) return unwrapped;
+	if (unwrapped.type !== "Identifier") return null;
+	const variable = resolveVariable(sourceCode, unwrapped);
+	if (variable === null || variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	if (definition === undefined) return null;
+	if (definition.type === "FunctionName" && isFunctionExpression(definition.node)) {
+		return definition.node;
+	}
+	if (definition.type !== "Variable" || definition.node.type !== "VariableDeclarator") {
+		return null;
+	}
+	const initializer = definition.node.init;
+	if (initializer === null) return null;
+	const unwrappedInitializer = unwrapExpression(initializer);
+	return isFunctionExpression(unwrappedInitializer) ? unwrappedInitializer : null;
+}
+
+function variableTypeAnnotation(
+	sourceCode: SourceCode,
+	variable: Variable,
+): ESTree.TSTypeAnnotation | null {
+	if (variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	if (definition === undefined) return null;
+	if (
+		definition.type === "Variable" &&
+		definition.node.type === "VariableDeclarator" &&
+		definition.node.id.type === "Identifier"
+	) {
+		return definition.node.id.typeAnnotation ?? null;
+	}
+	if (definition.type !== "Parameter" || !isFunctionExpression(definition.node)) {
+		return null;
+	}
+	const parameter = definition.node.params.find(
+		(candidate) =>
+			functionParameterBindingName(candidate, sourceCode) === variable.name,
+	);
+	return parameter === undefined ? null : (functionParameterTypeAnnotation(parameter) ?? null);
+}
+
+function hasInformativeType(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): boolean {
+	return classifyUnsafeDictionaryValue(type, environment) === null;
+}
+
+function hasKnownCallArgumentEvidence(
+	sourceCode: SourceCode,
+	expression: ESTree.Expression,
+	environment: TypeEnvironment,
+	visitedVariables = new Set<Variable>(),
+): boolean {
+	if (expression.type === "ParenthesizedExpression" || expression.type === "TSNonNullExpression") {
+		return hasKnownCallArgumentEvidence(
+			sourceCode,
+			expression.expression,
+			environment,
+			visitedVariables,
+		);
+	}
+	if (expression.type === "TSAsExpression" || expression.type === "TSTypeAssertion") {
+		return hasInformativeType(expression.typeAnnotation, environment);
+	}
+	if (expression.type === "TSSatisfiesExpression") {
+		return hasKnownCallArgumentEvidence(
+			sourceCode,
+			expression.expression,
+			environment,
+			visitedVariables,
+		);
+	}
+	if (expression.type === "CallExpression") {
+		const owner = localFunctionForCall(sourceCode, expression.callee);
+		const returnType = owner?.returnType?.typeAnnotation;
+		return returnType !== undefined && hasInformativeType(returnType, environment);
+	}
+	if (expression.type !== "Identifier") return isKnownEvidenceExpression(expression);
+	const variable = resolveVariable(sourceCode, expression);
+	if (variable === null || visitedVariables.has(variable)) return false;
+	const annotation = variableTypeAnnotation(sourceCode, variable);
+	if (annotation !== null) {
+		return hasInformativeType(annotation.typeAnnotation, environment);
+	}
+	const declarator = variableDeclarator(variable);
+	if (
+		declarator === null ||
+		declarator.init === null ||
+		!isStableConstVariable(variable, declarator)
+	) {
+		return false;
+	}
+	visitedVariables.add(variable);
+	return hasKnownCallArgumentEvidence(
+		sourceCode,
+		declarator.init,
+		environment,
+		visitedVariables,
+	);
+}
+
+function typePredicateSubjectIndex(
+	sourceCode: SourceCode,
+	owner: FunctionExpression,
+): number | null {
+	const predicate = owner.returnType?.typeAnnotation;
+	if (predicate?.type !== "TSTypePredicate" || predicate.parameterName.type !== "Identifier") {
+		return null;
+	}
+	const predicateParameterName = predicate.parameterName.name;
+	const index = owner.params.findIndex(
+		(parameter) =>
+			functionParameterBindingName(parameter, sourceCode) === predicateParameterName,
+	);
+	return index === -1 ? null : index;
+}
+
+function annotationTarget(
+	annotation: ESTree.TSTypeAnnotation | null | undefined,
+	environment: TypeEnvironment,
+): WideningTarget | null {
+	return annotation === null || annotation === undefined
+		? null
+		: classifyWideningTarget(annotation.typeAnnotation, environment);
+}
+
+function enclosingFunction(node: ESTree.Node): FunctionExpression | null {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (
+			current.type === "ArrowFunctionExpression" ||
+			current.type === "FunctionDeclaration" ||
+			current.type === "FunctionExpression"
+		) {
+			return current;
+		}
+		current = current.parent;
+	}
+	return null;
+}
+
+function sourceKeyName(sourceCode: SourceCode, key: ESTree.PropertyKey): string {
+	if (key.type === "Identifier" || key.type === "PrivateIdentifier") return key.name;
+	if (key.type === "Literal") return String(key.value);
+	return sourceCode.getText(key);
+}
+
+function functionName(sourceCode: SourceCode, owner: FunctionExpression | null): string {
+	if (owner === null) return "anonymous function";
+	if (owner.id !== null) return owner.id.name;
+	const parent = owner.parent;
+	if (parent.type === "VariableDeclarator" && parent.id.type === "Identifier")
+		return parent.id.name;
+	if (parent.type === "MethodDefinition") return sourceKeyName(sourceCode, parent.key);
+	return "anonymous function";
+}
+
+function isEmptyObjectExpression(expression: ESTree.Expression): boolean {
+	const unwrapped = unwrapExpression(expression);
+	return unwrapped.type === "ObjectExpression" && unwrapped.properties.length === 0;
+}
+
+function isDictionaryAccumulatorTarget(destination: WideningTarget): boolean {
+	return destination.kind === "open dictionary" || destination.kind === "generic container";
+}
+
+function hasParentAssertion(node: ESTree.Node): boolean {
+	return node.parent?.type === "TSAsExpression" || node.parent?.type === "TSTypeAssertion";
+}
+
+/** Detect sound syntactic cases where a known value is explicitly widened and loses evidence. */
+export const noKnownValueWideningRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow syntactically established values from flowing into explicitly broad or anonymous target types that discard useful evidence.",
+		},
+		messages: {
+			widening:
+				"The explicit {{target}} type on {{subject}} discards known type evidence. Keep inference, validate with `satisfies`, or use a named owner contract.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeEnvironment | null = null;
+
+		const reportFlow = (
+			expression: ESTree.Expression,
+			destination: WideningTarget | null,
+			subject: string,
+		) => {
+			if (destination === null) return;
+			if (
+				isDictionaryAccumulatorTarget(destination) &&
+				isEmptyObjectExpression(expression)
+			) {
+				return;
+			}
+			if (!hasKnownEvidence(context.sourceCode, expression)) return;
+			context.report({
+				node: expression,
+				messageId: "widening",
+				data: { subject, target: destination.kind },
+			});
+		};
+
+		const targetFromAnnotation = (annotation: ESTree.TSTypeAnnotation | null | undefined) =>
+			environment === null ? null : annotationTarget(annotation, environment);
+
+		return {
+			Program(node) {
+				environment = createTypeEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			VariableDeclarator(node) {
+				if (node.init === null || node.id.type !== "Identifier") return;
+				reportFlow(
+					node.init,
+					targetFromAnnotation(node.id.typeAnnotation),
+					`binding \`${node.id.name}\``,
+				);
+			},
+			PropertyDefinition(node) {
+				if (node.value === null) return;
+				reportFlow(
+					node.value,
+					targetFromAnnotation(node.typeAnnotation),
+					`property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+				);
+			},
+			AccessorProperty(node) {
+				if (node.value === null) return;
+				reportFlow(
+					node.value,
+					targetFromAnnotation(node.typeAnnotation),
+					`property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+				);
+			},
+			AssignmentExpression(node) {
+				if (node.operator !== "=" || node.left.type !== "Identifier") return;
+				const variable = resolveVariable(context.sourceCode, node.left);
+				if (variable === null) return;
+				const declarator = variableDeclarator(variable);
+				if (declarator === null || declarator.id.type !== "Identifier") return;
+				reportFlow(
+					node.right,
+					targetFromAnnotation(declarator.id.typeAnnotation),
+					`binding \`${declarator.id.name}\``,
+				);
+			},
+			CallExpression(node) {
+				if (environment === null) return;
+				const owner = localFunctionForCall(context.sourceCode, node.callee);
+				if (owner === null) return;
+				const parameterIndex = typePredicateSubjectIndex(context.sourceCode, owner);
+				if (parameterIndex === null) return;
+				const parameter = owner.params[parameterIndex];
+				const argument = node.arguments[parameterIndex];
+				if (parameter === undefined || argument === undefined || argument.type === "SpreadElement") {
+					return;
+				}
+				const parameterAnnotation = functionParameterTypeAnnotation(parameter);
+				if (
+					parameterAnnotation === null ||
+					parameterAnnotation === undefined ||
+					!containsUnknownType(parameterAnnotation.typeAnnotation)
+				) {
+					return;
+				}
+				if (
+					!hasKnownCallArgumentEvidence(
+						context.sourceCode,
+						argument,
+						environment,
+					)
+				) {
+					return;
+				}
+				context.report({
+					node: argument,
+					messageId: "widening",
+					data: {
+						subject: `argument for parameter \`${functionParameterBindingName(parameter, context.sourceCode)}\` of \`${functionName(context.sourceCode, owner)}\``,
+						target: "unknown",
+					},
+				});
+			},
+			ReturnStatement(node) {
+				if (node.argument === null) return;
+				const owner = enclosingFunction(node);
+				reportFlow(
+					node.argument,
+					targetFromAnnotation(owner?.returnType),
+					`return value of \`${functionName(context.sourceCode, owner)}\``,
+				);
+			},
+			ArrowFunctionExpression(node) {
+				if (node.body.type === "BlockStatement") return;
+				reportFlow(
+					node.body,
+					targetFromAnnotation(node.returnType),
+					`return value of \`${functionName(context.sourceCode, node)}\``,
+				);
+			},
+			TSAsExpression(node) {
+				if (environment === null || hasParentAssertion(node)) return;
+				reportFlow(
+					node.expression,
+					classifyWideningTarget(node.typeAnnotation, environment),
+					"assertion",
+				);
+			},
+			TSTypeAssertion(node) {
+				if (environment === null || hasParentAssertion(node)) return;
+				reportFlow(
+					node.expression,
+					classifyWideningTarget(node.typeAnnotation, environment),
+					"assertion",
+				);
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-module-mocking.ts
+++ b/tools/oxlint/anti-slop/rules/no-module-mocking.ts
@@ -1,0 +1,91 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+const moduleMockMethods = new Set(["doMock", "mock", "unstable_mockModule"]);
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function importedName(node: ESTree.Node): string | null {
+  if (node.type !== "ImportSpecifier") return null;
+  return node.imported.type === "Identifier" ? node.imported.name : node.imported.value;
+}
+
+function isTestFrameworkObject(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+): expression is ESTree.IdentifierReference {
+  if (expression.type !== "Identifier") return false;
+  if (
+    (expression.name === "vi" || expression.name === "jest") &&
+    sourceCode.isGlobalReference(expression)
+  ) {
+    return true;
+  }
+
+  const variable = resolveVariable(sourceCode, expression);
+  if (variable === null || variable.defs.length === 0) {
+    return expression.name === "vi" || expression.name === "jest";
+  }
+  return variable.defs.some((definition) => {
+    if (definition.type !== "ImportBinding" || definition.parent?.type !== "ImportDeclaration") {
+      return false;
+    }
+    const source = definition.parent.source.value;
+    const name = importedName(definition.node);
+    return (source === "vitest" && name === "vi") || (source === "@jest/globals" && name === "jest");
+  });
+}
+
+function moduleMockCall(sourceCode: SourceCode, callee: ESTree.Expression): boolean {
+  if (!("property" in callee) || !("object" in callee) || !("computed" in callee)) return false;
+  if (!isTestFrameworkObject(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  const method = callee.computed
+    ? property.type === "Literal" &&
+      (property.value === "doMock" ||
+        property.value === "mock" ||
+        property.value === "unstable_mockModule")
+      ? property.value
+      : null
+    : property.type === "Identifier"
+      ? property.name
+      : null;
+  return method !== null && moduleMockMethods.has(method);
+}
+
+/** Ban test framework module mocking in favor of real dependency seams. */
+export const noModuleMockingRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Vitest and Jest module mocking; tests must replace dependencies through real interfaces.",
+    },
+    messages: {
+      moduleMock:
+        "Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (moduleMockCall(context.sourceCode, node.callee)) {
+          context.report({ node, messageId: "moduleMock" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-object-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-object-parameters.ts
@@ -1,0 +1,83 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+	functionParameterBindingName,
+	functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
+import {
+	createTypeAliasEnvironment,
+	resolvedTypeMatches,
+	type TypeAliasEnvironment,
+} from "../shared/type-alias-resolution.ts";
+type ParameterOwner =
+	| ESTree.ArrowFunctionExpression
+	| ESTree.Function
+	| ESTree.TSCallSignatureDeclaration
+	| ESTree.TSConstructSignatureDeclaration
+	| ESTree.TSConstructorType
+	| ESTree.TSFunctionType
+	| ESTree.TSMethodSignature;
+
+/** Ban the broad object type on function inputs, including local aliases to object. */
+export const noObjectParametersRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow object function parameters; inputs must use an owner-provided type and be parsed at their boundary.",
+		},
+		messages: {
+			objectParameter:
+				"Parameter `{{parameter}}` uses the broad `object` type. Accept a named owner type; parse external input at its boundary before calling this function.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeAliasEnvironment | null = null;
+
+		const resolvesToObject = (type: ESTree.TSType): boolean =>
+			environment !== null &&
+			resolvedTypeMatches(type, environment, (resolved, matches) => {
+				if (resolved.type === "TSObjectKeyword") return true;
+				if (resolved.type === "TSParenthesizedType") {
+					return matches(resolved.typeAnnotation);
+				}
+				return (
+					resolved.type === "TSUnionType" && resolved.types.some(matches)
+				);
+			});
+
+		const checkParameters = (node: ParameterOwner) => {
+			for (const parameter of node.params) {
+				const annotation = functionParameterTypeAnnotation(parameter);
+				if (annotation === null || annotation === undefined) continue;
+				if (!resolvesToObject(annotation.typeAnnotation)) continue;
+				context.report({
+					node: annotation.typeAnnotation,
+					messageId: "objectParameter",
+					data: { parameter: functionParameterBindingName(parameter, context.sourceCode) },
+				});
+			}
+		};
+
+		return {
+			Program(node) {
+				environment = createTypeAliasEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			ArrowFunctionExpression: checkParameters,
+			FunctionDeclaration: checkParameters,
+			FunctionExpression: checkParameters,
+			TSCallSignatureDeclaration: checkParameters,
+			TSConstructSignatureDeclaration: checkParameters,
+			TSConstructorType: checkParameters,
+			TSDeclareFunction: checkParameters,
+			TSEmptyBodyFunctionExpression: checkParameters,
+			TSFunctionType: checkParameters,
+			TSMethodSignature: checkParameters,
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.ts";
+
+/** Ban Reflect.apply, which bypasses ordinary typed function calls. */
+export const noReflectApplyRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Reflect.apply; call typed functions directly or model dynamic dispatch behind an interface.",
+    },
+    messages: {
+      reflectApply:
+        "Replace `Reflect.apply` with a typed function call. Model dynamic dispatch behind a named interface.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "apply")) {
+          context.report({ node, messageId: "reflectApply" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-get.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-get.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.ts";
+
+/** Ban Reflect.get, which bypasses ordinary property access and useful type evidence. */
+export const noReflectGetRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Reflect.get; use typed property access or parse dynamic input into a domain type.",
+    },
+    messages: {
+      reflectGet:
+        "Replace `Reflect.get` with typed property access. Parse dynamic input into a named domain type before reading it.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "get")) {
+          context.report({ node, messageId: "reflectGet" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
+++ b/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
@@ -1,0 +1,77 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+type RuntimeFunction = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function isRuntimeFunction(node: ESTree.Node): node is RuntimeFunction {
+	return (
+		node.type === "ArrowFunctionExpression" ||
+		node.type === "FunctionDeclaration" ||
+		node.type === "FunctionExpression"
+	);
+}
+
+function isInsideTypeGuard(node: ESTree.Node): boolean {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (isRuntimeFunction(current)) {
+			return current.returnType?.typeAnnotation.type === "TSTypePredicate";
+		}
+		current = current.parent;
+	}
+	return false;
+}
+
+/** Return whether typeof safely probes for the existence of a possibly absent binding. */
+function isExistenceProbe(node: ESTree.UnaryExpression): boolean {
+	const parent = node.parent;
+	if (parent.type !== "BinaryExpression") return false;
+	if (!["===", "!==", "==", "!="].includes(parent.operator)) return false;
+	const other = parent.left === node ? parent.right : parent.left;
+	return other.type === "Literal" && other.value === "undefined";
+}
+
+/** Disallow runtime typeof checks that narrow unparsed values instead of decoding them. */
+export const noRuntimeTypeofRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow runtime typeof checks; external values must be decoded into meaningful types at their I/O boundary.",
+		},
+		messages: {
+			runtimeTypeof:
+				"A `typeof` check narrows a representation without establishing its contract. Parse input at its I/O boundary, then branch on the domain value.",
+		},
+		schema: [
+			{
+				type: "object",
+				properties: {
+					allowInTypeGuards: { type: "boolean" },
+				},
+				additionalProperties: false,
+			},
+		],
+		defaultOptions: [{ allowInTypeGuards: false }],
+	},
+	createOnce(context) {
+		return {
+			UnaryExpression(node) {
+				const option = context.options?.[0];
+				const allowInTypeGuards =
+					typeof option === "object" &&
+					option !== null &&
+					!Array.isArray(option) &&
+					option.allowInTypeGuards === true;
+				if (
+					node.operator === "typeof" &&
+					!isExistenceProbe(node) &&
+					(!allowInTypeGuards || !isInsideTypeGuard(node))
+				) {
+					context.report({ node, messageId: "runtimeTypeof" });
+				}
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
+++ b/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
@@ -1,0 +1,46 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+const FORBIDDEN_SYMBOL_NAME = "shape";
+
+function containsForbiddenSymbolName(name: string): boolean {
+  return name.toLowerCase().includes(FORBIDDEN_SYMBOL_NAME);
+}
+
+/** Return whether an identifier names a statically accessed member owned by another value. */
+function isBorrowedMemberName(node: ESTree.Node): boolean {
+  const parent = node.parent;
+  if (parent === null || parent.type !== "MemberExpression") return false;
+  return parent.property === node && parent.computed === false;
+}
+
+/** Ban the case-insensitive substring "shape" in every JavaScript and TypeScript symbol name. */
+export const noForbiddenTermInSymbolNamesRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        'Disallow the case-insensitive substring "shape" in JavaScript, TypeScript, private, and JSX symbol names.',
+    },
+    messages: {
+      forbiddenSymbolName:
+        'Rename symbol "{{name}}" for its domain role; "shape" describes structure rather than ownership.',
+    },
+  },
+  createOnce(context) {
+    const reportForbiddenSymbolName = (node: ESTree.Node & { name: string }) => {
+      if (!containsForbiddenSymbolName(node.name) || isBorrowedMemberName(node)) return;
+      context.report({
+        node,
+        messageId: "forbiddenSymbolName",
+        data: { name: node.name },
+      });
+    };
+
+    return {
+      Identifier: reportForbiddenSymbolName,
+      PrivateIdentifier: reportForbiddenSymbolName,
+      JSXIdentifier: reportForbiddenSymbolName,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
@@ -1,0 +1,69 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+  containsUnknownType,
+  functionParameterBindingName,
+  functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
+type ParameterOwner =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function isTypePredicateSubject(owner: ParameterOwner, parameterName: string): boolean {
+  const predicate = owner.returnType?.typeAnnotation;
+  return (
+    predicate?.type === "TSTypePredicate" &&
+    predicate.parameterName.type === "Identifier" &&
+    predicate.parameterName.name === parameterName
+  );
+}
+
+/** Disallow unknown inputs except explicitly named error-cause enrichment. */
+export const noUnknownParametersRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow explicitly unknown function parameters except `cause` and type-predicate subjects; decode unknown input at its I/O boundary instead.",
+    },
+    messages: {
+      unknownParameter:
+        "Parameter `{{parameter}}` leaves input unparsed. Accept a named domain type; run the expected schema or parser at the I/O boundary before calling this function.",
+    },
+  },
+  createOnce(context) {
+    const checkParameters = (node: ParameterOwner) => {
+      for (const parameter of node.params) {
+        const annotation = functionParameterTypeAnnotation(parameter);
+        if (annotation === null || annotation === undefined) continue;
+        if (!containsUnknownType(annotation.typeAnnotation)) continue;
+        const name = functionParameterBindingName(parameter, context.sourceCode);
+        if (name === "cause" || isTypePredicateSubject(node, name)) continue;
+        context.report({
+          node: annotation.typeAnnotation,
+          messageId: "unknownParameter",
+          data: { parameter: name },
+        });
+      }
+    };
+
+    return {
+      ArrowFunctionExpression: checkParameters,
+      FunctionDeclaration: checkParameters,
+      FunctionExpression: checkParameters,
+      TSCallSignatureDeclaration: checkParameters,
+      TSConstructSignatureDeclaration: checkParameters,
+      TSConstructorType: checkParameters,
+      TSDeclareFunction: checkParameters,
+      TSEmptyBodyFunctionExpression: checkParameters,
+      TSFunctionType: checkParameters,
+      TSMethodSignature: checkParameters,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
@@ -1,0 +1,82 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+  createTypeAliasEnvironment,
+  resolvedTypeMatches,
+  type TypeAliasEnvironment,
+} from "../shared/type-alias-resolution.ts";
+
+type FunctionWithReturnType =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+/** Ban function contracts that return unknown instead of a parsed domain type. */
+export const noUnknownReturnsRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow functions whose explicit return contract is unknown or Promise<unknown>.",
+    },
+    messages: {
+      unknownReturn:
+        "This function exposes `unknown` to its caller. Parse the value at its boundary and return a named domain type.",
+    },
+  },
+  createOnce(context) {
+    let environment: TypeAliasEnvironment | null = null;
+
+    const resolvesToUnknown = (type: ESTree.TSType): boolean =>
+      environment !== null &&
+      resolvedTypeMatches(type, environment, (resolved, matches) => {
+        if (resolved.type === "TSUnknownKeyword") return true;
+        if (resolved.type === "TSParenthesizedType") {
+          return matches(resolved.typeAnnotation);
+        }
+        if (resolved.type === "TSUnionType") return resolved.types.some(matches);
+        if (
+          resolved.type !== "TSTypeReference" ||
+          resolved.typeName.type !== "Identifier" ||
+          (resolved.typeName.name !== "Promise" &&
+            resolved.typeName.name !== "PromiseLike")
+        ) {
+          return false;
+        }
+        const value = resolved.typeArguments?.params[0];
+        return value !== undefined && matches(value);
+      });
+
+    const checkReturnType = (node: FunctionWithReturnType) => {
+      const annotation = node.returnType;
+      if (annotation === null || annotation === undefined) return;
+      if (!resolvesToUnknown(annotation.typeAnnotation)) return;
+      context.report({ node: annotation.typeAnnotation, messageId: "unknownReturn" });
+    };
+
+    return {
+      Program(node) {
+        environment = createTypeAliasEnvironment(
+          node,
+          context.sourceCode.visitorKeys,
+        );
+      },
+      ArrowFunctionExpression: checkReturnType,
+      FunctionDeclaration: checkReturnType,
+      FunctionExpression: checkReturnType,
+      TSCallSignatureDeclaration: checkReturnType,
+      TSConstructSignatureDeclaration: checkReturnType,
+      TSConstructorType: checkReturnType,
+      TSDeclareFunction: checkReturnType,
+      TSEmptyBodyFunctionExpression: checkReturnType,
+      TSFunctionType: checkReturnType,
+      TSMethodSignature: checkReturnType,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
@@ -1,0 +1,54 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+	createTypeAliasEnvironment,
+	resolvedTypeMatches,
+	type TypeAliasEnvironment,
+} from "../shared/type-alias-resolution.ts";
+
+/** Ban named aliases that merely conceal TypeScript's unknown top type. */
+export const noUnknownTypeAliasesRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow type aliases whose resolved type is unknown; unknown must remain visible at an allowed boundary.",
+		},
+		messages: {
+			unknownAlias:
+				"Type alias `{{alias}}` hides `unknown`. Keep `unknown` explicit at the parsing boundary or on an allowed `cause` field; otherwise use the parsed owner type.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeAliasEnvironment | null = null;
+
+		const resolvesToUnknown = (type: ESTree.TSType): boolean =>
+			environment !== null &&
+			resolvedTypeMatches(type, environment, (resolved, matches) => {
+				if (resolved.type === "TSUnknownKeyword") return true;
+				if (resolved.type === "TSParenthesizedType") {
+					return matches(resolved.typeAnnotation);
+				}
+				return resolved.type === "TSUnionType" && resolved.types.some(matches);
+			});
+
+		return {
+			Program(node) {
+				environment = createTypeAliasEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			TSTypeAliasDeclaration(node) {
+				if (!resolvesToUnknown(node.typeAnnotation)) return;
+				context.report({
+					node: node.id,
+					messageId: "unknownAlias",
+					data: { alias: node.id.name },
+				});
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
+++ b/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
@@ -1,0 +1,154 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	classifyUnsafeDictionary,
+	classifyUnsafeDictionaryValue,
+	createTypeEnvironment,
+	type TypeEnvironment,
+} from "../shared/dictionary-types.ts";
+import { visibleTypeAlias } from "../shared/type-alias-resolution.ts";
+
+import type { ESTree } from "@oxlint/plugins";
+
+const typeNodeKinds: ReadonlySet<string> = new Set([
+	"JSDocNonNullableType",
+	"JSDocNullableType",
+	"JSDocUnknownType",
+	"TSAnyKeyword",
+	"TSArrayType",
+	"TSBigIntKeyword",
+	"TSBooleanKeyword",
+	"TSConditionalType",
+	"TSConstructorType",
+	"TSFunctionType",
+	"TSImportType",
+	"TSIndexedAccessType",
+	"TSInferType",
+	"TSIntersectionType",
+	"TSIntrinsicKeyword",
+	"TSLiteralType",
+	"TSMappedType",
+	"TSNamedTupleMember",
+	"TSNeverKeyword",
+	"TSNullKeyword",
+	"TSNumberKeyword",
+	"TSObjectKeyword",
+	"TSParenthesizedType",
+	"TSStringKeyword",
+	"TSSymbolKeyword",
+	"TSTemplateLiteralType",
+	"TSThisType",
+	"TSTupleType",
+	"TSTypeLiteral",
+	"TSTypeOperator",
+	"TSTypePredicate",
+	"TSTypeQuery",
+	"TSTypeReference",
+	"TSUndefinedKeyword",
+	"TSUnionType",
+	"TSUnknownKeyword",
+	"TSVoidKeyword",
+]);
+
+function isTypeNode(node: ESTree.Node): node is ESTree.TSType {
+	return typeNodeKinds.has(node.type);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isInsideTypeAliasDeclaration(node: ESTree.Node): boolean {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (current.type === "TSTypeAliasDeclaration") return true;
+		current = current.parent;
+	}
+	return false;
+}
+
+function isPlainAliasConsumerUse(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (node.type !== "TSTypeReference" || node.typeArguments?.params.length) return false;
+	const name = typeReferenceName(node);
+	return (
+		name !== null &&
+		visibleTypeAlias(name, node, environment.typeAliases) !== null &&
+		!isInsideTypeAliasDeclaration(node)
+	);
+}
+
+function isInsideTypeParameterConstraint(node: ESTree.TSType): boolean {
+	let child: ESTree.Node = node;
+	let parent: ESTree.Node | null = child.parent;
+	while (parent !== null && parent.type !== "Program") {
+		if (parent.type === "TSTypeParameter" && parent.constraint === child) return true;
+		child = parent;
+		parent = child.parent;
+	}
+	return false;
+}
+
+function shouldReportType(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (isInsideTypeParameterConstraint(node)) return false;
+	if (isPlainAliasConsumerUse(node, environment)) return false;
+	if (classifyUnsafeDictionary(node, environment) === null) return false;
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (isTypeNode(current) && classifyUnsafeDictionary(current, environment) !== null)
+			return false;
+		current = current.parent;
+	}
+	return true;
+}
+
+/** Disallow object-dictionary contracts whose direct value type is an unsafe escape hatch. */
+export const noUnsafeDictionaryTypeRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow object-dictionary contracts whose direct value type is unknown, any, object, {}, or a union/alias containing one of those escape hatches.",
+		},
+		messages: {
+			unsafeDictionary:
+				"This dictionary's {{value}} value type gives callers no concrete value contract. Use an owner/schema-derived value type; parse external payloads before insertion.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeEnvironment | null = null;
+		const report = (node: ESTree.Node, value: string) => {
+			context.report({ node, messageId: "unsafeDictionary", data: { value } });
+		};
+		const reportIfUnsafe = (node: ESTree.TSType) => {
+			if (environment === null || !shouldReportType(node, environment)) return;
+			const unsafe = classifyUnsafeDictionary(node, environment);
+			if (unsafe === null) return;
+			report(node, unsafe.unsafeValue);
+		};
+
+		return {
+			Program(node) {
+				environment = createTypeEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			TSTypeReference: reportIfUnsafe,
+			TSTypeLiteral: reportIfUnsafe,
+			TSMappedType: reportIfUnsafe,
+			TSIndexSignature(node) {
+				if (
+					environment === null ||
+					node.typeAnnotation === null ||
+					node.parent.type === "TSTypeLiteral"
+				)
+					return;
+				const unsafe = classifyUnsafeDictionaryValue(
+					node.typeAnnotation.typeAnnotation,
+					environment,
+				);
+				if (unsafe !== null) report(node, unsafe.unsafeValue);
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -1,0 +1,366 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, Variable } from "@oxlint/plugins";
+
+type BroadTypeKind = "top" | "object" | "record";
+
+type KnownValueEvidence = {
+  readonly type: ESTree.TSType | null;
+};
+
+const functionBoundaryTypes = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "TSDeclareFunction",
+  "TSEmptyBodyFunctionExpression",
+]);
+
+function unwrapExpressionParentheses(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") current = current.expression;
+  return current;
+}
+
+function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (current.type === "TSParenthesizedType") current = current.typeAnnotation;
+  return current;
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isUnknownOrAnyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  return unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword";
+}
+
+function isBroadRecordKeyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (
+    unwrapped.type === "TSStringKeyword" ||
+    unwrapped.type === "TSNumberKeyword" ||
+    unwrapped.type === "TSSymbolKeyword"
+  ) {
+    return true;
+  }
+  if (unwrapped.type === "TSUnionType") return unwrapped.types.every(isBroadRecordKeyType);
+  return unwrapped.type === "TSTypeReference" && typeReferenceName(unwrapped) === "PropertyKey";
+}
+
+function isBroadRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+
+  if (unwrapped.type === "TSTypeReference") {
+    if (typeReferenceName(unwrapped) === "Readonly") {
+      const [inner] = unwrapped.typeArguments?.params ?? [];
+      return inner !== undefined && isBroadRecordType(inner);
+    }
+
+    if (typeReferenceName(unwrapped) !== "Record") return false;
+    const parameters = unwrapped.typeArguments?.params ?? [];
+    return (
+      parameters.length === 2 &&
+      parameters[0] !== undefined &&
+      parameters[1] !== undefined &&
+      isBroadRecordKeyType(parameters[0]) &&
+      isUnknownOrAnyType(parameters[1])
+    );
+  }
+
+  if (unwrapped.type !== "TSTypeLiteral" || unwrapped.members.length !== 1) return false;
+  const [member] = unwrapped.members;
+  const [parameter] = member?.type === "TSIndexSignature" ? member.parameters : [];
+  return (
+    member?.type === "TSIndexSignature" &&
+    member.parameters.length === 1 &&
+    parameter !== undefined &&
+    isBroadRecordKeyType(parameter.typeAnnotation.typeAnnotation) &&
+    isUnknownOrAnyType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function broadTypeKind(type: ESTree.TSType): BroadTypeKind | null {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword") return "top";
+  if (unwrapped.type === "TSObjectKeyword") return "object";
+  return isBroadRecordType(unwrapped) ? "record" : null;
+}
+
+function assertedExpression(
+  node: ESTree.TSAsExpression | ESTree.TSTypeAssertion,
+): ESTree.Expression {
+  return unwrapExpressionParentheses(node.expression);
+}
+
+function assertionFromExpression(
+  expression: ESTree.Expression,
+): ESTree.TSAsExpression | ESTree.TSTypeAssertion | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+  return unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion"
+    ? unwrapped
+    : null;
+}
+
+function normalizedTypeText(sourceText: string, type: ESTree.TSType): string {
+  return sourceText.slice(type.start, type.end).replaceAll(/\s+/gu, "");
+}
+
+function typesHaveSameSyntax(
+  sourceText: string,
+  left: ESTree.TSType | null,
+  right: ESTree.TSType,
+): boolean {
+  return (
+    left !== null &&
+    normalizedTypeText(sourceText, unwrapTypeParentheses(left)) ===
+      normalizedTypeText(sourceText, unwrapTypeParentheses(right))
+  );
+}
+
+function isDefinitelyObjectType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  switch (unwrapped.type) {
+    case "TSArrayType":
+    case "TSConstructorType":
+    case "TSFunctionType":
+    case "TSMappedType":
+    case "TSObjectKeyword":
+    case "TSTupleType":
+      return true;
+    case "TSTypeLiteral":
+      return unwrapped.members.length > 0;
+    case "TSIntersectionType":
+      return unwrapped.types.every(isDefinitelyObjectType);
+    case "TSTypeOperator":
+      return unwrapped.operator === "readonly" && isDefinitelyObjectType(unwrapped.typeAnnotation);
+    default:
+      return false;
+  }
+}
+
+function isDefinitelyNarrowerRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSTypeLiteral") {
+    return unwrapped.members.some((member) => member.type !== "TSIndexSignature");
+  }
+
+  if (unwrapped.type !== "TSTypeReference") return false;
+  if (typeReferenceName(unwrapped) === "Readonly") {
+    const [inner] = unwrapped.typeArguments?.params ?? [];
+    return inner !== undefined && isDefinitelyNarrowerRecordType(inner);
+  }
+  if (typeReferenceName(unwrapped) !== "Record") return false;
+
+  const parameters = unwrapped.typeArguments?.params ?? [];
+  return (
+    parameters.length === 2 && parameters[1] !== undefined && !isUnknownOrAnyType(parameters[1])
+  );
+}
+
+function functionBoundary(node: ESTree.Node): ESTree.Node | null {
+  let current = node.parent;
+  while (current !== null && current.type !== "Program") {
+    if (functionBoundaryTypes.has(current.type)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function resolvedVariableForIdentifier(
+  scopes: readonly {
+    readonly references: readonly {
+      readonly identifier: ESTree.Node;
+      readonly resolved: Variable | null;
+    }[];
+  }[],
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  for (const scope of scopes) {
+    const reference = scope.references.find(
+      (candidate) =>
+        candidate.identifier.start === identifier.start &&
+        candidate.identifier.end === identifier.end,
+    );
+    if (reference !== undefined) return reference.resolved;
+  }
+  return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+  for (const definition of variable.defs) {
+    if (definition.type === "Variable" && definition.node.type === "VariableDeclarator") {
+      return definition.node;
+    }
+  }
+  return null;
+}
+
+function knownValueEvidence(
+  expression: ESTree.Expression,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+  boundary: ESTree.Node | null,
+  visitedVariables: ReadonlySet<Variable>,
+): KnownValueEvidence | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+
+  if (unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion") {
+    if (broadTypeKind(unwrapped.typeAnnotation) !== null) return null;
+    return { type: unwrapped.typeAnnotation };
+  }
+
+  if (unwrapped.type === "Literal" || unwrapped.type === "TemplateLiteral") {
+    return { type: null };
+  }
+
+  if (
+    unwrapped.type === "ArrayExpression" ||
+    unwrapped.type === "ArrowFunctionExpression" ||
+    unwrapped.type === "ClassExpression" ||
+    unwrapped.type === "FunctionExpression" ||
+    unwrapped.type === "NewExpression" ||
+    unwrapped.type === "ObjectExpression"
+  ) {
+    return { type: null };
+  }
+
+  if (unwrapped.type !== "Identifier") return null;
+  const variable = resolvedVariableForIdentifier(scopes, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return null;
+
+  const annotatedIdentifier = variable.identifiers.find(
+    (identifier) => identifier.typeAnnotation !== null && identifier.typeAnnotation !== undefined,
+  );
+  const annotation = annotatedIdentifier?.typeAnnotation?.typeAnnotation;
+  if (annotation !== undefined && annotatedIdentifier !== undefined) {
+    if (functionBoundary(annotatedIdentifier) !== boundary || broadTypeKind(annotation) !== null) {
+      return null;
+    }
+    return { type: annotation };
+  }
+
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init) ||
+    functionBoundary(declarator) !== boundary
+  ) {
+    return null;
+  }
+
+  return knownValueEvidence(
+    declarator.init,
+    scopes,
+    boundary,
+    new Set([...visitedVariables, variable]),
+  );
+}
+
+function widenedBinding(
+  variable: Variable,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+): {
+  readonly broadKind: BroadTypeKind;
+  readonly evidence: KnownValueEvidence;
+  readonly declaredAt: number;
+  readonly boundary: ESTree.Node | null;
+} | null {
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.id.type !== "Identifier" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init)
+  ) {
+    return null;
+  }
+
+  const boundary = functionBoundary(declarator);
+  const declaredType = declarator.id.typeAnnotation?.typeAnnotation;
+  const initializerAssertion = assertionFromExpression(declarator.init);
+  const initializerBroadKind =
+    initializerAssertion === null ? null : broadTypeKind(initializerAssertion.typeAnnotation);
+  const declaredBroadKind = declaredType === undefined ? null : broadTypeKind(declaredType);
+  const broadKind = declaredBroadKind ?? initializerBroadKind;
+  if (broadKind === null) return null;
+
+  const originalExpression =
+    initializerAssertion !== null && initializerBroadKind !== null
+      ? assertedExpression(initializerAssertion)
+      : declarator.init;
+  const evidence = knownValueEvidence(originalExpression, scopes, boundary, new Set([variable]));
+  return evidence === null ? null : { broadKind, evidence, declaredAt: declarator.end, boundary };
+}
+
+function assertionIsNarrower(
+  sourceText: string,
+  broadKind: BroadTypeKind,
+  evidence: KnownValueEvidence,
+  assertedType: ESTree.TSType,
+): boolean {
+  if (broadTypeKind(assertedType) !== null) return false;
+  if (broadKind === "top") return true;
+  if (typesHaveSameSyntax(sourceText, evidence.type, assertedType)) return true;
+  if (broadKind === "object") return isDefinitelyObjectType(assertedType);
+  return isDefinitelyNarrowerRecordType(assertedType);
+}
+
+/** Detect immutable local bindings that erase a known type and are later asserted back to a narrower type. */
+export const noWidenThenAssertRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow local const flows that explicitly widen a known value before asserting the widened binding to a narrower type.",
+    },
+    messages: {
+      widenThenAssert:
+        'Binding "{{name}}" discards type evidence and later recreates it with an assertion. Keep the precise type from initialization through use; parse boundary input once.',
+    },
+  },
+  createOnce(context) {
+    let scopes: Parameters<typeof resolvedVariableForIdentifier>[0] = [];
+
+    const checkAssertion = (node: ESTree.TSAsExpression | ESTree.TSTypeAssertion) => {
+      const expression = assertedExpression(node);
+      if (expression.type !== "Identifier") return;
+
+      const variable = resolvedVariableForIdentifier(scopes, expression);
+      if (variable === null) return;
+      const widened = widenedBinding(variable, scopes);
+      if (
+        widened === null ||
+        node.start <= widened.declaredAt ||
+        functionBoundary(node) !== widened.boundary ||
+        !assertionIsNarrower(
+          context.sourceCode.text,
+          widened.broadKind,
+          widened.evidence,
+          node.typeAnnotation,
+        )
+      ) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: "widenThenAssert",
+        data: { name: expression.name },
+      });
+    };
+
+    return {
+      Program() {
+        scopes = context.sourceCode.scopeManager.scopes;
+      },
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
+++ b/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
@@ -1,0 +1,131 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+type TypeAssertion = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+const DEFAULT_SAFETY_MARKERS = ["SAFETY"] as const;
+
+const commentOwnerKinds = new Set([
+  "ExpressionStatement",
+  "PropertyDefinition",
+  "ReturnStatement",
+  "ThrowStatement",
+  "VariableDeclaration",
+]);
+
+function isConstAssertion(node: TypeAssertion): boolean {
+  return (
+    node.typeAnnotation.type === "TSTypeReference" &&
+    node.typeAnnotation.typeName.type === "Identifier" &&
+    node.typeAnnotation.typeName.name === "const"
+  );
+}
+
+function configuredSafetyMarkers(option: unknown): readonly string[] {
+  if (typeof option !== "object" || option === null || !("markers" in option)) {
+    return DEFAULT_SAFETY_MARKERS;
+  }
+  const configured = option.markers;
+  if (!Array.isArray(configured)) return DEFAULT_SAFETY_MARKERS;
+  const markers = configured.flatMap((marker) =>
+    typeof marker === "string" && marker.trim().length > 0 ? [marker.trim()] : [],
+  );
+  return markers.length > 0 ? markers : DEFAULT_SAFETY_MARKERS;
+}
+
+function markerPattern(markers: readonly string[]): RegExp {
+  const alternation = markers
+    .map((marker) => marker.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`))
+    .join("|");
+  return new RegExp(
+    String.raw`(?:^|[^\p{L}\p{N}_])(?:${alternation})\s*:\s*\S`,
+    "u",
+  );
+}
+
+function hasSafetyJustificationBefore(
+  sourceCode: SourceCode,
+  owner: ESTree.Node,
+  assertion: TypeAssertion,
+  pattern: RegExp,
+): boolean {
+  return sourceCode
+    .getCommentsBefore(owner)
+    .some(
+      (comment) => comment.end <= assertion.start && pattern.test(comment.value),
+    );
+}
+
+function hasSafetyComment(
+  sourceCode: SourceCode,
+  node: TypeAssertion,
+  pattern: RegExp,
+): boolean {
+  let current: ESTree.Node = node;
+  while (true) {
+    if (hasSafetyJustificationBefore(sourceCode, current, node, pattern)) return true;
+    if (commentOwnerKinds.has(current.type)) {
+      const exportDeclaration = current.parent;
+      return (
+        exportDeclaration.type === "ExportNamedDeclaration" &&
+        exportDeclaration.declaration === current &&
+        hasSafetyJustificationBefore(sourceCode, exportDeclaration, node, pattern)
+      );
+    }
+    if (current.parent.type === "Program") return false;
+    current = current.parent;
+  }
+}
+
+/** Require every non-const type assertion to state the invariant TypeScript cannot express. */
+export const requireSafetyCommentForTypeAssertionRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require a nearby SAFETY comment for every TypeScript type assertion except const assertions.",
+    },
+    messages: {
+      missingSafetyComment:
+        "This type assertion has no `{{marker}}:` justification. State the checked invariant immediately before the assertion or its containing statement.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          markers: {
+            type: "array",
+            items: { type: "string", minLength: 1 },
+            minItems: 1,
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    defaultOptions: [{ markers: ["SAFETY"] }],
+  },
+  createOnce(context) {
+    const patterns = new Map<string, RegExp>();
+
+    const checkAssertion = (node: TypeAssertion) => {
+      if (isConstAssertion(node)) return;
+      const markers = configuredSafetyMarkers(context.options?.[0]);
+      const patternKey = markers.join("\u0000");
+      const pattern = patterns.get(patternKey) ?? markerPattern(markers);
+      patterns.set(patternKey, pattern);
+      if (hasSafetyComment(context.sourceCode, node, pattern)) return;
+      context.report({
+        node,
+        messageId: "missingSafetyComment",
+        data: { marker: markers[0] ?? DEFAULT_SAFETY_MARKERS[0] },
+      });
+    };
+
+    return {
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/shared/dictionary-types.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.ts
@@ -1,0 +1,515 @@
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+	createTypeAliasEnvironment,
+	hasVisibleTypeBinding,
+	visibleTypeAlias,
+	type TypeAliasEnvironment as LexicalTypeAliasEnvironment,
+} from "./type-alias-resolution.ts";
+
+const BUILT_INS = new Set([
+	"Record",
+	"Readonly",
+	"Partial",
+	"Required",
+	"Pick",
+	"Omit",
+	"PropertyKey",
+	"NonNullable",
+]);
+const TRANSPARENT_WRAPPERS = new Set(["Readonly", "Partial", "Required", "NonNullable"]);
+
+type TypeAliasEnvironment = ReadonlyMap<string, ESTree.TSType>;
+
+type ResolvedType = {
+	readonly type: ESTree.TSType;
+	readonly substitutions: TypeAliasEnvironment;
+};
+
+export type UnsafeDictionary = {
+	readonly kind: "unsafe-dictionary";
+	readonly unsafeValue: "any" | "empty-object" | "object" | "union" | "unknown";
+};
+
+export type WideningTargetKind =
+	| "anonymous object"
+	| "generic container"
+	| "object"
+	| "open dictionary"
+	| "unknown";
+
+export type WideningTarget = {
+	readonly kind: WideningTargetKind;
+};
+
+export type TypeEnvironment = {
+	readonly interfaces: ReadonlyMap<string, readonly ESTree.TSInterfaceDeclaration[]>;
+	readonly typeAliases: LexicalTypeAliasEnvironment;
+};
+
+function declaredStatement(statement: ESTree.Statement): ESTree.Node | null {
+	return statement.type === "ExportNamedDeclaration" ||
+		statement.type === "ExportDefaultDeclaration"
+		? (statement.declaration ?? null)
+		: statement;
+}
+
+export function createTypeEnvironment(
+	program: ESTree.Program,
+	visitorKeys: Readonly<Record<string, readonly string[]>>,
+): TypeEnvironment {
+	const interfaces = new Map<string, ESTree.TSInterfaceDeclaration[]>();
+
+	for (const statement of program.body) {
+		const declaration = declaredStatement(statement);
+		if (declaration?.type !== "TSInterfaceDeclaration") continue;
+		const declarations = interfaces.get(declaration.id.name) ?? [];
+		declarations.push(declaration);
+		interfaces.set(declaration.id.name, declarations);
+	}
+
+	return {
+		interfaces,
+		typeAliases: createTypeAliasEnvironment(program, visitorKeys),
+	};
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isBuiltIn(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeEnvironment,
+): boolean {
+	return (
+		BUILT_INS.has(name) &&
+		!hasVisibleTypeBinding(name, use, environment.typeAliases)
+	);
+}
+
+function isUnappliedReferenceTo(type: ESTree.TSType, name: string): boolean {
+	const unwrapped = unwrapTransparentType(type);
+	return (
+		unwrapped.type === "TSTypeReference" &&
+		typeReferenceName(unwrapped) === name &&
+		(unwrapped.typeArguments === null ||
+			unwrapped.typeArguments === undefined ||
+			unwrapped.typeArguments.params.length === 0)
+	);
+}
+
+function unwrapTransparentType(type: ESTree.TSType): ESTree.TSType {
+	let current = type;
+	while (
+		current.type === "TSParenthesizedType" ||
+		(current.type === "TSTypeOperator" && current.operator === "readonly")
+	) {
+		current = current.typeAnnotation;
+	}
+	return current;
+}
+
+function isNeverType(type: ESTree.TSType): boolean {
+	return unwrapTransparentType(type).type === "TSNeverKeyword";
+}
+
+function isEffectivelyEmptyMember(member: ESTree.TSSignature): boolean {
+	return (
+		member.type === "TSPropertySignature" &&
+		member.optional === true &&
+		member.typeAnnotation !== null &&
+		member.typeAnnotation !== undefined &&
+		isNeverType(member.typeAnnotation.typeAnnotation)
+	);
+}
+
+function isEffectivelyEmptyTypeLiteral(type: ESTree.TSTypeLiteral): boolean {
+	return type.members.length === 0 || type.members.every(isEffectivelyEmptyMember);
+}
+
+function isEffectivelyEmptyInterface(
+	declarations: readonly ESTree.TSInterfaceDeclaration[],
+): boolean {
+	if (declarations.length !== 1) return false;
+	const [type] = declarations;
+	return (
+		type !== undefined &&
+		type.extends.length === 0 &&
+		(type.body.body.length === 0 || type.body.body.every(isEffectivelyEmptyMember))
+	);
+}
+
+function resolvedSubstitutionArgument(
+	type: ESTree.TSType,
+	base: TypeAliasEnvironment,
+	resolving: ReadonlySet<string> = new Set(),
+): ESTree.TSType {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type !== "TSTypeReference") return type;
+	const name = typeReferenceName(unwrapped);
+	if (name === null || resolving.has(name)) return type;
+	const substitution = base.get(name);
+	if (substitution === undefined) return type;
+	const nextResolving = new Set(resolving);
+	nextResolving.add(name);
+	return resolvedSubstitutionArgument(substitution, base, nextResolving);
+}
+
+function aliasSubstitution(
+	alias: ESTree.TSTypeAliasDeclaration,
+	type: ESTree.TSTypeReference,
+	base: TypeAliasEnvironment,
+): TypeAliasEnvironment | null {
+	const parameters = alias.typeParameters?.params ?? [];
+	const arguments_ = type.typeArguments?.params ?? [];
+	const next = new Map(base);
+	for (const [index, parameter] of parameters.entries()) {
+		const argument = arguments_[index] ?? parameter.default;
+		if (argument === null || argument === undefined) return null;
+		next.set(parameter.name.name, resolvedSubstitutionArgument(argument, next));
+	}
+	return next;
+}
+
+function unsafeDirectValue(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): UnsafeDictionary["unsafeValue"] | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return "unknown";
+	if (unwrapped.type === "TSAnyKeyword") return "any";
+	if (unwrapped.type === "TSObjectKeyword") return "object";
+	if (unwrapped.type === "TSTypeLiteral" && isEffectivelyEmptyTypeLiteral(unwrapped))
+		return "empty-object";
+	if (unwrapped.type === "TSUnionType") {
+		return unwrapped.types.some(
+			(member) => unsafeDirectValue(member, environment, substitutions, resolvingAliases) !== null,
+		)
+			? "union"
+			: null;
+	}
+	if (unwrapped.type === "TSIntersectionType") {
+		const unsafeMembers = unwrapped.types.map((member) =>
+			unsafeDirectValue(member, environment, substitutions, resolvingAliases),
+		);
+		if (unsafeMembers.includes("any")) return "any";
+		return unsafeMembers.length > 0 && unsafeMembers.every((member) => member !== null)
+			? unsafeMembers[0]
+			: null;
+	}
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? null
+			: unsafeDirectValue(wrapped, environment, substitutions, resolvingAliases);
+	}
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? null
+			: unsafeDirectValue(substitution, environment, substitutions, resolvingAliases);
+	}
+	const interfaceDeclarations = environment.interfaces.get(name);
+	if (interfaceDeclarations !== undefined) {
+		return isEffectivelyEmptyInterface(interfaceDeclarations) ? "empty-object" : null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return null;
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return null;
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return unsafeDirectValue(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+function dictionaryValueTypes(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): readonly ResolvedType[] {
+	const unwrapped = unwrapTransparentType(type);
+
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.flatMap((member): readonly ResolvedType[] =>
+			member.type === "TSIndexSignature" && member.typeAnnotation !== null
+				? [{ type: member.typeAnnotation.typeAnnotation, substitutions }]
+				: [],
+		);
+	}
+
+	if (unwrapped.type === "TSMappedType") {
+		return unwrapped.typeAnnotation === null
+			? []
+			: [{ type: unwrapped.typeAnnotation, substitutions }];
+	}
+
+	if (unwrapped.type !== "TSTypeReference") return [];
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return [];
+
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? []
+			: dictionaryValueTypes(substitution, environment, substitutions, resolvingAliases);
+	}
+
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? []
+			: dictionaryValueTypes(wrapped, environment, substitutions, resolvingAliases);
+	}
+
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		const value = unwrapped.typeArguments?.params[1] ?? null;
+		return value === null ? [] : [{ type: value, substitutions }];
+	}
+
+	if (
+		(name === "Pick" || name === "Omit") &&
+		isBuiltIn(name, unwrapped, environment)
+	) {
+		const source = unwrapped.typeArguments?.params[0];
+		return source === undefined
+			? []
+			: dictionaryValueTypes(source, environment, substitutions, resolvingAliases);
+	}
+
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return [];
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return [];
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return dictionaryValueTypes(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+export function classifyUnsafeDictionaryValue(
+	valueType: ESTree.TSType,
+	environment: TypeEnvironment,
+): UnsafeDictionary | null {
+	const unsafeValue = unsafeDirectValue(valueType, environment, new Map(), new Set());
+	return unsafeValue === null ? null : { kind: "unsafe-dictionary", unsafeValue };
+}
+
+export function classifyUnsafeDictionary(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): UnsafeDictionary | null {
+	for (const valueType of dictionaryValueTypes(type, environment, new Map(), new Set())) {
+		const unsafeValue = unsafeDirectValue(
+			valueType.type,
+			environment,
+			valueType.substitutions,
+			new Set(),
+		);
+		if (unsafeValue !== null) return { kind: "unsafe-dictionary", unsafeValue };
+	}
+	return null;
+}
+
+export function classifyWideningTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): WideningTarget | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+			? { kind: "open dictionary" }
+			: unwrapped.members.length > 0
+				? { kind: "anonymous object" }
+				: null;
+	}
+	if (unwrapped.type === "TSMappedType") return { kind: "open dictionary" };
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined ? null : classifyWideningTarget(wrapped, environment);
+	}
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		return hasBroadRecordKey(unwrapped, environment, new Map())
+			? { kind: "open dictionary" }
+			: null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null) return null;
+	if ((alias.typeParameters?.params.length ?? 0) > 0) {
+		const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+		const resolved =
+			substitutions === null
+				? null
+				: classifyAliasBroadTarget(
+						alias.typeAnnotation,
+						environment,
+						substitutions,
+						new Set([name]),
+					);
+		return resolved?.kind === "open dictionary" ? { kind: "generic container" } : null;
+	}
+	const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+	if (substitutions === null) return null;
+	const resolved = classifyAliasBroadTarget(
+		alias.typeAnnotation,
+		environment,
+		substitutions,
+		new Set([name]),
+	);
+	return resolved;
+}
+
+function hasBroadRecordKey(
+	type: ESTree.TSTypeReference,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+): boolean {
+	const key = type.typeArguments?.params[0];
+	return key === undefined || isBroadMappedKey(key, environment, substitutions);
+}
+
+function isBroadMappedKey(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	visitedAliases: ReadonlySet<string> = new Set(),
+): boolean {
+	const unwrapped = unwrapTransparentType(type);
+	if (
+		unwrapped.type === "TSStringKeyword" ||
+		unwrapped.type === "TSNumberKeyword" ||
+		unwrapped.type === "TSSymbolKeyword"
+	) {
+		return true;
+	}
+	if (unwrapped.type === "TSUnionType") {
+		return unwrapped.types.some((member) =>
+			isBroadMappedKey(member, environment, substitutions, visitedAliases),
+		);
+	}
+	if (unwrapped.type !== "TSTypeReference") return false;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return false;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined && !isUnappliedReferenceTo(substitution, name)) {
+		return isBroadMappedKey(substitution, environment, substitutions, visitedAliases);
+	}
+	if (name === "PropertyKey" && isBuiltIn(name, unwrapped, environment)) return true;
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (
+		alias === null ||
+		(alias.typeParameters?.params.length ?? 0) > 0 ||
+		visitedAliases.has(name)
+	) {
+		return false;
+	}
+	const nextVisited = new Set(visitedAliases);
+	nextVisited.add(name);
+	return isBroadMappedKey(alias.typeAnnotation, environment, substitutions, nextVisited);
+}
+
+function classifyAliasBroadTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): WideningTarget | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+			? { kind: "open dictionary" }
+			: null;
+	}
+	if (unwrapped.type === "TSMappedType") {
+		return isBroadMappedKey(unwrapped.constraint, environment, substitutions)
+			? { kind: "open dictionary" }
+			: null;
+	}
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? null
+			: classifyAliasBroadTarget(
+					substitution,
+					environment,
+					substitutions,
+					resolvingAliases,
+				);
+	}
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? null
+			: classifyAliasBroadTarget(wrapped, environment, substitutions, resolvingAliases);
+	}
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		return hasBroadRecordKey(unwrapped, environment, substitutions)
+			? { kind: "open dictionary" }
+			: null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return null;
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return null;
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return classifyAliasBroadTarget(
+		alias.typeAnnotation,
+		environment,
+		nextSubstitutions,
+		nextResolving,
+	);
+}
+
+export function isPopulatedObjectExpression(expression: ESTree.Expression): boolean {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression"
+	) {
+		current = current.expression;
+	}
+	return current.type === "ObjectExpression" && current.properties.length > 0;
+}
+
+export function isKnownEvidenceExpression(expression: ESTree.Expression): boolean {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression" ||
+		current.type === "TSSatisfiesExpression"
+	) {
+		current = current.expression;
+	}
+	if (current.type === "ObjectExpression") return true;
+	return (
+		current.type === "ArrayExpression" ||
+		current.type === "ArrowFunctionExpression" ||
+		current.type === "ClassExpression" ||
+		current.type === "FunctionExpression" ||
+		current.type === "NewExpression" ||
+		current.type === "Literal" ||
+		current.type === "TemplateLiteral" ||
+		current.type === "UnaryExpression"
+	);
+}

--- a/tools/oxlint/anti-slop/shared/function-parameters.ts
+++ b/tools/oxlint/anti-slop/shared/function-parameters.ts
@@ -1,0 +1,49 @@
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+export type FunctionParameter = ESTree.ParamPattern;
+
+/** Return whether a type is or contains TypeScript's absorbing unknown top type. */
+export function containsUnknownType(type: ESTree.TSType): boolean {
+	if (type.type === "TSUnknownKeyword") return true;
+	if (type.type === "TSParenthesizedType") return containsUnknownType(type.typeAnnotation);
+	return type.type === "TSUnionType" && type.types.some(containsUnknownType);
+}
+
+/** Return the TypeScript annotation attached to a function parameter or its wrapped binding. */
+export function functionParameterTypeAnnotation(
+	parameter: FunctionParameter,
+): ESTree.TSTypeAnnotation | null | undefined {
+	if (parameter.type === "TSParameterProperty") {
+		return functionParameterTypeAnnotation(parameter.parameter);
+	}
+	if (parameter.type === "RestElement") {
+		return parameter.typeAnnotation ?? functionParameterTypeAnnotation(parameter.argument);
+	}
+	if (parameter.type === "AssignmentPattern") {
+		return parameter.typeAnnotation ?? functionParameterTypeAnnotation(parameter.left);
+	}
+	return parameter.typeAnnotation;
+}
+
+/** Return only a function parameter's local binding, excluding its annotation and default value. */
+export function functionParameterBindingName(
+	parameter: FunctionParameter,
+	sourceCode: SourceCode,
+): string {
+	if (parameter.type === "TSParameterProperty") {
+		return functionParameterBindingName(parameter.parameter, sourceCode);
+	}
+	if (parameter.type === "AssignmentPattern") {
+		return functionParameterBindingName(parameter.left, sourceCode);
+	}
+	if (parameter.type === "RestElement") {
+		return functionParameterBindingName(parameter.argument, sourceCode);
+	}
+	if (parameter.type === "Identifier") return parameter.name;
+
+	const sourceText = sourceCode.getText(parameter);
+	const annotationStart = parameter.typeAnnotation?.start;
+	return annotationStart === undefined
+		? sourceText
+		: sourceText.slice(0, annotationStart - parameter.start).trimEnd();
+}

--- a/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
+++ b/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
@@ -1,0 +1,61 @@
+import type { ESTree } from "@oxlint/plugins";
+
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+
+function isNode(value: unknown): value is ESTree.Node {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		typeof value.type === "string"
+	);
+}
+
+function collectInferTypeParameterNames(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+	names: Set<string>,
+): void {
+	if (node.type === "TSInferType") names.add(node.typeParameter.name.name);
+	const record = node as unknown as Readonly<Record<string, unknown>>;
+	for (const key of visitorKeys[node.type] ?? []) {
+		const value = record[key];
+		if (isNode(value)) {
+			collectInferTypeParameterNames(value, visitorKeys, names);
+			continue;
+		}
+		if (!Array.isArray(value)) continue;
+		for (const child of value) {
+			if (isNode(child)) collectInferTypeParameterNames(child, visitorKeys, names);
+		}
+	}
+}
+
+/** Collect type binders that are in scope at a node and can shadow module aliases. */
+export function lexicalTypeParameterNames(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+): ReadonlySet<string> {
+	const names = new Set<string>();
+	let descendant: ESTree.Node = node;
+	let current: ESTree.Node | null = node;
+	while (current !== null && current.type !== "Program") {
+		if ("typeParameters" in current) {
+			for (const parameter of current.typeParameters?.params ?? []) {
+				names.add(parameter.name.name);
+			}
+		}
+		if (
+			current.type === "TSMappedType" &&
+			(descendant === current.nameType || descendant === current.typeAnnotation)
+		) {
+			names.add(current.key.name);
+		}
+		if (current.type === "TSConditionalType" && descendant === current.trueType) {
+			collectInferTypeParameterNames(current.extendsType, visitorKeys, names);
+		}
+		descendant = current;
+		current = current.parent;
+	}
+	return names;
+}

--- a/tools/oxlint/anti-slop/shared/reflect-method.ts
+++ b/tools/oxlint/anti-slop/shared/reflect-method.ts
@@ -1,0 +1,35 @@
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function isGlobalReflect(sourceCode: SourceCode, expression: ESTree.Expression): boolean {
+  if (expression.type !== "Identifier" || expression.name !== "Reflect") return false;
+  if (sourceCode.isGlobalReference(expression)) return true;
+  const variable = resolveVariable(sourceCode, expression);
+  return variable === null || variable.defs.length === 0;
+}
+
+/** Reports whether a call target names one method on the global Reflect object. */
+export function isGlobalReflectMethodCall(
+  sourceCode: SourceCode,
+  callee: ESTree.Expression,
+  methodName: string,
+): boolean {
+  if (!("property" in callee) || !("object" in callee) || !("computed" in callee)) return false;
+  if (!isGlobalReflect(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  return callee.computed
+    ? property.type === "Literal" && property.value === methodName
+    : property.type === "Identifier" && property.name === methodName;
+}

--- a/tools/oxlint/anti-slop/shared/type-alias-resolution.ts
+++ b/tools/oxlint/anti-slop/shared/type-alias-resolution.ts
@@ -1,0 +1,250 @@
+import type { ESTree } from "@oxlint/plugins";
+
+import { lexicalTypeParameterNames } from "./lexical-type-parameters.ts";
+
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+type TypeScope = ESTree.Node;
+
+type TypeBinding = {
+	readonly alias: ESTree.TSTypeAliasDeclaration | null;
+	readonly name: string;
+	readonly scope: TypeScope;
+};
+
+type Substitution = {
+	readonly substitutions: Substitutions;
+	readonly type: ESTree.TSType;
+};
+
+type Substitutions = ReadonlyMap<string, Substitution>;
+
+export type TypeAliasEnvironment = {
+	readonly aliases: readonly ESTree.TSTypeAliasDeclaration[];
+	readonly bindingsByName: ReadonlyMap<string, readonly TypeBinding[]>;
+	readonly visitorKeys: VisitorKeys;
+};
+
+export type ResolvedTypeMatcher = (
+	type: ESTree.TSType,
+	matches: (child: ESTree.TSType) => boolean,
+) => boolean;
+
+const environmentsByProgram = new WeakMap<ESTree.Program, TypeAliasEnvironment>();
+
+function isNode(value: unknown): value is ESTree.Node {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		typeof value.type === "string"
+	);
+}
+
+function enclosingTypeScope(node: ESTree.Node): TypeScope {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null) {
+		if (
+			current.type === "Program" ||
+			current.type === "BlockStatement" ||
+			current.type === "TSModuleBlock" ||
+			current.type === "StaticBlock" ||
+			current.type === "SwitchStatement"
+		) {
+			return current;
+		}
+		current = current.parent;
+	}
+	return node;
+}
+
+function declaredTypeBinding(node: ESTree.Node): {
+	readonly alias: ESTree.TSTypeAliasDeclaration | null;
+	readonly name: string;
+} | null {
+	if (node.type === "TSTypeAliasDeclaration") {
+		return { alias: node, name: node.id.name };
+	}
+	if (
+		node.type === "TSInterfaceDeclaration" ||
+		node.type === "TSEnumDeclaration" ||
+		node.type === "ClassDeclaration" ||
+		node.type === "ClassExpression"
+	) {
+		return node.id === null ? null : { alias: null, name: node.id.name };
+	}
+	if (
+		node.type === "ImportSpecifier" ||
+		node.type === "ImportDefaultSpecifier" ||
+		node.type === "ImportNamespaceSpecifier"
+	) {
+		return { alias: null, name: node.local.name };
+	}
+	return null;
+}
+
+function collectTypeBindings(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+	bindingsByName: Map<string, TypeBinding[]>,
+	aliases: ESTree.TSTypeAliasDeclaration[],
+): void {
+	const declared = declaredTypeBinding(node);
+	if (declared !== null) {
+		const bindings = bindingsByName.get(declared.name) ?? [];
+		bindings.push({ ...declared, scope: enclosingTypeScope(node) });
+		bindingsByName.set(declared.name, bindings);
+		if (declared.alias !== null) aliases.push(declared.alias);
+	}
+
+	// SAFETY: Oxlint's visitor keys identify only ESTree child-node properties.
+	const fields = node as unknown as Readonly<Record<string, unknown>>;
+	for (const key of visitorKeys[node.type] ?? []) {
+		const value = fields[key];
+		if (isNode(value)) {
+			collectTypeBindings(value, visitorKeys, bindingsByName, aliases);
+			continue;
+		}
+		if (!Array.isArray(value)) continue;
+		for (const child of value) {
+			if (isNode(child)) {
+				collectTypeBindings(child, visitorKeys, bindingsByName, aliases);
+			}
+		}
+	}
+}
+
+/** Collect every lexical type alias and competing type binding in a program. */
+export function createTypeAliasEnvironment(
+	program: ESTree.Program,
+	visitorKeys: VisitorKeys,
+): TypeAliasEnvironment {
+	const cached = environmentsByProgram.get(program);
+	if (cached !== undefined) return cached;
+	const bindingsByName = new Map<string, TypeBinding[]>();
+	const aliases: ESTree.TSTypeAliasDeclaration[] = [];
+	collectTypeBindings(program, visitorKeys, bindingsByName, aliases);
+	const environment = { aliases, bindingsByName, visitorKeys };
+	environmentsByProgram.set(program, environment);
+	return environment;
+}
+
+function ancestorDistance(ancestor: ESTree.Node, node: ESTree.Node): number | null {
+	let current: ESTree.Node | null = node;
+	let distance = 0;
+	while (current !== null) {
+		if (current === ancestor) return distance;
+		current = current.parent;
+		distance += 1;
+	}
+	return null;
+}
+
+function nearestTypeBindings(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): readonly TypeBinding[] {
+	const candidates = environment.bindingsByName.get(name) ?? [];
+	let nearestDistance = Number.POSITIVE_INFINITY;
+	let nearest: TypeBinding[] = [];
+	for (const candidate of candidates) {
+		const distance = ancestorDistance(candidate.scope, use);
+		if (distance === null || distance > nearestDistance) continue;
+		if (distance === nearestDistance) {
+			nearest.push(candidate);
+			continue;
+		}
+		nearestDistance = distance;
+		nearest = [candidate];
+	}
+	return nearest;
+}
+
+/** Resolve the nearest visible alias with this name, respecting lexical shadowing. */
+export function visibleTypeAlias(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): ESTree.TSTypeAliasDeclaration | null {
+	if (lexicalTypeParameterNames(use, environment.visitorKeys).has(name)) return null;
+	const bindings = nearestTypeBindings(name, use, environment);
+	return bindings.length === 1 ? (bindings[0]?.alias ?? null) : null;
+}
+
+/** Return whether a local declaration shadows a built-in type at this use. */
+export function hasVisibleTypeBinding(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): boolean {
+	return (
+		lexicalTypeParameterNames(use, environment.visitorKeys).has(name) ||
+		nearestTypeBindings(name, use, environment).length > 0
+	);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function aliasSubstitutions(
+	alias: ESTree.TSTypeAliasDeclaration,
+	reference: ESTree.TSTypeReference,
+	base: Substitutions,
+): Substitutions | null {
+	const parameters = alias.typeParameters?.params ?? [];
+	const arguments_ = reference.typeArguments?.params ?? [];
+	const next = new Map(base);
+	for (const [index, parameter] of parameters.entries()) {
+		const explicitArgument = arguments_[index];
+		const argument = explicitArgument ?? parameter.default;
+		if (argument === null || argument === undefined) return null;
+		const argumentSubstitutions = explicitArgument === undefined ? next : base;
+		next.set(parameter.name.name, {
+			type: argument,
+			substitutions: new Map(argumentSubstitutions),
+		});
+	}
+	return next;
+}
+
+/** Match a type after resolving visible aliases and substituting their type parameters. */
+export function resolvedTypeMatches(
+	type: ESTree.TSType,
+	environment: TypeAliasEnvironment,
+	matcher: ResolvedTypeMatcher,
+): boolean {
+	const evaluate = (
+		current: ESTree.TSType,
+		substitutions: Substitutions,
+		resolvingAliases: ReadonlySet<ESTree.TSTypeAliasDeclaration>,
+	): boolean => {
+		if (current.type === "TSTypeReference") {
+			const name = typeReferenceName(current);
+			if (name !== null) {
+				const substitution = substitutions.get(name);
+				if (substitution !== undefined && !current.typeArguments?.params.length) {
+					return evaluate(
+						substitution.type,
+						substitution.substitutions,
+						resolvingAliases,
+					);
+				}
+				const alias = visibleTypeAlias(name, current, environment);
+				if (alias !== null && !resolvingAliases.has(alias)) {
+					const nextSubstitutions = aliasSubstitutions(alias, current, substitutions);
+					if (nextSubstitutions !== null) {
+						const nextResolving = new Set(resolvingAliases);
+						nextResolving.add(alias);
+						return evaluate(alias.typeAnnotation, nextSubstitutions, nextResolving);
+					}
+				}
+			}
+		}
+		return matcher(current, (child) =>
+			evaluate(child, substitutions, resolvingAliases),
+		);
+	};
+
+	return evaluate(type, new Map(), new Set());
+}


### PR DESCRIPTION
## Summary

- Vendors the anti-slop Oxlint plugin under `tools/oxlint/anti-slop` and pins `@oxlint/plugins@1.63.0` to match the installed `oxlint`.
- Registers the plugin in `.oxlintrc.json`. High-impact rules (`no-chained-type-assertions`, `no-object-parameters`, `no-reflect-apply`, `no-reflect-get`, `no-unknown-type-aliases`, `no-widen-then-assert`) run at `error`; the remaining rules run at `warn` (1,597 warnings today) so lint can be enforced now and the warnings worked down over time.
- Adds `pnpm lint` and `pnpm format:check` steps to the Review Desktop CI workflow.
- Fixes all 30 chained `as unknown as` assertions and the one `object` parameter at their root causes rather than by re-casting:
  - CLI entry points accept a Node `Writable` / `CliInputStream` instead of tty-specific `NodeJS.WriteStream` / `NodeJS.ReadStream`; tests pass real streams.
  - The CLI runner takes a `ProgressiveReviewCommandTelemetry` port (the subset of the telemetry class it drives).
  - The Babel-based ESTree adapter returns `estree` `Program` / `Expression` at one documented boundary.
  - `remark-review-sections` uses `mdast-util-mdx-jsx` node types (added as a devDependency).
  - Sequence-diagram nodes carry typed React Flow node data; the ELK layout call is typed through `ElkNode`.
  - Test doubles implement `ResizeObserver` / `IntersectionObserver` / `DOMRectList`.

## Verification

- `pnpm lint`: 0 errors, 1,597 warnings.
- `pnpm format:check`: clean.
- `pnpm --filter @dev.fast/review typecheck`: only the pre-existing `scripts/check-tutorial.ts` error, which is present on `main`.
- `pnpm --filter @dev.fast/review test`: 150 files, 1,178 tests passing (after `build:tutorial-assets`, which the suite needs locally).
