### PR TITLE
Replace unknown-valued dictionaries with owner types

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -77,7 +77,7 @@
     "no-unmodified-loop-condition": "off",
     "anti-slop/no-chained-type-assertions": "error",
     "anti-slop/no-conditional-empty-object-spread": "warn",
-    "anti-slop/no-known-value-widening": "warn",
+    "anti-slop/no-known-value-widening": "error",
     "anti-slop/no-module-mocking": "warn",
     "anti-slop/no-object-parameters": "error",
     "anti-slop/no-reflect-apply": "error",
@@ -87,7 +87,7 @@
     "anti-slop/no-unknown-parameters": "warn",
     "anti-slop/no-unknown-returns": "warn",
     "anti-slop/no-unknown-type-aliases": "error",
-    "anti-slop/no-unsafe-dictionary-type": "warn",
+    "anti-slop/no-unsafe-dictionary-type": "error",
     "anti-slop/no-widen-then-assert": "error",
     "anti-slop/require-safety-comment-for-type-assertion": "warn"
   },
@@ -95,6 +95,14 @@
     {
       "name": "anti-slop",
       "specifier": "./tools/oxlint/anti-slop/index.ts"
+    }
+  ],
+  "overrides": [
+    {
+      "files": ["**/*.test.ts", "**/*.test.tsx"],
+      "rules": {
+        "anti-slop/require-safety-comment-for-type-assertion": "off"
+      }
     }
   ]
 }

--- a/packages/local-vcs/src/file-lock.test.ts
+++ b/packages/local-vcs/src/file-lock.test.ts
@@ -186,10 +186,7 @@ async function runWorker(workerPath: string, args: string[]): Promise<void> {
   return await spawnWorker(workerPath, args).completion;
 }
 
-function spawnWorker(
-  workerPath: string,
-  args: string[],
-): { child: ReturnType<typeof spawn>; completion: Promise<void> } {
+function spawnWorker(workerPath: string, args: string[]) {
   const child = spawn(
     process.execPath,
     ["--import", "tsx", workerPath, ...args],

--- a/packages/local-vcs/src/notes.ts
+++ b/packages/local-vcs/src/notes.ts
@@ -235,7 +235,7 @@ export async function writeNote(input: {
         tmp,
       ]);
       const blob = hashed.stdout.trim();
-      let lastError: unknown = null;
+      let lastError: Error | null = null;
       for (let attempt = 0; attempt < NOTES_WRITE_RETRIES; attempt += 1) {
         const added = await git(
           input.rootPath,
@@ -279,7 +279,7 @@ export function writeNoteSync(input: {
         gitArgsSync(input.rootPath, ["hash-object", "-w", "--no-filters", tmp]),
         { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
       ).trim();
-      let lastError: unknown = null;
+      let lastError: Error | null = null;
       for (let attempt = 0; attempt < NOTES_WRITE_RETRIES; attempt += 1) {
         try {
           execFileSync(
@@ -297,7 +297,7 @@ export function writeNoteSync(input: {
           );
           return;
         } catch (error) {
-          lastError = error;
+          lastError = error instanceof Error ? error : new Error(String(error));
         }
       }
       throw lastError;

--- a/packages/progressive-review/app/src/App.tsx
+++ b/packages/progressive-review/app/src/App.tsx
@@ -59,7 +59,10 @@ import {
 } from "./review-document-context";
 import { reportReviewDocumentRenderError } from "./review-document-error-report";
 import { ReviewDocumentContent } from "./review-document-surface";
-import type { ReadyReviewDocumentEntry } from "./review-documents-runtime";
+import type {
+  ReadyReviewDocumentEntry,
+  ReviewDocumentComponent,
+} from "./review-documents-runtime";
 import {
   type ReviewFindHost,
   ReviewFindProvider,
@@ -282,9 +285,7 @@ function ReviewLayoutContent({
   shellRef: RefObject<HTMLElement | null>;
   scrollRegionRef: RefObject<HTMLElement | null>;
   articleRef: RefObject<HTMLElement | null>;
-  ReviewDocument: ComponentType<{
-    components?: Record<string, unknown>;
-  }>;
+  ReviewDocument: ReviewDocumentComponent;
   documentRevision: string;
   softwareModels: NormalizedSoftwareModel[];
   repoSoftwareMap: NormalizedSoftwareModel | null;

--- a/packages/progressive-review/app/src/CodePeek.tsx
+++ b/packages/progressive-review/app/src/CodePeek.tsx
@@ -56,12 +56,17 @@ interface CodePeekResolveInput {
   includeDiffSummary: true;
 }
 
+export interface CodePeekLoadState {
+  isInitialLoad: boolean;
+  isRefreshing: boolean;
+}
+
 export function codePeekLoadState(input: {
   requestKey: string;
   pendingKey: string | null;
   displayedKey: string | null;
   error: string | null;
-}): { isInitialLoad: boolean; isRefreshing: boolean } {
+}): CodePeekLoadState {
   const hasDisplayedResult = input.displayedKey !== null;
   // Effects do not run until after the first paint. Treat a resolvable request
   // as pending immediately so a newly opened peek never flashes an empty body.

--- a/packages/progressive-review/app/src/ReviewCommitsView.tsx
+++ b/packages/progressive-review/app/src/ReviewCommitsView.tsx
@@ -201,11 +201,15 @@ function CommitRow({
   );
 }
 
-export function shapeCommitFiles(files: readonly ReviewDiffFileWire[]): {
+export interface VisibleCommitFiles {
   files: ReviewDiffFileWire[];
   testFilesOmitted: number;
   overflowFilesOmitted: number;
-} {
+}
+
+export function shapeCommitFiles(
+  files: readonly ReviewDiffFileWire[],
+): VisibleCommitFiles {
   const visible = files.filter((file) => !isTestFile(file.path));
   visible.sort(
     (left, right) =>

--- a/packages/progressive-review/app/src/authoring-contract.test.tsx
+++ b/packages/progressive-review/app/src/authoring-contract.test.tsx
@@ -350,13 +350,13 @@ describe("review authoring contract", () => {
   ] as const)(
     "rejects an invalid SequenceDiagram messages[0].%s before actor access",
     (property, invalidValue) => {
-      const message: Record<string, unknown> = {
+      const message = {
         from: actors.browser,
         to: actors.api,
         label: "Request",
         code: "GET /reviews",
+        [property]: invalidValue,
       };
-      message[property] = invalidValue;
 
       let caught: unknown;
       try {

--- a/packages/progressive-review/app/src/bug-report-dialog.test.tsx
+++ b/packages/progressive-review/app/src/bug-report-dialog.test.tsx
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
 
-import type { ReviewCanvasTutorialBridge } from "@dev.fast/review-protocol";
+import {
+  type JsonObject,
+  type ReviewCanvasTutorialBridge,
+  isJsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
 import { act } from "react";
 import { type Root, createRoot } from "react-dom/client";
 import {
@@ -253,12 +258,15 @@ describe("BugReportControl", () => {
     return input;
   }
 
-  function reportBody(): Record<string, unknown> {
+  function reportBody(): JsonObject {
     const call = request.mock.calls.find(([url]) =>
       String(url).includes("/telemetry/bug-report"),
     );
     if (!call) throw new Error("Bug-report request not found");
-    return JSON.parse(String(call[1]?.body)) as Record<string, unknown>;
+    const body = parseJsonText(String(call[1]?.body));
+    if (!isJsonObject(body))
+      throw new Error("Bug-report body is not an object");
+    return body;
   }
 });
 

--- a/packages/progressive-review/app/src/database-lens.tsx
+++ b/packages/progressive-review/app/src/database-lens.tsx
@@ -117,14 +117,16 @@ export interface DatabaseOperationHighlightInput {
   targetKey: string;
 }
 
-export function selectDatabaseOperationHighlights(
-  operations: DatabaseOperationHighlightInput[],
-  requestedAnchor: string | null | undefined,
-): {
+export interface DatabaseOperationHighlights {
   activeAnchor: string | null;
   operationStates: Map<string, DatabaseOperationHighlightState>;
   activeTargetKeys: Set<string>;
-} {
+}
+
+export function selectDatabaseOperationHighlights(
+  operations: DatabaseOperationHighlightInput[],
+  requestedAnchor: string | null | undefined,
+): DatabaseOperationHighlights {
   const activeAnchor =
     requestedAnchor &&
     operations.some((operation) => operation.anchorId === requestedAnchor)
@@ -640,6 +642,11 @@ export function initialDatabaseC4ExpandedNodeIds(
   );
 }
 
+export interface DatabaseC4ExpandedNodeIds {
+  expandedNodeIds: Set<string>;
+  seededDefaultNodeIds: Set<string>;
+}
+
 export function seedDatabaseC4DefaultExpandedNodeIds({
   expandedNodeIds,
   seededDefaultNodeIds,
@@ -648,7 +655,7 @@ export function seedDatabaseC4DefaultExpandedNodeIds({
   expandedNodeIds: ReadonlySet<string>;
   seededDefaultNodeIds: ReadonlySet<string>;
   defaultExpandedNodeIds: ReadonlySet<string>;
-}): { expandedNodeIds: Set<string>; seededDefaultNodeIds: Set<string> } {
+}): DatabaseC4ExpandedNodeIds {
   const nextExpandedNodeIds = new Set(expandedNodeIds);
   const nextSeededDefaultNodeIds = new Set(seededDefaultNodeIds);
   for (const nodeId of defaultExpandedNodeIds) {
@@ -988,10 +995,7 @@ function slugPart(value: string): string {
   return slug || "database";
 }
 
-function validateDatabaseLensProps(props: DatabaseLensProps): {
-  peekInputs: Map<string, ValidatedCodePeekInput>;
-  useCases: ParsedUseCase[];
-} {
+function validateDatabaseLensProps(props: DatabaseLensProps) {
   databaseLensPropsSchema.parse(props);
   const useCases = parseUseCases(props.children);
   if (useCases.length === 0) {
@@ -1177,7 +1181,12 @@ function exampleForField(field: FieldLeaf): unknown {
   return undefined;
 }
 
-function exampleForSchema(schema: FieldSchema): Record<string, unknown> {
+/** Example values keyed by field, nested like the schema they illustrate. */
+interface FieldSchemaExample {
+  [field: string]: FieldLeaf["example"] | FieldSchemaExample;
+}
+
+function exampleForSchema(schema: FieldSchema): FieldSchemaExample {
   return Object.fromEntries(
     Object.entries(schema).map(([key, value]) => [
       key,

--- a/packages/progressive-review/app/src/debug-settings.test.tsx
+++ b/packages/progressive-review/app/src/debug-settings.test.tsx
@@ -1,8 +1,10 @@
 // @vitest-environment jsdom
 
-import type {
-  ReviewSurfaceEvent,
-  ReviewTheme,
+import {
+  type ReviewSurfaceEvent,
+  type ReviewTheme,
+  isJsonObject,
+  parseJsonText,
 } from "@dev.fast/review-protocol";
 import { type ReactNode, act } from "react";
 import { createRoot } from "react-dom/client";
@@ -114,11 +116,12 @@ describe("ReviewDebugSettingsProvider theme", () => {
         container.querySelector("[data-node-tint='mineral']"),
       ).not.toBeNull();
 
-      const persisted = JSON.parse(
+      const persisted = parseJsonText(
         window.localStorage.getItem(
           "progressive-review:debug-settings:theme-test:/review.mdx",
         ) ?? "{}",
-      ) as Record<string, unknown>;
+      );
+      if (!isJsonObject(persisted)) throw new Error("expected settings object");
       expect(persisted.settingsVersion).toBe(3);
       expect(persisted).not.toHaveProperty("theme");
     },

--- a/packages/progressive-review/app/src/document-selection.ts
+++ b/packages/progressive-review/app/src/document-selection.ts
@@ -32,10 +32,15 @@ export const CHIP_GAP = 8;
  * sets `contain: layout`, so raw viewport coords from `getBoundingClientRect`
  * drop the chip on top of the text it belongs to.
  */
+export interface ChipPosition {
+  x: number;
+  y: number;
+}
+
 export function chipPositionClearOf(
   selectionRect: DOMRect,
   containerRect: { left: number; top: number; width: number },
-): { x: number; y: number } {
+): ChipPosition {
   const centerX = selectionRect.left + selectionRect.width / 2;
   const above = selectionRect.top - containerRect.top - CHIP_HEIGHT - CHIP_GAP;
   return {

--- a/packages/progressive-review/app/src/host/review-client.test.ts
+++ b/packages/progressive-review/app/src/host/review-client.test.ts
@@ -139,12 +139,7 @@ describe("review host client", () => {
 // The loader imports the runtime module for the request context, then the
 // rewritten document blob. Route blob imports to the document namespace and
 // everything else to a runtime stub.
-function documentImporter(importDocument: () => Promise<unknown>): {
-  importer: ReviewModuleImporter;
-  setReviewRequestContext: ReturnType<
-    typeof vi.fn<(context: { origin?: string; token?: string }) => void>
-  >;
-} {
+function documentImporter(importDocument: () => Promise<unknown>) {
   const setReviewRequestContext =
     vi.fn<(context: { origin?: string; token?: string }) => void>();
   const importer = vi.fn<ReviewModuleImporter>(async (url) =>

--- a/packages/progressive-review/app/src/review-components.tsx
+++ b/packages/progressive-review/app/src/review-components.tsx
@@ -305,10 +305,7 @@ export function ReviewSection(props: ReviewSectionProps) {
   );
 }
 
-function reviewSectionContent(
-  title: string,
-  children: ReactNode,
-): { heading: ReactElement; body: ReactNode[] } {
+function reviewSectionContent(title: string, children: ReactNode) {
   const childNodes = Children.toArray(children);
   const [firstChild, ...remainingChildren] = childNodes;
   if (isReviewSectionHeading(firstChild)) {
@@ -317,12 +314,15 @@ function reviewSectionContent(
   return { heading: <h2>{title}</h2>, body: childNodes };
 }
 
+/** Props of an authoring block that stands in for a heading element. */
+interface ReviewBlockTagProps {
+  "data-review-block-tag"?: string;
+}
+
 function isReviewSectionHeading(child: ReactNode): child is ReactElement {
-  if (!isValidElement(child)) return false;
+  if (!isValidElement<ReviewBlockTagProps>(child)) return false;
   if (child.type === "h2") return true;
-  return (
-    (child.props as Record<string, unknown>)["data-review-block-tag"] === "h2"
-  );
+  return child.props["data-review-block-tag"] === "h2";
 }
 
 function reviewSectionSummaryLabel(summary: ReviewSectionSummary): string {

--- a/packages/progressive-review/app/src/review-document-surface.tsx
+++ b/packages/progressive-review/app/src/review-document-surface.tsx
@@ -1,13 +1,10 @@
-import {
-  type ComponentProps,
-  type ComponentType,
-  type ReactElement,
-} from "react";
+import { type ComponentProps, type ReactElement } from "react";
 
 import { MarkdownCodeBlock } from "./code-block";
 import { reviewAuthoringComponents } from "./review-authoring-components";
 import { a } from "./review-components";
 import { ReviewDocumentMetaLine } from "./review-doc-meta";
+import type { ReviewDocumentComponent } from "./review-documents-runtime";
 
 export const reviewDocumentComponents = {
   ...reviewAuthoringComponents,
@@ -31,7 +28,7 @@ function ReviewDocumentTitle({
 export function ReviewDocumentContent({
   ReviewDocument,
 }: {
-  ReviewDocument: ComponentType<{ components?: Record<string, unknown> }>;
+  ReviewDocument: ReviewDocumentComponent;
 }): ReactElement {
   return <ReviewDocument components={reviewDocumentComponents} />;
 }

--- a/packages/progressive-review/app/src/review-documents-runtime.ts
+++ b/packages/progressive-review/app/src/review-documents-runtime.ts
@@ -1,7 +1,32 @@
+import type { JsonPrimitive } from "@dev.fast/review-protocol";
+import type { MDXComponents } from "mdx/types";
 import type { ComponentType } from "react";
 
 import type { AnchorRef } from "../../src/authoring";
+import type { SequenceRef } from "./diagrams";
 import type { NormalizedSoftwareModel } from "./software-map/model";
+
+/** The compiled MDX body of a review document. */
+export type ReviewDocumentComponent = ComponentType<{
+  components?: MDXComponents;
+}>;
+
+/**
+ * One export of a compiled review document module. Authors export software
+ * models, sequences and anchors, possibly nested in their own containers, so
+ * exports are walked structurally.
+ */
+export type ReviewDocumentExport =
+  | NormalizedSoftwareModel
+  | SequenceRef
+  | AnchorRef
+  | ReviewDocumentComponent
+  | JsonPrimitive
+  | undefined
+  | readonly ReviewDocumentExport[]
+  | { readonly [name: string]: ReviewDocumentExport };
+
+export type ReviewDocumentModuleExports = Record<string, ReviewDocumentExport>;
 
 export interface ReviewDocumentModuleInput {
   slug: string;
@@ -9,8 +34,8 @@ export interface ReviewDocumentModuleInput {
   filePath: string;
   title: string;
   modelNames: string[];
-  models: Record<string, unknown>;
-  Component: ComponentType<{ components?: Record<string, unknown> }> | null;
+  models: ReviewDocumentModuleExports;
+  Component: ReviewDocumentComponent | null;
   isDefault: boolean;
 }
 
@@ -22,7 +47,7 @@ export interface ReviewDocumentEntry {
   documentSoftwareModels: NormalizedSoftwareModel[];
   anchors: ReadonlyMap<string, AnchorRef>;
   anchorContents: ReadonlyMap<string, string>;
-  Component: ComponentType<{ components?: Record<string, unknown> }>;
+  Component: ReviewDocumentComponent;
   isDefault: boolean;
 }
 
@@ -54,10 +79,7 @@ export function createActiveReviewDocument(
   };
 }
 
-function collectReviewAnchors(models: Record<string, unknown>): {
-  anchors: ReadonlyMap<string, AnchorRef>;
-  anchorContents: ReadonlyMap<string, string>;
-} {
+function collectReviewAnchors(models: ReviewDocumentModuleExports) {
   const anchors = new Map<string, AnchorRef>();
   const anchorContents = new Map<string, string>();
   const visited = new Set<object>();
@@ -100,9 +122,7 @@ function collectReviewAnchors(models: Record<string, unknown>): {
       for (const entry of value) visit(entry);
       return;
     }
-    for (const entry of Object.values(value as Record<string, unknown>)) {
-      visit(entry);
-    }
+    for (const entry of Object.values(value)) visit(entry);
   };
   for (const value of Object.values(models)) visit(value);
   return { anchors, anchorContents };

--- a/packages/progressive-review/app/src/review-initial-data-context.ts
+++ b/packages/progressive-review/app/src/review-initial-data-context.ts
@@ -1,3 +1,4 @@
+import type { JsonObject } from "@dev.fast/review-protocol";
 import { createContext, useContext } from "react";
 
 /**
@@ -17,7 +18,7 @@ export interface SoftwareMapInitialResolvedData {
 }
 
 export interface ReviewInitialData {
-  comments: Record<string, unknown> | null;
+  comments: JsonObject | null;
   sessionResolvedBaseRef: string | null;
   documentMeta: {
     updatedAtMs?: number;

--- a/packages/progressive-review/app/src/software-map/SoftwareMap.tsx
+++ b/packages/progressive-review/app/src/software-map/SoftwareMap.tsx
@@ -20,7 +20,10 @@ import {
   type NodeProps as ReactFlowNodeProps,
   type Viewport,
 } from "@xyflow/react";
-import ELK, { type ElkNode } from "elkjs/lib/elk.bundled.js";
+import ELK, {
+  type ElkNode,
+  type LayoutOptions,
+} from "elkjs/lib/elk.bundled.js";
 import {
   type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
@@ -1220,9 +1223,14 @@ export function toggledSoftwareMapExpandedNodeIds(input: {
   return expandedNodeIds;
 }
 
+export interface SoftwareMapViewportFocusRequest {
+  nodeId: string;
+  requireExpanded: boolean;
+}
+
 export function toggledSoftwareMapViewportFocusRequest(
   node: Pick<SoftwareMapNodeSnapshot, "id" | "expanded">,
-): { nodeId: string; requireExpanded: boolean } {
+): SoftwareMapViewportFocusRequest {
   return {
     nodeId: node.id,
     requireExpanded: !node.expanded,
@@ -1427,10 +1435,8 @@ function SoftwareMapWithModel({
         : "",
     [softwareMapResolvedDataInput],
   );
-  const [viewportFocusRequest, setViewportFocusRequest] = useState<{
-    nodeId: string;
-    requireExpanded: boolean;
-  } | null>(null);
+  const [viewportFocusRequest, setViewportFocusRequest] =
+    useState<SoftwareMapViewportFocusRequest | null>(null);
   // Resolved diff data is applied only once the map is visible after
   // hydration.
   const [resolvedDataState, setResolvedDataState] =
@@ -3192,6 +3198,11 @@ export async function createC4MapFlow(
   return createC4MapFlowFromLayout(snapshot, layout, options);
 }
 
+export interface C4MapFlow {
+  nodes: C4MapAnyFlowNode[];
+  edges: ReactFlowEdge[];
+}
+
 export function createC4MapFlowFromLayout(
   snapshot: SoftwareMapResolvedSnapshot,
   layout: C4LayoutResult,
@@ -3206,7 +3217,7 @@ export function createC4MapFlowFromLayout(
     relationshipStateById?: ReadonlyMap<string, "active" | "inactive">;
     onOpenRelationship?: (relationshipId: string) => void;
   } = {},
-): { nodes: C4MapAnyFlowNode[]; edges: ReactFlowEdge[] } {
+): C4MapFlow {
   const viewName = options.viewName ?? snapshot.view ?? "unresolved";
   const diagram = options.diagram ?? viewName;
   const latestNodesById = new Map(
@@ -5029,7 +5040,7 @@ interface C4ElkPort {
   y?: number;
   width?: number;
   height?: number;
-  properties?: Record<string, unknown>;
+  properties?: LayoutOptions;
 }
 
 interface C4ElkLayoutEdge {
@@ -5918,12 +5929,7 @@ function c4RoutingEndpointRefs(
   edgeId: string,
   layoutNodes: readonly C4LayoutEntry[],
   axis: C4LayoutAxis,
-): {
-  sourcePortId?: string;
-  sourceSide: C4RoutingSide;
-  targetPortId?: string;
-  targetSide: C4RoutingSide;
-} {
+) {
   const entriesById = new Map(
     layoutNodes.map((entry) => [entry.node.id, entry]),
   );
@@ -6041,12 +6047,7 @@ function c4SchemaEndpointRefs(
   relationship: SoftwareMapRelationshipSnapshot,
   edgeId: string,
   layoutNodes: readonly C4LayoutEntry[],
-): {
-  sourcePortId?: string;
-  sourceSide: C4SchemaSide;
-  targetPortId?: string;
-  targetSide: C4SchemaSide;
-} {
+) {
   const entriesById = new Map(
     layoutNodes.map((entry) => [entry.node.id, entry]),
   );
@@ -6456,9 +6457,7 @@ export function softwareMapLiveDiagram(
   return { label, elements };
 }
 
-export function softwareMapNodeTargetPayload(
-  node: SoftwareMapNodeSnapshot,
-): unknown {
+export function softwareMapNodeTargetPayload(node: SoftwareMapNodeSnapshot) {
   return {
     label: node.label,
     type: node.type,
@@ -6479,7 +6478,7 @@ export function softwareMapNodeTargetPayload(
 
 export function softwareMapRelationshipTargetPayload(
   relationship: SoftwareMapRelationshipSnapshot,
-): unknown {
+) {
   return {
     label: relationship.label,
     kind: relationship.kind,
@@ -7204,14 +7203,7 @@ export function SoftwareMapDataStoreOutline({
   );
 }
 
-function softwareMapDataStoreOutlineGeometry(
-  shape: SoftwareMapDataStoreShape,
-): {
-  fillPath: string;
-  fillDetailPath?: string;
-  outlinePath: string;
-  detailPaths: string[];
-} {
+function softwareMapDataStoreOutlineGeometry(shape: SoftwareMapDataStoreShape) {
   if (shape === "bucket") {
     return {
       fillPath: "M18 24 C18 12 262 12 262 24 L238 118 C236 130 44 130 42 118 Z",

--- a/packages/progressive-review/app/src/software-map/c4-projection.ts
+++ b/packages/progressive-review/app/src/software-map/c4-projection.ts
@@ -432,9 +432,16 @@ function exampleForDataStoreField(field: SoftwareDataStoreFieldLeaf): unknown {
   return undefined;
 }
 
+/** Example values keyed by field, nested like the schema they illustrate. */
+interface DataStoreSchemaExample {
+  [field: string]:
+    | SoftwareDataStoreFieldLeaf["example"]
+    | DataStoreSchemaExample;
+}
+
 function exampleForDataStoreSchema(
   schema: SoftwareDataStoreFieldSchema,
-): Record<string, unknown> {
+): DataStoreSchemaExample {
   return Object.fromEntries(
     Object.entries(schema).map(([key, value]) => [
       key,

--- a/packages/progressive-review/app/src/target-fingerprint.ts
+++ b/packages/progressive-review/app/src/target-fingerprint.ts
@@ -223,11 +223,15 @@ export function buildSelection(
   return { start, length, hash: stableHash(quote), quote };
 }
 
-export function resolvedCodeSurface(resolution: CodePeekResolution): {
+export interface ResolvedCodeSurface {
   text: string;
   file: string;
   fromLine: number;
-} {
+}
+
+export function resolvedCodeSurface(
+  resolution: CodePeekResolution,
+): ResolvedCodeSurface {
   const root = resolution.snapshot.roots[0];
   const resolved = root
     ? resolution.snapshot.resolved[root.sourceId]
@@ -338,10 +342,10 @@ function stableSerialize(value: unknown): string {
   if (Array.isArray(value)) {
     return `[${value.map(stableSerialize).join(",")}]`;
   }
-  const record = value as Record<string, unknown>;
-  return `{${Object.keys(record)
-    .filter((key) => record[key] !== undefined)
-    .sort()
-    .map((key) => `${JSON.stringify(key)}:${stableSerialize(record[key])}`)
+  const fields: [string, unknown][] = Object.entries(value);
+  return `{${fields
+    .filter(([, field]) => field !== undefined)
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([key, field]) => `${JSON.stringify(key)}:${stableSerialize(field)}`)
     .join(",")}}`;
 }

--- a/packages/progressive-review/app/src/thread-annotations.tsx
+++ b/packages/progressive-review/app/src/thread-annotations.tsx
@@ -851,7 +851,7 @@ function targetStateMapsEqual(
 function draftPopoverPlacement(
   popoverHost: HTMLElement,
   draftTarget: CommentDraftTarget,
-): { x: number; y: number } {
+) {
   const hostRect = popoverHost.getBoundingClientRect();
   const viewportX = clamp(
     draftTarget.placement?.x ?? hostRect.left + hostRect.width / 2,
@@ -1044,10 +1044,7 @@ export function textNodeClientRects(
   return selectedTextGeometry(range, root).rects;
 }
 
-function selectedTextGeometry(
-  range: Range,
-  root: HTMLElement,
-): { blocks: Set<HTMLElement>; rects: DOMRect[] } {
+function selectedTextGeometry(range: Range, root: HTMLElement) {
   const blocks = new Set<HTMLElement>();
   const rects: DOMRect[] = [];
   const walker = root.ownerDocument.createTreeWalker(

--- a/packages/progressive-review/app/src/trace-ruler.tsx
+++ b/packages/progressive-review/app/src/trace-ruler.tsx
@@ -39,11 +39,16 @@ export function rulerTickCount(height: number, eventCount: number): number {
 }
 
 /** Half-open event range [start, end) represented by one tick. */
+export interface RulerBucketRange {
+  start: number;
+  end: number;
+}
+
 export function rulerBucketRange(
   tick: number,
   tickCount: number,
   eventCount: number,
-): { start: number; end: number } {
+): RulerBucketRange {
   const start = Math.floor((tick * eventCount) / tickCount);
   const end = Math.max(
     start + 1,

--- a/packages/progressive-review/app/src/tutorial-section-context.tsx
+++ b/packages/progressive-review/app/src/tutorial-section-context.tsx
@@ -16,9 +16,11 @@ export const TutorialSectionProvider = TutorialSectionContext.Provider;
  * The tutorial chapter state of a document section. Outside the tutorial (no
  * provider) every section gets null.
  */
-export function useTutorialSection(title: string): {
+export interface TutorialSection {
   state: TutorialChapterState | null;
-} {
+}
+
+export function useTutorialSection(title: string): TutorialSection {
   const value = useContext(TutorialSectionContext);
   return { state: value?.chapterStates.get(title) ?? null };
 }

--- a/packages/progressive-review/app/src/ui-telemetry.ts
+++ b/packages/progressive-review/app/src/ui-telemetry.ts
@@ -10,9 +10,7 @@ type UiTelemetryProperties = Record<string, UiTelemetryPropertyValue>;
 
 let appOpenedSent = false;
 
-export function reviewAppTelemetryHeaders(
-  session: ReviewSession,
-): Record<string, string> {
+export function reviewAppTelemetryHeaders(session: ReviewSession) {
   return { [REVIEW_APP_SESSION_ID_HEADER]: session.appSessionId };
 }
 
@@ -73,11 +71,14 @@ export function captureClientError(
   );
 }
 
-function packClientError(error: unknown): {
+/** The raw error envelope sent beside the event, as the server reads it. */
+interface PackedClientError {
   name?: string;
   message?: string;
   stack?: string;
-} {
+}
+
+function packClientError(error: unknown): PackedClientError {
   if (!(error instanceof Error)) return { message: String(error) };
   return {
     name: error.name,

--- a/packages/progressive-review/package.json
+++ b/packages/progressive-review/package.json
@@ -106,6 +106,7 @@
     "@types/estree": "1.0.8",
     "@types/hast": "3.0.4",
     "@types/mdast": "4.0.4",
+    "@types/mdx": "2.0.14",
     "@types/node": "24.12.2",
     "@types/react-dom": "19.2.3",
     "@types/semver": "7.7.1",

--- a/packages/progressive-review/src/agent-fff.ts
+++ b/packages/progressive-review/src/agent-fff.ts
@@ -4,9 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
-import type {
-  ReviewFffInstallTarget,
-  ReviewFffManagedRegistration,
+import {
+  type JsonValue,
+  type ReviewFffInstallTarget,
+  type ReviewFffManagedRegistration,
+  isJsonArray,
+  isJsonObject,
+  parseJsonText,
 } from "@dev.fast/review-protocol";
 
 import { isFile } from "./fs-utils";
@@ -155,7 +159,7 @@ export function fffRegistrationMatches(
 
   if (registration.target === "codex") {
     try {
-      const config = findStdioConfig(JSON.parse(output));
+      const config = findStdioConfig(parseJsonText(output));
       return (
         config?.command === binaryPath &&
         config.args.length === 1 &&
@@ -221,18 +225,18 @@ function fffTargetLabel(target: ReviewFffInstallTarget): string {
 }
 
 function findStdioConfig(
-  value: unknown,
+  value: JsonValue,
 ): { command: string; args: string[] } | null {
-  if (!value || typeof value !== "object") return null;
-  const record = value as Record<string, unknown>;
+  if (!isJsonObject(value)) return null;
+  const { command, args } = value;
   if (
-    typeof record.command === "string" &&
-    Array.isArray(record.args) &&
-    record.args.every((arg) => typeof arg === "string")
+    typeof command === "string" &&
+    isJsonArray(args) &&
+    args.every((arg): arg is string => typeof arg === "string")
   ) {
-    return { command: record.command, args: record.args as string[] };
+    return { command, args };
   }
-  for (const child of Object.values(record)) {
+  for (const child of Object.values(value)) {
     const found = findStdioConfig(child);
     if (found) return found;
   }

--- a/packages/progressive-review/src/agent-trace-hooks.ts
+++ b/packages/progressive-review/src/agent-trace-hooks.ts
@@ -3,6 +3,14 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import {
+  type JsonObject,
+  type JsonValue,
+  isJsonArray,
+  isJsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
 export interface AgentTraceHookInstallResult {
   agent: "claude" | "codex" | "pi";
   path: string;
@@ -82,17 +90,17 @@ export async function installClaudeTraceHook(
   const settingsDir = path.join(homeDir, ".claude");
   const settingsPath = path.join(settingsDir, "settings.json");
 
-  let parsed: Record<string, unknown> = {};
+  let parsed: JsonObject = {};
   if (existsSync(settingsPath)) {
     try {
-      const content = await readFile(settingsPath, "utf8");
-      parsed = JSON.parse(content);
+      const content = parseJsonText(await readFile(settingsPath, "utf8"));
+      if (isJsonObject(content)) parsed = content;
     } catch {
       parsed = {};
     }
   }
 
-  const hooks = (parsed.hooks as Record<string, unknown>) ?? {};
+  const hooks: JsonObject = isJsonObject(parsed.hooks) ? parsed.hooks : {};
   let modified = false;
 
   const hookCommand = (
@@ -107,12 +115,15 @@ export async function installClaudeTraceHook(
     "UserPromptSubmit",
     "SessionEnd",
   ] as const) {
-    const existingGroup = (hooks[eventName] as unknown[]) ?? [];
+    const existing = hooks[eventName];
+    const existingGroup: JsonValue[] = isJsonArray(existing) ? existing : [];
     const hasHook = existingGroup.some((entry) => {
-      if (typeof entry !== "object" || !entry) return false;
-      const subHooks = (entry as { hooks?: Array<{ command?: string }> }).hooks;
-      if (Array.isArray(subHooks)) {
-        return subHooks.some((h) => isReviewTraceHookCommand(h.command));
+      if (!isJsonObject(entry)) return false;
+      const subHooks = entry.hooks;
+      if (isJsonArray(subHooks)) {
+        return subHooks.some(
+          (h) => isJsonObject(h) && isReviewTraceHookCommand(h.command),
+        );
       }
       return false;
     });
@@ -219,38 +230,33 @@ export async function removeAgentTraceHook(
   if (agent === "claude") {
     const settingsPath = path.join(homeDir, ".claude", "settings.json");
     if (!existsSync(settingsPath)) return false;
-    let parsed: Record<string, unknown>;
+    let parsed: JsonValue;
     try {
-      parsed = JSON.parse(await readFile(settingsPath, "utf8")) as Record<
-        string,
-        unknown
-      >;
+      parsed = parseJsonText(await readFile(settingsPath, "utf8"));
     } catch {
       return false;
     }
-    const hooks = parsed.hooks as Record<string, unknown> | undefined;
-    if (!hooks) return false;
+    if (!isJsonObject(parsed)) return false;
+    const hooks = parsed.hooks;
+    if (!isJsonObject(hooks)) return false;
     let changed = false;
     for (const eventName of [
       "SessionStart",
       "UserPromptSubmit",
       "SessionEnd",
     ] as const) {
-      const groups = Array.isArray(hooks[eventName]) ? hooks[eventName] : [];
-      const keptGroups = groups.flatMap((group) => {
-        if (!group || typeof group !== "object") return [group];
-        const record = group as Record<string, unknown>;
-        if (!Array.isArray(record.hooks)) return [group];
-        const keptHooks = record.hooks.filter((hook) => {
-          const command =
-            hook && typeof hook === "object"
-              ? (hook as { command?: unknown }).command
-              : undefined;
+      const existing = hooks[eventName];
+      const groups: JsonValue[] = isJsonArray(existing) ? existing : [];
+      const keptGroups = groups.flatMap((group): JsonValue[] => {
+        if (!isJsonObject(group)) return [group];
+        if (!isJsonArray(group.hooks)) return [group];
+        const keptHooks = group.hooks.filter((hook) => {
+          const command = isJsonObject(hook) ? hook.command : undefined;
           const owned = isReviewTraceHookCommand(command);
           if (owned) changed = true;
           return !owned;
         });
-        return keptHooks.length > 0 ? [{ ...record, hooks: keptHooks }] : [];
+        return keptHooks.length > 0 ? [{ ...group, hooks: keptHooks }] : [];
       });
       if (keptGroups.length > 0) hooks[eventName] = keptGroups;
       else delete hooks[eventName];

--- a/packages/progressive-review/src/agent-trace-parser.ts
+++ b/packages/progressive-review/src/agent-trace-parser.ts
@@ -1,8 +1,10 @@
 import path from "node:path";
 
-import type {
-  ReviewAgentTraceEvent,
-  ReviewAgentTraceSession,
+import {
+  type JsonObject,
+  type ReviewAgentTraceEvent,
+  type ReviewAgentTraceSession,
+  isJsonObject,
 } from "@dev.fast/review-protocol";
 
 export const AGENT_TRACE_PARSER_VERSION = "1";
@@ -249,7 +251,7 @@ function claudeToolEvent(
   cwd: string | null,
 ): AgentTraceToolEvent {
   const name = block.name ?? "tool";
-  const input = (block.input ?? {}) as Record<string, unknown>;
+  const input: JsonObject = isJsonObject(block.input) ? block.input : {};
   const event: AgentTraceToolEvent = {
     kind: "tool",
     tool: name,
@@ -257,8 +259,10 @@ function claudeToolEvent(
     title: name,
     at,
   };
-  const inputText = (key: string): string | null =>
-    typeof input[key] === "string" ? (input[key] as string) : null;
+  const inputText = (key: string): string | null => {
+    const value = input[key];
+    return typeof value === "string" ? value : null;
+  };
   const filePath =
     inputText("file_path") ?? inputText("path") ?? inputText("notebook_path");
   switch (name) {
@@ -525,15 +529,7 @@ function codexText(payload: CodexPayload): string {
     .trim();
 }
 
-function codexPatchSummary(
-  patch: string,
-  cwd: string | null,
-): {
-  filePath?: string;
-  additions: number;
-  deletions: number;
-  files: string[];
-} {
+function codexPatchSummary(patch: string, cwd: string | null) {
   const files: string[] = [];
   let additions = 0;
   let deletions = 0;
@@ -553,10 +549,7 @@ function codexPatchSummary(
 const CODE_MODE_FILE_PATTERN =
   /\*\*\* (?:Add|Update|Delete) File: ([^\n\\"`]+)/g;
 
-function unifiedDiffCounts(diff: string): {
-  additions: number;
-  deletions: number;
-} {
+function unifiedDiffCounts(diff: string) {
   let additions = 0;
   let deletions = 0;
   for (const line of diff.split("\n")) {
@@ -995,7 +988,7 @@ interface PiContentBlock {
   thinking?: string;
   id?: string;
   name?: string;
-  arguments?: Record<string, unknown>;
+  arguments?: JsonObject;
 }
 
 interface PiRecord {
@@ -1024,9 +1017,11 @@ function piToolEvent(
   cwd: string | null,
 ): AgentTraceToolEvent {
   const name = block.name ?? "tool";
-  const args = block.arguments ?? {};
-  const argText = (key: string): string | null =>
-    typeof args[key] === "string" ? (args[key] as string) : null;
+  const args: JsonObject = block.arguments ?? {};
+  const argText = (key: string): string | null => {
+    const value = args[key];
+    return typeof value === "string" ? value : null;
+  };
   const event: AgentTraceToolEvent = {
     kind: "tool",
     tool: name,

--- a/packages/progressive-review/src/authoring.ts
+++ b/packages/progressive-review/src/authoring.ts
@@ -459,12 +459,10 @@ export const callStackEntrySchema = z.union([
 ]);
 export type CallStackEntry = z.infer<typeof callStackEntrySchema>;
 
-export function isCallsAssertion(value: unknown): value is CallsAssertion {
-  return (
-    Boolean(value) &&
-    typeof value === "object" &&
-    (value as { __kind?: unknown }).__kind === "call-assertion"
-  );
+export function isCallsAssertion(
+  value: CallStackEntry,
+): value is CallsAssertion {
+  return value.__kind === "call-assertion";
 }
 
 // The frame a call-stack entry renders: the anchor itself, or the child of
@@ -650,19 +648,19 @@ export type CollectionRefs<T> =
     : never;
 
 type FieldRefs<T> = T extends SoftwareDataStoreFieldLeaf
-  ? T extends { schema: infer Schema extends Record<string, unknown> }
+  ? T extends { schema: infer Schema extends SoftwareDataStoreFieldSchema }
     ? AuthoredTargetRef & FieldRefs<Schema>
     : AuthoredTargetRef
-  : T extends Record<string, unknown>
+  : T extends SoftwareDataStoreFieldSchema
     ? {
         [K in keyof T]: AuthoredTargetRef &
           (T[K] extends SoftwareDataStoreFieldLeaf
             ? T[K] extends {
-                schema: infer Schema extends Record<string, unknown>;
+                schema: infer Schema extends SoftwareDataStoreFieldSchema;
               }
               ? FieldRefs<Schema>
               : unknown
-            : T[K] extends Record<string, unknown>
+            : T[K] extends SoftwareDataStoreFieldSchema
               ? FieldRefs<T[K]>
               : unknown);
       }
@@ -1042,8 +1040,9 @@ function defineCollections(
         path: [],
       };
       const fields = defineFieldTargets(target, collection.schema, []);
-      const authored = Object.assign({}, fields) as CollectionRef &
-        Record<PropertyKey, unknown>;
+      // SAFETY: the handle's symbol-keyed target and schema are defined on
+      // the next statement, before the collection ref escapes.
+      const authored = Object.assign({}, fields) as CollectionRef;
       Object.defineProperties(authored, {
         [authoredTargetRefKey]: { value: Object.freeze(target) },
         [collectionSchemaKey]: { value: collection.schema },
@@ -1075,10 +1074,12 @@ function defineFieldTargets(
         path,
       };
       const nestedSchema = isNestedSchema(value) ? value : value.schema;
+      // SAFETY: the symbol-keyed target is defined on the next statement,
+      // before the field ref escapes.
       const authored = Object.assign(
         {},
         nestedSchema ? defineFieldTargets(collection, nestedSchema, path) : {},
-      ) as AuthoredTargetRef & Record<PropertyKey, unknown>;
+      ) as AuthoredTargetRef & Record<string, AuthoredTargetRef>;
       Object.defineProperty(authored, authoredTargetRefKey, {
         value: Object.freeze(target),
       });

--- a/packages/progressive-review/src/cli-output.ts
+++ b/packages/progressive-review/src/cli-output.ts
@@ -33,10 +33,15 @@ export function humanStream(output: CliJsonOutput): Writable {
   return output.json ? output.stderr : output.stdout;
 }
 
+/** Every JSON event names itself; commands add their own fields. */
+export interface CliJsonEvent {
+  event: string;
+}
+
 /** Writes one event line, and only under --json. */
-export function emitJsonEvent(
+export function emitJsonEvent<T extends CliJsonEvent>(
   output: CliJsonOutput,
-  event: Record<string, unknown>,
+  event: T,
 ): void {
   if (output.json) output.stdout.write(`${JSON.stringify(event)}\n`);
 }

--- a/packages/progressive-review/src/cli-runner.ts
+++ b/packages/progressive-review/src/cli-runner.ts
@@ -163,6 +163,13 @@ interface ReviewCodexWaitOptions {
 
 type OutputSurface = ProgressiveReviewCommand | "plain";
 
+interface CliRunState {
+  exitCode: number;
+  parseSurface: OutputSurface;
+  parserErrorOutput: string;
+  json: boolean;
+}
+
 export async function runProgressiveReviewCli(
   input: ProgressiveReviewCliInput,
 ): Promise<number> {
@@ -172,12 +179,7 @@ export async function runProgressiveReviewCli(
     input.cliVersion ?? readProgressiveReviewPackageVersion(import.meta.url);
   const runtime = progressiveReviewCliRuntime(input.runtime);
   const telemetry = input.telemetry ?? ProgressiveReviewTelemetry.fromEnv(env);
-  const state: {
-    exitCode: number;
-    parseSurface: OutputSurface;
-    parserErrorOutput: string;
-    json: boolean;
-  } = {
+  const state: CliRunState = {
     exitCode: 0,
     parseSurface: "review",
     parserErrorOutput: "",
@@ -1393,7 +1395,7 @@ function progressiveReviewMapHelp(): string {
 function mapCommandProperties(
   mapArgs: readonly string[],
   parsed: ReturnType<typeof parseSoftwareMapCliArgs>,
-): Record<string, boolean | string> {
+) {
   const metadata = parsed.ok
     ? mapTelemetryMetadata(parsed.command, parsed.force, parsed.diffRefs)
     : mapTelemetryMetadata("check", false, {});
@@ -1589,13 +1591,15 @@ function telemetryCommandPath(
   return undefined;
 }
 
+interface ErrorClassification {
+  errorName: ProgressiveReviewTelemetryErrorName;
+  errorCategory: ProgressiveReviewTelemetryErrorCategory;
+}
+
 function errorClassification(
   command: ProgressiveReviewCommandPath,
   error: unknown,
-): {
-  errorName: ProgressiveReviewTelemetryErrorName;
-  errorCategory: ProgressiveReviewTelemetryErrorCategory;
-} {
+): ErrorClassification {
   if (error instanceof CommanderError || command === "invalid") {
     return { errorName: "usage_error", errorCategory: "user_input" };
   }

--- a/packages/progressive-review/src/cli.test.ts
+++ b/packages/progressive-review/src/cli.test.ts
@@ -15,7 +15,10 @@ import { describe, expect, it, vi } from "vitest";
 import { runProgressiveReviewCli } from "./cli-runner";
 import { runInstall as runInstallActual } from "./install";
 import { runReviewMigration as runReviewMigrationActual } from "./migrate";
-import { PostHogCaptureClient } from "./posthog-capture-client";
+import {
+  PostHogCaptureClient,
+  type PostHogCaptureProperties,
+} from "./posthog-capture-client";
 import {
   type ProgressiveReviewCommandTelemetry,
   ProgressiveReviewTelemetry,
@@ -451,7 +454,7 @@ describe("Review CLI", () => {
         ([, init]) =>
           JSON.parse(String(init?.body)).batch as Array<{
             event: string;
-            properties: Record<string, unknown>;
+            properties: PostHogCaptureProperties;
           }>,
       );
       const lifecycle = sent.filter((event) =>

--- a/packages/progressive-review/src/codex-thread-wakeup.test.ts
+++ b/packages/progressive-review/src/codex-thread-wakeup.test.ts
@@ -3,6 +3,11 @@ import { type Socket, createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import {
+  type JsonObject,
+  isJsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
 import { afterEach, describe, expect, test } from "vitest";
 
 import {
@@ -23,7 +28,7 @@ afterEach(async () => {
 describe("Codex thread wake-up", () => {
   test("routes a text follow-up to the desktop task owner", async () => {
     const fixture = await ipcFixture();
-    const received: JsonRecord[] = [];
+    const received: JsonObject[] = [];
     fixture.server.on("connection", (socket) => {
       readFrames(socket, (message) => {
         received.push(message);
@@ -148,8 +153,6 @@ describe("Codex thread wake-up", () => {
   });
 });
 
-type JsonRecord = Record<string, unknown>;
-
 async function ipcFixture() {
   const root = await mkdtemp(join(tmpdir(), "dev-fast-codex-ipc-test-"));
   roots.push(root);
@@ -173,7 +176,7 @@ async function ipcFixture() {
 
 function readFrames(
   socket: Socket,
-  onMessage: (message: JsonRecord) => void,
+  onMessage: (message: JsonObject) => void,
 ): void {
   let buffered = Buffer.alloc(0);
   socket.on("data", (chunk: Buffer) => {
@@ -183,12 +186,14 @@ function readFrames(
       if (buffered.length < bodyBytes + 4) return;
       const body = buffered.subarray(4, bodyBytes + 4);
       buffered = buffered.subarray(bodyBytes + 4);
-      onMessage(JSON.parse(body.toString("utf8")) as JsonRecord);
+      const message = parseJsonText(body.toString("utf8"));
+      if (!isJsonObject(message)) throw new Error("frame is not an object");
+      onMessage(message);
     }
   });
 }
 
-function writeFrame(socket: Socket, message: JsonRecord): void {
+function writeFrame(socket: Socket, message: JsonObject): void {
   const json = JSON.stringify(message);
   const frame = Buffer.alloc(4 + Buffer.byteLength(json));
   frame.writeUInt32LE(Buffer.byteLength(json), 0);

--- a/packages/progressive-review/src/codex-thread-wakeup.ts
+++ b/packages/progressive-review/src/codex-thread-wakeup.ts
@@ -5,6 +5,12 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import {
+  type JsonObject,
+  isJsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
+import {
   type ReviewCodexWaitRegistration,
   registerReviewCodexWait,
 } from "./review-codex-wait-state";
@@ -16,8 +22,6 @@ const WAKE_RETRY_INTERVAL_MS = 2_000;
 const WAKE_RETRY_TIMEOUT_MS = 60_000;
 const CODEX_START_TURN_METHOD = "thread-follower-start-turn";
 const CODEX_START_TURN_VERSION = 1;
-
-type JsonRecord = Record<string, unknown>;
 
 // Deliberately duplicated from packages/cli/src/commands/codex-thread-wakeup.ts.
 export type CodexWaitProcessInput = {
@@ -228,18 +232,20 @@ function connectSocket(socketPath: string): Promise<Socket> {
   });
 }
 
-function framedMessages(socket: Socket): {
+interface FramedMessages {
   dispose(): void;
-  waitForResponse(requestId: string): Promise<JsonRecord>;
-} {
+  waitForResponse(requestId: string): Promise<JsonObject>;
+}
+
+function framedMessages(socket: Socket): FramedMessages {
   let buffered = Buffer.alloc(0);
   let failed: Error | undefined;
-  const queued: JsonRecord[] = [];
+  const queued: JsonObject[] = [];
   const waiters = new Map<
     string,
     {
       reject(error: Error): void;
-      resolve(message: JsonRecord): void;
+      resolve(message: JsonObject): void;
       timer: NodeJS.Timeout;
     }
   >();
@@ -254,7 +260,7 @@ function framedMessages(socket: Socket): {
     waiters.clear();
   };
 
-  const dispatch = (message: JsonRecord): void => {
+  const dispatch = (message: JsonObject): void => {
     const requestId =
       typeof message.requestId === "string" ? message.requestId : undefined;
     if (requestId === undefined) {
@@ -288,8 +294,8 @@ function framedMessages(socket: Socket): {
       const frame = buffered.subarray(IPC_FRAME_HEADER_BYTES, totalBytes);
       buffered = buffered.subarray(totalBytes);
       try {
-        const parsed = JSON.parse(frame.toString("utf8")) as unknown;
-        if (!isRecord(parsed)) {
+        const parsed = parseJsonText(frame.toString("utf8"));
+        if (!isJsonObject(parsed)) {
           throw new TypeError("frame is not an object");
         }
         dispatch(parsed);
@@ -329,7 +335,7 @@ function framedMessages(socket: Socket): {
       if (queuedIndex >= 0) {
         return queued.splice(queuedIndex, 1)[0]!;
       }
-      return await new Promise<JsonRecord>((resolve, reject) => {
+      return await new Promise<JsonObject>((resolve, reject) => {
         const timer = setTimeout(() => {
           waiters.delete(requestId);
           reject(
@@ -345,7 +351,7 @@ function framedMessages(socket: Socket): {
   };
 }
 
-function writeFrame(socket: Socket, message: JsonRecord): void {
+function writeFrame(socket: Socket, message: JsonObject): void {
   const json = JSON.stringify(message);
   const bodyBytes = Buffer.byteLength(json, "utf8");
   const frame = Buffer.allocUnsafe(IPC_FRAME_HEADER_BYTES + bodyBytes);
@@ -354,12 +360,12 @@ function writeFrame(socket: Socket, message: JsonRecord): void {
   socket.write(frame);
 }
 
-function initializedClientId(message: JsonRecord): string {
+function initializedClientId(message: JsonObject): string {
   if (message.resultType !== "success" || message.method !== "initialize") {
     throw responseError("initialize", message);
   }
   const result = message.result;
-  if (!isRecord(result) || typeof result.clientId !== "string") {
+  if (!isJsonObject(result) || typeof result.clientId !== "string") {
     throw new CodexIpcProtocolError(
       "Codex IPC returned a malformed initialize response.",
     );
@@ -367,7 +373,7 @@ function initializedClientId(message: JsonRecord): string {
   return result.clientId;
 }
 
-function assertSuccessfulWake(message: JsonRecord): void {
+function assertSuccessfulWake(message: JsonObject): void {
   if (
     message.resultType !== "success" ||
     message.method !== CODEX_START_TURN_METHOD
@@ -376,13 +382,9 @@ function assertSuccessfulWake(message: JsonRecord): void {
   }
 }
 
-function responseError(method: string, message: JsonRecord): Error {
+function responseError(method: string, message: JsonObject): Error {
   const detail = typeof message.error === "string" ? `: ${message.error}` : "";
   return new CodexIpcProtocolError(
     `Codex IPC request "${method}" failed${detail}.`,
   );
-}
-
-function isRecord(value: unknown): value is JsonRecord {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/progressive-review/src/compiler/review-document-compiler.ts
+++ b/packages/progressive-review/src/compiler/review-document-compiler.ts
@@ -119,8 +119,20 @@ function sanitizeDiagnosticSource(source: string): string {
     .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "�");
 }
 
-interface EstreeNode extends Record<string, unknown> {
+// ESTree property values: child nodes, lists of children, or literal scalars.
+type EstreeValue =
+  | EstreeNode
+  | EstreeValue[]
+  | string
+  | number
+  | boolean
+  | bigint
+  | null
+  | undefined;
+
+interface EstreeNode {
   type?: string;
+  [property: string]: EstreeValue;
 }
 
 interface GeneratedMdxRegion {
@@ -564,7 +576,7 @@ function checkAuthoredTypescript(
   });
 }
 
-function reviewReactTypePaths(): Record<string, string[]> {
+function reviewReactTypePaths() {
   const reactTypesRoot = path.dirname(
     require.resolve("@types/react/package.json"),
   );
@@ -851,7 +863,7 @@ function eraseTypescriptRecma() {
   };
 }
 
-function eraseTypescriptNode(value: unknown): unknown {
+function eraseTypescriptNode(value: EstreeValue): EstreeValue {
   if (!value || typeof value !== "object") return value;
   if (Array.isArray(value)) {
     return value
@@ -859,7 +871,7 @@ function eraseTypescriptNode(value: unknown): unknown {
       .filter((entry) => entry !== null);
   }
 
-  const node = value as EstreeNode;
+  const node = value;
   if (
     node.type === "TSSatisfiesExpression" ||
     node.type === "TSAsExpression" ||

--- a/packages/progressive-review/src/compiler/review-documents-module.ts
+++ b/packages/progressive-review/src/compiler/review-documents-module.ts
@@ -41,10 +41,20 @@ interface ReviewDocumentScanFingerprint {
   reviewDocuments: ReviewDocumentScanFingerprintEntry[];
 }
 
-interface ReviewDocumentScanAsyncResult {
+interface ReviewDocumentScanResult {
   manifests: ReviewDocumentModuleManifest[];
   softwareMapPaths: string[];
   sourceRoots: string[];
+}
+
+interface ReviewDocumentSoftwareMapPaths {
+  headSoftwareMapPath: string | null;
+  baseSoftwareMapPath: string | null;
+}
+
+interface ReviewDocumentSourceMetadata {
+  title: string;
+  modelNames: string[];
 }
 
 interface ReviewDocumentScanInput {
@@ -64,7 +74,7 @@ export function collectReviewDocumentScanForRuntime(input: {
   reviewPath: string;
   reviewDocumentsDir: string;
   reviewRootPath: string;
-}): Promise<ReviewDocumentScanAsyncResult> {
+}): Promise<ReviewDocumentScanResult> {
   return collectReviewDocumentScanForRuntimeInner(input);
 }
 
@@ -72,7 +82,7 @@ async function collectReviewDocumentScanForRuntimeInner(input: {
   reviewPath: string;
   reviewDocumentsDir: string;
   reviewRootPath: string;
-}): Promise<ReviewDocumentScanAsyncResult> {
+}): Promise<ReviewDocumentScanResult> {
   const normalized = normalizeReviewDocumentScanInput(input);
   const fingerprint = collectReviewDocumentScanFingerprint(normalized);
   const discoveredDocuments = collectReviewDocumentDirectoryDocuments(
@@ -216,10 +226,7 @@ async function resolveReviewDocumentRefs(
 
 function reviewDocumentModuleManifestFromMetadata(
   document: ReviewDocumentInputWithMeta,
-  metadata: {
-    title: string;
-    modelNames: string[];
-  },
+  metadata: ReviewDocumentSourceMetadata,
 ): ReviewDocumentModuleManifest {
   return {
     slug: document.slug,
@@ -244,10 +251,7 @@ async function reviewDocumentSoftwareMapPathsAsyncInner(input: {
   repoRoot: string;
   headRef: string | null;
   baseRef: string | null;
-}): Promise<{
-  headSoftwareMapPath: string | null;
-  baseSoftwareMapPath: string | null;
-}> {
+}): Promise<ReviewDocumentSoftwareMapPaths> {
   const repoRootPath = input.repoRoot;
   // Both roles are strict note reads: an unpinned head resolves to the
   // working copy's commit (the caller passed it as headRef) and reads that
@@ -392,10 +396,7 @@ function reviewDocumentTitleFromSource(
 function reviewDocumentSourceMetadata(
   filePath: string,
   fallback: string,
-): {
-  title: string;
-  modelNames: string[];
-} {
+): ReviewDocumentSourceMetadata {
   try {
     const source = readFileSync(filePath, "utf8");
     return {

--- a/packages/progressive-review/src/error-telemetry.ts
+++ b/packages/progressive-review/src/error-telemetry.ts
@@ -17,6 +17,8 @@
 
 import { createHash } from "node:crypto";
 
+import type { JsonObject } from "@dev.fast/review-protocol";
+
 import { cleanTelemetryText } from "./telemetry-clean-text";
 import {
   BUNDLE_FRAME_PATTERN,
@@ -128,14 +130,13 @@ const SERVER_DERIVED_PROPERTIES = [
  * adding the real ones.
  */
 export function mergeErrorTelemetryProperties(
-  clientProperties: Record<string, unknown>,
+  clientProperties: JsonObject,
   rawError: unknown,
-): Record<string, unknown> {
-  const merged: Record<string, unknown> = { ...clientProperties };
+): JsonObject {
+  const merged = { ...clientProperties };
   for (const key of SERVER_DERIVED_PROPERTIES) delete merged[key];
-  return rawError
-    ? { ...merged, ...deriveErrorTelemetryProperties(rawError) }
-    : merged;
+  if (rawError) Object.assign(merged, deriveErrorTelemetryProperties(rawError));
+  return merged;
 }
 
 /**

--- a/packages/progressive-review/src/migrate.ts
+++ b/packages/progressive-review/src/migrate.ts
@@ -15,6 +15,12 @@ import path from "node:path";
 import type { Writable } from "node:stream";
 import { promisify } from "node:util";
 
+import {
+  type JsonObject,
+  isJsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
 import { emitJsonEvent, humanStream } from "./cli-output";
 import { errorMessage } from "./error-message";
 import { defaultPackageRoot } from "./install";
@@ -470,13 +476,13 @@ export async function removeLegacyDesktopCatalog(input: {
       result.blockers.push(`${filePath} has an unknown catalog file name.`);
       continue;
     }
-    let record: Record<string, unknown>;
+    let record: JsonObject;
     try {
-      const value: unknown = JSON.parse(await readFile(filePath, "utf8"));
-      if (!value || typeof value !== "object" || Array.isArray(value)) {
+      const value = parseJsonText(await readFile(filePath, "utf8"));
+      if (!isJsonObject(value)) {
         throw new Error("catalog entry must contain an object");
       }
-      record = value as Record<string, unknown>;
+      record = value;
     } catch (error) {
       result.blockers.push(
         `${filePath} is not valid JSON: ${errorMessage(error)}`,
@@ -496,33 +502,26 @@ export async function removeLegacyDesktopCatalog(input: {
 }
 
 function isLegacyDesktopCatalogRecord(
-  record: Record<string, unknown>,
+  record: JsonObject,
   reviewKey: string,
 ): boolean {
   const repository = record.repository;
-  if (
-    !repository ||
-    typeof repository !== "object" ||
-    Array.isArray(repository)
-  ) {
-    return false;
-  }
-  const repositoryRecord = repository as Record<string, unknown>;
+  if (!isJsonObject(repository)) return false;
   const requiredStrings = [
     record.rootPath,
     record.reviewPath,
     record.baseRef,
     record.routePath,
-    repositoryRecord.repositoryId,
-    repositoryRecord.repositoryPath,
-    repositoryRecord.worktreeRoot,
+    repository.repositoryId,
+    repository.repositoryPath,
+    repository.worktreeRoot,
   ];
   return (
     record.reviewKey === reviewKey &&
     requiredStrings.every(
       (value) => typeof value === "string" && value.length > 0,
     ) &&
-    ["git", "jj", "none"].includes(String(repositoryRecord.kind)) &&
+    ["git", "jj", "none"].includes(String(repository.kind)) &&
     Number.isSafeInteger(record.startedAt) &&
     Number(record.startedAt) > 0 &&
     Number.isSafeInteger(record.updatedAt) &&
@@ -667,10 +666,8 @@ export async function removeLegacyGlobalReviewInstalls(input: {
       seen.add(canonicalRoot);
       result.checked += 1;
       try {
-        const metadata = JSON.parse(
-          await readFile(packagePath, "utf8"),
-        ) as Record<string, unknown>;
-        if (metadata.name !== PACKAGE_NAME) {
+        const metadata = parseJsonText(await readFile(packagePath, "utf8"));
+        if (!isJsonObject(metadata) || metadata.name !== PACKAGE_NAME) {
           result.blockers.push(
             `${packageRoot} is not a positively identified ${PACKAGE_NAME} installation.`,
           );

--- a/packages/progressive-review/src/native-agent/native-observer.ts
+++ b/packages/progressive-review/src/native-agent/native-observer.ts
@@ -1,3 +1,5 @@
+import type { JsonObject } from "@dev.fast/review-protocol";
+
 import { AsyncQueue } from "./async-queue";
 import { readClaudeReviewMessages } from "./claude-transcript";
 import { readCodexReviewMessages } from "./codex-transcript";
@@ -274,11 +276,13 @@ function isMissingTranscript(error: unknown): boolean {
   return / has no (?:rollout|transcript) file\.$/u.test(error.message);
 }
 
-function nativeHookEvent(payload: Record<string, unknown>): {
+interface NativeHookEvent {
   sessionId?: string;
   transcriptPath?: string;
   completesTurn: boolean;
-} {
+}
+
+function nativeHookEvent(payload: JsonObject): NativeHookEvent {
   const sessionId = firstString(
     payload.session_id,
     payload.sessionId,

--- a/packages/progressive-review/src/native-agent/native-turn-launcher.ts
+++ b/packages/progressive-review/src/native-agent/native-turn-launcher.ts
@@ -4,7 +4,11 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { delimiter, dirname, extname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import type { ReviewVerbRequest } from "@dev.fast/review-protocol";
+import {
+  type JsonValue,
+  type ReviewVerbRequest,
+  isJsonObject,
+} from "@dev.fast/review-protocol";
 
 import { DEV_REVIEW_HOME_ENV, devReviewHome } from "../review-storage";
 import { writePathShim } from "../server/cli-install";
@@ -373,7 +377,7 @@ function shellQuote(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
-function tomlInline(value: unknown): string {
+function tomlInline(value: JsonValue): string {
   if (typeof value === "boolean" || typeof value === "number") {
     return String(value);
   }
@@ -381,7 +385,7 @@ function tomlInline(value: unknown): string {
   if (Array.isArray(value)) {
     return `[${value.map(tomlInline).join(", ")}]`;
   }
-  if (isRecord(value)) {
+  if (isJsonObject(value)) {
     return `{ ${Object.entries(value)
       .map(([key, entry]) => {
         const name = /^[A-Za-z0-9_-]+$/u.test(key) ? key : JSON.stringify(key);
@@ -390,8 +394,4 @@ function tomlInline(value: unknown): string {
       .join(", ")} }`;
   }
   throw new TypeError("Codex hook configuration contains an invalid value.");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/progressive-review/src/native-agent/transcript-json.ts
+++ b/packages/progressive-review/src/native-agent/transcript-json.ts
@@ -1,9 +1,16 @@
 import { readFile } from "node:fs/promises";
 
-export type JsonRecord = Record<string, unknown>;
+import {
+  type JsonObject,
+  isJsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
+/** One parsed transcript line; the harness parsers narrow its fields. */
+export type JsonRecord = JsonObject;
 
 export function isJsonRecord(value: unknown): value is JsonRecord {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  return isJsonObject(value);
 }
 
 export async function readJsonLines(path: string): Promise<JsonRecord[]> {
@@ -11,7 +18,7 @@ export async function readJsonLines(path: string): Promise<JsonRecord[]> {
   return source.split("\n").flatMap((line) => {
     if (!line.trim()) return [];
     try {
-      const value: unknown = JSON.parse(line);
+      const value = parseJsonText(line);
       return isJsonRecord(value) ? [value] : [];
     } catch {
       // A native writer can leave the last line incomplete during a read.

--- a/packages/progressive-review/src/progressive-review-telemetry.test.ts
+++ b/packages/progressive-review/src/progressive-review-telemetry.test.ts
@@ -2,6 +2,11 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import {
+  type JsonObject,
+  isJsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { findProgressiveReviewPackageRoot } from "./package-paths";
@@ -458,13 +463,7 @@ function createTelemetry(input?: {
   env?: NodeJS.ProcessEnv;
   installationId?: string;
   commandRunId?: string;
-}): {
-  configPath: string;
-  events: PostHogCaptureInput[];
-  legacyConfigPath: string;
-  rootPath: string;
-  telemetry: ProgressiveReviewTelemetry;
-} {
+}) {
   const rootPath = path.join(
     os.tmpdir(),
     `progressive-review-telemetry-${Date.now()}-${Math.random()
@@ -513,13 +512,12 @@ async function writeStoredConfig(
   await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
 }
 
-async function readStoredConfig(
-  configPath: string,
-): Promise<Record<string, unknown>> {
-  return JSON.parse(await readFile(configPath, "utf8")) as Record<
-    string,
-    unknown
-  >;
+async function readStoredConfig(configPath: string): Promise<JsonObject> {
+  const value = parseJsonText(await readFile(configPath, "utf8"));
+  if (!isJsonObject(value)) {
+    throw new Error(`Stored config at ${configPath} is not an object.`);
+  }
+  return value;
 }
 
 async function progressiveReviewPackageVersion(): Promise<string> {

--- a/packages/progressive-review/src/progressive-review-telemetry.ts
+++ b/packages/progressive-review/src/progressive-review-telemetry.ts
@@ -168,12 +168,16 @@ export interface ProgressiveReviewTelemetryOptions {
   timeoutMs?: number;
 }
 
+/** A single structured value a log line may carry beside its message. */
+export type LoggerAttributeValue = string | number | boolean | null | undefined;
+export type LoggerAttributes = Record<string, LoggerAttributeValue>;
+
 export interface Logger {
-  trace(message: string, attributes?: Record<string, unknown>): void;
-  debug(message: string, attributes?: Record<string, unknown>): void;
-  info(message: string, attributes?: Record<string, unknown>): void;
-  warn(message: string, attributes?: Record<string, unknown>): void;
-  error(message: string, attributes?: Record<string, unknown>): void;
+  trace(message: string, attributes?: LoggerAttributes): void;
+  debug(message: string, attributes?: LoggerAttributes): void;
+  info(message: string, attributes?: LoggerAttributes): void;
+  warn(message: string, attributes?: LoggerAttributes): void;
+  error(message: string, attributes?: LoggerAttributes): void;
 }
 
 const noop = () => undefined;

--- a/packages/progressive-review/src/review-agent-traces.ts
+++ b/packages/progressive-review/src/review-agent-traces.ts
@@ -1361,7 +1361,12 @@ export async function readRepoMetaFields(
   return { author: author || null, branch: branch || null };
 }
 
-export function parseRepo(value: string): { owner: string; repo: string } {
+export interface TraceRepo {
+  owner: string;
+  repo: string;
+}
+
+export function parseRepo(value: string): TraceRepo {
   const parts = value.split("/");
   if (parts.length !== 2 || !parts[0] || !parts[1]) {
     throw new Error("Repository must be OWNER/REPO.");
@@ -1369,9 +1374,7 @@ export function parseRepo(value: string): { owner: string; repo: string } {
   return { owner: parts[0], repo: parts[1] };
 }
 
-export async function inferRepoFromGit(
-  cwd: string,
-): Promise<{ owner: string; repo: string }> {
+export async function inferRepoFromGit(cwd: string): Promise<TraceRepo> {
   if (process.env.GITHUB_REPOSITORY) {
     return parseRepo(process.env.GITHUB_REPOSITORY);
   }
@@ -1442,16 +1445,16 @@ export interface TraceR2Config {
   region: string;
 }
 
-let cachedTraceEnv: Record<string, string> | null = null;
+let cachedTraceEnv: Map<string, string> | null = null;
 
 export function clearTraceEnvCache(): void {
   cachedTraceEnv = null;
   lastCheckedTimes.clear();
 }
 
-function traceEnvFile(): Record<string, string> {
+function traceEnvFile(): Map<string, string> {
   if (cachedTraceEnv) return cachedTraceEnv;
-  const values: Record<string, string> = {};
+  const values = new Map<string, string>();
   const envPath =
     process.env.TRACE_ENV_FILE ??
     path.join(homedir(), ".config", "dev-trace", "env");
@@ -1459,7 +1462,7 @@ function traceEnvFile(): Record<string, string> {
     for (const line of readFileSync(envPath, "utf8").split("\n")) {
       const match = /^\s*(?:export\s+)?([A-Z0-9_]+)=(.*)$/.exec(line);
       if (!match) continue;
-      values[match[1]] = match[2].replace(/^["']|["']$/g, "").trim();
+      values.set(match[1], match[2].replace(/^["']|["']$/g, "").trim());
     }
   } catch {
     // No env file; exported variables may still be present.
@@ -1469,7 +1472,7 @@ function traceEnvFile(): Record<string, string> {
 }
 
 export function traceEnvValue(name: string): string | undefined {
-  return process.env[name] ?? traceEnvFile()[name];
+  return process.env[name] ?? traceEnvFile().get(name);
 }
 
 // Codex reads CODEX_HOME from its own environment only, so this does not

--- a/packages/progressive-review/src/review-bundled-tools.ts
+++ b/packages/progressive-review/src/review-bundled-tools.ts
@@ -15,6 +15,8 @@ import { Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { setTimeout as delay } from "node:timers/promises";
 
+import { isJsonObject, parseJsonText } from "@dev.fast/review-protocol";
+
 export interface EnsureBundledToolInput {
   tool: string;
   sourcePath?: string;
@@ -153,10 +155,11 @@ function installedToolMatches(
 ): boolean {
   if (!isExecutable(executable)) return false;
   try {
-    const stamp = JSON.parse(
+    const stamp = parseJsonText(
       fs.readFileSync(path.join(destination, "review-tool.json"), "utf8"),
-    ) as Record<string, unknown>;
+    );
     return (
+      isJsonObject(stamp) &&
       stamp.tool === identity.tool &&
       stamp.platform === identity.platform &&
       stamp.sha256 === identity.sha256

--- a/packages/progressive-review/src/review-code-target-migration.ts
+++ b/packages/progressive-review/src/review-code-target-migration.ts
@@ -6,7 +6,9 @@ import {
 import {
   type GitLabDiffPosition,
   type GitLabTextDiffRow,
+  type JsonObject,
   createGitLabTextDiffPosition,
+  isJsonObject,
 } from "@dev.fast/review-protocol";
 
 import { type DiffHunk, parseUnifiedPatch } from "./unified-diff";
@@ -120,7 +122,7 @@ export function createLegacyCodeRecordMigrator(
     const migratedThread = objectRecord(thread, "migrated code comment thread");
     const inputs = Array.isArray(draft.inputs)
       ? draft.inputs.map((input) => {
-          if (!isObject(input) || !isLegacyCodeTarget(input.target))
+          if (!isJsonObject(input) || !isLegacyCodeTarget(input.target))
             return input;
           return { ...input, target: migratedThread.target };
         })
@@ -296,17 +298,13 @@ function parseLegacySpan(value: unknown): LegacyCodeSpan {
   return { startLine: span.startLine, endLine: span.endLine };
 }
 
-function isLegacyCodeTarget(value: unknown): value is Record<string, unknown> {
-  return isObject(value) && value.kind === "code" && "path" in value;
+function isLegacyCodeTarget(value: unknown): value is JsonObject {
+  return isJsonObject(value) && value.kind === "code" && "path" in value;
 }
 
-function objectRecord(value: unknown, name: string): Record<string, unknown> {
-  if (!isObject(value)) throw new Error(`${name} is malformed.`);
+function objectRecord(value: unknown, name: string): JsonObject {
+  if (!isJsonObject(value)) throw new Error(`${name} is malformed.`);
   return value;
-}
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function positiveInteger(value: unknown): value is number {

--- a/packages/progressive-review/src/review-commits.ts
+++ b/packages/progressive-review/src/review-commits.ts
@@ -1,9 +1,14 @@
 import type { LocalVcsCommitSummary } from "@dev.fast/local-vcs";
 
+export interface ReviewCommitRefs {
+  baseRef: string;
+  headRef: string;
+}
+
 export function resolveReviewCommitScope(
   commits: readonly LocalVcsCommitSummary[],
   commit: string,
-): { baseRef: string; headRef: string } {
+): ReviewCommitRefs {
   const entry = commits.find((candidate) => candidate.commit === commit);
   if (!entry) {
     throw new Error("The commit is outside the pinned review range.");

--- a/packages/progressive-review/src/review-home.ts
+++ b/packages/progressive-review/src/review-home.ts
@@ -13,12 +13,14 @@ import path from "node:path";
 import { currentHead, listCommitRange } from "@dev.fast/local-vcs";
 import {
   DEFAULT_DISMISSED_RETENTION_DAYS,
+  type JsonObject,
   REVIEW_SCHEMA_VERSION,
   type ReviewAgentSessionRole,
   type ReviewDescriptor,
   type ReviewRecord,
   ReviewRecordSchema,
   type ReviewSourceIdentity,
+  isJsonObject,
   summarizeReviewDiffFiles,
 } from "@dev.fast/review-protocol";
 
@@ -603,10 +605,7 @@ function reviewHomeError(
   value: unknown,
   error: { message: string; code?: string },
 ): ReviewHomeError {
-  const record =
-    value && typeof value === "object" && !Array.isArray(value)
-      ? (value as Record<string, unknown>)
-      : undefined;
+  const record = isJsonObject(value) ? value : undefined;
   const directoryUuid = path.basename(reviewDir);
   const storedUuid = typeof record?.uuid === "string" ? record.uuid : null;
   const reviewUuid = UUID_PATTERN.test(storedUuid ?? "")
@@ -638,10 +637,8 @@ export function parseStoredReviewRecord(value: unknown): StoredReviewRecord {
 export function parseStoredReviewRecordForMigration(
   value: unknown,
 ): StoredReviewRecord {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return parseStoredReviewRecord(value);
-  }
-  const record = stripLegacySoftwareMap(value) as Record<string, unknown>;
+  if (!isJsonObject(value)) return parseStoredReviewRecord(value);
+  const record = stripLegacySoftwareMap(value);
   if (record.schemaVersion === 3) {
     const { agentSession, schemaVersion: _schemaVersion, ...current } = record;
     return StoredReviewRecordSchema.parse({
@@ -670,14 +667,11 @@ export function safeParseStoredReviewRecord(value: unknown) {
   return StoredReviewRecordSchema.safeParse(stripLegacySoftwareMap(value));
 }
 
+function stripLegacySoftwareMap(value: JsonObject): JsonObject;
+function stripLegacySoftwareMap(value: unknown): unknown;
 function stripLegacySoftwareMap(value: unknown): unknown {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return value;
-  }
-  const { softwareMap: _legacySoftwareMap, ...record } = value as Record<
-    string,
-    unknown
-  >;
+  if (!isJsonObject(value)) return value;
+  const { softwareMap: _legacySoftwareMap, ...record } = value;
   return record;
 }
 
@@ -704,7 +698,7 @@ function defaultReviewMdx(review: ReviewRecord): string {
   return `# ${review.title}\n\nThis review document is ready for repo-specific notes.\n\n{/* Review source: ${review.sourceCommit ?? "unbound"} */}\n`;
 }
 
-function reviewPackageJson(uuid: string): Record<string, unknown> {
+function reviewPackageJson(uuid: string) {
   return {
     name: `review-${uuid}`,
     private: true,

--- a/packages/progressive-review/src/review-logger.test.ts
+++ b/packages/progressive-review/src/review-logger.test.ts
@@ -62,10 +62,7 @@ describe("Review structured logger", () => {
   });
 });
 
-function writableOutput(): {
-  stream: NodeJS.WritableStream;
-  text: () => string;
-} {
+function writableOutput() {
   const chunks: string[] = [];
   return {
     stream: new Writable({

--- a/packages/progressive-review/src/review-logger.ts
+++ b/packages/progressive-review/src/review-logger.ts
@@ -75,11 +75,22 @@ export function emitReviewEvent(
   logger.event(event);
 }
 
+/** The fields a thrown non-Error value may carry that the log record keeps. */
+interface ThrownValueFields {
+  name?: unknown;
+  message?: unknown;
+  stack?: unknown;
+  component?: unknown;
+  propertyPath?: unknown;
+  expected?: unknown;
+  received?: unknown;
+}
+
 export function serializeReviewError(error: unknown): ReviewLifecycleError {
+  // SAFETY: every field is optional and re-checked with typeof/in below, so
+  // any non-null object satisfies the shape.
   const value =
-    error && typeof error === "object"
-      ? (error as Record<string, unknown>)
-      : null;
+    error && typeof error === "object" ? (error as ThrownValueFields) : null;
   return {
     name:
       error instanceof Error

--- a/packages/progressive-review/src/review-map-publish.ts
+++ b/packages/progressive-review/src/review-map-publish.ts
@@ -6,7 +6,7 @@ import {
   authoringSessionKey,
   resolveAuthoringSessionRef,
 } from "./authoring-session";
-import { emitJsonEvent } from "./cli-output";
+import { type CliJsonEvent, emitJsonEvent } from "./cli-output";
 import { readReviewDesktopDiscovery } from "./desktop-discovery";
 import {
   parseStoredReviewRecord,
@@ -145,11 +145,15 @@ export async function runReviewMapPublish(input: {
   }
 }
 
+interface MapPublishStageDetails {
+  revision?: string;
+}
+
 interface MapPublishReporter {
   stage(
     name: string,
     status: "running" | "complete",
-    details?: Record<string, unknown>,
+    details?: MapPublishStageDetails,
   ): void;
   error(stage: string, diagnostics: string[]): void;
   published(
@@ -165,7 +169,7 @@ function mapPublishReporter(input: {
   stderr: Writable;
 }): MapPublishReporter {
   if (input.json) {
-    const emit = (event: Record<string, unknown>) =>
+    const emit = <T extends CliJsonEvent>(event: T) =>
       emitJsonEvent(input, event);
     return {
       stage: (name, status, details = {}) =>
@@ -192,9 +196,9 @@ function mapPublishReporter(input: {
     stage(name, status, details = {}) {
       if (status !== "complete") return;
       const suffix =
-        typeof details.revision === "string"
-          ? ` ${details.revision.slice(0, 12)}`
-          : "";
+        details.revision === undefined
+          ? ""
+          : ` ${details.revision.slice(0, 12)}`;
       input.stdout.write(
         `${name === "load" ? "Load map" : name}: ok${suffix}\n`,
       );

--- a/packages/progressive-review/src/review-preferences.ts
+++ b/packages/progressive-review/src/review-preferences.ts
@@ -1,7 +1,12 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
-import { DEFAULT_DISMISSED_RETENTION_DAYS } from "@dev.fast/review-protocol";
+import {
+  DEFAULT_DISMISSED_RETENTION_DAYS,
+  type JsonValue,
+  isJsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
 
 import type { DismissedRetentionDays } from "./review-attention";
 import { devReviewHome } from "./review-storage";
@@ -30,7 +35,7 @@ export async function readReviewPreferences(
   devHome?: string,
 ): Promise<ReviewPreferences> {
   try {
-    const raw: unknown = JSON.parse(
+    const raw = parseJsonText(
       await readFile(reviewPreferencesPath(devHome), "utf8"),
     );
     return { dismissedRetentionDays: parseRetentionDays(raw) };
@@ -52,11 +57,11 @@ export async function writeReviewPreferences(
   return next;
 }
 
-function parseRetentionDays(raw: unknown): DismissedRetentionDays {
-  if (typeof raw !== "object" || raw === null) {
+function parseRetentionDays(raw: JsonValue): DismissedRetentionDays {
+  if (!isJsonObject(raw)) {
     return DEFAULT_DISMISSED_RETENTION_DAYS;
   }
-  const value = (raw as Record<string, unknown>).dismissedRetentionDays;
+  const value = raw.dismissedRetentionDays;
   if (value === null) return null;
   return normalizeRetentionDays(typeof value === "number" ? value : undefined);
 }

--- a/packages/progressive-review/src/review-publish-element-audit.ts
+++ b/packages/progressive-review/src/review-publish-element-audit.ts
@@ -23,25 +23,53 @@ const FRAGMENT = Symbol.for("react.fragment");
 export interface PublishAuditElement {
   [ELEMENT_MARKER]: true;
   type: unknown;
-  props: Record<string, unknown>;
+  props: PublishValidationProps;
   key: unknown;
+}
+
+// The tree the audit walks: element records, text, and the values
+// React.Children drops (booleans, null, undefined), nested in arrays.
+export type PublishAuditNode =
+  | PublishAuditElement
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | PublishAuditNode[];
+
+export type PublishAuditComponent = (
+  props: PublishValidationProps,
+) => PublishAuditNode;
+
+// Prop values as the audit reads and writes them: `children` is a node tree,
+// `label` is a string, and `components` is the stub map handed to the
+// document. Every other authored prop is opaque here; the component's zod
+// schema parses it.
+export type PublishValidationPropValue =
+  | PublishAuditNode
+  | Record<string, PublishAuditComponent>;
+
+export interface PublishValidationProps {
+  children?: PublishAuditNode;
+  [prop: string]: PublishValidationPropValue;
 }
 
 type AuthoringComponentName = keyof typeof reviewAuthoringPropsSchemas;
 
-function isAuditElement(value: unknown): value is PublishAuditElement {
+function isAuditElement(value: PublishAuditNode): value is PublishAuditElement {
   if (typeof value !== "object" || value === null) return false;
-  const obj = value as Record<string, unknown>;
   return (
-    obj[ELEMENT_MARKER] === true ||
-    obj.$$typeof === Symbol.for("react.element") ||
-    obj.$$typeof === Symbol.for("react.transitional.element")
+    (ELEMENT_MARKER in value && value[ELEMENT_MARKER] === true) ||
+    ("$$typeof" in value &&
+      (value.$$typeof === Symbol.for("react.element") ||
+        value.$$typeof === Symbol.for("react.transitional.element")))
   );
 }
 
 function makeElement(
   type: unknown,
-  props: Record<string, unknown> | null | undefined,
+  props: PublishValidationProps | null | undefined,
   key: unknown,
 ): PublishAuditElement {
   return { [ELEMENT_MARKER]: true, type, props: props ?? {}, key };
@@ -51,25 +79,41 @@ function makeElement(
 // arrays flatten recursively; null, undefined, and booleans disappear.
 // Fragments do NOT flatten — React.Children treats a fragment as one child,
 // and the lens parsers in the app rely on that.
-function flattenChildren(children: unknown): unknown[] {
+function flattenChildren(children: PublishAuditNode): PublishAuditNode[] {
   if (children === null || children === undefined) return [];
   if (typeof children === "boolean") return [];
   if (Array.isArray(children)) return children.flatMap(flattenChildren);
   return [children];
 }
 
-export function createPublishValidationReact(): Record<string, unknown> {
+// The React surface the validation runtime exposes. `React` points back at
+// the object itself so `import React from "react"` sees the same members.
+export interface PublishValidationReact extends PublishValidationReactMembers {
+  React?: PublishValidationReact;
+}
+
+type PublishValidationReactMembers = ReturnType<
+  typeof publishValidationReactMembers
+>;
+
+export function createPublishValidationReact(): PublishValidationReact {
+  const react: PublishValidationReact = { ...publishValidationReactMembers() };
+  react.React = react;
+  return react;
+}
+
+function publishValidationReactMembers() {
   const noop = () => undefined;
   const identity = (value: unknown) => value;
   // A plain function keeps `class X extends Component` working: unlike an
   // arrow function it has a prototype, and the stub is never instantiated.
   function StubComponent(): void {}
-  const jsx = (type: unknown, props?: Record<string, unknown>, key?: unknown) =>
+  const jsx = (type: unknown, props?: PublishValidationProps, key?: unknown) =>
     makeElement(type, props, key);
   const createElement = (
     type: unknown,
-    props?: Record<string, unknown> | null,
-    ...children: unknown[]
+    props?: PublishValidationProps | null,
+    ...children: PublishAuditNode[]
   ) =>
     makeElement(
       type,
@@ -78,27 +122,27 @@ export function createPublishValidationReact(): Record<string, unknown> {
         : (props ?? {}),
       props?.key,
     );
-  const react: Record<string, unknown> = {
+  return {
     Children: {
       map: (
-        children: unknown,
-        fn: (child: unknown, index: number) => unknown,
+        children: PublishAuditNode,
+        fn: (child: PublishAuditNode, index: number) => PublishAuditNode,
       ) => flattenChildren(children).map(fn),
       forEach: (
-        children: unknown,
-        fn: (child: unknown, index: number) => void,
+        children: PublishAuditNode,
+        fn: (child: PublishAuditNode, index: number) => void,
       ) => {
         flattenChildren(children).forEach(fn);
       },
-      count: (children: unknown) => flattenChildren(children).length,
-      only: (children: unknown) => {
+      count: (children: PublishAuditNode) => flattenChildren(children).length,
+      only: (children: PublishAuditNode) => {
         const flat = flattenChildren(children);
         if (flat.length !== 1 || !isAuditElement(flat[0])) {
           throw new Error("React.Children.only expected a single child.");
         }
         return flat[0];
       },
-      toArray: (children: unknown) => flattenChildren(children),
+      toArray: (children: PublishAuditNode) => flattenChildren(children),
     },
     Component: StubComponent,
     Fragment: FRAGMENT,
@@ -111,8 +155,8 @@ export function createPublishValidationReact(): Record<string, unknown> {
     captureOwnerStack: () => null,
     cloneElement: (
       element: PublishAuditElement,
-      props?: Record<string, unknown>,
-      ...children: unknown[]
+      props?: PublishValidationProps,
+      ...children: PublishAuditNode[]
     ) =>
       makeElement(
         element.type,
@@ -157,8 +201,6 @@ export function createPublishValidationReact(): Record<string, unknown> {
     jsxs: jsx,
     jsxDEV: jsx,
   };
-  react.React = react;
-  return react;
 }
 
 export interface PublishAuditTraceQuote {
@@ -168,7 +210,7 @@ export interface PublishAuditTraceQuote {
   text: string;
 }
 
-export function extractAuditText(node: unknown): string {
+export function extractAuditText(node: PublishAuditNode): string {
   if (node === null || node === undefined || typeof node === "boolean") {
     return "";
   }
@@ -194,7 +236,7 @@ export function auditReviewDocumentComponent(input: {
   collectTraceQuote?: (quote: PublishAuditTraceQuote) => void;
 }): void {
   if (typeof input.Component !== "function") return;
-  const components = new Map<AuthoringComponentName, unknown>();
+  const components = new Map<AuthoringComponentName, PublishAuditComponent>();
   const componentNames = new Map<unknown, AuthoringComponentName>();
   for (const name of Object.keys(
     reviewAuthoringPropsSchemas,
@@ -205,9 +247,12 @@ export function auditReviewDocumentComponent(input: {
     componentNames.set(stub, name);
   }
 
-  let tree: unknown;
+  let tree: PublishAuditNode;
   try {
-    tree = (input.Component as (props: unknown) => unknown)({
+    // SAFETY: the document component is the bundle's default export, compiled
+    // from MDX against this runtime's `jsx`; it takes a props record and
+    // returns the element tree those calls built.
+    tree = (input.Component as PublishAuditComponent)({
       components: Object.fromEntries(components),
     });
   } catch (error) {
@@ -217,7 +262,10 @@ export function auditReviewDocumentComponent(input: {
     return;
   }
 
-  const walk = (node: unknown, parentName: AuthoringComponentName | null) => {
+  const walk = (
+    node: PublishAuditNode,
+    parentName: AuthoringComponentName | null,
+  ) => {
     for (const child of flattenChildren(node)) {
       if (!isAuditElement(child)) continue;
       const name = componentNames.get(child.type) ?? null;
@@ -252,9 +300,11 @@ export function auditReviewDocumentComponent(input: {
         // Best-effort expansion of document-local components: MDX-generated
         // helpers are hook-free and expand; anything that throws under the
         // stub hooks is skipped, exactly as inert as it was before the audit.
-        let rendered: unknown = null;
+        let rendered: PublishAuditNode = null;
         try {
-          rendered = (child.type as (props: unknown) => unknown)(child.props);
+          // SAFETY: a function-typed element is a document-local component
+          // compiled against this runtime; it renders to the same node tree.
+          rendered = (child.type as PublishAuditComponent)(child.props);
         } catch {
           rendered = null;
         }

--- a/packages/progressive-review/src/review-publish-evaluate.ts
+++ b/packages/progressive-review/src/review-publish-evaluate.ts
@@ -43,6 +43,15 @@ const RUNTIME_SPECIFIER = "review-doc-runtime";
 const RUNTIME_MODULE_FILE = "review-doc-runtime.mjs";
 const DOCUMENT_MODULE_FILE = "review-document.mjs";
 
+type PublishValidationRuntime = ReturnType<typeof validationRuntimeExports>;
+
+// The generated runtime module reads its exports from this global slot: the
+// evaluation installs the runtime before importing the document and restores
+// whatever the slot held afterwards.
+interface PublishValidationRuntimeGlobal {
+  [RUNTIME_GLOBAL]?: PublishValidationRuntime;
+}
+
 // The stub module must declare every name the bundle imports from the runtime
 // (ESM checks named imports at link time), so the export list is derived from
 // the bundle's own import statements instead of mirroring doc-runtime.ts by
@@ -177,9 +186,11 @@ export async function evaluateReviewDocumentBundleForPublish(input: {
     ".build",
     `publish-validate-${process.pid}-${Math.random().toString(36).slice(2)}`,
   );
-  const globalHolder = globalThis as Record<string, unknown>;
+  // SAFETY: the slot is a private key on globalThis that only this evaluation
+  // writes; it holds a runtime from `validationRuntimeExports` or nothing.
+  const globalHolder = globalThis as PublishValidationRuntimeGlobal;
   const previousRuntime = globalHolder[RUNTIME_GLOBAL];
-  let importError: unknown = null;
+  let importErrorMessage: string | null = null;
   try {
     const runtimeImportNames = await collectRuntimeImportNames(
       input.bundleCode,
@@ -205,7 +216,7 @@ export async function evaluateReviewDocumentBundleForPublish(input: {
     try {
       await import(moduleUrl.href);
     } catch (error) {
-      importError = error;
+      importErrorMessage = errorMessage(error);
     }
   } finally {
     globalHolder[RUNTIME_GLOBAL] = previousRuntime;
@@ -314,8 +325,8 @@ export async function evaluateReviewDocumentBundleForPublish(input: {
   const errors =
     failures.length > 0
       ? failures
-      : importError !== null
-        ? [errorMessage(importError)]
+      : importErrorMessage !== null
+        ? [importErrorMessage]
         : [];
   const warnings = [
     ...sessions.flatMap((session) =>
@@ -393,7 +404,7 @@ function validationRuntimeExports(input: {
   reportAuditError: (message: string) => void;
   collectCallStackDiff: (props: CallStackDiffProps) => void;
   collectTraceQuote: (quote: PublishAuditTraceQuote) => void;
-}): Record<string, unknown> {
+}) {
   const noop = () => undefined;
   // The React substitute is not inert: `jsx` builds element records so the
   // audit below can parse every authored element's props at publish time.

--- a/packages/progressive-review/src/review-publish.ts
+++ b/packages/progressive-review/src/review-publish.ts
@@ -3,7 +3,7 @@ import type { Writable } from "node:stream";
 import type { ReviewView } from "@dev.fast/review-protocol";
 
 import { resolveAuthoringSessionRef } from "./authoring-session";
-import { emitJsonEvent } from "./cli-output";
+import { type CliJsonEvent, emitJsonEvent } from "./cli-output";
 import type { ReviewDocumentDiagnostic } from "./compiler/review-document-compiler";
 import { requireHealthyReviewDesktop } from "./desktop-discovery";
 import { REVIEW_PUBLISH_CANDIDATE_MESSAGE } from "./review-document-versions";
@@ -141,11 +141,19 @@ async function publish(
   return 0;
 }
 
+type PublishStage = "validate" | "revision" | "mount";
+
+interface PublishStageDetails {
+  revision?: string;
+  sessionId?: string;
+  skipped?: boolean;
+}
+
 interface PublishReporter {
   stage(
-    name: string,
+    name: PublishStage,
     status: "running" | "complete",
-    details?: Record<string, unknown>,
+    details?: PublishStageDetails,
   ): void;
   warning(stage: string, diagnostics: string[]): void;
   error(stage: string, diagnostics: string[]): void;
@@ -157,18 +165,19 @@ interface PublishReporter {
   ): void;
 }
 
-const STAGE_LABELS: Record<string, string> = {
+const STAGE_LABELS = {
   validate: "Validate document",
   revision: "Seal revision",
   mount: "Mount",
-};
+} satisfies Record<PublishStage, string>;
 
 function createPublishReporter(input: {
   json: boolean;
   stdout: Writable;
   stderr: Writable;
 }): PublishReporter {
-  const emit = (event: Record<string, unknown>) => emitJsonEvent(input, event);
+  const emit = <T extends CliJsonEvent>(event: T) =>
+    emitJsonEvent(input, event);
   if (input.json) {
     return {
       stage(name, status, details = {}) {
@@ -205,7 +214,7 @@ function createPublishReporter(input: {
   return {
     stage(name, status, details = {}) {
       if (status !== "complete") return;
-      const label = STAGE_LABELS[name] ?? name;
+      const label = STAGE_LABELS[name];
       const suffix =
         "revision" in details
           ? ` ${String(details.revision).slice(0, 12)}`

--- a/packages/progressive-review/src/review-scaffold.ts
+++ b/packages/progressive-review/src/review-scaffold.ts
@@ -462,7 +462,7 @@ function traceSetupFailure(
   sessions: ReviewScaffoldTraceSession[],
   warning: string,
   progress?: (message: string) => void,
-): { traces: ReviewScaffoldTraces; warnings: string[] } {
+) {
   progress?.(`Warning: ${warning}`);
   return {
     traces: emptyScaffoldTraces(

--- a/packages/progressive-review/src/review-source-agent-session.ts
+++ b/packages/progressive-review/src/review-source-agent-session.ts
@@ -3,6 +3,8 @@ import { randomUUID } from "node:crypto";
 import { readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
+import { isJsonObject, parseJsonText } from "@dev.fast/review-protocol";
+
 import type { SessionRef } from "./authoring-session";
 import { findClaudeTranscript } from "./native-agent/claude-transcript";
 import { forkCodexThread } from "./native-agent/codex-app-server";
@@ -50,7 +52,15 @@ async function createClaudeReviewSourceSession(input: {
   const records = source
     .split("\n")
     .filter((line) => line.trim())
-    .map((line) => JSON.parse(line) as Record<string, unknown>);
+    .map((line) => {
+      const record = parseJsonText(line);
+      if (!isJsonObject(record)) {
+        throw new Error(
+          `Claude transcript ${sourcePath} has a non-object line.`,
+        );
+      }
+      return record;
+    });
   const fork = records.map((record) => ({
     ...record,
     ...(record.sessionId === undefined ? {} : { sessionId }),
@@ -87,9 +97,11 @@ function runPiProcess(
     });
     const timer = setTimeout(() => {
       child.kill("SIGKILL");
-      const error = new Error(`Command timed out: pi ${args.join(" ")}`);
-      (error as { stderr?: string }).stderr = stderr;
-      reject(error);
+      reject(
+        Object.assign(new Error(`Command timed out: pi ${args.join(" ")}`), {
+          stderr,
+        }),
+      );
     }, options.timeout);
     child.on("error", (error) => {
       clearTimeout(timer);
@@ -101,9 +113,11 @@ function runPiProcess(
         resolve();
         return;
       }
-      const error = new Error(`Command failed: pi ${args.join(" ")}`);
-      (error as { stderr?: string }).stderr = stderr;
-      reject(error);
+      reject(
+        Object.assign(new Error(`Command failed: pi ${args.join(" ")}`), {
+          stderr,
+        }),
+      );
     });
   });
 }

--- a/packages/progressive-review/src/review-state-store.ts
+++ b/packages/progressive-review/src/review-state-store.ts
@@ -8,6 +8,7 @@ import {
   type GitLabDiffPosition,
   ReviewRecordSchema,
   gitLabDiffPositionRows,
+  isJsonObject,
 } from "@dev.fast/review-protocol";
 
 import { writeFileAtomic } from "./atomic-write";
@@ -40,10 +41,6 @@ import type {
 
 export { reviewStateDir } from "./review-thread-store-backend";
 
-function isObject(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
 interface ReviewCodeTargetContext {
   rootPath: string;
   baseCommit: string;
@@ -51,12 +48,12 @@ interface ReviewCodeTargetContext {
 }
 
 function isLegacyCodeTarget(target: unknown): boolean {
-  if (!isObject(target) || target.kind !== "text") return false;
-  if (!isObject(target.surface)) return false;
+  if (!isJsonObject(target) || target.kind !== "text") return false;
+  if (!isJsonObject(target.surface)) return false;
   if (target.surface.type === "native") return true;
   return (
     target.surface.type === "anchor" &&
-    isObject(target.surface.part) &&
+    isJsonObject(target.surface.part) &&
     target.surface.part.type === "code"
   );
 }
@@ -186,10 +183,15 @@ function writeReviewComments(
   reviewThreadStoreBackend(reviewMdxPath).writeComments(comments);
 }
 
+export interface AppendReviewCommentResult {
+  threadId: string;
+  thread: ReviewCommentThreadRecord;
+}
+
 export function appendReviewComment(
   reviewMdxPath: string,
   input: CreateReviewCommentInput & { author: string },
-): { threadId: string; thread: ReviewCommentThreadRecord } {
+): AppendReviewCommentResult {
   if (!input.threadId.trim()) {
     throw new Error("Comment threadId is required.");
   }
@@ -257,10 +259,15 @@ function writeReviewCommentDrafts(
   reviewThreadStoreBackend(reviewMdxPath).writeCommentDrafts(drafts);
 }
 
+export interface AppendReviewCommentDraftResult {
+  threadId: string;
+  draft: ReviewCommentDraftThread;
+}
+
 export function appendReviewCommentDraft(
   reviewMdxPath: string,
   input: CreateReviewCommentInput & { author: string },
-): { threadId: string; draft: ReviewCommentDraftThread } {
+): AppendReviewCommentDraftResult {
   const { author, ...draftInput } = input;
   requireValidCodeTarget(reviewMdxPath, input.target);
   const drafts = readReviewCommentDrafts(reviewMdxPath);
@@ -399,13 +406,15 @@ export function deleteReviewCommentDraftMessage(
   return next;
 }
 
+export interface SubmitReviewCommentDraftsResult {
+  threads: ReviewCommentThreadRecord[];
+  deletedDraftThreadIds: string[];
+}
+
 export function submitReviewCommentDrafts(
   reviewMdxPath: string,
   expectedInputs: CreateReviewCommentInput[],
-): {
-  threads: ReviewCommentThreadRecord[];
-  deletedDraftThreadIds: string[];
-} {
+): SubmitReviewCommentDraftsResult {
   const backend = reviewThreadStoreBackend(reviewMdxPath);
   const comments = backend.readComments();
   const drafts = backend.readCommentDrafts();
@@ -531,7 +540,7 @@ function normalizeReviewCommentMessage(
 function upsertThreadMessage(
   thread: ReviewCommentThreadRecord,
   message: ReviewCommentMessage,
-): { thread: ReviewCommentThreadRecord; changed: boolean } {
+) {
   const index = thread.messages.findIndex(
     (candidate) => candidate.id === message.id,
   );
@@ -702,10 +711,16 @@ function nextDocHistoryVersion(dir: string): number {
  * the latest snapshot is byte-identical (so re-running a review with no doc
  * change doesn't accumulate duplicate versions).
  */
+export interface SaveReviewDocHistoryResult {
+  version: number;
+  path: string;
+  isNew: boolean;
+}
+
 export function saveReviewDocHistory(
   reviewMdxPath: string,
   content: string,
-): { version: number; path: string; isNew: boolean } {
+): SaveReviewDocHistoryResult {
   const dir = reviewHistoryDocDir(reviewMdxPath);
   const nextVersion = nextDocHistoryVersion(dir);
   if (nextVersion > 1) {

--- a/packages/progressive-review/src/review-thread-store-backend.ts
+++ b/packages/progressive-review/src/review-thread-store-backend.ts
@@ -3,6 +3,11 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
 import {
+  type JsonObject,
+  isJsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+import {
   ReviewCommentDraftThreadMapSchema,
   parseReviewCommentThreadMap,
   parseStoredReviewCommentThreadMap,
@@ -264,47 +269,43 @@ function migrateNativeAgentSessionRecord(
   value: unknown,
   table: "comments" | "comment_drafts",
 ): unknown {
-  if (!isRecord(value)) return value;
+  if (!isJsonObject(value)) return value;
   if (table === "comment_drafts") {
-    if (!isRecord(value.thread)) return value;
+    if (!isJsonObject(value.thread)) return value;
     const thread = migrateNativeAgentSessionThread(value.thread);
     return thread === value.thread ? value : { ...value, thread };
   }
   return migrateNativeAgentSessionThread(value);
 }
 
-function migrateNativeAgentSessionThread(
-  thread: Record<string, unknown>,
-): Record<string, unknown> {
+function migrateNativeAgentSessionThread(thread: JsonObject): JsonObject {
   const originalMessages = Array.isArray(thread.messages)
     ? thread.messages
     : undefined;
   const migratedMessages = originalMessages
     ? originalMessages.map((message) => {
-        if (!isRecord(message)) return message;
+        if (!isJsonObject(message)) return message;
         const agentInput = message.agentInput === true;
         if (!("native" in message) && message.agentInput === agentInput) {
           return message;
         }
-        const preserved: Record<string, unknown> = { ...message, agentInput };
-        delete preserved.native;
-        return preserved;
+        const { native: _native, ...preserved } = message;
+        return { ...preserved, agentInput };
       })
     : undefined;
   const messagesChanged =
     originalMessages !== undefined &&
-    migratedMessages!.some(
+    migratedMessages !== undefined &&
+    migratedMessages.some(
       (message, index) => message !== originalMessages[index],
     );
   const migratedThread = messagesChanged
     ? { ...thread, messages: migratedMessages }
     : thread;
   if (!("agentSession" in migratedThread)) return migratedThread;
-  const session = migratedThread.agentSession;
-  const preserved = { ...migratedThread };
-  delete preserved.agentSession;
+  const { agentSession: session, ...preserved } = migratedThread;
   if (
-    !isRecord(session) ||
+    !isJsonObject(session) ||
     (session.harness !== "claude-code" &&
       session.harness !== "codex" &&
       session.harness !== "pi") ||
@@ -320,10 +321,6 @@ function migrateNativeAgentSessionThread(
       sessionId: session.sessionId,
     },
   };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 async function migrateLegacyCodeRecords(
@@ -389,19 +386,19 @@ function hasLegacyCodeTargets(db: DatabaseSync): boolean {
   return Boolean(draft);
 }
 
-function readThreadTable<T>(
+function readThreadTable(
   dbPath: string,
   table: "comments" | "comment_drafts",
   keyColumn: "thread_id",
-): Record<string, T> {
+): JsonObject {
   const db = openThreadDb(dbPath, { create: false });
   if (!db) return {};
   const rows = db
     .prepare(`SELECT ${keyColumn} AS key, record_json FROM ${table}`)
     .all() as Array<{ key: string; record_json: string }>;
-  const result: Record<string, T> = {};
+  const result: JsonObject = {};
   for (const row of rows) {
-    result[row.key] = JSON.parse(row.record_json) as T;
+    result[row.key] = parseJsonText(row.record_json);
   }
   return result;
 }
@@ -410,7 +407,7 @@ function writeThreadTable(
   dbPath: string,
   table: "comments" | "comment_drafts",
   keyColumn: "thread_id",
-  value: Record<string, unknown>,
+  value: ReviewCommentThreadMap | ReviewCommentDraftThreadMap,
 ): void {
   const db = openThreadDb(dbPath, { create: true });
   if (!db) throw new Error(`Could not open ${dbPath}.`);
@@ -478,7 +475,7 @@ function sqliteThreadStoreBackend(
       ),
     readCommentDrafts: () =>
       ReviewCommentDraftThreadMapSchema.parse(
-        readThreadTable<unknown>(dbPath, "comment_drafts", "thread_id"),
+        readThreadTable(dbPath, "comment_drafts", "thread_id"),
       ),
     writeCommentDrafts: (drafts) =>
       writeThreadTable(
@@ -493,7 +490,7 @@ function sqliteThreadStoreBackend(
 }
 
 function readValidComments(dbPath: string): ReviewCommentThreadMap {
-  const stored = readThreadTable<unknown>(dbPath, "comments", "thread_id");
+  const stored = readThreadTable(dbPath, "comments", "thread_id");
   const comments = parseReviewCommentThreadMap(stored);
   const dropped = Object.keys(stored).filter((key) => !(key in comments));
   if (dropped.length === 0) return comments;

--- a/packages/progressive-review/src/server/bug-report-trace.test.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.test.ts
@@ -11,7 +11,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { gunzipSync } from "node:zlib";
 
-import { REVIEW_SCHEMA_VERSION } from "@dev.fast/review-protocol";
+import {
+  type JsonObject,
+  REVIEW_SCHEMA_VERSION,
+} from "@dev.fast/review-protocol";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { ReviewAgentHarness } from "../authoring-session";
@@ -624,10 +627,7 @@ describe("readAuthoringTraceAttachment", () => {
   }
 });
 
-function historyBase(
-  parentId: string,
-  endOrdinalExclusive: number,
-): { parentId: string; endOrdinalExclusive: number } {
+function historyBase(parentId: string, endOrdinalExclusive: number) {
   return { parentId, endOrdinalExclusive };
 }
 
@@ -638,7 +638,7 @@ function codexId(index: number): string {
 function codexTrace(
   id: string,
   startOrdinal: number,
-  records: Array<Record<string, unknown>>,
+  records: JsonObject[],
   parent?: ReturnType<typeof historyBase>,
 ): string {
   const metaPayload = {

--- a/packages/progressive-review/src/server/bug-report-trace.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.ts
@@ -8,6 +8,12 @@ import { pipeline } from "node:stream/promises";
 import { createGzip } from "node:zlib";
 
 import {
+  type JsonObject,
+  isJsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
+import {
   type ReviewAgentHarness,
   parseAuthoringSessionKey,
 } from "../authoring-session";
@@ -47,10 +53,6 @@ export interface AuthoringTraceAttachment {
   payload: AuthoringTracePayload;
   parts: AuthoringTraceUploadPart[];
   cleanup: () => Promise<void>;
-}
-
-interface JsonObject {
-  [key: string]: unknown;
 }
 
 interface CodexHistoryBase {
@@ -486,14 +488,10 @@ function redactTraceText(contents: string): string {
 
 function parseJsonObject(line: string): JsonObject | undefined {
   try {
-    return objectValue(JSON.parse(line));
+    return objectValue(parseJsonText(line));
   } catch {
     return undefined;
   }
-}
-
-function isJsonObject(value: unknown): value is JsonObject {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function objectValue(value: unknown): JsonObject | undefined {

--- a/packages/progressive-review/src/server/bug-report.test.ts
+++ b/packages/progressive-review/src/server/bug-report.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { gunzipSync } from "node:zlib";
 
 import {
+  type JsonObject,
   REVIEW_SCHEMA_VERSION,
   type ReviewBugReportRequest,
 } from "@dev.fast/review-protocol";
@@ -479,7 +480,7 @@ interface CapturedPart {
   value: string | { filename: string; type: string; bytes: Buffer };
 }
 
-function captureFetch(): {
+interface CapturedFetch {
   fetchImpl: typeof fetch;
   url: () => string;
   headers: () => Headers;
@@ -487,7 +488,9 @@ function captureFetch(): {
   textPart: (name: string) => string;
   filePart: (name: string) => Buffer;
   fileParts: (name: string) => Buffer[];
-} {
+}
+
+function captureFetch(): CapturedFetch {
   let url: string | undefined;
   let headers: Headers | undefined;
   const capturedParts: CapturedPart[] = [];
@@ -557,7 +560,7 @@ function successResponse(): Response {
 function codexTrace(
   id: string,
   startOrdinal: number,
-  records: Array<Record<string, unknown>>,
+  records: JsonObject[],
   parent?: {
     parentId: string;
     endOrdinalExclusive: number;

--- a/packages/progressive-review/src/server/bug-report.ts
+++ b/packages/progressive-review/src/server/bug-report.ts
@@ -389,9 +389,7 @@ async function readReviewSourceFiles(
   documentPath: string,
 ): Promise<{ files: Record<string, string>; omitted: string[] }> {
   const documentName = path.basename(documentPath);
-  const files: Record<string, string> = {
-    [documentName]: await readFile(documentPath, "utf8"),
-  };
+  const files = { [documentName]: await readFile(documentPath, "utf8") };
   const omitted: string[] = [];
 
   const directory = path.dirname(documentPath);

--- a/packages/progressive-review/src/server/desktop-server-tutorial.test.ts
+++ b/packages/progressive-review/src/server/desktop-server-tutorial.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { type JsonObject, isJsonObject } from "@dev.fast/review-protocol";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { SessionRef } from "../authoring-session";
@@ -534,22 +535,22 @@ function tutorialRequest(
   });
 }
 
-async function tutorialJson(
+function tutorialJson(
   serverUrl: string,
   route: string,
   method: "POST",
-): Promise<Record<string, unknown>> {
-  const response = await tutorialRequest(serverUrl, route, method);
-  expect(response.status).toBe(200);
-  return (await response.json()) as Record<string, unknown>;
+): Promise<JsonObject> {
+  return responseJson(tutorialRequest(serverUrl, route, method));
 }
 
-async function responseJson(
-  response: Promise<Response>,
-): Promise<Record<string, unknown>> {
+async function responseJson(response: Promise<Response>): Promise<JsonObject> {
   const resolved = await response;
   expect(resolved.status).toBe(200);
-  return (await resolved.json()) as Record<string, unknown>;
+  const body = await resolved.json();
+  if (!isJsonObject(body)) {
+    throw new Error("Expected a JSON object response body.");
+  }
+  return body;
 }
 
 function submissionEvent(): ReviewSubmissionEvent {

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import {
+  type JsonObject,
   REVIEW_DESKTOP_DISCOVERY_VERSION,
   type ReviewDescriptor,
   type ReviewDesktopDiscovery,
@@ -16,6 +17,7 @@ import {
   type ReviewTutorialOpenResponse,
   type ReviewVerbRequest,
   type ReviewView,
+  isJsonObject,
   parseReviewCliInstallApplyRequest,
   parseReviewPublishReadyRequest,
   reviewViewSchema,
@@ -342,10 +344,7 @@ export function createGlobalReviewServer(
   app.post("/telemetry/event", async (context) => {
     try {
       const body = await readBoundedRequestJson(context.req.raw, undefined, {});
-      const payload =
-        body && typeof body === "object"
-          ? (body as Record<string, unknown>)
-          : {};
+      const payload: JsonObject = isJsonObject(body) ? body : {};
       let flushBeforeOptOut = false;
       await captureSanitizedUiTelemetry(
         telemetry,
@@ -2149,11 +2148,10 @@ function latestAgentSessionWithRole(
     )[0]?.[0];
 }
 
-function parseInfoRequest(value: unknown): RunReviewInfoInput {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+function parseInfoRequest(input: unknown): RunReviewInfoInput {
+  if (!isJsonObject(input)) {
     throw new HttpJsonError("Info request must be an object.", 400);
   }
-  const input = value as Record<string, unknown>;
   const allowed = new Set(["cwd", "all", "reviewUuid"]);
   if (Object.keys(input).some((key) => !allowed.has(key))) {
     throw new HttpJsonError("Info request has unexpected fields.", 400);

--- a/packages/progressive-review/src/server/global-verb-relay.test.ts
+++ b/packages/progressive-review/src/server/global-verb-relay.test.ts
@@ -99,16 +99,7 @@ describe("global Review Desktop verb relay", () => {
   });
 });
 
-function createWriter(): {
-  abort: AbortController;
-  close: ReturnType<typeof vi.fn>;
-  frames: string[];
-  writer: {
-    signal: AbortSignal;
-    write(frame: string): void;
-    close(): void;
-  };
-} {
+function createWriter() {
   const abort = new AbortController();
   const close = vi.fn<() => void>();
   const frames: string[] = [];
@@ -118,7 +109,7 @@ function createWriter(): {
     frames,
     writer: {
       signal: abort.signal,
-      write(frame) {
+      write(frame: string) {
         frames.push(frame);
       },
       close,

--- a/packages/progressive-review/src/server/review-api.ts
+++ b/packages/progressive-review/src/server/review-api.ts
@@ -10,9 +10,12 @@ import {
   resolveRevision,
 } from "@dev.fast/local-vcs";
 import {
+  type JsonObject,
+  type ReviewCommentThreadRecord,
   type ReviewSessionWire,
   type ReviewThreadsCommit,
   type ReviewVerbRequest,
+  isJsonObject,
   parseReviewFileContentRequest,
 } from "@dev.fast/review-protocol";
 import { type Context, Hono } from "hono";
@@ -167,10 +170,7 @@ export async function captureSanitizedUiTelemetry(
 ): Promise<void> {
   const appSessionId =
     request.headers.get(REVIEW_APP_SESSION_ID_HEADER) ?? undefined;
-  const rawProperties =
-    properties && typeof properties === "object"
-      ? (properties as Record<string, unknown>)
-      : {};
+  const rawProperties: JsonObject = isJsonObject(properties) ? properties : {};
   const sanitized = sanitizeUiTelemetryEvent({
     name,
     properties: {
@@ -476,10 +476,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   ): Promise<Response> {
     try {
       const body = await readJson(context.req.raw);
-      const payload =
-        body && typeof body === "object"
-          ? (body as Record<string, unknown>)
-          : {};
+      const payload: JsonObject = isJsonObject(body) ? body : {};
       await captureSanitizedUiTelemetry(
         telemetry,
         context.req.raw,
@@ -813,7 +810,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   async function codePeekResolve(
     context: Context<ReviewHonoEnv>,
   ): Promise<Response> {
-    const body = (await readJson(context.req.raw)) as Record<string, unknown>;
+    const body = await readJsonObject(context.req.raw);
     const sourceTarget = await resolveRequestSourceTarget({
       reviewRootPath,
     });
@@ -850,7 +847,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   async function softwareMapResolvedData(
     context: Context<ReviewHonoEnv>,
   ): Promise<Response> {
-    const body = (await readJson(context.req.raw)) as Record<string, unknown>;
+    const body = await readJsonObject(context.req.raw);
     const codeElements = parseSoftwareMapCodeElements(body.codeElements);
     const coverageClaims = parseSoftwareMapCoverageClaims(body.coverageClaims);
     const sourceTarget = await resolveRequestSourceTarget({
@@ -1040,9 +1037,30 @@ function readJson(request: Request): Promise<unknown> {
   return readBoundedRequestJson(request, undefined, {});
 }
 
-function reviewApiJsonResponse(
+async function readJsonObject(request: Request): Promise<JsonObject> {
+  const body = await readJson(request);
+  if (!isJsonObject(body)) {
+    throw new Error("Request body must be a JSON object.");
+  }
+  return body;
+}
+
+interface ReviewApiStatusBody {
+  ok: boolean;
+}
+
+/** The native-agent thread lookup answers with the thread record itself. */
+interface ReviewApiThreadBody {
+  review: string;
+  state: "draft" | "submitted";
+  comment: ReviewCommentThreadRecord;
+}
+
+type ReviewApiResponseBody = ReviewApiStatusBody | ReviewApiThreadBody;
+
+function reviewApiJsonResponse<T extends ReviewApiResponseBody>(
   status: number,
-  body: Record<string, unknown>,
+  body: T,
 ): Response {
   return jsonResponse(body, status as ContentfulStatusCode, {
     contentType: "application/json",
@@ -1500,6 +1518,12 @@ function resolveReviewDocumentPath(
   });
 }
 
+export interface ReviewRequestDiffTarget {
+  rootPath: string;
+  baseRef?: string;
+  headRef?: string;
+}
+
 export function resolveRequestDiffTarget(
   url: URL,
   input: {
@@ -1508,7 +1532,7 @@ export function resolveRequestDiffTarget(
     rootPath: string;
     session?: ReviewSessionWire;
   },
-): { rootPath: string; baseRef?: string; headRef?: string } {
+): ReviewRequestDiffTarget {
   const reviewDocumentPath = resolveReviewDocumentPath(url, input);
   if (!reviewDocumentPath) {
     throw new Error("Review document not found.");

--- a/packages/progressive-review/src/server/session-handler.test.ts
+++ b/packages/progressive-review/src/server/session-handler.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import type {
   CreateReviewCommentInput,
+  JsonObject,
   ReviewThreadsCommit,
 } from "@dev.fast/review-protocol";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -74,7 +75,7 @@ describe("createReviewSessionHandler", () => {
         startedAt: Date.now(),
       },
     });
-    const capture = (name: string, properties?: Record<string, unknown>) =>
+    const capture = (name: string, properties?: JsonObject) =>
       handler.handle(
         new Request(
           new URL("/__progressive-review/telemetry/event", sessionUrl),

--- a/packages/progressive-review/src/server/session-handler.ts
+++ b/packages/progressive-review/src/server/session-handler.ts
@@ -426,7 +426,7 @@ export async function createReviewSessionHandler(
     ),
   );
 
-  function reviewSessionPayload(): Record<string, unknown> {
+  function reviewSessionPayload() {
     return {
       ...session,
       sessionId: reviewSessionId(),

--- a/packages/progressive-review/src/software-map-artifact.ts
+++ b/packages/progressive-review/src/software-map-artifact.ts
@@ -578,7 +578,7 @@ export function materializeSoftwareMapAtRefSync(input: {
 function writeMaterializedArtifact(input: {
   gitDir: string;
   read: SoftwareMapSourceReadResult;
-}): { outputPath: string; status: "written" | "unchanged" } {
+}) {
   const outputPath = path.join(
     materializedSoftwareMapDir(input.gitDir, input.read.commit),
     SOFTWARE_MAP_FILE_NAME,

--- a/packages/progressive-review/src/software-map-bundle.ts
+++ b/packages/progressive-review/src/software-map-bundle.ts
@@ -109,6 +109,12 @@ export function sameReviewSoftwareMapBundle(
   );
 }
 
+// The review-doc-runtime substitute a legacy bundle evaluates against lives
+// in a pid-keyed global slot so concurrent migrations never share one.
+interface LegacyMapMigrationGlobal<Runtime> {
+  [slot: `__reviewLegacyMapMigration${number}`]: Runtime | undefined;
+}
+
 export async function extractLegacyReviewSoftwareMapBundle(input: {
   bundleCode: string;
   evaluationDir: string;
@@ -136,9 +142,6 @@ export async function extractLegacyReviewSoftwareMapBundle(input: {
       if (/^[A-Za-z_$][\w$]*$/.test(name)) names.add(name);
     }
   }
-  const holder = globalThis as Record<string, unknown>;
-  const key = `__reviewLegacyMapMigration${process.pid}`;
-  const prior = holder[key];
   let captured: {
     repoSoftwareMap?: unknown;
     baseSoftwareMap?: unknown;
@@ -154,7 +157,7 @@ export async function extractLegacyReviewSoftwareMapBundle(input: {
     defineSoftwareActors: (_model: unknown, value: unknown) => value,
     defineSoftwareStores: (_model: unknown, value: unknown) => value,
   };
-  holder[key] = {
+  const runtime = {
     createActiveReviewDocument(value: typeof captured) {
       captured = value;
       return value;
@@ -168,6 +171,12 @@ export async function extractLegacyReviewSoftwareMapBundle(input: {
     jsxDEV: () => ({}),
     React: {},
   };
+  const key: `__reviewLegacyMapMigration${number}` = `__reviewLegacyMapMigration${process.pid}`;
+  // SAFETY: the slot is private to this module and namespaced by pid; it only
+  // ever holds `runtime`, and the prior value is restored in `finally`.
+  const holder = globalThis as LegacyMapMigrationGlobal<typeof runtime>;
+  const prior = holder[key];
+  holder[key] = runtime;
   try {
     await mkdir(input.evaluationDir, { recursive: true, mode: 0o700 });
     const runtimeSource = [

--- a/packages/progressive-review/src/software-map-diff-counts.ts
+++ b/packages/progressive-review/src/software-map-diff-counts.ts
@@ -167,12 +167,14 @@ export function parseGitUnifiedDiffLineCounts(diff: string): FileLineCounts {
   return countsByFile;
 }
 
+export interface SoftwareMapElementDiffCounts {
+  countsByElementPath: SoftwareMapDiffCountsByElementPath;
+}
+
 export function mapDiffLineCountsToSoftwareMapElements(input: {
   codeElements: SoftwareMapCodeElementInput[];
   countsByFile: FileLineCounts;
-}): {
-  countsByElementPath: SoftwareMapDiffCountsByElementPath;
-} {
+}): SoftwareMapElementDiffCounts {
   const countsByElementPath: SoftwareMapDiffCountsByElementPath = {};
 
   for (const element of input.codeElements) {
@@ -205,7 +207,7 @@ export function mapDiffLineCountsToSoftwareMapElements(input: {
 export function mapDiffLineCountsToCoverageClaims(input: {
   coverageClaims: SoftwareMapCoverageClaimInput[];
   countsByFile: FileLineCounts;
-}): SoftwareMapUnmappedDiffByElementPath {
+}) {
   const result: SoftwareMapUnmappedDiffByElementPath = {};
   const claims = input.coverageClaims
     .filter(

--- a/packages/progressive-review/src/software-map-model.ts
+++ b/packages/progressive-review/src/software-map-model.ts
@@ -239,12 +239,11 @@ export function defineSoftwareMap(
   input: SoftwareModelInput,
 ): NormalizedSoftwareModel {
   const errors: string[] = [];
-  const rawInput = input as Record<string, unknown>;
   const elements: ElementDraft[] = [];
   const elementsByPath = new Map<string, ElementDraft>();
   const pendingRelationships: PendingRelationship[] = [];
 
-  if ("views" in rawInput) {
+  if ("views" in input) {
     errors.push(
       "Software model must not author views; SoftwareMap derives inline C4 projection from elements, relationships, and expansion state.",
     );
@@ -440,19 +439,18 @@ function validateElementShape(
   input: SoftwareElementBaseInput,
   errors: string[],
 ) {
-  const rawInput = input as Record<string, unknown>;
-  if ("additions" in rawInput || "deletions" in rawInput) {
+  if ("additions" in input || "deletions" in input) {
     errors.push(
       `Element "${path}" must not author additions or deletions; diff counts are computed automatically.`,
     );
   }
   if (
-    "changeStatus" in rawInput &&
-    rawInput.changeStatus !== undefined &&
-    rawInput.changeStatus !== "added" &&
-    rawInput.changeStatus !== "removed" &&
-    rawInput.changeStatus !== "modified" &&
-    rawInput.changeStatus !== "unchanged"
+    "changeStatus" in input &&
+    input.changeStatus !== undefined &&
+    input.changeStatus !== "added" &&
+    input.changeStatus !== "removed" &&
+    input.changeStatus !== "modified" &&
+    input.changeStatus !== "unchanged"
   ) {
     errors.push(
       `Element "${path}" changeStatus must be one of "added", "removed", "modified", or "unchanged".`,
@@ -460,35 +458,32 @@ function validateElementShape(
   }
   if (
     type === "dataStore" &&
-    "kind" in rawInput &&
-    rawInput.kind !== undefined &&
-    rawInput.kind !== "database" &&
-    rawInput.kind !== "objectStore" &&
-    rawInput.kind !== "bucket" &&
-    rawInput.kind !== "artifactStore" &&
-    rawInput.kind !== "fileStore"
+    "kind" in input &&
+    input.kind !== undefined &&
+    input.kind !== "database" &&
+    input.kind !== "objectStore" &&
+    input.kind !== "bucket" &&
+    input.kind !== "artifactStore" &&
+    input.kind !== "fileStore"
   ) {
     errors.push(
       `Data store "${path}" kind must be one of "database", "objectStore", "bucket", "artifactStore", or "fileStore".`,
     );
   }
-  if (type !== "dataStore" && "kind" in rawInput) {
+  if (type !== "dataStore" && "kind" in input) {
     errors.push(`Only data stores may define kind: "${path}".`);
   }
-  if (
-    type !== "dataStore" &&
-    ("tables" in rawInput || "documents" in rawInput)
-  ) {
+  if (type !== "dataStore" && ("tables" in input || "documents" in input)) {
     errors.push(`Only data stores may define tables or documents: "${path}".`);
   }
   if (type === "codeElement") {
-    if ("codeElements" in rawInput) {
+    if ("codeElements" in input) {
       errors.push(`Code element "${path}" cannot contain code elements.`);
     }
   }
   if (
-    "coverage" in rawInput &&
-    rawInput.coverage !== undefined &&
+    "coverage" in input &&
+    input.coverage !== undefined &&
     type !== "softwareSystem" &&
     type !== "container" &&
     type !== "dataStore" &&
@@ -614,13 +609,13 @@ function validateDataStoreFieldSchema(
 }
 
 function isDataStoreFieldLeaf(
-  value: unknown,
+  value: SoftwareDataStoreFieldSchema[string],
 ): value is SoftwareDataStoreFieldLeaf {
   return (
     value !== null &&
     typeof value === "object" &&
     "type" in value &&
-    typeof (value as { type?: unknown }).type === "string"
+    typeof value.type === "string"
   );
 }
 
@@ -640,11 +635,10 @@ function normalizeCoverage(
     return undefined;
   }
 
-  const rawCoverage = coverage as Record<string, unknown>;
   const files: NormalizedSoftwareCoverageFile[] = [];
   const globs: string[] = [];
 
-  if (rawCoverage.files !== undefined && !Array.isArray(rawCoverage.files)) {
+  if (coverage.files !== undefined && !Array.isArray(coverage.files)) {
     errors.push(`Element "${path}" coverage.files must be an array.`);
   }
   for (const [index, file] of (coverage.files ?? []).entries()) {
@@ -673,7 +667,7 @@ function normalizeCoverage(
     );
   }
 
-  if (rawCoverage.globs !== undefined && !Array.isArray(rawCoverage.globs)) {
+  if (coverage.globs !== undefined && !Array.isArray(coverage.globs)) {
     errors.push(`Element "${path}" coverage.globs must be an array.`);
   }
   for (const [index, glob] of (coverage.globs ?? []).entries()) {

--- a/packages/progressive-review/src/stored-review-migration.test.ts
+++ b/packages/progressive-review/src/stored-review-migration.test.ts
@@ -3,9 +3,10 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { parseJsonText } from "@dev.fast/review-protocol";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { createReviewDir } from "./review-home";
+import { createReviewDir, parseStoredReviewRecord } from "./review-home";
 import { migrateStoredReviewData } from "./stored-review-migration";
 
 const tempRoots: string[] = [];
@@ -53,9 +54,11 @@ describe("migrateStoredReviewData", () => {
       sourceCommit,
       sourceIdentity: { kind: "git-branch", name: "main" },
     });
-    const current = JSON.parse(
-      await readFile(path.join(created.dir, "review.json"), "utf8"),
-    ) as Record<string, unknown>;
+    const current = parseStoredReviewRecord(
+      parseJsonText(
+        await readFile(path.join(created.dir, "review.json"), "utf8"),
+      ),
+    );
     const {
       presentedDocumentRevision: _documentRevision,
       presentedSoftwareMapRevision: _softwareMapRevision,

--- a/packages/progressive-review/src/stored-review-migration.ts
+++ b/packages/progressive-review/src/stored-review-migration.ts
@@ -1,7 +1,11 @@
 import { cp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { REVIEW_SCHEMA_VERSION } from "@dev.fast/review-protocol";
+import {
+  type JsonObject,
+  REVIEW_SCHEMA_VERSION,
+  isJsonObject,
+} from "@dev.fast/review-protocol";
 import type { Expression, Program } from "estree";
 
 import {
@@ -383,9 +387,7 @@ export async function migrateStoredReviewData(input: {
         });
       }
       if (
-        !value ||
-        typeof value !== "object" ||
-        Array.isArray(value) ||
+        !isJsonObject(value) ||
         (schemaVersion !== REVIEW_SCHEMA_VERSION &&
           schemaVersion !== 3 &&
           schemaVersion !== 2)
@@ -399,15 +401,14 @@ export async function migrateStoredReviewData(input: {
       if (schemaVersion === 3 || schemaVersion === 2) {
         const migratedSource = await migrateReviewSourceSession({
           onWarning: (message) => input.log?.(message),
-          value: value as Record<string, unknown>,
+          value,
         });
         migrationValue = migratedSource;
       }
       const migratedRecord =
         parseStoredReviewRecordForMigration(migrationValue);
       if (schemaVersion === 2) {
-        const legacyRevision = (value as { presentedRevision?: unknown })
-          .presentedRevision;
+        const legacyRevision = value.presentedRevision;
         try {
           if (typeof legacyRevision === "string") {
             await migrateLegacyPresentedArtifacts({
@@ -496,8 +497,8 @@ export async function migrateStoredReviewData(input: {
 
 async function migrateReviewSourceSession(input: {
   onWarning?: (message: string) => void;
-  value: Record<string, unknown>;
-}): Promise<Record<string, unknown>> {
+  value: JsonObject;
+}): Promise<JsonObject> {
   const source = parseAuthoringSessionKey(
     typeof input.value.agentSession === "string"
       ? input.value.agentSession

--- a/packages/progressive-review/src/threads-cli.ts
+++ b/packages/progressive-review/src/threads-cli.ts
@@ -2,7 +2,10 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import type { Writable } from "node:stream";
 
-import { ReviewCommentThreadRecordSchema } from "@dev.fast/review-protocol";
+import {
+  ReviewCommentThreadRecordSchema,
+  isJsonObject,
+} from "@dev.fast/review-protocol";
 
 import { reviewUuidForManagedCheckout } from "./review-head-checkout";
 import { type StoredReview, findReview, listReviews } from "./review-home";
@@ -90,11 +93,10 @@ async function readAttachedReviewThread(input: {
       `Review Desktop could not read the thread (${response.status}).`,
     );
   }
-  const value: unknown = await response.json();
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+  const record: unknown = await response.json();
+  if (!isJsonObject(record)) {
     throw new Error("Review Desktop returned an invalid thread response.");
   }
-  const record = value as Record<string, unknown>;
   const review = record.review;
   const state = record.state;
   if (

--- a/packages/progressive-review/src/trace-cli.ts
+++ b/packages/progressive-review/src/trace-cli.ts
@@ -285,6 +285,13 @@ export async function runReviewTraceShow(input: {
   return 0;
 }
 
+/** Which sessions a `trace pull` selected, echoed back in its JSON report. */
+type TracePullScope =
+  | { review: string }
+  | { commit: string }
+  | { session: string }
+  | { repository: string };
+
 export async function runReviewTracePull(input: {
   cwd: string;
   repo?: string;
@@ -297,7 +304,7 @@ export async function runReviewTracePull(input: {
   stderr: Writable;
 }): Promise<number> {
   try {
-    let scope: Record<string, string>;
+    let scope: TracePullScope;
     let sessions: Array<{ id: string; traces?: string[] }>;
     let repoRoot = input.cwd;
 

--- a/packages/progressive-review/src/ui-telemetry-events.ts
+++ b/packages/progressive-review/src/ui-telemetry-events.ts
@@ -16,6 +16,8 @@
 // accepting the property. Either the cleaner finished the job or only the
 // digest goes; a wrong producer cannot put raw text on the wire through here.
 
+import { type JsonObject, isJsonObject } from "@dev.fast/review-protocol";
+
 import {
   containsFilePathShape,
   hasPossibleUserInfo,
@@ -437,6 +439,10 @@ const COMMON_PROPERTIES = {
   app_session_id: "opaque_id",
 } as const satisfies Record<string, UiTelemetryPropertySpec>;
 
+function isUiTelemetryEventName(name: string): name is UiTelemetryEventName {
+  return Object.hasOwn(UI_TELEMETRY_EVENTS, name);
+}
+
 /**
  * Validate a raw UI event payload against the allowlist. Returns the PostHog
  * event name plus only the sanctioned properties, or null when the event
@@ -450,18 +456,16 @@ export function sanitizeUiTelemetryEvent(input: {
   event: string;
   properties: Record<string, string | number | boolean>;
 } | null {
-  if (typeof input.name !== "string") return null;
-  const spec = (
-    UI_TELEMETRY_EVENTS as Record<string, UiTelemetryEventSpec | undefined>
-  )[input.name];
-  if (!spec) return null;
+  if (typeof input.name !== "string" || !isUiTelemetryEventName(input.name)) {
+    return null;
+  }
+  const spec: UiTelemetryEventSpec = UI_TELEMETRY_EVENTS[input.name];
 
-  const raw =
-    input.properties && typeof input.properties === "object"
-      ? (input.properties as Record<string, unknown>)
-      : {};
+  const raw: JsonObject = isJsonObject(input.properties)
+    ? input.properties
+    : {};
   const properties: Record<string, string | number | boolean> = {};
-  const propertySpecs: Record<string, UiTelemetryPropertySpec> = {
+  const propertySpecs: UiTelemetryEventSpec["properties"] = {
     ...COMMON_PROPERTIES,
     ...spec.properties,
   };

--- a/packages/review-protocol/scripts/generate-native-source.mjs
+++ b/packages/review-protocol/scripts/generate-native-source.mjs
@@ -23,6 +23,7 @@ const index = readFileSync(path.join(packageRoot, "src/index.ts"), "utf8")
   .replace(/^import \{ z \} from "zod";\n\n/, "")
   .replace(/import \{[\s\S]*?\} from "\.\/contracts\.js";\n\n/, "")
   .replace('export * from "./bug-report.js";\n', "")
+  .replace('export * from "./json.js";\n', "")
   .replace('export * from "./contracts.js";\n\n', "");
 
 writeFileSync(

--- a/packages/review-protocol/src/contracts.test.ts
+++ b/packages/review-protocol/src/contracts.test.ts
@@ -44,6 +44,7 @@ import {
   reviewViewSchema,
   summarizeReviewDiffFiles,
 } from "./contracts.js";
+import type { JsonObject } from "./json.js";
 
 const repository = {
   kind: "jj",
@@ -124,7 +125,7 @@ const anchor = {
   threadId: "thread-1",
   kind: "comment",
 };
-const contracts: Array<[string, ZodType, Record<string, unknown>]> = [
+const contracts: Array<[string, ZodType, JsonObject]> = [
   ["review record", ReviewRecordSchema, reviewRecord],
   ["review descriptor", ReviewDescriptorSchema, reviewDescriptor],
   [

--- a/packages/review-protocol/src/index.ts
+++ b/packages/review-protocol/src/index.ts
@@ -42,6 +42,7 @@ import {
 } from "./contracts.js";
 
 export * from "./bug-report.js";
+export * from "./json.js";
 export * from "./contracts.js";
 
 export function parseReviewDesktopDiscovery(

--- a/packages/review-protocol/src/json.ts
+++ b/packages/review-protocol/src/json.ts
@@ -1,0 +1,32 @@
+/**
+ * JSON values as they come off the wire or out of a file. Parse into one of
+ * these at the I/O boundary, then narrow into a domain type; never carry an
+ * `unknown`-valued dictionary past the boundary.
+ */
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonArray | JsonObject;
+export type JsonArray = JsonValue[];
+export type JsonObject = { [key: string]: JsonValue };
+
+export function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isJsonArray(value: unknown): value is JsonArray {
+  return Array.isArray(value);
+}
+
+/** Parses JSON text into a JsonValue; throws SyntaxError on malformed input. */
+export function parseJsonText(text: string): JsonValue {
+  // SAFETY: JSON.parse only ever produces JSON primitives, arrays, and plain
+  // objects, which is exactly the JsonValue union.
+  return JSON.parse(text) as JsonValue;
+}
+
+/** Reads one property of a JSON object; missing keys read as undefined. */
+export function jsonProperty(
+  value: JsonObject,
+  key: string,
+): JsonValue | undefined {
+  return Object.hasOwn(value, key) ? value[key] : undefined;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       '@types/mdast':
         specifier: 4.0.4
         version: 4.0.4
+      '@types/mdx':
+        specifier: 2.0.14
+        version: 2.0.14
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2


### PR DESCRIPTION
## Summary

Second anti-slop pass. Promotes `anti-slop/no-unsafe-dictionary-type` and `anti-slop/no-known-value-widening` from `warn` to `error` and clears all 218 findings (117 + 101) across 81 files.

- **JSON boundary types** in `@dev.fast/review-protocol`: `JsonValue`, `JsonObject`, `JsonArray`, `isJsonObject`, `isJsonArray`, `parseJsonText`, `jsonProperty`. Every `JSON.parse(...) as Record<string, unknown>` and `value as Record<string, unknown>` on file, HTTP, sqlite, or process output now parses into `JsonValue` and narrows from there.
- **Named owner types** for telemetry attributes (`LoggerAttributes`), CLI events (`CliJsonEvent`, with `emitJsonEvent` generic so literal callers are unchanged), publish stage details, ELK port properties (`LayoutOptions`), MDX components (`MDXComponents` from `@types/mdx`, now an explicit devDependency), and the publish-validation React shim.
- **Anonymous return types** replaced by inference for private helpers and exported interfaces for exported functions.
- **Six remaining single assertions** (globalThis slots, thrown values, the audit shim) carry `SAFETY:` comments. No `as unknown as`, `any`, `object`, or disables were introduced.
- `require-safety-comment-for-type-assertion` is turned off for `*.test.*` via an `overrides` block; test doubles cast into an interface document nothing.
- The native-source generator strips the new `json.js` re-export so the Code OSS overlay bundle is unchanged.

## Behavioral notes

- `codePeekResolve`, `softwareMapDiffCounts`, `softwareMapResolvedData` return 400 for a JSON body that is not an object (previously fell through or threw).
- Claude hook install/remove treats a non-object `hooks` value as empty instead of crashing; the Claude transcript reader throws a clear error on a non-object line.
- `sanitizeUiTelemetryEvent` looks up event names with `Object.hasOwn`, so prototype keys no longer resolve.

## Verification

- `pnpm lint`: 0 errors (1,129 warnings, down from 1,597).
- `pnpm format:check`: clean.
- `pnpm typecheck`: only the pre-existing `scripts/check-tutorial.ts` error on `main`.
- Tests: progressive-review 150 files / 1,178 tests, local-vcs 58, review-protocol 111, all passing.
