### PR TITLE
Deduplicate Code OSS review helpers

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
@@ -111,6 +111,7 @@ import {
 	REVIEW_BASE_SCHEME,
 	reviewResourceIdentity,
 } from "../../../common/reviewCodeResources.js";
+import { reviewTelemetryEventRequest } from "../../../common/reviewTelemetryRequest.js";
 import { IReviewTelemetryService } from "../../../services/reviewTelemetryService.js";
 import { IReviewSessionService } from "../../../services/reviewSessionService.js";
 import { ReviewCommentStore } from "../../../services/reviewCommentStore.js";
@@ -1453,19 +1454,16 @@ export class ReviewCanvasEditorPane extends EditorPane {
 
 	private async captureReviewPresented(model: ReviewSessionModel): Promise<void> {
 		const session = model.session;
-		const headers = new Headers({
-			"content-type": "application/json",
-			"x-review-token": session.token,
-			"x-review-app-session-id": this.reviewTelemetryService.appSessionId,
-		});
 		await model.request(
 			`${session.sessionUrl}/__progressive-review/telemetry/event`,
-			{
-				method: "POST",
-				headers,
-				body: JSON.stringify({ name: "review_presented" }),
-				keepalive: true,
-			},
+			reviewTelemetryEventRequest(
+				{
+					token: session.token,
+					appSessionId: this.reviewTelemetryService.appSessionId,
+				},
+				{ name: "review_presented" },
+				{ keepalive: true },
+			),
 		).catch(() => undefined);
 	}
 

--- a/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
@@ -56,8 +56,6 @@ import {
 	parseReviewListResponse,
 	parseReviewVerbRequest,
 	parseReviewSessionResponse,
-	ReviewDocModuleResponseSchema,
-	ReviewSoftwareMapModuleResponseSchema,
 	DEFAULT_DISMISSED_RETENTION_DAYS,
 	REVIEW_CANVAS_RESUME_EVENT,
 	REVIEW_TUTORIAL_PROGRESS_STORAGE_KEY,
@@ -117,8 +115,11 @@ import { IReviewSessionService } from "../../../services/reviewSessionService.js
 import { ReviewCommentStore } from "../../../services/reviewCommentStore.js";
 import {
 	IReviewSessionModelService,
+	loadReviewSessionDocument,
+	loadReviewSessionSoftwareMap,
 	type ReviewDesktopSession,
 	type ReviewSessionModel,
+	reviewSessionApiRequest,
 } from "../../../services/reviewSessionModelService.js";
 import { IReviewCanvasEditorTabsService } from "../../../services/reviewCanvasEditorTabsService.js";
 import { IReviewExplorerPartsService } from "../explorer/reviewExplorerPart.js";
@@ -1406,19 +1407,7 @@ export class ReviewCanvasEditorPane extends EditorPane {
 		lifecycle?: ReviewCanvasLoadLifecycle,
 	): ReviewCanvasBridge {
 		const session = model.session;
-		const config: ReviewRuntimeConfig = {
-			serverUrl: session.serverUrl,
-			sessionUrl: session.sessionUrl,
-			routePath: session.descriptor.routePath,
-			sessionId: session.session.sessionId,
-			token: session.token,
-			wasmUrl: assets.reviewWasmUrl,
-			docRuntimeUrl: assets.reviewDocRuntimeUrl,
-			appVersion:
-				this.productService.reviewVersion ?? this.productService.version,
-			theme: this.colorScheme(),
-			host: "desktop",
-		};
+		const config = this.reviewRuntimeConfig(session, assets);
 		return {
 			appSessionId: this.reviewTelemetryService.appSessionId,
 			config,
@@ -1449,6 +1438,25 @@ export class ReviewCanvasEditorPane extends EditorPane {
 				);
 				lifecycle?.reportDiagnostic(diagnostic);
 			},
+		};
+	}
+
+	private reviewRuntimeConfig(
+		session: ReviewDesktopSession,
+		assets: ReviewCanvasAssetsModule,
+	): ReviewRuntimeConfig {
+		return {
+			serverUrl: session.serverUrl,
+			sessionUrl: session.sessionUrl,
+			routePath: session.descriptor.routePath,
+			sessionId: session.session.sessionId,
+			token: session.token,
+			wasmUrl: assets.reviewWasmUrl,
+			docRuntimeUrl: assets.reviewDocRuntimeUrl,
+			appVersion:
+				this.productService.reviewVersion ?? this.productService.version,
+			theme: this.colorScheme(),
+			host: "desktop",
 		};
 	}
 
@@ -1490,25 +1498,23 @@ export class ReviewCanvasEditorPane extends EditorPane {
 		try {
 			const assets = await this.loadAssets();
 			const session = await this.resolveValidationSession(sessionId);
-			const documentPromise = this.loadValidationDocument(
+			const documentPromise = loadReviewSessionDocument(
 				session,
-				assets.reviewDocRuntimeUrl,
+				(draftSession, moduleUrl) =>
+					loadReviewDocumentModule(
+						draftSession,
+						moduleUrl,
+						assets.reviewDocRuntimeUrl,
+					),
 			);
-			const softwareMapPromise = this.loadValidationSoftwareMap(session);
-			const request = (endpoint: string, init: RequestInit = {}) => {
-				const url = new URL(
-					`${session.sessionUrl}/__progressive-review${endpoint}`,
-				);
-				const routePath =
-					session.session.routePath ?? session.descriptor.routePath;
-				if (routePath && routePath !== "/") {
-					url.searchParams.set("document", routePath);
-				}
-				const headers = new Headers(init.headers);
-				headers.set("x-review-token", session.token);
-				return fetch(url.href, { ...init, headers });
-			};
-			comments = new ReviewCommentStore({ request });
+			const softwareMapPromise = loadReviewSessionSoftwareMap(
+				session,
+				loadReviewSoftwareMapModules,
+			);
+			comments = new ReviewCommentStore({
+				request: (endpoint, init) =>
+					reviewSessionApiRequest(session, endpoint, init),
+			});
 			let finished = false;
 			let finishMount!: (error: Error | null) => void;
 			const mountResult = new Promise<Error | null>((resolve) => {
@@ -1520,19 +1526,7 @@ export class ReviewCanvasEditorPane extends EditorPane {
 			});
 			const bridge: ReviewCanvasBridge = {
 				appSessionId: this.reviewTelemetryService.appSessionId,
-				config: {
-					serverUrl: session.serverUrl,
-					sessionUrl: session.sessionUrl,
-					routePath: session.descriptor.routePath,
-					sessionId: session.descriptor.sessionId,
-					token: session.token,
-					wasmUrl: assets.reviewWasmUrl,
-					docRuntimeUrl: assets.reviewDocRuntimeUrl,
-					appVersion:
-						this.productService.reviewVersion ?? this.productService.version,
-					theme: this.colorScheme(),
-					host: "desktop",
-				},
+				config: this.reviewRuntimeConfig(session, assets),
 				comments,
 				inlineEditors: this.inlineEditors,
 				// A validation mount must build no diff widgets off-screen and
@@ -1684,64 +1678,6 @@ export class ReviewCanvasEditorPane extends EditorPane {
 			review,
 			session: payload.session as ReviewDesktopSession["session"],
 		};
-	}
-
-	private async loadValidationDocument(
-		session: ReviewDesktopSession,
-		reviewDocRuntimeUrl: string,
-	): Promise<unknown> {
-		const url = new URL(
-			`${session.sessionUrl}/__progressive-review/doc-module`,
-		);
-		const routePath = session.session.routePath ?? session.descriptor.routePath;
-		if (routePath && routePath !== "/") {
-			url.searchParams.set("document", routePath);
-		}
-		const response = await fetch(url, {
-			headers: { "x-review-token": session.token },
-			signal: AbortSignal.timeout(30_000),
-		});
-		const payload = ReviewDocModuleResponseSchema.parse(await response.json());
-		if (!response.ok || !payload.ok) {
-			throw new Error(
-				payload.ok
-					? `Review document module returned ${response.status}.`
-					: payload.error,
-			);
-		}
-		return loadReviewDocumentModule(
-			session,
-			payload.moduleUrl,
-			reviewDocRuntimeUrl,
-		);
-	}
-
-	private async loadValidationSoftwareMap(
-		session: ReviewDesktopSession,
-	): Promise<unknown | null> {
-		const response = await fetch(
-			`${session.sessionUrl}/__progressive-review/software-map-module`,
-			{
-				headers: { "x-review-token": session.token },
-				signal: AbortSignal.timeout(30_000),
-			},
-		);
-		if (response.status === 404) return null;
-		const payload = ReviewSoftwareMapModuleResponseSchema.parse(
-			await response.json(),
-		);
-		if (!response.ok || !payload.ok) {
-			throw new Error(
-				payload.ok
-					? `Software map module returned ${response.status}.`
-					: payload.error,
-			);
-		}
-		return loadReviewSoftwareMapModules(
-			session,
-			payload.headModuleUrl,
-			payload.baseModuleUrl,
-		);
 	}
 
 	private async resetSessionForGeneration(

--- a/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewDocumentModule.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewDocumentModule.ts
@@ -5,6 +5,7 @@
 
 import { createTrustedTypesPolicy } from "../../../../base/browser/trustedTypes.js";
 import { ReviewDocumentModuleCache } from "../../../common/reviewDocumentModuleCache.js";
+import { rewriteReviewDocumentRuntime } from "../../../common/reviewProtocol.js";
 import type { ReviewDesktopSession } from "../../../services/reviewSessionModelService.js";
 
 type ReviewDocumentImporter = (url: string) => Promise<unknown>;
@@ -135,19 +136,6 @@ function loadSoftwareMapModule(
 function unwrapDefault(module: unknown): unknown {
 	if (!module || typeof module !== "object") return module;
 	return (module as { default?: unknown }).default ?? module;
-}
-
-export function rewriteReviewDocumentRuntime(
-	source: string,
-	runtimeUrl: string,
-): string {
-	const runtimeSpecifier = JSON.stringify("review-doc-runtime");
-	if (!source.includes(runtimeSpecifier)) {
-		throw new Error("Review document module has no runtime import.");
-	}
-	return source
-		.split(runtimeSpecifier)
-		.join(JSON.stringify(new URL(runtimeUrl).href));
 }
 
 function importBlobReviewModule(url: string): Promise<unknown> {

--- a/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewDocumentModule.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewDocumentModule.ts
@@ -4,18 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { createTrustedTypesPolicy } from "../../../../base/browser/trustedTypes.js";
-import { ReviewDocumentModuleCache } from "../../../common/reviewDocumentModuleCache.js";
+import { ReviewModuleCache } from "../../../common/reviewModuleCache.js";
 import { rewriteReviewDocumentRuntime } from "../../../common/reviewProtocol.js";
 import type { ReviewDesktopSession } from "../../../services/reviewSessionModelService.js";
 
 type ReviewDocumentImporter = (url: string) => Promise<unknown>;
 
-const softwareMapModules = new Map<string, Promise<unknown>>();
+const softwareMapModules = new ReviewModuleCache();
 
 const reviewDocumentPolicy = createTrustedTypesPolicy("reviewDocumentModule", {
 	createScriptURL: (value: string) => value,
 });
-const reviewDocumentModules = new ReviewDocumentModuleCache();
+const reviewDocumentModules = new ReviewModuleCache();
 
 export async function loadReviewDocumentModule(
 	session: ReviewDesktopSession,
@@ -27,8 +27,7 @@ export async function loadReviewDocumentModule(
 	const resolvedModuleUrl = url.href;
 	const resolvedRuntimeUrl = new URL(runtimeUrl).href;
 	return reviewDocumentModules.load(
-		resolvedModuleUrl,
-		resolvedRuntimeUrl,
+		JSON.stringify([resolvedModuleUrl, resolvedRuntimeUrl]),
 		async () => {
 			if (session.token) {
 				url.searchParams.set("token", session.token);
@@ -100,37 +99,26 @@ function loadSoftwareMapModule(
 ): Promise<unknown> {
 	const url = new URL(moduleUrl, session.serverUrl);
 	if (session.token) url.searchParams.set("token", session.token);
-	const cacheKey = url.href;
-	const cached = softwareMapModules.get(cacheKey);
-	if (cached) return cached;
-	const pending = fetch(url, {
-		headers: session.token
-			? { "x-review-token": session.token }
-			: undefined,
-	})
-		.then(async (response) => {
-			if (!response.ok) {
-				throw new Error(`Software map module returned ${response.status}.`);
-			}
-			const blobUrl = URL.createObjectURL(
-				new Blob([await response.text()], { type: "text/javascript" }),
-			);
-			try {
-				const trustedUrl =
-					reviewDocumentPolicy?.createScriptURL(blobUrl) ?? blobUrl;
-				return await importModule(trustedUrl as string);
-			} finally {
-				URL.revokeObjectURL(blobUrl);
-			}
-		})
-		.catch((error) => {
-			if (softwareMapModules.get(cacheKey) === pending) {
-				softwareMapModules.delete(cacheKey);
-			}
-			throw error;
+	return softwareMapModules.load(url.href, async () => {
+		const response = await fetch(url, {
+			headers: session.token
+				? { "x-review-token": session.token }
+				: undefined,
 		});
-	softwareMapModules.set(cacheKey, pending);
-	return pending;
+		if (!response.ok) {
+			throw new Error(`Software map module returned ${response.status}.`);
+		}
+		const blobUrl = URL.createObjectURL(
+			new Blob([await response.text()], { type: "text/javascript" }),
+		);
+		try {
+			const trustedUrl =
+				reviewDocumentPolicy?.createScriptURL(blobUrl) ?? blobUrl;
+			return await importModule(trustedUrl as string);
+		} finally {
+			URL.revokeObjectURL(blobUrl);
+		}
+	});
 }
 
 function unwrapDefault(module: unknown): unknown {

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewModuleCache.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewModuleCache.test.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ReviewModuleCache } from "./reviewModuleCache.js";
+
+test("concurrent loads of one key share a single loader call", async () => {
+	const cache = new ReviewModuleCache();
+	let calls = 0;
+	const loader = async () => {
+		calls += 1;
+		return "module";
+	};
+	const [first, second] = await Promise.all([
+		cache.load("a", loader),
+		cache.load("a", loader),
+	]);
+	assert.equal(first, "module");
+	assert.equal(second, "module");
+	assert.equal(calls, 1);
+	assert.equal(await cache.load("a", loader), "module");
+	assert.equal(calls, 1);
+});
+
+test("a rejected load is evicted so the next caller retries", async () => {
+	const cache = new ReviewModuleCache();
+	let calls = 0;
+	const loader = async () => {
+		calls += 1;
+		if (calls === 1) throw new Error("boom");
+		return "recovered";
+	};
+	await assert.rejects(cache.load("a", loader), /boom/);
+	assert.equal(await cache.load("a", loader), "recovered");
+	assert.equal(calls, 2);
+});
+
+test("a loader that throws synchronously rejects instead of throwing", async () => {
+	const cache = new ReviewModuleCache();
+	await assert.rejects(
+		cache.load("a", () => {
+			throw new Error("sync");
+		}),
+		/sync/,
+	);
+});
+
+test("clear forces the next load to run the loader again", async () => {
+	const cache = new ReviewModuleCache();
+	let calls = 0;
+	const loader = async () => ++calls;
+	assert.equal(await cache.load("a", loader), 1);
+	cache.clear();
+	assert.equal(await cache.load("a", loader), 2);
+});

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewModuleCache.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewModuleCache.ts
@@ -3,15 +3,15 @@
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export class ReviewDocumentModuleCache {
+/**
+ * Caches in-flight and settled module loads by key. Concurrent callers share
+ * one promise, a fulfilled load stays cached until `clear()`, and a rejected
+ * load is evicted so the next caller retries.
+ */
+export class ReviewModuleCache {
 	private readonly entries = new Map<string, Promise<unknown>>();
 
-	load<T>(
-		moduleUrl: string,
-		runtimeUrl: string,
-		loader: () => Promise<T>,
-	): Promise<T> {
-		const key = JSON.stringify([moduleUrl, runtimeUrl]);
+	load<T>(key: string, loader: () => Promise<T>): Promise<T> {
 		const cached = this.entries.get(key) as Promise<T> | undefined;
 		if (cached) {
 			return cached;
@@ -28,5 +28,9 @@ export class ReviewDocumentModuleCache {
 			});
 		this.entries.set(key, pending);
 		return pending;
+	}
+
+	clear(): void {
+		this.entries.clear();
 	}
 }

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
@@ -2174,6 +2174,19 @@ export function parseReviewAgentTraceResponse(
   return parseZod(ReviewAgentTraceResponseSchema, value);
 }
 
+export function rewriteReviewDocumentRuntime(
+  source: string,
+  runtimeUrl: string,
+): string {
+  const runtimeSpecifier = JSON.stringify("review-doc-runtime");
+  if (!source.includes(runtimeSpecifier)) {
+    throw new Error("Review document module has no runtime import.");
+  }
+  return source
+    .split(runtimeSpecifier)
+    .join(JSON.stringify(new URL(runtimeUrl).href));
+}
+
 export function parseZod<T>(
   schema: z.ZodType<T>,
   value: unknown,

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewReconnect.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewReconnect.test.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	REVIEW_CLIENT_RECONNECT_DELAYS,
+	reconnectUntilAborted,
+} from "./reviewReconnect.js";
+
+function failing(times: number): (onConnected: () => void) => Promise<void> {
+	let calls = 0;
+	return async () => {
+		calls += 1;
+		if (calls <= times) throw new Error(`failure ${calls}`);
+	};
+}
+
+test("walks the delay table between failures and returns once connect resolves", async () => {
+	const waits: number[] = [];
+	const errors: string[] = [];
+	await reconnectUntilAborted(new AbortController().signal, failing(3), {
+		onRetry: (error) => errors.push((error as Error).message),
+		wait: async (ms) => {
+			waits.push(ms);
+		},
+	});
+	assert.deepEqual(waits, REVIEW_CLIENT_RECONNECT_DELAYS.slice(0, 3));
+	assert.deepEqual(errors, ["failure 1", "failure 2", "failure 3"]);
+});
+
+test("keeps retrying at the last delay when no exhaustion handler is given", async () => {
+	const waits: number[] = [];
+	const total = REVIEW_CLIENT_RECONNECT_DELAYS.length + 2;
+	await reconnectUntilAborted(new AbortController().signal, failing(total), {
+		wait: async (ms) => {
+			waits.push(ms);
+		},
+	});
+	const last = REVIEW_CLIENT_RECONNECT_DELAYS[REVIEW_CLIENT_RECONNECT_DELAYS.length - 1];
+	assert.deepEqual(waits, [...REVIEW_CLIENT_RECONNECT_DELAYS, last, last]);
+});
+
+test("calls onExhausted with the last error once the table runs out", async () => {
+	const waits: number[] = [];
+	await assert.rejects(
+		reconnectUntilAborted(
+			new AbortController().signal,
+			failing(REVIEW_CLIENT_RECONNECT_DELAYS.length + 1),
+			{
+				onExhausted: (error) => {
+					throw new Error("exhausted", { cause: error });
+				},
+				wait: async (ms) => {
+					waits.push(ms);
+				},
+			},
+		),
+		(error: Error) =>
+			error.message === "exhausted" &&
+			(error.cause as Error).message ===
+				`failure ${REVIEW_CLIENT_RECONNECT_DELAYS.length + 1}`,
+	);
+	assert.deepEqual(waits, [...REVIEW_CLIENT_RECONNECT_DELAYS]);
+});
+
+test("a successful connection restarts the delay table", async () => {
+	const waits: number[] = [];
+	let calls = 0;
+	await reconnectUntilAborted(
+		new AbortController().signal,
+		async (onConnected) => {
+			calls += 1;
+			if (calls === 1) throw new Error("first");
+			if (calls === 2) {
+				onConnected();
+				throw new Error("stream ended");
+			}
+		},
+		{
+			wait: async (ms) => {
+				waits.push(ms);
+			},
+		},
+	);
+	const first = REVIEW_CLIENT_RECONNECT_DELAYS[0];
+	assert.deepEqual(waits, [first, first]);
+});
+
+test("returns quietly when the signal aborts during a failure", async () => {
+	const controller = new AbortController();
+	let waited = false;
+	await reconnectUntilAborted(
+		controller.signal,
+		async () => {
+			controller.abort();
+			throw new Error("aborted mid-connect");
+		},
+		{
+			onRetry: () => assert.fail("must not retry after abort"),
+			wait: async () => {
+				waited = true;
+			},
+		},
+	);
+	assert.equal(waited, false);
+});

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewReconnect.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewReconnect.ts
@@ -12,3 +12,50 @@ export const REVIEW_CLIENT_RECONNECT_DELAYS = [
   ...REVIEW_SERVER_RESTART_DELAYS,
   4_000,
 ] as const;
+
+export interface ReviewReconnectOptions {
+  /** Observes each failure before the next delay. */
+  readonly onRetry?: (error: unknown) => void;
+  /**
+   * Called once every delay in the table has been used since the last
+   * successful connection. Omit it to keep retrying at the last delay.
+   */
+  readonly onExhausted?: (error: unknown) => never;
+  readonly wait?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Runs `connect` until it resolves or `signal` aborts, backing off through
+ * `REVIEW_CLIENT_RECONNECT_DELAYS` between failures. `connect` receives an
+ * `onConnected` callback that restarts the delay table.
+ */
+export async function reconnectUntilAborted(
+  signal: AbortSignal,
+  connect: (onConnected: () => void) => Promise<void>,
+  options: ReviewReconnectOptions = {},
+): Promise<void> {
+  const wait =
+    options.wait ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  let attempt = 0;
+  while (!signal.aborted) {
+    try {
+      await connect(() => {
+        attempt = 0;
+      });
+      return;
+    } catch (error) {
+      if (signal.aborted) return;
+      options.onRetry?.(error);
+      let delay = REVIEW_CLIENT_RECONNECT_DELAYS[attempt++];
+      if (delay === undefined) {
+        options.onExhausted?.(error);
+        delay =
+          REVIEW_CLIENT_RECONNECT_DELAYS[
+            REVIEW_CLIENT_RECONNECT_DELAYS.length - 1
+          ];
+      }
+      await wait(delay);
+    }
+  }
+}

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewTelemetryRequest.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewTelemetryRequest.test.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { reviewTelemetryEventRequest } from "./reviewTelemetryRequest.js";
+
+test("builds an authenticated JSON POST for a telemetry event", () => {
+	const request = reviewTelemetryEventRequest(
+		{ token: "secret", appSessionId: "app-1" },
+		{ name: "review_presented" },
+	);
+	assert.equal(request.method, "POST");
+	assert.deepEqual(request.headers, {
+		"content-type": "application/json",
+		"x-review-token": "secret",
+		"x-review-app-session-id": "app-1",
+	});
+	assert.deepEqual(JSON.parse(String(request.body)), { name: "review_presented" });
+	assert.equal(request.keepalive, false);
+});
+
+test("keepalive is opt-in", () => {
+	const request = reviewTelemetryEventRequest(
+		{ token: "secret", appSessionId: "app-1" },
+		{ name: "x" },
+		{ keepalive: true },
+	);
+	assert.equal(request.keepalive, true);
+});

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewTelemetryRequest.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewTelemetryRequest.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface ReviewTelemetryAuth {
+	readonly token: string;
+	readonly appSessionId: string;
+}
+
+/**
+ * The POST every telemetry sender makes to a Review server `telemetry/event`
+ * endpoint; callers pick the URL and how the request is dispatched.
+ */
+export function reviewTelemetryEventRequest(
+	auth: ReviewTelemetryAuth,
+	event: unknown,
+	options: { readonly keepalive?: boolean } = {},
+): RequestInit {
+	return {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+			"x-review-token": auth.token,
+			"x-review-app-session-id": auth.appSessionId,
+		},
+		body: JSON.stringify(event),
+		keepalive: options.keepalive ?? false,
+	};
+}

--- a/apps/review-desktop/code-oss/src/vs/review/contrib/extensions/reviewOptionalExtensionManagement.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/extensions/reviewOptionalExtensionManagement.ts
@@ -20,15 +20,29 @@ export class OptionalExtensionInstallError extends Error {
 	}
 }
 
-export interface OptionalExtensionInstallTransaction<T> {
+export interface OptionalExtensionInstallCallbacks {
+	readonly onInstalled?: (extensionId: string, trigger: OptionalExtensionInstallTrigger, durationMs: number) => void;
+	readonly onInstallFailed?: (extensionId: string, trigger: OptionalExtensionInstallTrigger, phase: OptionalExtensionInstallPhase) => void;
+}
+
+export interface OptionalExtensionInstallTransaction<T> extends OptionalExtensionInstallCallbacks {
 	readonly groups: readonly string[];
 	readonly installedIds: ReadonlySet<string>;
 	readonly download: (extensionId: string) => Promise<string>;
 	readonly install: (extensionId: string, vsixPath: string) => Promise<T>;
 	readonly rollback: (installed: T) => Promise<void>;
-	readonly onInstalled?: (extensionId: string, trigger: OptionalExtensionInstallTrigger, durationMs: number) => void;
-	readonly onInstallFailed?: (extensionId: string, trigger: OptionalExtensionInstallTrigger, phase: OptionalExtensionInstallPhase) => void;
 	readonly onRolledBack?: (extensionId: string) => void;
+}
+
+/** Support extensions install before the primary extension that activates them. */
+function compareOptionalExtensionInstallOrder(
+	left: { readonly role: string },
+	right: { readonly role: string }
+): number {
+	if (left.role === right.role) {
+		return 0;
+	}
+	return left.role === 'support' ? -1 : 1;
 }
 
 export async function installMissingOptionalExtensions<T>(
@@ -56,12 +70,7 @@ export async function installMissingOptionalExtensions<T>(
 	}));
 
 	const installed: { readonly extensionId: string; readonly local: T }[] = [];
-	const installOrder = [...missing].sort((left, right) => {
-		if (left.role === right.role) {
-			return 0;
-		}
-		return left.role === 'support' ? -1 : 1;
-	});
+	const installOrder = [...missing].sort(compareOptionalExtensionInstallOrder);
 	try {
 		for (const extension of installOrder) {
 			const vsixPath = downloads.get(extension.id);
@@ -106,14 +115,12 @@ export interface InstalledOptionalExtensionPin {
 	readonly version: string;
 }
 
-export interface OptionalExtensionPinUpgradeTransaction {
+export interface OptionalExtensionPinUpgradeTransaction extends OptionalExtensionInstallCallbacks {
 	readonly installed: readonly InstalledOptionalExtensionPin[];
 	readonly download: (extensionId: string) => Promise<string>;
 	readonly install: (extensionId: string, vsixPath: string) => Promise<void>;
 	readonly stageRustAnalyzer: () => Promise<void>;
 	readonly logError: (message: string, error: unknown) => void;
-	readonly onInstalled?: (extensionId: string, trigger: OptionalExtensionInstallTrigger, durationMs: number) => void;
-	readonly onInstallFailed?: (extensionId: string, trigger: OptionalExtensionInstallTrigger, phase: OptionalExtensionInstallPhase) => void;
 }
 
 export async function upgradeOptionalExtensionPins(
@@ -130,7 +137,7 @@ export async function upgradeOptionalExtensionPins(
 
 		const members = reviewOptionalExtensionCatalog
 			.filter(extension => extension.group === group)
-			.sort((left, right) => left.role === right.role ? 0 : left.role === 'support' ? -1 : 1);
+			.sort(compareOptionalExtensionInstallOrder);
 		for (const extension of members) {
 			const currentVersion = installed.get(extension.id);
 			if (currentVersion && !semver.lt(currentVersion, extension.version)) {

--- a/apps/review-desktop/code-oss/src/vs/review/electron-main/reviewMainErrorTelemetry.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/electron-main/reviewMainErrorTelemetry.ts
@@ -10,6 +10,7 @@ import {
   ReviewErrorReportLimiter,
   type ReviewErrorReport,
 } from "../common/reviewErrorReport.js";
+import { reviewTelemetryEventRequest } from "../common/reviewTelemetryRequest.js";
 import { drainReviewBootstrapBreadcrumbs } from "../node/reviewBootstrapBreadcrumb.js";
 
 export interface ReviewMainErrorTelemetryOptions {
@@ -149,19 +150,17 @@ export class ReviewMainErrorTelemetry {
     if (!this.options.isTelemetryEnabled()) return;
     const send = this.options.fetchImpl ?? fetch;
     try {
-      void send(`${connection.url}/telemetry/event`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-review-token": connection.token,
-          "x-review-app-session-id": this.appSessionId,
-        },
-        body: JSON.stringify({
-          name: pending.name,
-          properties: pending.properties,
-          error: pending.error,
-        }),
-      }).catch(() => undefined);
+      void send(
+        `${connection.url}/telemetry/event`,
+        reviewTelemetryEventRequest(
+          { token: connection.token, appSessionId: this.appSessionId },
+          {
+            name: pending.name,
+            properties: pending.properties,
+            error: pending.error,
+          },
+        ),
+      ).catch(() => undefined);
     } catch (error) {
       this.options.logError?.(
         `[Review Desktop] could not report a main-process telemetry event: ${error}`,

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.ts
@@ -15,6 +15,7 @@ import {
 	createDecorator,
 	IInstantiationService,
 } from "../../platform/instantiation/common/instantiation.js";
+import { ReviewModuleCache } from "../common/reviewModuleCache.js";
 import {
 	ReviewDocModuleResponseSchema,
 	ReviewSoftwareMapModuleResponseSchema,
@@ -86,8 +87,7 @@ export class ReviewSessionModel extends Disposable {
 	}
 
 	private documentRevision: string;
-	private documentPromise: Promise<unknown> | undefined;
-	private softwareMapPromise: Promise<unknown | null> | undefined;
+	private readonly modules = new ReviewModuleCache();
 	private refreshPromise: Promise<void> | undefined;
 	private _comments: ReviewCommentStore;
 	get comments(): ReviewCommentStoreBridge {
@@ -190,8 +190,7 @@ export class ReviewSessionModel extends Disposable {
 					return;
 				}
 				if (this.documentRevision !== previousRevision) {
-					this.documentPromise = undefined;
-					this.softwareMapPromise = undefined;
+					this.modules.clear();
 				}
 				this._onDidChange.fire();
 			})
@@ -216,33 +215,15 @@ export class ReviewSessionModel extends Disposable {
 	}
 
 	resolveDocument(loader: ReviewDocumentModuleLoader): Promise<unknown> {
-		if (this.documentPromise) {
-			return this.documentPromise;
-		}
-		let pending: Promise<unknown>;
-		pending = this.loadDocument(loader).catch((error) => {
-			if (this.documentPromise === pending) {
-				this.documentPromise = undefined;
-			}
-			throw error;
-		});
-		this.documentPromise = pending;
-		return pending;
+		return this.modules.load("document", () => this.loadDocument(loader));
 	}
 
 	resolveSoftwareMap(
 		loader: ReviewSoftwareMapModuleLoader,
 	): Promise<unknown | null> {
-		if (this.softwareMapPromise) return this.softwareMapPromise;
-		let pending: Promise<unknown | null>;
-		pending = this.loadSoftwareMap(loader).catch((error) => {
-			if (this.softwareMapPromise === pending) {
-				this.softwareMapPromise = undefined;
-			}
-			throw error;
-		});
-		this.softwareMapPromise = pending;
-		return pending;
+		return this.modules.load("software-map", () =>
+			this.loadSoftwareMap(loader),
+		);
 	}
 
 	async request(url: string, init: RequestInit = {}): Promise<Response> {

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.ts
@@ -230,84 +230,99 @@ export class ReviewSessionModel extends Disposable {
 		return fetch(url, init);
 	}
 
-	private async loadDocument(
-		loader: ReviewDocumentModuleLoader,
-	): Promise<unknown> {
-		const session = this._session;
-		const url = new URL(
-			`${session.sessionUrl}/__progressive-review/doc-module`,
-		);
-		const routePath = session.session.routePath ?? session.descriptor.routePath;
-		if (routePath && routePath !== "/") {
-			url.searchParams.set("document", routePath);
-		}
-		const response = await fetch(url, {
-			headers: { "x-review-token": session.token },
-			signal: AbortSignal.timeout(30_000),
-		});
-		const payload = ReviewDocModuleResponseSchema.parse(await response.json());
-		if (!response.ok || !payload.ok) {
-			throw new Error(
-				payload.ok
-					? `Review document module returned ${response.status}.`
-					: payload.error,
-			);
-		}
-		return loader(session, payload.moduleUrl);
+	private loadDocument(loader: ReviewDocumentModuleLoader): Promise<unknown> {
+		return loadReviewSessionDocument(this._session, loader);
 	}
 
-	private async loadSoftwareMap(
+	private loadSoftwareMap(
 		loader: ReviewSoftwareMapModuleLoader,
 	): Promise<unknown | null> {
-		const session = this._session;
-		const url = new URL(
-			`${session.sessionUrl}/__progressive-review/software-map-module`,
-		);
-		const response = await fetch(url, {
-			headers: { "x-review-token": session.token },
-			signal: AbortSignal.timeout(30_000),
-		});
-		if (response.status === 404) return null;
-		const payload = ReviewSoftwareMapModuleResponseSchema.parse(
-			await response.json(),
-		);
-		if (!response.ok || !payload.ok) {
-			throw new Error(
-				payload.ok
-					? `Software map module returned ${response.status}.`
-					: payload.error,
-			);
-		}
-		return loader(session, payload.headModuleUrl, payload.baseModuleUrl);
+		return loadReviewSessionSoftwareMap(this._session, loader);
 	}
 
 	private createCommentStore(): ReviewCommentStore {
 		return new ReviewCommentStore({
-			request: (endpoint, init = {}) => this.reviewApiRequest(endpoint, init),
+			request: (endpoint, init = {}) =>
+				reviewSessionApiRequest(this._session, endpoint, init, (url, request) =>
+					this.request(url, request),
+				),
 		});
-	}
-
-	private reviewApiRequest(
-		endpoint: string,
-		init: RequestInit = {},
-	): Promise<Response> {
-		const session = this._session;
-		const url = new URL(
-			`${session.sessionUrl}/__progressive-review${endpoint}`,
-		);
-		const routePath = session.session.routePath ?? session.descriptor.routePath;
-		if (routePath && routePath !== "/") {
-			url.searchParams.set("document", routePath);
-		}
-		const headers = new Headers(init.headers);
-		headers.set("x-review-token", session.token);
-		return this.request(url.href, { ...init, headers });
 	}
 
 	override dispose(): void {
 		this._comments.dispose();
 		super.dispose();
 	}
+}
+
+/**
+ * Sends a Review API request scoped to `session`, adding the document route
+ * and the session token. Callers that must not touch a model's request path
+ * (the publish-gate validation mount) pass the session explicitly.
+ */
+export function reviewSessionApiRequest(
+	session: ReviewDesktopSession,
+	endpoint: string,
+	init: RequestInit = {},
+	fetchImpl: (url: string, init: RequestInit) => Promise<Response> = fetch,
+): Promise<Response> {
+	const url = new URL(`${session.sessionUrl}/__progressive-review${endpoint}`);
+	const routePath = session.session.routePath ?? session.descriptor.routePath;
+	if (routePath && routePath !== "/") {
+		url.searchParams.set("document", routePath);
+	}
+	const headers = new Headers(init.headers);
+	headers.set("x-review-token", session.token);
+	return fetchImpl(url.href, { ...init, headers });
+}
+
+export async function loadReviewSessionDocument(
+	session: ReviewDesktopSession,
+	loader: ReviewDocumentModuleLoader,
+): Promise<unknown> {
+	const url = new URL(`${session.sessionUrl}/__progressive-review/doc-module`);
+	const routePath = session.session.routePath ?? session.descriptor.routePath;
+	if (routePath && routePath !== "/") {
+		url.searchParams.set("document", routePath);
+	}
+	const response = await fetch(url, {
+		headers: { "x-review-token": session.token },
+		signal: AbortSignal.timeout(30_000),
+	});
+	const payload = ReviewDocModuleResponseSchema.parse(await response.json());
+	if (!response.ok || !payload.ok) {
+		throw new Error(
+			payload.ok
+				? `Review document module returned ${response.status}.`
+				: payload.error,
+		);
+	}
+	return loader(session, payload.moduleUrl);
+}
+
+export async function loadReviewSessionSoftwareMap(
+	session: ReviewDesktopSession,
+	loader: ReviewSoftwareMapModuleLoader,
+): Promise<unknown | null> {
+	const url = new URL(
+		`${session.sessionUrl}/__progressive-review/software-map-module`,
+	);
+	const response = await fetch(url, {
+		headers: { "x-review-token": session.token },
+		signal: AbortSignal.timeout(30_000),
+	});
+	if (response.status === 404) return null;
+	const payload = ReviewSoftwareMapModuleResponseSchema.parse(
+		await response.json(),
+	);
+	if (!response.ok || !payload.ok) {
+		throw new Error(
+			payload.ok
+				? `Software map module returned ${response.status}.`
+				: payload.error,
+		);
+	}
+	return loader(session, payload.headModuleUrl, payload.baseModuleUrl);
 }
 
 function reviewDocumentRevision(session: ReviewDesktopSession): string {

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
@@ -36,7 +36,7 @@ import {
 	parseReviewTutorialOpenResponse,
 } from "../common/reviewProtocol.js";
 import { consumeReviewEventStream } from "../common/reviewEventStream.js";
-import { REVIEW_CLIENT_RECONNECT_DELAYS } from "../common/reviewReconnect.js";
+import { reconnectUntilAborted } from "../common/reviewReconnect.js";
 import { IReviewTelemetryService } from "./reviewTelemetryService.js";
 
 const REVIEW_LIST_TIMEOUT_MS = 30_000;
@@ -721,22 +721,17 @@ export class ReviewSessionService
 			value: unknown,
 		) => Promise<ReviewVerbResponse>,
 	): Promise<void> {
-		let attempt = 0;
-		while (!this.controller.signal.aborted) {
-			try {
+		await reconnectUntilAborted(
+			this.controller.signal,
+			async () => {
 				await this.initialize();
 				await this.maintainControl(dispatch);
-				return;
-			} catch (error) {
-				if (this.controller.signal.aborted) return;
-				console.error("[Review Desktop] control channel stopped", error);
-				const delay =
-					REVIEW_CLIENT_RECONNECT_DELAYS[
-						Math.min(attempt++, REVIEW_CLIENT_RECONNECT_DELAYS.length - 1)
-					] ?? 1_000;
-				await new Promise((resolve) => setTimeout(resolve, delay));
-			}
-		}
+			},
+			{
+				onRetry: (error) =>
+					console.error("[Review Desktop] control channel stopped", error),
+			},
+		);
 	}
 
 	private async waitForHealth(): Promise<void> {
@@ -802,27 +797,25 @@ export class ReviewSessionService
 	}
 
 	private async maintainGlobalEvents(onConnected: () => void): Promise<void> {
-		let attempt = 0;
-		while (!this.controller.signal.aborted) {
-			try {
+		await reconnectUntilAborted(
+			this.controller.signal,
+			async (onStreamConnected) => {
 				await this.watchGlobalEvents(() => {
-					attempt = 0;
+					onStreamConnected();
 					onConnected();
 				});
 				if (this.controller.signal.aborted) return;
 				throw new Error("The embedded Review server event stream ended.");
-			} catch (error) {
-				if (this.controller.signal.aborted) return;
-				const delay = REVIEW_CLIENT_RECONNECT_DELAYS[attempt++];
-				if (delay === undefined) {
+			},
+			{
+				onExhausted: (error) => {
 					throw new Error(
 						"The embedded Review server exhausted its restart attempts.",
 						{ cause: error },
 					);
-				}
-				await new Promise((resolve) => setTimeout(resolve, delay));
-			}
-		}
+				},
+			},
+		);
 	}
 
 	private async watchGlobalEvents(onConnected: () => void): Promise<void> {
@@ -919,21 +912,19 @@ export class ReviewSessionService
 			value: unknown,
 		) => Promise<ReviewVerbResponse>,
 	): Promise<void> {
-		let attempt = 0;
-		while (!this.controller.signal.aborted) {
-			try {
-				await this.consumeControl(dispatch, () => {
-					attempt = 0;
-				});
+		await reconnectUntilAborted(
+			this.controller.signal,
+			async (onConnected) => {
+				await this.consumeControl(dispatch, onConnected);
 				if (this.controller.signal.aborted) return;
 				throw new Error("The Review Desktop control stream ended.");
-			} catch (error) {
-				if (this.controller.signal.aborted) return;
-				const delay = REVIEW_CLIENT_RECONNECT_DELAYS[attempt++];
-				if (delay === undefined) throw error;
-				await new Promise((resolve) => setTimeout(resolve, delay));
-			}
-		}
+			},
+			{
+				onExhausted: (error) => {
+					throw error;
+				},
+			},
+		);
 	}
 
 	private async consumeControl(

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewTelemetryService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewTelemetryService.ts
@@ -14,6 +14,7 @@ import {
 } from "../common/reviewDesktopBootstrap.js";
 import { REVIEW_TELEMETRY_SETTING } from "../common/reviewConfigurationDefaults.js";
 import type { ReviewErrorReport } from "../common/reviewErrorReport.js";
+import { reviewTelemetryEventRequest } from "../common/reviewTelemetryRequest.js";
 
 type ReviewTelemetryProperties = Record<string, string | number | boolean>;
 
@@ -110,16 +111,14 @@ export class ReviewTelemetryService implements IReviewTelemetryService {
 		const connection = this.connection;
 		if (!connection) return;
 		let request: Promise<void>;
-		request = fetch(`${connection.url}/telemetry/event`, {
-			method: "POST",
-			headers: {
-				"content-type": "application/json",
-				"x-review-token": connection.token,
-				"x-review-app-session-id": this.appSessionId,
-			},
-			body: JSON.stringify(event),
-			keepalive: true,
-		})
+		request = fetch(
+			`${connection.url}/telemetry/event`,
+			reviewTelemetryEventRequest(
+				{ token: connection.token, appSessionId: this.appSessionId },
+				event,
+				{ keepalive: true },
+			),
+		)
 			.then(() => undefined)
 			.catch(() => undefined)
 			.finally(() => this.inFlight.delete(request));

--- a/packages/progressive-review/app/src/host/review-client.test.ts
+++ b/packages/progressive-review/app/src/host/review-client.test.ts
@@ -8,7 +8,6 @@ import {
   reviewFetch,
   reviewStorageKey,
   reviewWasmUrl,
-  rewriteReviewDocumentRuntime,
 } from "./review-client";
 
 const injectedConfig = {
@@ -60,29 +59,6 @@ describe("review host client", () => {
     expect(new Headers(requestInit?.headers).get("x-review-token")).toBe(
       "secret-token",
     );
-  });
-
-  it("rewrites each document rebuild to the current bundled runtime URL", () => {
-    const source =
-      'import { createActiveReviewDocument } from "review-doc-runtime";\nexport const version = 1;';
-    expect(
-      rewriteReviewDocumentRuntime(
-        source,
-        "vscode-file://review/assets/doc-runtime-first.js",
-      ),
-    ).toContain("vscode-file://review/assets/doc-runtime-first.js");
-    expect(
-      rewriteReviewDocumentRuntime(
-        source.replace("version = 1", "version = 2"),
-        "vscode-file://review/assets/doc-runtime-second.js",
-      ),
-    ).toContain("vscode-file://review/assets/doc-runtime-second.js");
-    expect(() =>
-      rewriteReviewDocumentRuntime(
-        "export const version = 3;",
-        "vscode-file://review/assets/doc-runtime.js",
-      ),
-    ).toThrow("no runtime import");
   });
 
   it("retries a rejected document module import", async () => {

--- a/packages/progressive-review/app/src/host/review-client.ts
+++ b/packages/progressive-review/app/src/host/review-client.ts
@@ -1,4 +1,7 @@
-import type { ReviewRuntimeConfig } from "@dev.fast/review-protocol";
+import {
+  type ReviewRuntimeConfig,
+  rewriteReviewDocumentRuntime,
+} from "@dev.fast/review-protocol";
 
 const REVIEW_API_PREFIX = "/__progressive-review";
 export type ReviewClientConfig = Partial<
@@ -118,19 +121,6 @@ async function loadReviewModule(
 
 function importBlobReviewModule(url: string): Promise<unknown> {
   return import(/* @vite-ignore */ url);
-}
-
-export function rewriteReviewDocumentRuntime(
-  source: string,
-  runtimeUrl: string,
-): string {
-  const runtimeSpecifier = JSON.stringify("review-doc-runtime");
-  if (!source.includes(runtimeSpecifier)) {
-    throw new Error("Review document module has no runtime import.");
-  }
-  return source
-    .split(runtimeSpecifier)
-    .join(JSON.stringify(new URL(runtimeUrl).href));
 }
 
 export function reviewBeaconUrl(

--- a/packages/progressive-review/src/review-source-agent-session.ts
+++ b/packages/progressive-review/src/review-source-agent-session.ts
@@ -6,6 +6,7 @@ import { dirname, join } from "node:path";
 import { isJsonObject, parseJsonText } from "@dev.fast/review-protocol";
 
 import type { SessionRef } from "./authoring-session";
+import { errorMessage } from "./error-message";
 import { findClaudeTranscript } from "./native-agent/claude-transcript";
 import { forkCodexThread } from "./native-agent/codex-app-server";
 
@@ -167,5 +168,5 @@ function commandError(error: unknown): string {
     const stderr = String(error.stderr).trim();
     if (stderr) return stderr;
   }
-  return error instanceof Error ? error.message : String(error);
+  return errorMessage(error);
 }

--- a/packages/progressive-review/src/runtime.ts
+++ b/packages/progressive-review/src/runtime.ts
@@ -10,6 +10,7 @@ import {
   resolveRevision,
 } from "@dev.fast/local-vcs";
 
+import { errorMessage } from "./error-message";
 import { reviewMdxPath } from "./review-file";
 
 const DEFAULT_REVIEW_ROUTE = "/";
@@ -217,9 +218,9 @@ export async function resolvePullRequestReviewSubject(input: {
         throw new Error(
           [
             `Unable to read pull request metadata with gh pr view for ${input.value}.`,
-            `The unauthenticated public GitHub API fallback also failed: ${formatCommandError(fallbackError)}`,
+            `The unauthenticated public GitHub API fallback also failed: ${errorMessage(fallbackError)}`,
             "For private repositories or exhausted public API rate limits, run `gh auth status` and authenticate the GitHub CLI.",
-            `Original gh error: ${formatCommandError(error)}`,
+            `Original gh error: ${errorMessage(error)}`,
           ].join("\n"),
         );
       }
@@ -228,7 +229,7 @@ export async function resolvePullRequestReviewSubject(input: {
         [
           `Unable to read pull request metadata with gh pr view for ${input.value}.`,
           "Progressive review could not determine a public GitHub repository and numeric PR for an unauthenticated API fallback; run `gh auth status` for this host and ensure the CLI can access the repository.",
-          `Original error: ${formatCommandError(error)}`,
+          `Original error: ${errorMessage(error)}`,
         ].join("\n"),
       );
     }
@@ -239,7 +240,7 @@ export async function resolvePullRequestReviewSubject(input: {
       parsed = JSON.parse(stdout ?? "") as PullRequestMetadata;
     } catch (error) {
       throw new Error(
-        `Unable to parse gh pr view output for ${input.value}: ${formatCommandError(
+        `Unable to parse gh pr view output for ${input.value}: ${errorMessage(
           error,
         )}`,
       );
@@ -470,7 +471,7 @@ async function preparePullRequestRefs(input: {
         pullRequestNumber: input.pullRequestNumber,
         baseRefName: input.baseRefName,
         error: new Error(
-          `${formatCommandError(error)}\nFrozen base ${input.baseRefOid} fallback failed: ${formatCommandError(fallbackError)}`,
+          `${errorMessage(error)}\nFrozen base ${input.baseRefOid} fallback failed: ${errorMessage(fallbackError)}`,
         ),
       });
     }
@@ -614,7 +615,7 @@ function formatPullRequestFetchError(input: {
       `Unable to fetch refs for PR ${input.pullRequestNumber} with git fetch origin.`,
       `Progressive review uses your existing git remote credentials; verify \`git fetch origin ${input.baseRefName}\` and your SSH/HTTPS credential setup, then retry.`,
       "If you are in a jj-only workspace, ensure it is backed by a Git remote that jj can import.",
-      `Original error: ${formatCommandError(input.error)}`,
+      `Original error: ${errorMessage(input.error)}`,
     ].join("\n"),
   );
 }
@@ -662,10 +663,6 @@ async function gitRefExists(
   } catch {
     return false;
   }
-}
-
-function formatCommandError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 export function activeReviewMdxPath(rootPath: string): string {

--- a/packages/progressive-review/src/server/review-api.ts
+++ b/packages/progressive-review/src/server/review-api.ts
@@ -549,7 +549,10 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       session: {
         resolvedBaseRef,
         ...(stateReviewPath
-          ? { reviewStatus: readReviewStatus(stateReviewPath) }
+          ? {
+              reviewStatus: readReviewStoreRecord(path.dirname(stateReviewPath))
+                .status,
+            }
           : {}),
       },
     });
@@ -816,10 +819,8 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     });
     const baseSourceTarget = sourceTarget.preparedBase;
     const graph = parseCodePeekGraph(body.graph);
-    const includeDiff = parseCodePeekIncludeDiff(body.includeDiff);
-    const includeDiffSummary = parseCodePeekIncludeDiffSummary(
-      body.includeDiffSummary,
-    );
+    const includeDiff = body.includeDiff === true;
+    const includeDiffSummary = body.includeDiffSummary === true;
     const primaryTarget = graph === "base" ? baseSourceTarget : sourceTarget;
     if (!primaryTarget) {
       throw new Error("The pinned base worktree is unavailable.");
@@ -1019,18 +1020,6 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
 
 function parseCodePeekGraph(value: unknown): "head" | "base" {
   return value === "base" ? "base" : "head";
-}
-
-function parseCodePeekIncludeDiff(value: unknown): boolean {
-  return value === true;
-}
-
-function parseCodePeekIncludeDiffSummary(value: unknown): boolean {
-  return value === true;
-}
-
-function readReviewStatus(stateReviewPath: string): string {
-  return readReviewStoreRecord(path.dirname(stateReviewPath)).status;
 }
 
 function readJson(request: Request): Promise<unknown> {

--- a/packages/review-protocol/src/index.test.ts
+++ b/packages/review-protocol/src/index.test.ts
@@ -13,6 +13,7 @@ import {
   parseReviewOpenResponse,
   parseReviewSessionResponse,
   parseReviewVerbRequest,
+  rewriteReviewDocumentRuntime,
 } from "./index.js";
 
 describe("review protocol parsers", () => {
@@ -315,5 +316,28 @@ describe("review protocol parsers", () => {
 
     expect(normalizeReviewRoutePath(pathname)).toBe(pathname);
     expect(performance.now() - startedAt).toBeLessThan(100);
+  });
+
+  it("rewrites each document rebuild to the current bundled runtime URL", () => {
+    const source =
+      'import { createActiveReviewDocument } from "review-doc-runtime";\nexport const version = 1;';
+    expect(
+      rewriteReviewDocumentRuntime(
+        source,
+        "vscode-file://review/assets/doc-runtime-first.js",
+      ),
+    ).toContain("vscode-file://review/assets/doc-runtime-first.js");
+    expect(
+      rewriteReviewDocumentRuntime(
+        source.replace("version = 1", "version = 2"),
+        "vscode-file://review/assets/doc-runtime-second.js",
+      ),
+    ).toContain("vscode-file://review/assets/doc-runtime-second.js");
+    expect(() =>
+      rewriteReviewDocumentRuntime(
+        "export const version = 3;",
+        "vscode-file://review/assets/doc-runtime.js",
+      ),
+    ).toThrow("no runtime import");
   });
 });

--- a/packages/review-protocol/src/index.ts
+++ b/packages/review-protocol/src/index.ts
@@ -151,6 +151,19 @@ export function parseReviewAgentTraceResponse(
   return parseZod(ReviewAgentTraceResponseSchema, value);
 }
 
+export function rewriteReviewDocumentRuntime(
+  source: string,
+  runtimeUrl: string,
+): string {
+  const runtimeSpecifier = JSON.stringify("review-doc-runtime");
+  if (!source.includes(runtimeSpecifier)) {
+    throw new Error("Review document module has no runtime import.");
+  }
+  return source
+    .split(runtimeSpecifier)
+    .join(JSON.stringify(new URL(runtimeUrl).href));
+}
+
 export function parseZod<T>(
   schema: z.ZodType<T>,
   value: unknown,


### PR DESCRIPTION
The Code OSS half of the simplification pass's deduplication section (B). PR #94 consolidated the app and backend helpers and left "the wider Code OSS deduplication" for a separate change; this is that change. Everything touched lives under `code-oss/src/vs/review/**` (the Review fork's own tree) plus `review-protocol` and three one-line backend leftovers. No upstream VS Code files change.

One commit per item, each independently green (review-desktop typecheck + test at every commit):

1. **`rewriteReviewDocumentRuntime` lives in review-protocol.** The app host and `reviewDocumentModule.ts` carried byte-identical copies; the Code OSS copy now comes through the generated overlay. Its tests moved to `review-protocol/src/index.test.ts`.
2. **One `ReviewModuleCache`.** The software-map module map and the two single-slot promise fields on `ReviewSessionModel` reimplemented the evict-on-rejection cache `ReviewDocumentModuleCache` already provided. Generalised to a keyed cache with `clear()`; new unit tests.
3. **One reconnect loop.** The three `REVIEW_CLIENT_RECONNECT_DELAYS` loops in `reviewSessionService.ts` share `reconnectUntilAborted`; each keeps its own exhaustion policy (retry at the last delay forever / wrap the error / rethrow). New unit tests cover the table walk, reset-on-connect, clamping, exhaustion, and abort.
4. **One telemetry request builder.** The main-process error telemetry, the renderer telemetry service, and `captureReviewPresented` now build their POST through `reviewTelemetryEventRequest`; URL, dispatch path, and keepalive stay per site.
5. **Optional-extension management.** Shared install-order comparator and callback interface.
6. **Publish-gate mount reuses the session-model loaders.** `validateSessionMount` lost its private copies of the document, software-map, and API-request loaders and the second runtime-config literal. `resolveValidationSession` still bypasses the session service so the draft never opens a tab. Method names and order are unchanged, so `review-presented-telemetry-contract.test.mjs` still pins the same region.
7. **Backend leftovers.** `formatCommandError` was `errorMessage` under another name; three one-line wrappers in `review-api.ts` inlined.

Deviations from the audit, deliberately:
- Task 5 keeps the `<T>` generic on `installMissingOptionalExtensions`; collapsing it would pull `ILocalExtension` into an otherwise platform-free helper for no behavioural gain. `installMissingOptionalExtensions` is not renamed (contract-test pin).
- The single-flight maps in `reviewOptionalExtensionInstaller.ts` and `reviewCodeResourceService.ts` are not merged into the cache: they clear on success too, which is a different contract.

Notes for rebasing: commit 1 regenerates the committed protocol overlay. Once #98 lands (overlay generated at build time, gitignored) that hunk simply drops.

Verification: `pnpm run ci` green (lint 0 errors, format clean, review-protocol 95, local-vcs 57, progressive-review 1160, review-desktop 144 `.mjs` + 72 `.test.ts`); `git rebase --exec` ran typecheck + the review-desktop suite at each of the seven commits; telemetry smoke scripts (`smoke-error-telemetry`, `smoke-telemetry-delivery`) against the built app.
