### PR TITLE
Decode JSON at the boundary and drop unknown from signatures

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -82,10 +82,10 @@
     "anti-slop/no-object-parameters": "error",
     "anti-slop/no-reflect-apply": "error",
     "anti-slop/no-reflect-get": "error",
-    "anti-slop/no-runtime-typeof": "warn",
+    "anti-slop/no-runtime-typeof": "error",
     "anti-slop/no-shape-in-symbol-names": "warn",
-    "anti-slop/no-unknown-parameters": "warn",
-    "anti-slop/no-unknown-returns": "warn",
+    "anti-slop/no-unknown-parameters": "error",
+    "anti-slop/no-unknown-returns": "error",
     "anti-slop/no-unknown-type-aliases": "error",
     "anti-slop/no-unsafe-dictionary-type": "error",
     "anti-slop/no-widen-then-assert": "error",
@@ -102,6 +102,12 @@
       "files": ["**/*.test.ts", "**/*.test.tsx"],
       "rules": {
         "anti-slop/require-safety-comment-for-type-assertion": "off"
+      }
+    },
+    {
+      "files": ["packages/review-protocol/src/runtime-value.ts"],
+      "rules": {
+        "anti-slop/no-runtime-typeof": "off"
       }
     }
   ]

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewEventStream.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewEventStream.ts
@@ -5,6 +5,8 @@
 
 import { createParser } from "eventsource-parser";
 
+import { type JsonValue, parseJsonText } from "./reviewProtocol.js";
+
 const DEFAULT_MAX_EVENT_CHARACTERS = 1024 * 1024;
 const EVENT_BOUNDARY = /(?:\r\n|\r|\n)(?:\r\n|\r|\n)/g;
 
@@ -14,7 +16,7 @@ export interface ConsumeReviewEventStreamOptions {
 
 export async function consumeReviewEventStream(
   stream: ReadableStream<Uint8Array>,
-  onValue: (value: unknown) => void | Promise<void>,
+  onValue: (value: JsonValue) => void | Promise<void>,
   signal: AbortSignal,
   options: ConsumeReviewEventStreamOptions = {},
 ): Promise<void> {
@@ -42,7 +44,7 @@ export async function consumeReviewEventStream(
       const payload = pendingPayloads.shift();
       if (payload === undefined) continue;
       try {
-        await onValue(JSON.parse(payload));
+        await onValue(parseJsonText(payload));
       } catch (error) {
         console.error(error);
       }

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewProtocol.ts
@@ -1,4 +1,93 @@
 // GENERATED from @dev.fast/review-protocol. Do not edit.
+/**
+ * Realm-safe primitive checks. This module is the one sanctioned home for
+ * `typeof`; every other decoder in the repo narrows through these predicates.
+ * `instanceof Object` is not a substitute: values created in another realm
+ * (a worker, a vm context, an iframe) fail it while `typeof` still answers.
+ */
+export function isStringValue(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+export function isNumberValue(value: unknown): value is number {
+  return typeof value === "number";
+}
+
+export function isBooleanValue(value: unknown): value is boolean {
+  return typeof value === "boolean";
+}
+
+/** A non-null object, arrays and functions excluded. */
+export function isObjectValue(value: unknown): value is object {
+  return typeof value === "object" && value !== null;
+}
+
+export function isCallableValue(
+  value: unknown,
+): value is (...args: never[]) => void {
+  return typeof value === "function";
+}
+
+/**
+ * JSON values as they come off the wire or out of a file. Parse into one of
+ * these at the I/O boundary, then narrow into a domain type; never carry an
+ * `unknown`-valued dictionary past the boundary.
+ */
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonArray | JsonObject;
+export type JsonArray = JsonValue[];
+export type JsonObject = { [key: string]: JsonValue };
+
+export function isJsonObject(value: unknown): value is JsonObject {
+  return isObjectValue(value) && !Array.isArray(value);
+}
+
+export function isJsonArray(value: unknown): value is JsonArray {
+  return Array.isArray(value);
+}
+
+/** Parses JSON text into a JsonValue; throws SyntaxError on malformed input. */
+export function parseJsonText(text: string): JsonValue {
+  // SAFETY: JSON.parse only ever produces JSON primitives, arrays, and plain
+  // objects, which is exactly the JsonValue union.
+  return JSON.parse(text) as JsonValue;
+}
+
+/** Reads one property of a JSON object; missing keys read as undefined. */
+export function jsonProperty(
+  value: JsonObject,
+  key: string,
+): JsonValue | undefined {
+  return Object.hasOwn(value, key) ? value[key] : undefined;
+}
+
+/** The string a JSON value holds, or undefined when it is not a string. */
+export function jsonString(value: JsonValue | undefined): string | undefined {
+  return isStringValue(value) ? value : undefined;
+}
+
+/** The finite number a JSON value holds, or undefined otherwise. */
+export function jsonNumber(value: JsonValue | undefined): number | undefined {
+  return isNumberValue(value) && Number.isFinite(value) ? value : undefined;
+}
+
+/** The boolean a JSON value holds, or undefined otherwise. */
+export function jsonBoolean(value: JsonValue | undefined): boolean | undefined {
+  return isBooleanValue(value) ? value : undefined;
+}
+
+/** The object a JSON value holds, or undefined otherwise. */
+export function jsonObject(
+  value: JsonValue | undefined,
+): JsonObject | undefined {
+  return isObjectValue(value) && !Array.isArray(value) ? value : undefined;
+}
+
+/** The array a JSON value holds, or undefined otherwise. */
+export function jsonArray(value: JsonValue | undefined): JsonArray | undefined {
+  return Array.isArray(value) ? value : undefined;
+}
+
 import { z } from "zod/v4";
 
 z.config({ jitless: true });
@@ -570,15 +659,15 @@ export type ReviewCommentDraftThreadMap = z.infer<
 >;
 
 export function parseStoredReviewCommentThreadMap(
-  value: unknown,
+  value: JsonValue,
 ): ReviewCommentThreadMap {
   return ReviewCommentThreadMapSchema.parse(value);
 }
 
 export function parseReviewCommentThreadMap(
-  value: unknown,
+  value: JsonValue,
 ): ReviewCommentThreadMap {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  if (!isJsonObject(value)) return {};
   const comments: ReviewCommentThreadMap = {};
   for (const [threadId, candidate] of Object.entries(value)) {
     const parsed = ReviewCommentThreadRecordSchema.safeParse(candidate);
@@ -2069,107 +2158,107 @@ export type ReviewAgentTraceResponse = z.infer<
 >;
 
 export function parseReviewDesktopDiscovery(
-  value: unknown,
+  value: JsonValue,
 ): ReviewDesktopDiscovery {
   return parseZod(ReviewDesktopDiscoverySchema, value);
 }
 
-export function parseReviewListResponse(value: unknown): ReviewListResponse {
+export function parseReviewListResponse(value: JsonValue): ReviewListResponse {
   return parseZod(ReviewListResponseSchema, value);
 }
 
 export function parseReviewCliInstallStatus(
-  value: unknown,
+  value: JsonValue,
 ): ReviewCliInstallStatus {
   return parseZod(ReviewCliInstallStatusSchema, value);
 }
 
 export function parseReviewCliInstallApplyRequest(
-  value: unknown,
+  value: JsonValue,
 ): ReviewCliInstallApplyRequest {
   return parseZod(ReviewCliInstallApplyRequestSchema, value);
 }
 
 export function parseReviewCliInstallApplyResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewCliInstallApplyResponse {
   return parseZod(ReviewCliInstallApplyResponseSchema, value);
 }
 
 export function parseReviewPublishReadyRequest(
-  value: unknown,
+  value: JsonValue,
 ): ReviewPublishReadyRequest {
   return parseZod(ReviewPublishReadyRequestSchema, value);
 }
 
-export function parseReviewOpenResponse(value: unknown): ReviewOpenResponse {
+export function parseReviewOpenResponse(value: JsonValue): ReviewOpenResponse {
   return parseZod(ReviewOpenResponseSchema, value);
 }
 
 export function parseReviewTutorialOpenResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewTutorialOpenResponse {
   return parseZod(ReviewTutorialOpenResponseSchema, value);
 }
 
 export function parseReviewDesktopGlobalEvent(
-  value: unknown,
+  value: JsonValue,
 ): ReviewDesktopGlobalEvent {
   return parseZod(ReviewDesktopGlobalEventSchema, value);
 }
 
 export function parseReviewDesktopVerbFrame(
-  value: unknown,
+  value: JsonValue,
 ): ReviewDesktopVerbFrame {
   return parseZod(ReviewDesktopVerbFrameSchema, value);
 }
 
 export function parseReviewDesktopVerbResult(
-  value: unknown,
+  value: JsonValue,
 ): ReviewDesktopVerbResult {
   return parseZod(ReviewDesktopVerbResultSchema, value);
 }
 
 export function parseReviewSessionResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewSessionResponse {
   return parseZod(ReviewSessionResponseSchema, value);
 }
 
 export function parseReviewDiffFilesResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewDiffFilesResponse {
   return parseZod(ReviewDiffFilesResponseSchema, value);
 }
 
 export function parseReviewFileContentResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewFileContentResponse {
   return parseZod(ReviewFileContentResponseSchema, value);
 }
 
 export function parseReviewFileContentRequest(
-  value: unknown,
+  value: JsonValue,
 ): ReviewFileContentRequest {
   return parseZod(ReviewFileContentRequestSchema, value);
 }
 
-export function parseReviewVerbRequest(value: unknown): ReviewVerbRequest {
+export function parseReviewVerbRequest(value: JsonValue): ReviewVerbRequest {
   return parseZod(ReviewVerbRequestSchema, value);
 }
 
-export function parseReviewVerbResponse(value: unknown): ReviewVerbResponse {
+export function parseReviewVerbResponse(value: JsonValue): ReviewVerbResponse {
   return parseZod(ReviewVerbResponseSchema, value);
 }
 
 export function parseReviewAgentTraceListResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewAgentTraceListResponse {
   return parseZod(ReviewAgentTraceListResponseSchema, value);
 }
 
 export function parseReviewAgentTraceResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewAgentTraceResponse {
   return parseZod(ReviewAgentTraceResponseSchema, value);
 }
@@ -2189,7 +2278,7 @@ export function rewriteReviewDocumentRuntime(
 
 export function parseZod<T>(
   schema: z.ZodType<T>,
-  value: unknown,
+  value: JsonValue,
   label?: string,
   prefixPath = false,
 ): T {
@@ -2211,8 +2300,8 @@ export function parseZod<T>(
 function formatIssuePath(path: PropertyKey[]): string {
   let output = "";
   for (const segment of path) {
-    if (typeof segment === "number") {
-      output += `[${segment}]`;
+    if (Number.isInteger(segment)) {
+      output += `[${String(segment)}]`;
     } else {
       output += `${output ? "." : ""}${String(segment)}`;
     }

--- a/apps/review-desktop/code-oss/src/vs/review/contrib/verbs/reviewVerbs.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/verbs/reviewVerbs.ts
@@ -43,6 +43,7 @@ import { IHostService } from "../../../workbench/services/host/browser/host.js";
 import {
   type ReviewDesktopState,
   type ReviewDiffSide,
+  type JsonValue,
   type ReviewOpenEditorWire,
   type ReviewSurfaceEvent,
   type ReviewVerbRequest,
@@ -88,7 +89,7 @@ export interface IReviewVerbsService {
   readonly _serviceBrand: undefined;
   readonly onDidEmitSurfaceEvent: Event<ReviewSurfaceEvent>;
   readonly onDidRequestCanvasFocus: Event<void>;
-  dispatch(sessionId: string, value: unknown): Promise<ReviewVerbResponse>;
+  dispatch(sessionId: string, value: JsonValue): Promise<ReviewVerbResponse>;
   state(): ReviewDesktopState;
   resetSession(): Promise<void>;
 }
@@ -158,7 +159,7 @@ export class ReviewVerbsService
 
   async dispatch(
     sessionId: string,
-    value: unknown,
+    value: JsonValue,
   ): Promise<ReviewVerbResponse> {
     try {
       const request = parseReviewVerbRequest(value);

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
@@ -27,6 +27,7 @@ import {
 	type ReviewSessionDescriptor,
 	type ReviewTutorialOpenResponse,
 	type ReviewVerbResponse,
+	type JsonValue,
 	parseReviewCliInstallApplyResponse,
 	parseReviewCliInstallStatus,
 	parseReviewDesktopGlobalEvent,
@@ -128,7 +129,7 @@ export interface IReviewSessionService {
 	attachControl(
 		dispatch: (
 			sessionId: string,
-			value: unknown,
+			value: JsonValue,
 		) => Promise<ReviewVerbResponse>,
 	): void;
 }
@@ -192,7 +193,7 @@ export class ReviewSessionService
 	private readonly controller = new AbortController();
 	private controlAttached = false;
 	private controlDispatch:
-		| ((sessionId: string, value: unknown) => Promise<ReviewVerbResponse>)
+		| ((sessionId: string, value: JsonValue) => Promise<ReviewVerbResponse>)
 		| undefined;
 	/**
 	 * The main process owns the embedded server's endpoint and credentials and
@@ -594,7 +595,7 @@ export class ReviewSessionService
 			}),
 			signal: AbortSignal.timeout(120_000),
 		});
-		const payload: unknown = await response.json().catch(() => ({}));
+		const payload: JsonValue = await response.json().catch(() => ({}));
 		if (!response.ok) {
 			const detail = payload as { output?: unknown; error?: unknown };
 			throw new Error(
@@ -666,7 +667,7 @@ export class ReviewSessionService
 	attachControl(
 		dispatch: (
 			sessionId: string,
-			value: unknown,
+			value: JsonValue,
 		) => Promise<ReviewVerbResponse>,
 	): void {
 		this.controlDispatch = dispatch;
@@ -718,7 +719,7 @@ export class ReviewSessionService
 	private async initializeAndMaintainControl(
 		dispatch: (
 			sessionId: string,
-			value: unknown,
+			value: JsonValue,
 		) => Promise<ReviewVerbResponse>,
 	): Promise<void> {
 		await reconnectUntilAborted(
@@ -785,7 +786,7 @@ export class ReviewSessionService
 	 * The server lists every review, drafts included. A review stays a draft
 	 * until its first publish, so it belongs to no picker or list event yet.
 	 */
-	private applyReviewList(payload: unknown): void {
+	private applyReviewList(payload: JsonValue): void {
 		const parsed = parseReviewListResponse(payload);
 		this._reviews = parsed.reviews.filter(
 			(review) => review.status !== "draft",
@@ -909,7 +910,7 @@ export class ReviewSessionService
 	private async maintainControl(
 		dispatch: (
 			sessionId: string,
-			value: unknown,
+			value: JsonValue,
 		) => Promise<ReviewVerbResponse>,
 	): Promise<void> {
 		await reconnectUntilAborted(
@@ -930,7 +931,7 @@ export class ReviewSessionService
 	private async consumeControl(
 		dispatch: (
 			sessionId: string,
-			value: unknown,
+			value: JsonValue,
 		) => Promise<ReviewVerbResponse>,
 		onConnected: () => void,
 	): Promise<void> {

--- a/apps/review-desktop/scripts/product-hardening.test.mjs
+++ b/apps/review-desktop/scripts/product-hardening.test.mjs
@@ -122,7 +122,7 @@ test("keeps upstream identity out of the fields Review has claimed", () => {
   ];
   for (const key of claimedKeys) {
     const value = product[key];
-    assert.equal(typeof value, "string", key);
+    assert.match(value, /\S/u, key);
     assert.doesNotMatch(value, /vscode|Microsoft|code-oss|CodeOSS/i, key);
   }
 });
@@ -217,3 +217,4 @@ test("configures Zod's CSP-safe mode before the canvas module evaluates", () => 
     /canvasGlobal\.__zod_globalConfig\.jitless = true;/,
   );
 });
+

--- a/apps/review-desktop/scripts/smoke-error-telemetry.mjs
+++ b/apps/review-desktop/scripts/smoke-error-telemetry.mjs
@@ -61,7 +61,7 @@ function cases(home) {
   return [
     {
       name: "engine error keeps its message",
-      throws: () => {
+      runs: () => {
         const missing = undefined;
         return missing.uri;
       },
@@ -234,14 +234,14 @@ export async function smokeErrorTelemetry({
         await page.evaluate((message) => {
           setTimeout(() => void Promise.reject(new Error(message)), 0);
         }, probe.rejects);
-      } else if (typeof probe.throws === "string") {
+      } else if (probe.throws) {
         await page.evaluate((message) => {
           setTimeout(() => {
             throw new Error(message);
           }, 0);
         }, probe.throws);
       } else {
-        await page.evaluate(`setTimeout(() => { (${probe.throws})(); }, 0)`);
+        await page.evaluate(`setTimeout(() => { (${probe.runs})(); }, 0)`);
       }
       // The window drops a repeat of the same message inside one second.
       await sleep(1200);

--- a/apps/review-desktop/scripts/stage-review-runtime.mjs
+++ b/apps/review-desktop/scripts/stage-review-runtime.mjs
@@ -255,13 +255,7 @@ export async function readTutorialRuntimeManifest(tutorialRoot) {
   const validEntries = (entries) =>
     Array.isArray(entries) &&
     entries.length > 0 &&
-    entries.every(
-      (entry) =>
-        typeof entry === "string" &&
-        entry.length > 0 &&
-        !path.isAbsolute(entry) &&
-        !entry.split(/[\\/]/u).includes(".."),
-    );
+    entries.every(isSafeManifestPath);
   if (
     value?.version !== 1 ||
     !validEntries(value.reviewFiles) ||
@@ -275,6 +269,17 @@ export async function readTutorialRuntimeManifest(tutorialRoot) {
     reviewFiles: [...new Set(value.reviewFiles)],
     requiredPaths: [...new Set(value.requiredPaths)],
   };
+}
+
+/** A manifest entry that names a file inside the tutorial tree. */
+function isSafeManifestPath(entry) {
+  // Only a JSON string equals its own String() rendering by identity.
+  return (
+    String(entry) === entry &&
+    entry.length > 0 &&
+    !path.isAbsolute(entry) &&
+    !entry.split(/[\\/]/u).includes("..")
+  );
 }
 
 /**

--- a/packages/local-vcs/src/file-lock.ts
+++ b/packages/local-vcs/src/file-lock.ts
@@ -225,8 +225,8 @@ function lstatSyncOrNull(lockPath: string): fs.Stats | null {
   }
 }
 
-function isLockContentionError(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException)?.code;
+function isLockContentionError(cause: unknown): boolean {
+  const code = (cause as NodeJS.ErrnoException)?.code;
   return (
     code === "EEXIST" ||
     code === "ELOCKED" ||

--- a/packages/local-vcs/src/index.ts
+++ b/packages/local-vcs/src/index.ts
@@ -1050,8 +1050,8 @@ async function diffForKind(input: {
   kind: LocalVcsKind;
 }): Promise<string> {
   if (input.kind === "jj") {
-    return readJjDiff(input).catch((error: unknown) => {
-      if (!canUseGitFallbackSync(input.rootPath, input.kind)) throw error;
+    return readJjDiff(input).catch((cause: unknown) => {
+      if (!canUseGitFallbackSync(input.rootPath, input.kind)) throw cause;
       return readGitDiff(input);
     });
   }
@@ -1120,8 +1120,8 @@ async function diffNameStatusForKind(input: {
   kind: LocalVcsKind;
 }): Promise<DiffNameStatus> {
   if (input.kind === "jj") {
-    return readJjDiffNameStatus(input).catch((error: unknown) => {
-      if (!canUseGitFallbackSync(input.rootPath, input.kind)) throw error;
+    return readJjDiffNameStatus(input).catch((cause: unknown) => {
+      if (!canUseGitFallbackSync(input.rootPath, input.kind)) throw cause;
       return readGitDiffNameStatus(input);
     });
   }

--- a/packages/progressive-review/app/desktop-trusted-types.test.ts
+++ b/packages/progressive-review/app/desktop-trusted-types.test.ts
@@ -42,7 +42,7 @@ describe("libavoid Trusted Types hardening", () => {
         ...args: Array<{ trustedScript: string }>
       ) => (...values: unknown[]) => number
     >((...args: Array<{ trustedScript: string }>) => {
-      if (args.some((argument) => typeof argument === "string")) {
+      if (!args.every((argument) => argument instanceof Object)) {
         throw new TypeError(
           "Function constructor arguments must be TrustedScript values",
         );

--- a/packages/progressive-review/app/desktop.vite.config.ts
+++ b/packages/progressive-review/app/desktop.vite.config.ts
@@ -39,9 +39,9 @@ export default defineConfig({
             continue;
           }
           const source =
-            typeof output.source === "string"
-              ? output.source
-              : new TextDecoder().decode(output.source);
+            output.source instanceof Uint8Array
+              ? new TextDecoder().decode(output.source)
+              : output.source;
           output.source = scopeReviewCanvasCss(source);
         }
       },

--- a/packages/progressive-review/app/src/CodePeek.test.tsx
+++ b/packages/progressive-review/app/src/CodePeek.test.tsx
@@ -262,7 +262,7 @@ describe("CodePeek native editor", () => {
     ).toBe(true);
 
     expect(container.querySelector(".code-peek-card")).toBeNull();
-    expect(typeof created[0]?.onDidOpen).toBe("function");
+    expect(created[0]?.onDidOpen).toBeTypeOf("function");
 
     await act(async () => {
       created[0]?.onDidOpen?.();
@@ -474,7 +474,7 @@ describe("CodePeek native editor", () => {
 
     expect(container.querySelector(".code-peek-card")).toBeNull();
     expect(created[0]?.diffStats).toBeUndefined();
-    expect(typeof created[0]?.onDidOpen).toBe("function");
+    expect(created[0]?.onDidOpen).toBeTypeOf("function");
     expect(
       container.querySelector("[data-review-inline-editor]"),
     ).not.toBeNull();

--- a/packages/progressive-review/app/src/CodePeek.tsx
+++ b/packages/progressive-review/app/src/CodePeek.tsx
@@ -538,8 +538,8 @@ function codePeekRootFromProps(input: {
 }): CodePeekRootSpec | null {
   if (
     input.file &&
-    typeof input.fromLine === "number" &&
-    typeof input.toLine === "number"
+    input.fromLine !== undefined &&
+    input.toLine !== undefined
   ) {
     return {
       kind: "range",
@@ -717,9 +717,9 @@ async function fetchCodePeekResultWithRetry(
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
-function isRetryableCodePeekError(error: unknown) {
-  if (!(error instanceof Error)) return false;
-  return error.message.includes("fetch");
+function isRetryableCodePeekError(cause: unknown) {
+  if (!(cause instanceof Error)) return false;
+  return cause.message.includes("fetch");
 }
 
 function delay(ms: number) {

--- a/packages/progressive-review/app/src/ReviewCommitsView.tsx
+++ b/packages/progressive-review/app/src/ReviewCommitsView.tsx
@@ -116,10 +116,10 @@ function CommitRow({
           });
     request
       .then((files) => setFilesState({ status: "loaded", files }))
-      .catch((error: unknown) => {
+      .catch((cause: unknown) => {
         setFilesState({
           status: "error",
-          error: error instanceof Error ? error.message : String(error),
+          error: cause instanceof Error ? cause.message : String(cause),
         });
       });
   };

--- a/packages/progressive-review/app/src/ReviewTraceView.tsx
+++ b/packages/progressive-review/app/src/ReviewTraceView.tsx
@@ -118,11 +118,11 @@ export function ReviewTraceView({
           sessions: result.sessions,
         });
       })
-      .catch((error: unknown) => {
+      .catch((cause: unknown) => {
         if (controller.signal.aborted) return;
         setList({
           status: "error",
-          error: error instanceof Error ? error.message : String(error),
+          error: cause instanceof Error ? cause.message : String(cause),
         });
       });
     return () => controller.abort();

--- a/packages/progressive-review/app/src/agent-markdown.tsx
+++ b/packages/progressive-review/app/src/agent-markdown.tsx
@@ -1,3 +1,4 @@
+import { isNumberValue, isStringValue } from "@dev.fast/review-protocol";
 // Deliberately separate from the MDX document pipeline: this renderer walks the
 // mdast of untrusted runtime strings (agent/thread message bodies) and never
 // evaluates them, whereas MDX compilation produces executable code and must
@@ -309,10 +310,13 @@ function isLocalFilesystemHref(value: string | undefined): boolean {
   );
 }
 
+/** A React child that renders as its own text: a string or a number. */
+export function isReactTextNode(node: ReactNode): node is string | number {
+  return isStringValue(node) || isNumberValue(node);
+}
+
 function textFromChildren(children: ReactNode): string | null {
-  if (typeof children === "string" || typeof children === "number") {
-    return String(children);
-  }
+  if (isReactTextNode(children)) return String(children);
   if (Array.isArray(children)) {
     const text = children
       .map((child) => textFromChildren(child) ?? "")

--- a/packages/progressive-review/app/src/bug-report-dialog.test.tsx
+++ b/packages/progressive-review/app/src/bug-report-dialog.test.tsx
@@ -285,7 +285,7 @@ function tutorialBridge(): ReviewCanvasTutorialBridge {
   };
 }
 
-function jsonResponse(body: unknown, status = 200): Response {
+function jsonResponse(body: JsonObject, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: { "content-type": "application/json" },

--- a/packages/progressive-review/app/src/bug-report-screenshot.ts
+++ b/packages/progressive-review/app/src/bug-report-screenshot.ts
@@ -1,4 +1,8 @@
-import type { ReviewCanvasBridge } from "@dev.fast/review-protocol";
+import {
+  type ReviewCanvasBridge,
+  isJsonObject,
+  jsonString,
+} from "@dev.fast/review-protocol";
 
 const MAX_SCREENSHOT_BYTES = 3 * 1024 * 1024;
 const MAX_SCREENSHOT_DIMENSION = 1600;
@@ -19,7 +23,7 @@ export class ScreenshotTooLargeError extends Error {
 export async function normalizeScreenshot(
   source: Blob | string,
 ): Promise<string | null> {
-  const blob = typeof source === "string" ? dataUrlBlob(source) : source;
+  const blob = source instanceof Blob ? source : dataUrlBlob(source);
   if (!SUPPORTED_IMAGE_MIMES.has(blob.type.toLowerCase())) {
     throw new Error("Screenshot must be a PNG, JPEG, or WebP image.");
   }
@@ -63,14 +67,11 @@ export async function captureWindowScreenshot(
     ]);
     if (!response?.ok) return null;
     const result = response.result;
-    if (
-      !result ||
-      typeof result !== "object" ||
-      typeof (result as { dataUrl?: unknown }).dataUrl !== "string"
-    ) {
-      return null;
-    }
-    return await normalizeScreenshot((result as { dataUrl: string }).dataUrl);
+    const dataUrl = isJsonObject(result)
+      ? jsonString(result.dataUrl)
+      : undefined;
+    if (dataUrl === undefined) return null;
+    return await normalizeScreenshot(dataUrl);
   } catch {
     return null;
   } finally {

--- a/packages/progressive-review/app/src/code-block.tsx
+++ b/packages/progressive-review/app/src/code-block.tsx
@@ -1,3 +1,4 @@
+import { isNumberValue, isStringValue } from "@dev.fast/review-protocol";
 import {
   type ShjLanguage,
   type ShjToken,
@@ -105,10 +106,7 @@ export function MarkdownCodeBlock({
   const codeElement = isValidElement<ComponentProps<"code">>(children)
     ? children
     : null;
-  const codeClassName =
-    typeof codeElement?.props.className === "string"
-      ? codeElement.props.className
-      : "";
+  const codeClassName = codeElement?.props.className ?? "";
   const language = codeClassName
     .split(/\s+/)
     .find((name) => name.startsWith("language-"))
@@ -193,11 +191,14 @@ function normalizeMarkdownCodeLanguage(language: string): ShjLanguage | null {
 }
 
 function reactTextContent(node: ReactNode): string {
-  if (node == null || typeof node === "boolean") return "";
-  if (typeof node === "string" || typeof node === "number") return String(node);
   if (Array.isArray(node)) return node.map(reactTextContent).join("");
   if (isValidElement<{ children?: ReactNode }>(node)) {
     return reactTextContent(node.props.children);
   }
-  return "";
+  return isReactText(node) ? String(node) : "";
+}
+
+/** Text React renders verbatim; booleans, null and undefined render nothing. */
+function isReactText(node: ReactNode): node is string | number {
+  return isStringValue(node) || isNumberValue(node);
 }

--- a/packages/progressive-review/app/src/database-lens.tsx
+++ b/packages/progressive-review/app/src/database-lens.tsx
@@ -44,7 +44,14 @@ import { HoverCommentButton } from "./hover-comment-button";
 import { useReview } from "./review-context";
 import type { GuidedTour } from "./review-panel-model";
 import { useTourPersist, useTourRestore } from "./review-view-state";
-import { formatSchemaExample } from "./software-map/c4-projection";
+import {
+  type DataStoreFieldExample,
+  exampleForDataStoreField,
+  exampleForDataStoreSchema,
+  foreignKeyTarget,
+  formatSchemaExample,
+  isDataStoreFieldLeaf,
+} from "./software-map/c4-projection";
 import type {
   SoftwareDataStoreFieldLeaf,
   SoftwareDataStoreFieldSchema,
@@ -107,7 +114,7 @@ interface FieldRow {
   type?: string;
   pk?: boolean;
   fk?: ForeignKeyRef;
-  example?: unknown;
+  example?: DataStoreFieldExample;
 }
 
 export type DatabaseOperationHighlightState = "active" | "inactive";
@@ -1118,19 +1125,6 @@ function targetKey(target: TargetRef, path = target.path): string {
   return `${collectionKey(target)}.${path.join(".")}`;
 }
 
-function foreignKeyTarget(
-  fk: ForeignKeyRef,
-): { table: string; fieldPath: string[] } | null {
-  if (typeof fk === "string") {
-    const [table, ...fieldPath] = fk.split(".").filter(Boolean);
-    return table && fieldPath.length > 0 ? { table, fieldPath } : null;
-  }
-  const fieldPath = fk.field.split(".").filter(Boolean);
-  return fk.table && fieldPath.length > 0
-    ? { table: fk.table, fieldPath }
-    : null;
-}
-
 function schemaValue(row: FieldRow): string {
   return row.type ?? "object";
 }
@@ -1140,7 +1134,7 @@ function flattenSchemaRows(schema: FieldSchema): FieldRow[] {
   const visit = (node: FieldSchema, prefix: string[], depth: number) => {
     for (const [field, value] of Object.entries(node)) {
       const nextPath = [...prefix, field];
-      if (isFieldLeaf(value)) {
+      if (isDataStoreFieldLeaf(value)) {
         rows.push({
           path: nextPath,
           label: field,
@@ -1148,7 +1142,7 @@ function flattenSchemaRows(schema: FieldSchema): FieldRow[] {
           type: value.type,
           pk: value.pk,
           fk: value.fk,
-          example: exampleForField(value),
+          example: exampleForDataStoreField(value),
         });
         if (value.schema) visit(value.schema, nextPath, depth + 1);
       } else {
@@ -1156,7 +1150,7 @@ function flattenSchemaRows(schema: FieldSchema): FieldRow[] {
           path: nextPath,
           label: field,
           depth,
-          example: exampleForSchema(value),
+          example: exampleForDataStoreSchema(value),
         });
         visit(value, nextPath, depth + 1);
       }
@@ -1164,35 +1158,6 @@ function flattenSchemaRows(schema: FieldSchema): FieldRow[] {
   };
   visit(schema, [], 0);
   return rows;
-}
-
-function isFieldLeaf(value: unknown): value is FieldLeaf {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    "type" in value &&
-    typeof (value as { type?: unknown }).type === "string"
-  );
-}
-
-function exampleForField(field: FieldLeaf): unknown {
-  if ("example" in field) return field.example;
-  if (field.schema) return exampleForSchema(field.schema);
-  return undefined;
-}
-
-/** Example values keyed by field, nested like the schema they illustrate. */
-interface FieldSchemaExample {
-  [field: string]: FieldLeaf["example"] | FieldSchemaExample;
-}
-
-function exampleForSchema(schema: FieldSchema): FieldSchemaExample {
-  return Object.fromEntries(
-    Object.entries(schema).map(([key, value]) => [
-      key,
-      isFieldLeaf(value) ? exampleForField(value) : exampleForSchema(value),
-    ]),
-  );
 }
 
 function tourIdFor(lensId: string, useCaseId: string): string {

--- a/packages/progressive-review/app/src/debug-settings.tsx
+++ b/packages/progressive-review/app/src/debug-settings.tsx
@@ -1,3 +1,4 @@
+import type { JsonValue } from "@dev.fast/review-protocol";
 import {
   type ReactNode,
   createContext,
@@ -116,7 +117,7 @@ function readStoredSettings(session: ReviewSession): StoredReviewDebugSettings {
   };
 }
 
-function normalizeNodeTint(value: unknown): ReviewNodeTint {
+function normalizeNodeTint(value: JsonValue | undefined): ReviewNodeTint {
   return value === "none" || value === "mineral" || value === "slate"
     ? value
     : "slate";

--- a/packages/progressive-review/app/src/diagrams.tsx
+++ b/packages/progressive-review/app/src/diagrams.tsx
@@ -1,3 +1,4 @@
+import { isStringValue } from "@dev.fast/review-protocol";
 import {
   BaseEdge,
   EdgeLabelRenderer,
@@ -93,10 +94,11 @@ interface UncheckedSequenceInput {
   messages: UncheckedSequenceMessageInput[];
 }
 
-export interface SequenceMessageCodeBlock {
+// A type alias so message code can travel inside a graph target payload.
+export type SequenceMessageCodeBlock = {
   language?: string;
   text: string;
-}
+};
 
 export interface SequenceMessage {
   id: string;
@@ -266,10 +268,17 @@ function actorSoftwareMapPath(actor: SequenceActorInput): string | undefined {
   return "__kind" in actor ? actor.softwareMapPath : undefined;
 }
 
+/** Message code written as bare text rather than a `{ text, language }` block. */
+function isSequenceMessageCodeText(
+  code: SequenceMessageCodeInput,
+): code is string {
+  return isStringValue(code);
+}
+
 function normalizeSequenceMessageCode(
   code: SequenceMessageCodeInput | undefined,
 ): SequenceMessageCodeBlock | undefined {
-  if (typeof code === "string") {
+  if (code !== undefined && isSequenceMessageCodeText(code)) {
     const text = code.trim();
     return text ? { text } : undefined;
   }

--- a/packages/progressive-review/app/src/host/review-client.test.ts
+++ b/packages/progressive-review/app/src/host/review-client.test.ts
@@ -115,12 +115,14 @@ describe("review host client", () => {
 // The loader imports the runtime module for the request context, then the
 // rewritten document blob. Route blob imports to the document namespace and
 // everything else to a runtime stub.
-function documentImporter(importDocument: () => Promise<unknown>) {
+function documentImporter<TDocument>(importDocument: () => Promise<TDocument>) {
   const setReviewRequestContext =
     vi.fn<(context: { origin?: string; token?: string }) => void>();
-  const importer = vi.fn<ReviewModuleImporter>(async (url) =>
-    url.startsWith("blob:") ? importDocument() : { setReviewRequestContext },
-  );
+  // The stub is not generic; the loader names each module's exports itself.
+  const importer = (async (url: string) =>
+    url.startsWith("blob:")
+      ? importDocument()
+      : { setReviewRequestContext }) as ReviewModuleImporter;
   return { importer, setReviewRequestContext };
 }
 

--- a/packages/progressive-review/app/src/host/review-client.ts
+++ b/packages/progressive-review/app/src/host/review-client.ts
@@ -17,7 +17,15 @@ export type ReviewClientConfig = Partial<
   >
 >;
 
-export type ReviewModuleImporter = (url: string) => Promise<unknown>;
+/** Loads a module namespace; the caller names the exports it expects. */
+export type ReviewModuleImporter = <T>(url: string) => Promise<T>;
+
+interface ReviewDocRuntimeModule {
+  setReviewRequestContext?: (context: {
+    origin?: string;
+    token?: string;
+  }) => void;
+}
 
 export interface ReviewRequestOptions {
   origin?: string;
@@ -76,21 +84,15 @@ export function importReviewModule<T>(
       new Error("Review document runtime URL is unavailable."),
     );
   }
-  const docRuntimeUrl = config.docRuntimeUrl;
-  return loadReviewModule(
-    config,
-    url,
-    docRuntimeUrl,
-    importModule,
-  ) as Promise<T>;
+  return loadReviewModule<T>(config, url, config.docRuntimeUrl, importModule);
 }
 
-async function loadReviewModule(
+async function loadReviewModule<T>(
   config: ReviewClientConfig,
   url: URL,
   docRuntimeUrl: string,
   importModule: ReviewModuleImporter,
-): Promise<unknown> {
+): Promise<T> {
   const response = await reviewFetchUrl(config, url);
   if (!response.ok) {
     throw new Error(`Review document module returned ${response.status}.`);
@@ -99,12 +101,9 @@ async function loadReviewModule(
   const rewritten = rewriteReviewDocumentRuntime(source, docRuntimeUrl);
   // Published bundles carry no origin or token; hand the runtime this
   // session's request context before the document module evaluates.
-  const runtime = (await importModule(new URL(docRuntimeUrl).href)) as {
-    setReviewRequestContext?: (context: {
-      origin?: string;
-      token?: string;
-    }) => void;
-  };
+  const runtime = await importModule<ReviewDocRuntimeModule>(
+    new URL(docRuntimeUrl).href,
+  );
   runtime.setReviewRequestContext?.({
     origin: config.sessionUrl,
     token: config.token,
@@ -113,13 +112,13 @@ async function loadReviewModule(
     new Blob([rewritten], { type: "text/javascript" }),
   );
   try {
-    return await importModule(blobUrl);
+    return await importModule<T>(blobUrl);
   } finally {
     URL.revokeObjectURL(blobUrl);
   }
 }
 
-function importBlobReviewModule(url: string): Promise<unknown> {
+function importBlobReviewModule<T>(url: string): Promise<T> {
   return import(/* @vite-ignore */ url);
 }
 

--- a/packages/progressive-review/app/src/review-components.tsx
+++ b/packages/progressive-review/app/src/review-components.tsx
@@ -171,7 +171,7 @@ function ReviewPanelFrame({
           {title && (
             <h2 {...panelSelectionStamp(titleSelectionStamp)}>{title}</h2>
           )}
-          {typeof count === "number" && count > 0 && <em>{count}</em>}
+          {count !== undefined && count > 0 && <em>{count}</em>}
           {titleAccessory}
         </div>
         <button

--- a/packages/progressive-review/app/src/review-context.tsx
+++ b/packages/progressive-review/app/src/review-context.tsx
@@ -551,8 +551,8 @@ function ReviewCoordinator({
           setSubmissionOutcome("changes-requested");
         }
       })
-      .catch((error: unknown) => {
-        console.error("Review status fetch failed", error);
+      .catch((cause: unknown) => {
+        console.error("Review status fetch failed", cause);
       });
     return () => {
       disposed = true;
@@ -677,12 +677,11 @@ function createSubmissionId(): string {
 
 export function createClientId(): string {
   const crypto = globalThis.crypto;
-  if (typeof crypto?.randomUUID === "function") {
-    return crypto.randomUUID();
-  }
-  if (typeof crypto?.getRandomValues !== "function") {
+  if (!crypto) {
     throw new Error("Review thread creation requires browser cryptography.");
   }
+  // randomUUID is only exposed in secure contexts.
+  if (crypto.randomUUID !== undefined) return crypto.randomUUID();
   const bytes = crypto.getRandomValues(new Uint8Array(16));
   bytes[6] = (bytes[6]! & 0x0f) | 0x40;
   bytes[8] = (bytes[8]! & 0x3f) | 0x80;
@@ -898,8 +897,8 @@ function sourceEndLine(source: ResolvedCommentCodeSource): number {
   return source.fromLine + source.text.split("\n").length - 1;
 }
 
-function reportBackgroundReviewError(error: unknown): void {
-  console.error(error instanceof Error ? error : new Error(String(error)));
+function reportBackgroundReviewError(cause: unknown): void {
+  console.error(cause instanceof Error ? cause : new Error(String(cause)));
 }
 
 export function useReview(): ReviewContextValue {

--- a/packages/progressive-review/app/src/review-diff-files-context.test.tsx
+++ b/packages/progressive-review/app/src/review-diff-files-context.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import type { ReviewDiffFileWire } from "@dev.fast/review-protocol";
+import type { JsonValue, ReviewDiffFileWire } from "@dev.fast/review-protocol";
 import { act, useLayoutEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -144,8 +144,8 @@ describe("ReviewDiffFilesProvider", () => {
   });
 
   it("never exposes or restores files from a previous document key", async () => {
-    let resolveSecondDocument!: (value: unknown) => void;
-    const secondDocument = new Promise<unknown>((resolve) => {
+    let resolveSecondDocument!: (value: JsonValue) => void;
+    const secondDocument = new Promise<JsonValue>((resolve) => {
       resolveSecondDocument = resolve;
     });
     const responses = [
@@ -248,7 +248,7 @@ describe("ReviewDiffFilesProvider", () => {
   });
 });
 
-function responseWithJson(json: unknown | Promise<unknown>): Response {
+function responseWithJson(json: JsonValue | Promise<JsonValue>): Response {
   return {
     ok: true,
     json: async () => json,

--- a/packages/progressive-review/app/src/review-diff-files-context.tsx
+++ b/packages/progressive-review/app/src/review-diff-files-context.tsx
@@ -86,13 +86,13 @@ export function ReviewDiffFilesProvider({
         });
         recordDiffSummaryReady(container);
       })
-      .catch((error: unknown) => {
+      .catch((cause: unknown) => {
         if (controller.signal.aborted) return;
         setSnapshot({
           documentKey,
           state: {
             status: "error",
-            error: error instanceof Error ? error.message : String(error),
+            error: cause instanceof Error ? cause.message : String(cause),
           },
         });
       });

--- a/packages/progressive-review/app/src/review-document-boundary.test.tsx
+++ b/packages/progressive-review/app/src/review-document-boundary.test.tsx
@@ -7,24 +7,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sequenceDiagramPropsSchema } from "../../src/authoring";
 import { ReviewDocumentBoundary } from "./review-document-boundary";
 import { testReviewSession } from "./review-session-test-utils";
-import { captureClientError } from "./ui-telemetry";
+import {
+  captureClientError,
+  type captureUiEvent,
+  type clientErrorName,
+} from "./ui-telemetry";
 
 const session = testReviewSession();
 
 vi.mock("./ui-telemetry", () => ({
-  captureUiEvent:
-    vi.fn<
-      (
-        session: unknown,
-        name: string,
-        properties?: Record<string, string | number | boolean>,
-        error?: unknown,
-      ) => void
-    >(),
-  captureClientError:
-    vi.fn<(session: unknown, errorSource: string, error: unknown) => void>(),
-  clientErrorName: (error: unknown) =>
+  captureUiEvent: vi.fn<typeof captureUiEvent>(),
+  captureClientError: vi.fn<typeof captureClientError>(),
+  clientErrorName: vi.fn<typeof clientErrorName>((error) =>
     error instanceof Error ? error.name : "Error",
+  ),
 }));
 
 const roots: Array<ReturnType<typeof createRoot>> = [];
@@ -50,7 +46,7 @@ describe("ReviewDocumentBoundary", () => {
   });
 
   it("contains a document render error, leaves the shell mounted, and recovers on a new revision", async () => {
-    const onError = vi.fn<(revision: string, error: unknown) => void>();
+    const onError = vi.fn<(revision: string, error: Error) => void>();
     const container = document.createElement("div");
     document.body.append(container);
     const root = createRoot(container);

--- a/packages/progressive-review/app/src/review-document-boundary.tsx
+++ b/packages/progressive-review/app/src/review-document-boundary.tsx
@@ -7,7 +7,7 @@ import { captureClientError } from "./ui-telemetry";
 interface ReviewDocumentBoundaryProps {
   session: ReviewSession;
   revision: string;
-  onError: (revision: string, error: unknown) => void;
+  onError: (revision: string, error: Error) => void;
   children: ReactNode;
 }
 
@@ -26,7 +26,7 @@ export class ReviewDocumentBoundary extends Component<
     return { hasError: true };
   }
 
-  componentDidCatch(error: unknown, _info: ErrorInfo): void {
+  componentDidCatch(error: Error, _info: ErrorInfo): void {
     if (this.reported) return;
     this.reported = true;
     captureClientError(this.props.session, "render", error);

--- a/packages/progressive-review/app/src/review-document-error-report.ts
+++ b/packages/progressive-review/app/src/review-document-error-report.ts
@@ -1,3 +1,5 @@
+import { isJsonObject, jsonString } from "@dev.fast/review-protocol";
+
 import type { ReviewSession } from "./host/review-session";
 
 // Wire contract for shipping a review-document render failure from the browser
@@ -16,32 +18,29 @@ export interface ReviewDocumentErrorReport {
 }
 
 export function reviewDocumentErrorReport(
-  error: unknown,
+  cause: unknown,
 ): ReviewDocumentErrorReport {
-  if (error instanceof Error) {
+  if (cause instanceof Error) {
     return {
-      name: error.name,
-      message: error.message,
-      ...(error.stack ? { stack: error.stack } : {}),
+      name: cause.name,
+      message: cause.message,
+      ...(cause.stack ? { stack: cause.stack } : {}),
     };
   }
-  const value = error as {
-    name?: unknown;
-    message?: unknown;
-    stack?: unknown;
-  } | null;
+  const fields = isJsonObject(cause) ? cause : undefined;
+  const stack = jsonString(fields?.stack);
   return {
-    name: typeof value?.name === "string" ? value.name : "Error",
-    message: typeof value?.message === "string" ? value.message : String(error),
-    ...(typeof value?.stack === "string" ? { stack: value.stack } : {}),
+    name: jsonString(fields?.name) ?? "Error",
+    message: jsonString(fields?.message) ?? String(cause),
+    ...(stack === undefined ? {} : { stack }),
   };
 }
 
 export function reportReviewDocumentRenderError(
   session: ReviewSession,
-  error: unknown,
+  cause: unknown,
 ): void {
-  const report = reviewDocumentErrorReport(error);
+  const report = reviewDocumentErrorReport(cause);
   session.reportDiagnostic({
     level: "error",
     source: "render",

--- a/packages/progressive-review/app/src/review-documents-runtime.ts
+++ b/packages/progressive-review/app/src/review-documents-runtime.ts
@@ -1,4 +1,5 @@
 import type { JsonPrimitive } from "@dev.fast/review-protocol";
+import { isObjectValue } from "@dev.fast/review-protocol";
 import type { MDXComponents } from "mdx/types";
 import type { ComponentType } from "react";
 
@@ -28,6 +29,12 @@ export type ReviewDocumentExport =
 
 export type ReviewDocumentModuleExports = Record<string, ReviewDocumentExport>;
 
+/** Exports whose fields can hold anchors: models, refs and author containers. */
+type ReviewDocumentExportContainer = Exclude<
+  ReviewDocumentExport,
+  JsonPrimitive | undefined | ReviewDocumentComponent
+>;
+
 export interface ReviewDocumentModuleInput {
   slug: string;
   routePath: string;
@@ -56,7 +63,7 @@ export type ReadyReviewDocumentEntry = ReviewDocumentEntry;
 export function createActiveReviewDocument(
   input: ReviewDocumentModuleInput,
 ): ReadyReviewDocumentEntry {
-  if (typeof input.Component !== "function") {
+  if (!input.Component) {
     throw new Error(
       `Review document ${input.filePath} did not export a React component.`,
     );
@@ -83,39 +90,30 @@ function collectReviewAnchors(models: ReviewDocumentModuleExports) {
   const anchors = new Map<string, AnchorRef>();
   const anchorContents = new Map<string, string>();
   const visited = new Set<object>();
-  const visit = (value: unknown): void => {
-    if (!value || typeof value !== "object") return;
+  const visit = (value: ReviewDocumentExport): void => {
+    if (!isReviewDocumentExportContainer(value)) return;
     if (visited.has(value)) return;
     visited.add(value);
-    if ((value as { __kind?: unknown }).__kind === "review-sequence-ref") {
-      const messages = (
-        value as {
-          messages?: Array<{ anchor?: AnchorRef; code?: { text?: unknown } }>;
+    if (isSequenceRefExport(value)) {
+      for (const message of value.messages) {
+        if (!message.code) continue;
+        const existing = anchorContents.get(message.anchor.id);
+        if (existing !== undefined && existing !== message.code.text) {
+          throw new Error(
+            `Review anchor id "${message.anchor.id}" has more than one authored content body.`,
+          );
         }
-      ).messages;
-      if (Array.isArray(messages)) {
-        for (const message of messages) {
-          if (!message.anchor || typeof message.code?.text !== "string")
-            continue;
-          const existing = anchorContents.get(message.anchor.id);
-          if (existing !== undefined && existing !== message.code.text) {
-            throw new Error(
-              `Review anchor id "${message.anchor.id}" has more than one authored content body.`,
-            );
-          }
-          anchorContents.set(message.anchor.id, message.code.text);
-        }
+        anchorContents.set(message.anchor.id, message.code.text);
       }
     }
-    if ((value as { __kind?: unknown }).__kind === "db-anchor-ref") {
-      const anchor = value as AnchorRef;
-      const existing = anchors.get(anchor.id);
-      if (existing && existing !== anchor) {
+    if (isAnchorRefExport(value)) {
+      const existing = anchors.get(value.id);
+      if (existing && existing !== value) {
         throw new Error(
-          `Review anchor id "${anchor.id}" is defined more than once.`,
+          `Review anchor id "${value.id}" is defined more than once.`,
         );
       }
-      anchors.set(anchor.id, anchor);
+      anchors.set(value.id, value);
       return;
     }
     if (Array.isArray(value)) {
@@ -128,11 +126,32 @@ function collectReviewAnchors(models: ReviewDocumentModuleExports) {
   return { anchors, anchorContents };
 }
 
-function isSoftwareModel(value: unknown): value is NormalizedSoftwareModel {
+function isReviewDocumentExportContainer(
+  value: ReviewDocumentExport,
+): value is ReviewDocumentExportContainer {
+  return isObjectValue(value);
+}
+
+function isSequenceRefExport(
+  value: ReviewDocumentExportContainer,
+): value is SequenceRef {
+  return "__kind" in value && value.__kind === "review-sequence-ref";
+}
+
+function isAnchorRefExport(
+  value: ReviewDocumentExportContainer,
+): value is AnchorRef {
+  return "__kind" in value && value.__kind === "db-anchor-ref";
+}
+
+function isSoftwareModel(
+  value: ReviewDocumentExport,
+): value is NormalizedSoftwareModel {
   return (
-    Boolean(value) &&
-    typeof value === "object" &&
-    Array.isArray((value as { elements?: unknown }).elements) &&
-    Array.isArray((value as { relationships?: unknown }).relationships)
+    isReviewDocumentExportContainer(value) &&
+    "elements" in value &&
+    Array.isArray(value.elements) &&
+    "relationships" in value &&
+    Array.isArray(value.relationships)
   );
 }

--- a/packages/progressive-review/app/src/review-find.tsx
+++ b/packages/progressive-review/app/src/review-find.tsx
@@ -496,19 +496,17 @@ function compareDocumentOrder(left: Node, right: Node): number {
   return position & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
 }
 
-interface HighlightRegistry {
-  set(name: string, value: unknown): void;
-  delete(name: string): void;
-}
-
 function highlightApi(document: Document | null | undefined): {
   registry: HighlightRegistry;
-  Highlight: new (...ranges: Range[]) => unknown;
+  Highlight: typeof Highlight;
 } | null {
+  // SAFETY: lib.dom only declares the CSS Custom Highlight API on globalThis;
+  // it is read off the document's own window, and both members stay optional
+  // because jsdom does not implement it.
   const view = document?.defaultView as
     | (Window & {
         CSS?: { highlights?: HighlightRegistry };
-        Highlight?: new (...ranges: Range[]) => unknown;
+        Highlight?: typeof Highlight;
       })
     | null;
   const registry = view?.CSS?.highlights;

--- a/packages/progressive-review/app/src/review-interaction-event.ts
+++ b/packages/progressive-review/app/src/review-interaction-event.ts
@@ -1,8 +1,15 @@
+import { z } from "zod";
+
 export const REVIEW_INTERACTION_EVENT = "review-interaction";
 
-export type ReviewInteractionDetail =
-  | { kind: "inline-hover"; path: string }
-  | { kind: "inline-navigation"; path: string };
+const ReviewInteractionDetailSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("inline-hover"), path: z.string() }),
+  z.object({ kind: z.literal("inline-navigation"), path: z.string() }),
+]);
+
+export type ReviewInteractionDetail = z.infer<
+  typeof ReviewInteractionDetailSchema
+>;
 
 export function emitReviewInteraction(
   target: HTMLElement | null,
@@ -20,11 +27,6 @@ export function reviewInteractionDetail(
   event: Event,
 ): ReviewInteractionDetail | null {
   if (!(event instanceof CustomEvent)) return null;
-  const detail = event.detail as Partial<ReviewInteractionDetail> | undefined;
-  if (detail?.kind !== "inline-hover" && detail?.kind !== "inline-navigation") {
-    return null;
-  }
-  return typeof detail.path === "string"
-    ? (detail as ReviewInteractionDetail)
-    : null;
+  const detail = ReviewInteractionDetailSchema.safeParse(event.detail);
+  return detail.success ? detail.data : null;
 }

--- a/packages/progressive-review/app/src/review-view-state.ts
+++ b/packages/progressive-review/app/src/review-view-state.ts
@@ -1,3 +1,13 @@
+import {
+  type JsonObject,
+  type JsonValue,
+  isJsonObject,
+  jsonNumber,
+  jsonObject,
+  jsonProperty,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
 import type { ReactNode, RefObject } from "react";
 import {
   createContext,
@@ -127,7 +137,10 @@ export function useReviewViewStateSync({
 
   const persist = useCallback(
     (next: PersistedReviewViewState) => {
-      const normalized = parsePersistedReviewViewState(next);
+      // Normalise exactly as a stored value reads back.
+      const normalized = parsePersistedReviewViewState(
+        parseJsonText(JSON.stringify(next)),
+      );
       if (JSON.stringify(normalized) === JSON.stringify(persistedRef.current)) {
         return;
       }
@@ -224,7 +237,7 @@ export function reviewViewStateKey(config: ReviewClientConfig): string {
 export function readPersistedReviewViewState(
   config: ReviewClientConfig,
 ): PersistedReviewViewState {
-  const value = readReviewUiState<unknown>(
+  const value = readReviewUiState<JsonValue>(
     "session",
     reviewViewStateKey(config),
   );
@@ -402,71 +415,57 @@ function persistedPanelState(
 }
 
 function parsePersistedReviewViewState(
-  value: unknown,
+  value: JsonValue | null,
 ): PersistedReviewViewState {
-  if (!value || typeof value !== "object") return {};
-  const candidate = value as {
-    scrollTop?: unknown;
-    activeView?: unknown;
-    panel?: {
-      kind?: unknown;
-      tourId?: unknown;
-      activeAnchor?: unknown;
-      // Legacy layered panel state.
-      thread?: { kind?: unknown; threadId?: unknown };
-      tour?: { tourId?: unknown; activeAnchor?: unknown };
-    };
-    overlayTour?: { tourId?: unknown; activeAnchor?: unknown };
-  };
+  if (!isJsonObject(value)) return {};
   const state: PersistedReviewViewState = {};
+  const scrollTop = jsonNumber(jsonProperty(value, "scrollTop"));
+  if (scrollTop !== undefined && scrollTop >= 0) state.scrollTop = scrollTop;
+  const activeView = jsonString(jsonProperty(value, "activeView"));
   if (
-    typeof candidate.scrollTop === "number" &&
-    Number.isFinite(candidate.scrollTop) &&
-    candidate.scrollTop >= 0
+    activeView === "review" ||
+    activeView === "commits" ||
+    activeView === "map" ||
+    activeView === "diff"
   ) {
-    state.scrollTop = candidate.scrollTop;
+    state.activeView = activeView;
   }
-  if (
-    candidate.activeView === "review" ||
-    candidate.activeView === "commits" ||
-    candidate.activeView === "map" ||
-    candidate.activeView === "diff"
-  ) {
-    state.activeView = candidate.activeView;
-  }
-  if (
-    candidate.panel?.kind === "tour" &&
-    typeof candidate.panel.tourId === "string" &&
-    typeof candidate.panel.activeAnchor === "string"
-  ) {
-    state.panel = {
-      kind: "tour",
-      tourId: candidate.panel.tourId,
-      activeAnchor: candidate.panel.activeAnchor,
-    };
-  } else if (
-    candidate.panel?.kind === "threads" ||
-    candidate.panel?.thread?.kind === "threads"
-  ) {
-    state.panel = { kind: "threads" };
-  } else if (
-    typeof candidate.panel?.tour?.tourId === "string" &&
-    typeof candidate.panel.tour.activeAnchor === "string"
-  ) {
-    state.panel = {
-      kind: "tour",
-      tourId: candidate.panel.tour.tourId,
-      activeAnchor: candidate.panel.tour.activeAnchor,
-    };
-  }
-  if (
-    typeof candidate.overlayTour?.tourId === "string" &&
-    typeof candidate.overlayTour.activeAnchor === "string"
-  ) {
-    state.overlayTour = {
-      tourId: candidate.overlayTour.tourId,
-      activeAnchor: candidate.overlayTour.activeAnchor,
-    };
-  }
+  const panel = parsePersistedPanel(jsonObject(jsonProperty(value, "panel")));
+  if (panel) state.panel = panel;
+  const overlayTour = parsePersistedTourState(
+    jsonObject(jsonProperty(value, "overlayTour")),
+  );
+  if (overlayTour) state.overlayTour = overlayTour;
   return state;
+}
+
+/** The persisted panel, also accepting the legacy layered `{ thread, tour }` form. */
+function parsePersistedPanel(
+  panel: JsonObject | undefined,
+): PersistedReviewPanel | undefined {
+  if (!panel) return undefined;
+  const kind = jsonString(jsonProperty(panel, "kind"));
+  const tour = parsePersistedTourState(panel);
+  if (kind === "tour" && tour) return { kind: "tour", ...tour };
+  const legacyThread = jsonObject(jsonProperty(panel, "thread"));
+  if (
+    kind === "threads" ||
+    jsonString(legacyThread && jsonProperty(legacyThread, "kind")) === "threads"
+  ) {
+    return { kind: "threads" };
+  }
+  const legacyTour = parsePersistedTourState(
+    jsonObject(jsonProperty(panel, "tour")),
+  );
+  return legacyTour ? { kind: "tour", ...legacyTour } : undefined;
+}
+
+function parsePersistedTourState(
+  tour: JsonObject | undefined,
+): PersistedReviewViewState["overlayTour"] {
+  const tourId = jsonString(tour && jsonProperty(tour, "tourId"));
+  const activeAnchor = jsonString(tour && jsonProperty(tour, "activeAnchor"));
+  return tourId !== undefined && activeAnchor !== undefined
+    ? { tourId, activeAnchor }
+    : undefined;
 }

--- a/packages/progressive-review/app/src/sequence-tour.test.ts
+++ b/packages/progressive-review/app/src/sequence-tour.test.ts
@@ -515,7 +515,7 @@ describe("sequence diagram guided tour", () => {
 });
 
 function expectZodIssue(
-  run: () => unknown,
+  run: () => void,
   path: PropertyKey[],
   message?: string,
 ): void {

--- a/packages/progressive-review/app/src/side-panel-resizer.ts
+++ b/packages/progressive-review/app/src/side-panel-resizer.ts
@@ -227,7 +227,7 @@ export function useRightPanelResize({
   const setWidth = useCallback(
     (nextWidth: number | ((width: number) => number)) => {
       setRequestedWidth((currentWidth) =>
-        typeof nextWidth === "function"
+        nextWidth instanceof Function
           ? nextWidth(constrainWidth(currentWidth))
           : nextWidth,
       );

--- a/packages/progressive-review/app/src/sidepeek-thread-ui.tsx
+++ b/packages/progressive-review/app/src/sidepeek-thread-ui.tsx
@@ -451,10 +451,10 @@ export function usePanelThreadController({
       (source) => {
         if (!cancelled) setBaseSource(source);
       },
-      (error: unknown) => {
+      (cause: unknown) => {
         if (!cancelled) {
           setBaseSourceError(
-            error instanceof Error ? error.message : String(error),
+            cause instanceof Error ? cause.message : String(cause),
           );
         }
       },

--- a/packages/progressive-review/app/src/software-map/SoftwareMap.test.ts
+++ b/packages/progressive-review/app/src/software-map/SoftwareMap.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 
+import type { Edge as ReactFlowEdge } from "@xyflow/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { testReviewSession } from "../review-session-test-utils";
@@ -4286,7 +4287,9 @@ function c4SiblingGaps(
   };
 }
 
-function c4EdgePointsForTest(data: unknown): Array<{ x: number; y: number }> {
+function c4EdgePointsForTest(
+  data: ReactFlowEdge["data"],
+): Array<{ x: number; y: number }> {
   const sections = (
     data as
       | {

--- a/packages/progressive-review/app/src/software-map/SoftwareMap.tsx
+++ b/packages/progressive-review/app/src/software-map/SoftwareMap.tsx
@@ -1,4 +1,11 @@
 import {
+  type JsonValue,
+  isJsonObject,
+  jsonArray,
+  jsonProperty,
+  jsonString,
+} from "@dev.fast/review-protocol";
+import {
   type ElkGraph as LibavoidElkGraph,
   init as initLibavoidEdgeRouter,
   routeEdges as routeLibavoidEdges,
@@ -39,6 +46,7 @@ import {
   useState,
 } from "react";
 import { createPortal } from "react-dom";
+import { z } from "zod";
 
 import { throwAuthoringIssue } from "../../../src/authoring";
 import { CodePeekGroup } from "../CodePeek";
@@ -79,7 +87,10 @@ import type {
   SoftwareChangeStatus,
   SoftwareDataStoreKind,
 } from "./model";
-import { SoftwareMapUnavailable } from "./software-map-absence";
+import {
+  SoftwareMapUnavailable,
+  softwareMapCssLength,
+} from "./software-map-absence";
 import { refreshSoftwareMapArtifacts } from "./software-map-patch-client";
 
 import "./styles.css";
@@ -255,15 +266,17 @@ function softwareMapDiffFileRanges(file: SoftwareMapUnmappedDiffFile): Array<{
   });
 }
 
-export interface SoftwareMapDataStoreSchemaSectionSnapshot {
+// Type aliases, not interfaces: snapshots travel inside graph target
+// payloads, which need the implicit index signature.
+export type SoftwareMapDataStoreSchemaSectionSnapshot = {
   id: string;
   label: string;
   kind: "table" | "document";
   key?: string;
   rows: SoftwareMapDataStoreSchemaRowSnapshot[];
-}
+};
 
-export interface SoftwareMapDataStoreSchemaRowSnapshot {
+export type SoftwareMapDataStoreSchemaRowSnapshot = {
   id: string;
   label: string;
   depth?: number;
@@ -272,7 +285,7 @@ export interface SoftwareMapDataStoreSchemaRowSnapshot {
   primaryKey?: boolean;
   foreignKey?: boolean;
   state?: "active" | "inactive";
-}
+};
 
 export interface SoftwareMapRelationshipSnapshot {
   id?: string;
@@ -662,8 +675,8 @@ function createSoftwareMapSignature() {
     hash = Math.imul(hash, 0x01000193);
   };
   return {
-    add(value: unknown) {
-      const text = value === null || value === undefined ? "" : String(value);
+    add(value: string | number) {
+      const text = String(value);
       addText(`${text.length}:${text}`);
     },
     value(prefix: string, size: number) {
@@ -703,7 +716,7 @@ function softwareMapModelKey({
     signature.add(relationship.to);
     signature.add(relationship.kind);
     signature.add(
-      relationship.kind === "semantic" ? relationship.semanticKind : "",
+      relationship.kind === "semantic" ? (relationship.semanticKind ?? "") : "",
     );
   }
   return signature.value(
@@ -918,21 +931,18 @@ function readStoredSoftwareMapNavigationState(
   session: ReviewSession,
   key: string,
 ): SoftwareMapNavigationState | null {
-  const parsed = readReviewUiState<Partial<SoftwareMapNavigationState>>(
+  const parsed = readReviewUiState<JsonValue>(
     "window",
     softwareMapNavigationStorageKey(session, key),
   );
-  if (!parsed) return null;
+  if (!isJsonObject(parsed)) return null;
   return {
-    modelKey: parsed.modelKey,
-    expandedNodeIds: Array.isArray(parsed.expandedNodeIds)
-      ? parsed.expandedNodeIds.filter(
-          (entry): entry is string => typeof entry === "string",
-        )
-      : [],
-    selectedNodeId:
-      typeof parsed.selectedNodeId === "string" ? parsed.selectedNodeId : null,
-    expanded: parsed.expanded === true,
+    modelKey: jsonString(jsonProperty(parsed, "modelKey")),
+    expandedNodeIds: (jsonArray(jsonProperty(parsed, "expandedNodeIds")) ?? [])
+      .map(jsonString)
+      .filter((entry): entry is string => entry !== undefined),
+    selectedNodeId: jsonString(jsonProperty(parsed, "selectedNodeId")) ?? null,
+    expanded: jsonProperty(parsed, "expanded") === true,
   };
 }
 
@@ -1551,7 +1561,9 @@ function SoftwareMapWithModel({
     if (initialEntry && refreshEpoch === 0) {
       applyResolvedDataState({
         key: initialEntry.key,
-        ...parseSoftwareMapResolvedDataResponse(initialEntry.response),
+        ...parseSoftwareMapResolvedDataResponse(
+          isJsonObject(initialEntry.response) ? initialEntry.response : null,
+        ),
       });
       return;
     }
@@ -1574,11 +1586,11 @@ function SoftwareMapWithModel({
           });
         }
       })
-      .catch((caught: unknown) => {
+      .catch((cause: unknown) => {
         if (!cancelled) {
           setPendingResolvedDataKey(null);
           setResolvedDataError(
-            caught instanceof Error ? caught.message : String(caught),
+            cause instanceof Error ? cause.message : String(cause),
           );
         }
       });
@@ -1772,9 +1784,9 @@ function SoftwareMapWithModel({
       .then(() => {
         setRefreshEpoch((current) => current + 1);
       })
-      .catch((caught: unknown) => {
+      .catch((cause: unknown) => {
         setResolvedDataError(
-          caught instanceof Error ? caught.message : String(caught),
+          cause instanceof Error ? cause.message : String(cause),
         );
       })
       .finally(() => {
@@ -2152,33 +2164,66 @@ async function fetchSoftwareMapResolvedDataUncached(
     headers: { "content-type": "application/json" },
     body: JSON.stringify(input),
   });
-  const json = await response.json();
-  if (!response.ok) {
-    return parseSoftwareMapResolvedDataResponse({ ok: false });
+  const json: unknown = await response.json();
+  if (!response.ok || !isJsonObject(json)) {
+    return parseSoftwareMapResolvedDataResponse(null);
   }
   return parseSoftwareMapResolvedDataResponse(json);
 }
 
+const softwareMapDiffCountsSchema = z.object({
+  additions: z.number(),
+  deletions: z.number(),
+});
+
+const softwareMapUnmappedDiffSummarySchema = softwareMapDiffCountsSchema.extend(
+  {
+    files: z.array(
+      softwareMapDiffCountsSchema.extend({
+        file: z.string(),
+        hunks: z.array(
+          z.object({
+            startLine: z.number(),
+            lines: z.array(
+              z.object({
+                kind: z.enum(["add", "remove"]),
+                oldLine: z.number().nullable(),
+                newLine: z.number().nullable(),
+                text: z.string(),
+              }),
+            ),
+          }),
+        ),
+      }),
+    ),
+  },
+);
+
+/** The `ok` body of the resolved-data route; any other body yields no data. */
+const softwareMapResolvedDataResponseSchema = z.object({
+  ok: z.literal(true),
+  countsByElementPath: z
+    .record(z.string(), softwareMapDiffCountsSchema)
+    .optional(),
+  unmappedByElementPath: z
+    .record(z.string(), softwareMapUnmappedDiffSummarySchema)
+    .optional(),
+});
+
 export function parseSoftwareMapResolvedDataResponse(
-  json: unknown,
+  json: JsonValue,
 ): SoftwareMapResolvedDataPayload {
-  const body = json as
-    | {
-        ok: true;
-        countsByElementPath?: Record<string, SoftwareMapDiffCounts>;
-        unmappedByElementPath?: Record<string, SoftwareMapUnmappedDiffSummary>;
-      }
-    | { ok: false; error?: string };
-  if (!body || typeof body !== "object" || !body.ok) {
+  const body = softwareMapResolvedDataResponseSchema.safeParse(json);
+  if (!body.success) {
     return {
       counts: new Map(),
       unmappedByElementPath: new Map(),
     };
   }
   return {
-    counts: new Map(Object.entries(body.countsByElementPath ?? {})),
+    counts: new Map(Object.entries(body.data.countsByElementPath ?? {})),
     unmappedByElementPath: new Map(
-      Object.entries(body.unmappedByElementPath ?? {}),
+      Object.entries(body.data.unmappedByElementPath ?? {}),
     ),
   };
 }
@@ -2310,8 +2355,7 @@ export function SoftwareMapFrame({
   const style =
     height && !expanded
       ? ({
-          "--software-map-height":
-            typeof height === "number" ? `${height}px` : height,
+          "--software-map-height": softwareMapCssLength(height),
         } as CSSProperties)
       : undefined;
   const bodyStyle = inspectedNode
@@ -2755,11 +2799,9 @@ function C4MapCanvas({
           layout: nextLayout.layout,
         });
       })
-      .catch((caught: unknown) => {
+      .catch((cause: unknown) => {
         if (cancelled) return;
-        setLayoutError(
-          caught instanceof Error ? caught.message : String(caught),
-        );
+        setLayoutError(cause instanceof Error ? cause.message : String(cause));
       });
     return () => {
       cancelled = true;
@@ -2830,7 +2872,7 @@ function C4MapCanvas({
       });
     };
     scheduleFit();
-    if (!canvas || typeof ResizeObserver !== "function") {
+    if (!canvas || !hasResizeObserver()) {
       return () => {
         if (frame !== 0) cancelAnimationFrame(frame);
       };
@@ -3560,35 +3602,36 @@ function c4FinitePositive(value: number) {
   return Number.isFinite(value) && value > 0;
 }
 
+/** ResizeObserver is missing in jsdom; the canvas then fits once on mount. */
+function hasResizeObserver(): boolean {
+  return typeof ResizeObserver !== "undefined";
+}
+
 function c4FlowNodeWidth(node: C4MapAnyFlowNode): number {
   return (
     numericStyleDimension(node.style?.width) ??
-    (typeof node.width === "number"
-      ? node.width
-      : typeof node.measured?.width === "number"
-        ? node.measured.width
-        : C4_NODE_WIDTH)
+    node.width ??
+    node.measured?.width ??
+    C4_NODE_WIDTH
   );
 }
 
 function c4FlowNodeHeight(node: C4MapAnyFlowNode): number {
   return (
     numericStyleDimension(node.style?.height) ??
-    (typeof node.height === "number"
-      ? node.height
-      : typeof node.measured?.height === "number"
-        ? node.measured.height
-        : C4_MIN_NODE_HEIGHT)
+    node.height ??
+    node.measured?.height ??
+    C4_MIN_NODE_HEIGHT
   );
 }
 
-function numericStyleDimension(value: unknown): number | undefined {
-  if (typeof value === "number") return value;
-  if (typeof value === "string") {
-    const parsed = Number.parseFloat(value);
-    return Number.isFinite(parsed) ? parsed : undefined;
-  }
-  return undefined;
+/** The leading number of a CSS dimension (`240` or `"240px"`), if any. */
+function numericStyleDimension(
+  value: CSSProperties["width"] | CSSProperties["height"],
+): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number.parseFloat(String(value));
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function c4PreviousLayoutCenters(
@@ -4353,9 +4396,7 @@ function c4MeasuredNodeDimensions(
 }
 
 function c4PositiveDimension(value: number | undefined, fallback: number) {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? value
-    : fallback;
+  return value !== undefined && c4FinitePositive(value) ? value : fallback;
 }
 
 function c4LocalFallbackPoint(index: number): C4ElkPoint {
@@ -5236,19 +5277,13 @@ function c4EdgeLabelNodeObstacles(
 function c4ElkLabelFromLayout(
   label: Partial<C4ElkLabel> | undefined,
 ): C4ElkLabel | null {
-  const x = label?.x;
-  const y = label?.y;
-  const width = label?.width;
-  const height = label?.height;
+  const { x, y, width, height } = label ?? {};
   if (
-    typeof x !== "number" ||
-    typeof y !== "number" ||
-    typeof width !== "number" ||
-    typeof height !== "number" ||
-    !Number.isFinite(x) ||
-    !Number.isFinite(y) ||
-    !Number.isFinite(width) ||
-    !Number.isFinite(height)
+    x === undefined ||
+    y === undefined ||
+    width === undefined ||
+    height === undefined ||
+    ![x, y, width, height].every(Number.isFinite)
   ) {
     return null;
   }
@@ -5857,7 +5892,7 @@ function c4SpreadRoutingPorts(
     for (const port of ports) {
       if (!laneByPortId.has(port.id)) continue;
       const side = port.properties?.["port.side"];
-      if (typeof side !== "string") continue;
+      if (side === undefined) continue;
       const sidePorts = portsBySide.get(side) ?? [];
       sidePorts.push(port);
       portsBySide.set(side, sidePorts);
@@ -6027,7 +6062,7 @@ function c4AddSchemaPort({
     kind === "header"
       ? c4SchemaHeaderCenterY(entry.node, entry.height, laneKey)
       : c4SchemaFieldCenterY(entry.node, entry.height, fieldPath);
-  if (typeof y !== "number") return;
+  if (y === undefined) return;
   seenPortIds.add(portId);
   const ports = portsByNodeId.get(entry.node.id) ?? [];
   ports.push({
@@ -6104,8 +6139,7 @@ function c4SchemaPortPlaceable(
   if (!entry) return false;
   if (kind === "header") return true;
   return (
-    typeof c4SchemaFieldCenterY(entry.node, entry.height, fieldPath) ===
-    "number"
+    c4SchemaFieldCenterY(entry.node, entry.height, fieldPath) !== undefined
   );
 }
 
@@ -6227,9 +6261,7 @@ function SoftwareMapC4Edge(props: ReactFlowEdgeProps) {
   const data = props.data as C4MapEdgeData | undefined;
   const label = data?.relationship.hideLabel
     ? undefined
-    : typeof props.label === "string"
-      ? props.label
-      : (data?.label ?? data?.semanticKind);
+    : (data?.label ?? data?.semanticKind);
   const points = c4EdgePointsFromSections(data?.sections);
   if (points.length < 2) return null;
   const path = c4PolylinePath(points);
@@ -7344,10 +7376,10 @@ export function SoftwareMapNodeFrame({
           {node.file && (
             <span>
               {node.file}
-              {typeof node.line === "number" ? `:L${node.line}` : ""}
+              {node.line === undefined ? "" : `:L${node.line}`}
             </span>
           )}
-          {typeof node.childCount === "number" && node.childCount > 0 && (
+          {node.childCount !== undefined && node.childCount > 0 && (
             <span>{node.childCount} children</span>
           )}
           {node.boundary && <span>boundary</span>}
@@ -7484,9 +7516,7 @@ function SoftwareMapChangeBadge({
 }
 
 export function visibleSoftwareMapChangeCount(count?: number) {
-  return typeof count === "number" && Number.isFinite(count) && count > 0
-    ? count
-    : 0;
+  return count !== undefined && c4FinitePositive(count) ? count : 0;
 }
 
 function createPlaceholderSnapshot(

--- a/packages/progressive-review/app/src/software-map/c4-projection.ts
+++ b/packages/progressive-review/app/src/software-map/c4-projection.ts
@@ -1,3 +1,6 @@
+import { isStringValue } from "@dev.fast/review-protocol";
+import { z } from "zod";
+
 import { parseDataStoreSchemaEndpoint } from "./model";
 import type {
   NormalizedSoftwareDataStoreCollection,
@@ -375,7 +378,7 @@ interface DataStoreSchemaRow {
   type?: string;
   pk?: boolean;
   fk?: SoftwareDataStoreForeignKeyRef;
-  example?: unknown;
+  example?: DataStoreFieldExample;
 }
 
 function flattenDataStoreSchemaRows(
@@ -415,18 +418,24 @@ function flattenDataStoreSchemaRows(
   return rows;
 }
 
-function isDataStoreFieldLeaf(
-  value: unknown,
+/** A schema entry is a leaf when its `type` names the field's type. */
+export function isDataStoreFieldLeaf(
+  value: SoftwareDataStoreFieldLeaf | SoftwareDataStoreFieldSchema,
 ): value is SoftwareDataStoreFieldLeaf {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    "type" in value &&
-    typeof (value as { type?: unknown }).type === "string"
-  );
+  return "type" in value && isStringValue(value.type);
 }
 
-function exampleForDataStoreField(field: SoftwareDataStoreFieldLeaf): unknown {
+/**
+ * The authored example of a field: the leaf's own example, or the examples of
+ * its nested schema keyed by field.
+ */
+export type DataStoreFieldExample =
+  | SoftwareDataStoreFieldLeaf["example"]
+  | DataStoreSchemaExample;
+
+export function exampleForDataStoreField(
+  field: SoftwareDataStoreFieldLeaf,
+): DataStoreFieldExample {
   if ("example" in field) return field.example;
   if (field.schema) return exampleForDataStoreSchema(field.schema);
   return undefined;
@@ -434,12 +443,10 @@ function exampleForDataStoreField(field: SoftwareDataStoreFieldLeaf): unknown {
 
 /** Example values keyed by field, nested like the schema they illustrate. */
 interface DataStoreSchemaExample {
-  [field: string]:
-    | SoftwareDataStoreFieldLeaf["example"]
-    | DataStoreSchemaExample;
+  [field: string]: DataStoreFieldExample;
 }
 
-function exampleForDataStoreSchema(
+export function exampleForDataStoreSchema(
   schema: SoftwareDataStoreFieldSchema,
 ): DataStoreSchemaExample {
   return Object.fromEntries(
@@ -452,13 +459,14 @@ function exampleForDataStoreSchema(
   );
 }
 
-export function formatSchemaExample(value: unknown): string | undefined {
+const scalarExampleSchema = z.union([z.string(), z.number(), z.boolean()]);
+
+export function formatSchemaExample(
+  value: DataStoreFieldExample,
+): string | undefined {
   if (value === undefined) return undefined;
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  return JSON.stringify(value);
+  const scalar = scalarExampleSchema.safeParse(value);
+  return scalar.success ? String(scalar.data) : JSON.stringify(value);
 }
 
 function dataStoreCollectionPaths(
@@ -691,14 +699,30 @@ function foreignKeyTargetEndpoint(
   dataStorePath: string,
   fk: SoftwareDataStoreForeignKeyRef,
 ): string | undefined {
-  if (typeof fk === "string") {
+  const target = foreignKeyTarget(fk);
+  if (!target) return undefined;
+  return `${dataStorePath}.tables.${target.table}.${target.fieldPath.join(".")}`;
+}
+
+/** The table and field a foreign key points at, or undefined when malformed. */
+export function foreignKeyTarget(
+  fk: SoftwareDataStoreForeignKeyRef,
+): { table: string; fieldPath: string[] } | undefined {
+  if (isForeignKeyShorthand(fk)) {
     const [table, ...fieldPath] = fk.split(".").filter(Boolean);
-    if (!table || fieldPath.length === 0) return undefined;
-    return `${dataStorePath}.tables.${table}.${fieldPath.join(".")}`;
+    return table && fieldPath.length > 0 ? { table, fieldPath } : undefined;
   }
   const fieldPath = fk.field.split(".").filter(Boolean);
-  if (!fk.table || fieldPath.length === 0) return undefined;
-  return `${dataStorePath}.tables.${fk.table}.${fieldPath.join(".")}`;
+  return fk.table && fieldPath.length > 0
+    ? { table: fk.table, fieldPath }
+    : undefined;
+}
+
+/** Foreign keys may be authored as a dotted `table.field` path. */
+function isForeignKeyShorthand(
+  fk: SoftwareDataStoreForeignKeyRef,
+): fk is string {
+  return isStringValue(fk);
 }
 
 function projectModifiedOnlyRelationships(

--- a/packages/progressive-review/app/src/software-map/model.test.ts
+++ b/packages/progressive-review/app/src/software-map/model.test.ts
@@ -528,7 +528,7 @@ describe("defineSoftwareModel", () => {
   });
 });
 
-function expectValidationErrors(action: () => unknown) {
+function expectValidationErrors(action: () => void) {
   try {
     action();
   } catch (error) {

--- a/packages/progressive-review/app/src/software-map/software-map-absence.tsx
+++ b/packages/progressive-review/app/src/software-map/software-map-absence.tsx
@@ -2,6 +2,11 @@ import type { CSSProperties, ReactElement } from "react";
 
 import type { NormalizedSoftwareModel } from "./model";
 
+/** The CSS length for a size prop: bare numbers are pixel counts. */
+export function softwareMapCssLength(value: number | string): string {
+  return Number.isFinite(value) ? `${value}px` : `${value}`;
+}
+
 export function SoftwareMapUnavailable({
   title,
   height,
@@ -15,8 +20,7 @@ export function SoftwareMapUnavailable({
     height === undefined
       ? undefined
       : ({
-          "--software-map-empty-height":
-            typeof height === "number" ? `${height}px` : height,
+          "--software-map-empty-height": softwareMapCssLength(height),
         } as CSSProperties);
   return (
     <section

--- a/packages/progressive-review/app/src/target-fingerprint.ts
+++ b/packages/progressive-review/app/src/target-fingerprint.ts
@@ -2,6 +2,7 @@ import {
   type GitLabTextDiffRow,
   createGitLabTextDiffPosition,
   gitLabDiffPositionRows,
+  isObjectValue,
 } from "@dev.fast/review-protocol";
 
 import type { CodePeekResolution } from "../../src/authoring";
@@ -186,11 +187,27 @@ export function projectCodeTarget(
   return span ? { ...resource, span } : null;
 }
 
+/**
+ * The data that identifies a graph element. It is serialised canonically, so
+ * key order and undefined fields do not change the hash.
+ */
+export type GraphTargetPayload = {
+  readonly [key: string]: GraphTargetPayloadValue;
+};
+type GraphTargetPayloadValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | readonly GraphTargetPayloadValue[]
+  | GraphTargetPayload;
+
 export function buildGraphTarget(input: {
   diagram: string;
   type: "node" | "edge";
   path: string[];
-  payload: unknown;
+  payload: GraphTargetPayload;
   quote: string;
 }): Extract<ThreadTarget, { kind: "graph" }> {
   return {
@@ -199,7 +216,7 @@ export function buildGraphTarget(input: {
     element: {
       type: input.type,
       path: input.path,
-      hash: stableHash(fingerprintPayload(input.payload)),
+      hash: stableHash(stableSerialize(input.payload)),
       quote: input.quote,
     },
   };
@@ -275,10 +292,6 @@ export function stableHash(value: string): string {
   return (hash >>> 0).toString(16).padStart(8, "0");
 }
 
-function fingerprintPayload(value: unknown): string {
-  return typeof value === "string" ? value : stableSerialize(value);
-}
-
 function positionUsesSide(
   start: GitLabTextDiffRow,
   end: GitLabTextDiffRow,
@@ -331,21 +344,27 @@ function diffLineMatchesPosition(
   return line.oldLine === row.old_line && line.newLine === row.new_line;
 }
 
-function stableSerialize(value: unknown): string {
-  if (value === null || typeof value !== "object") {
+function stableSerialize(value: GraphTargetPayloadValue): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableSerialize).join(",")}]`;
+  }
+  if (!isGraphTargetPayloadRecord(value)) {
     const serialized = JSON.stringify(value);
     if (serialized === undefined) {
       throw new Error("Target fingerprint payload is not serializable.");
     }
     return serialized;
   }
-  if (Array.isArray(value)) {
-    return `[${value.map(stableSerialize).join(",")}]`;
-  }
-  const fields: [string, unknown][] = Object.entries(value);
+  const fields = Object.entries(value);
   return `{${fields
     .filter(([, field]) => field !== undefined)
     .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
     .map(([key, field]) => `${JSON.stringify(key)}:${stableSerialize(field)}`)
     .join(",")}}`;
+}
+
+function isGraphTargetPayloadRecord(
+  value: GraphTargetPayloadValue,
+): value is GraphTargetPayload {
+  return isObjectValue(value) && !Array.isArray(value);
 }

--- a/packages/progressive-review/app/src/thread-card.tsx
+++ b/packages/progressive-review/app/src/thread-card.tsx
@@ -381,7 +381,7 @@ function ThreadScroll({
 function useClampedOverflow(
   ref: RefObject<HTMLElement | null>,
   active: boolean,
-  content: unknown,
+  content: string,
 ): boolean {
   const [clamped, setClamped] = useState(false);
 

--- a/packages/progressive-review/app/src/thread-target-model.tsx
+++ b/packages/progressive-review/app/src/thread-target-model.tsx
@@ -106,11 +106,11 @@ function useReviewSessionRefs(documentRoute?: string): {
           });
         }
       })
-      .catch((error: unknown) => {
+      .catch((cause: unknown) => {
         // Base-side comment creation guards on the missing value with its own
         // explicit error; log the fetch failure rather than swallowing it.
         console.error(
-          error instanceof Error ? error : new Error(String(error)),
+          cause instanceof Error ? cause : new Error(String(cause)),
         );
       });
     return () => {

--- a/packages/progressive-review/app/src/trace-document.tsx
+++ b/packages/progressive-review/app/src/trace-document.tsx
@@ -1068,9 +1068,8 @@ export function TraceDocument({
     const targetTurn = document.getElementById("review-trace-target-event");
     const quoteMark = targetTurn?.querySelector(".review-trace-quote-mark");
     const el = quoteMark ?? targetTurn;
-    if (el && typeof el.scrollIntoView === "function") {
-      el.scrollIntoView({ block: "center", behavior: "auto" });
-    }
+    // jsdom has no scrollIntoView, so the call stays optional.
+    el?.scrollIntoView?.({ block: "center", behavior: "auto" });
   }, [targetEventIndex, events, highlightQuote]);
 
   const [expandedGaps, setExpandedGaps] = useState<ReadonlySet<number>>(

--- a/packages/progressive-review/app/src/trace-quote.tsx
+++ b/packages/progressive-review/app/src/trace-quote.tsx
@@ -1,27 +1,15 @@
-import type { ReactNode } from "react";
+import { type ReactNode, isValidElement } from "react";
 
 import type { TraceQuoteProps } from "../../src/authoring";
+import { isReactTextNode } from "./agent-markdown";
 import { ProsePeekAnchor } from "./review-components";
 import { useOptionalReviewPanel } from "./review-panel";
 
 function extractText(node: ReactNode): string {
-  if (node === null || node === undefined || typeof node === "boolean") {
-    return "";
-  }
-  if (typeof node === "string" || typeof node === "number") {
-    return String(node);
-  }
-  if (Array.isArray(node)) {
-    return node.map(extractText).join("");
-  }
-  if (
-    typeof node === "object" &&
-    "props" in node &&
-    (node as { props?: { children?: ReactNode } }).props
-  ) {
-    return extractText(
-      (node as { props: { children?: ReactNode } }).props.children,
-    );
+  if (isReactTextNode(node)) return String(node);
+  if (Array.isArray(node)) return node.map(extractText).join("");
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return extractText(node.props.children);
   }
   return "";
 }
@@ -74,9 +62,8 @@ export function TraceQuote({
         const targetTurn = document.getElementById("review-trace-target-event");
         const quoteMark = targetTurn?.querySelector(".review-trace-quote-mark");
         const el = quoteMark ?? targetTurn;
-        if (el && typeof el.scrollIntoView === "function") {
-          el.scrollIntoView({ block: "center", behavior: "auto" });
-        }
+        // jsdom has no scrollIntoView, so the call stays optional.
+        el?.scrollIntoView?.({ block: "center", behavior: "auto" });
       }}
     >
       {children}

--- a/packages/progressive-review/app/src/trace-ruler.tsx
+++ b/packages/progressive-review/app/src/trace-ruler.tsx
@@ -270,7 +270,8 @@ export function TraceRuler({
         .sort((left, right) => left.index - right.index);
       const target =
         wrappers.find((entry) => entry.index >= start) ?? wrappers.at(-1);
-      if (target && typeof target.wrapper.scrollIntoView === "function") {
+      // jsdom has no scrollIntoView, so the call stays optional.
+      if (target?.wrapper.scrollIntoView) {
         target.wrapper.scrollIntoView({ block: "start", behavior: "auto" });
         return;
       }

--- a/packages/progressive-review/app/src/ui-telemetry.ts
+++ b/packages/progressive-review/app/src/ui-telemetry.ts
@@ -1,3 +1,5 @@
+import { jsonBoolean, jsonNumber, jsonString } from "@dev.fast/review-protocol";
+
 import {
   REVIEW_APP_SESSION_ID_HEADER,
   UI_TELEMETRY_EVENTS,
@@ -24,7 +26,7 @@ export function captureUiEvent(
   session: ReviewSession,
   name: UiTelemetryEventName,
   properties?: UiTelemetryProperties,
-  error?: unknown,
+  error?: PackedClientError,
 ): void {
   const sanitizedProperties = sanitizeEventProperties(name, properties);
   if (!sanitizedProperties) return;
@@ -37,7 +39,7 @@ export function captureUiEvent(
       body: JSON.stringify({
         name,
         properties: sanitizedProperties,
-        ...(error === undefined ? {} : { error: packClientError(error) }),
+        ...(error === undefined ? {} : { error }),
       }),
       keepalive: true,
     }).catch(() => undefined);
@@ -55,7 +57,7 @@ export function captureUiEvent(
 export function captureClientError(
   session: ReviewSession,
   errorSource: string,
-  error: unknown,
+  cause: unknown,
   properties?: UiTelemetryProperties,
 ): void {
   captureUiEvent(
@@ -64,10 +66,10 @@ export function captureClientError(
     {
       error_source: errorSource,
       error_process: "canvas",
-      error_name: clientErrorName(error),
+      error_name: clientErrorName(cause),
       ...properties,
     },
-    error,
+    cause === undefined ? undefined : packClientError(cause),
   );
 }
 
@@ -78,19 +80,18 @@ interface PackedClientError {
   stack?: string;
 }
 
-function packClientError(error: unknown): PackedClientError {
-  if (!(error instanceof Error)) return { message: String(error) };
+function packClientError(cause: unknown): PackedClientError {
+  if (!(cause instanceof Error)) return { message: String(cause) };
   return {
-    name: error.name,
-    message: error.message,
-    ...(typeof error.stack === "string" ? { stack: error.stack } : {}),
+    name: cause.name,
+    message: cause.message,
+    ...(cause.stack === undefined ? {} : { stack: cause.stack }),
   };
 }
 
-export function clientErrorName(error: unknown): string {
-  const name =
-    error && typeof error === "object" ? error.constructor?.name : undefined;
-  return validFreeString(name) ? name : "Error";
+export function clientErrorName(cause: unknown): string {
+  const name = cause instanceof Object ? cause.constructor?.name : undefined;
+  return name !== undefined && validFreeString(name) ? name : "Error";
 }
 
 function sanitizeEventProperties(
@@ -103,38 +104,34 @@ function sanitizeEventProperties(
   for (const [key, propSpec] of Object.entries(spec.properties)) {
     const value = properties?.[key];
     if (value === undefined || value === null) continue;
+    const text = jsonString(value);
     if (propSpec === "number") {
-      if (typeof value === "number" && Number.isFinite(value)) {
-        sanitized[key] = value;
-      }
+      const number = jsonNumber(value);
+      if (number !== undefined) sanitized[key] = number;
       continue;
     }
     if (propSpec === "boolean") {
-      if (typeof value === "boolean") sanitized[key] = value;
+      const boolean = jsonBoolean(value);
+      if (boolean !== undefined) sanitized[key] = boolean;
       continue;
     }
     if (propSpec === "enum_free_short") {
-      if (typeof value === "string" && validFreeString(value)) {
-        sanitized[key] = value;
-      }
+      if (text !== undefined && validFreeString(text)) sanitized[key] = text;
       continue;
     }
     if (
       Array.isArray(propSpec) &&
-      typeof value === "string" &&
-      (propSpec as readonly string[]).includes(value)
+      text !== undefined &&
+      (propSpec as readonly string[]).includes(text)
     ) {
-      sanitized[key] = value;
+      sanitized[key] = text;
     }
   }
   return sanitized;
 }
 
-function validFreeString(value: unknown): value is string {
+function validFreeString(value: string): boolean {
   return (
-    typeof value === "string" &&
-    value.length > 0 &&
-    value.length <= 40 &&
-    /^[A-Za-z0-9_$-]+$/.test(value)
+    value.length > 0 && value.length <= 40 && /^[A-Za-z0-9_$-]+$/.test(value)
   );
 }

--- a/packages/progressive-review/app/src/use-agent-trace.ts
+++ b/packages/progressive-review/app/src/use-agent-trace.ts
@@ -75,13 +75,13 @@ export function useAgentTrace(
           setState({ key, traceState: { status: "loaded", trace: result } });
         }
       })
-      .catch((error: unknown) => {
+      .catch((cause: unknown) => {
         if (controller.signal.aborted) return;
         setState({
           key,
           traceState: {
             status: "error",
-            error: error instanceof Error ? error.message : String(error),
+            error: cause instanceof Error ? cause.message : String(cause),
           },
         });
       });

--- a/packages/progressive-review/scripts/build-tutorial-assets.ts
+++ b/packages/progressive-review/scripts/build-tutorial-assets.ts
@@ -19,6 +19,8 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 import { writeNote } from "@dev.fast/local-vcs";
+import { parseJsonText } from "@dev.fast/review-protocol";
+import { z } from "zod";
 
 import { writeReviewDocumentBundle } from "../src/review-bundle";
 import { createReviewDir } from "../src/review-home";
@@ -35,6 +37,40 @@ import { loadPublishSoftwareMaps } from "../src/software-map-health";
 const execFilePromise = promisify(execFile);
 const packageRoot = path.resolve(import.meta.dirname, "..");
 const tutorialDir = path.join(packageRoot, "tutorial");
+
+/** A manifest entry that names a file inside the tutorial tree. */
+const safeManifestPathSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (entry) => !path.isAbsolute(entry) && !entry.split(/[\\/]/u).includes(".."),
+  );
+
+export const tutorialRuntimeManifestSchema = z
+  .object({
+    version: z.literal(1),
+    reviewFiles: z.array(safeManifestPathSchema).min(1),
+    requiredPaths: z.array(safeManifestPathSchema).min(1),
+  })
+  .refine((manifest) =>
+    manifest.reviewFiles.every((entry) =>
+      manifest.requiredPaths.includes(entry),
+    ),
+  );
+
+export async function readTutorialRuntimeManifest(
+  tutorialRoot: string,
+): Promise<z.infer<typeof tutorialRuntimeManifestSchema>> {
+  const parsed = tutorialRuntimeManifestSchema.safeParse(
+    parseJsonText(
+      await readFile(path.join(tutorialRoot, "runtime-manifest.json"), "utf8"),
+    ),
+  );
+  if (!parsed.success) {
+    throw new Error("Tutorial runtime manifest is invalid.");
+  }
+  return parsed.data;
+}
 
 /* The commit hash must be identical on every build machine: the map-bundle
    manifest bakes it in, and the runtime checks the shipped repo's HEAD
@@ -76,22 +112,7 @@ export async function buildTutorialAssets(
   input: { outDir?: string } = {},
 ): Promise<BuiltTutorialAssets> {
   const outDir = input.outDir ?? tutorialDir;
-  const runtimeManifest = JSON.parse(
-    await readFile(path.join(tutorialDir, "runtime-manifest.json"), "utf8"),
-  ) as { reviewFiles?: unknown };
-  if (
-    !Array.isArray(runtimeManifest.reviewFiles) ||
-    runtimeManifest.reviewFiles.length === 0 ||
-    !runtimeManifest.reviewFiles.every(
-      (entry) =>
-        typeof entry === "string" &&
-        entry.length > 0 &&
-        !path.isAbsolute(entry) &&
-        !entry.split(/[\\/]/u).includes(".."),
-    )
-  ) {
-    throw new Error("Tutorial runtime manifest is invalid.");
-  }
+  const runtimeManifest = await readTutorialRuntimeManifest(tutorialDir);
   const temporaryRoot = await mkdtemp(
     path.join(os.tmpdir(), "review-tutorial-build-"),
   );

--- a/packages/progressive-review/scripts/check-tutorial.ts
+++ b/packages/progressive-review/scripts/check-tutorial.ts
@@ -7,13 +7,21 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
+import {
+  jsonObject,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
 import ts from "typescript";
 
 import {
   reviewAuthoringPropsSchemas,
   tutorialAuthoringConversationSchema,
 } from "../src/authoring";
-import { buildTutorialAssets } from "./build-tutorial-assets";
+import {
+  buildTutorialAssets,
+  readTutorialRuntimeManifest,
+} from "./build-tutorial-assets";
 
 const execFilePromise = promisify(execFile);
 const packageRoot = path.resolve(import.meta.dirname, "..");
@@ -130,50 +138,25 @@ async function readBuiltTutorialIdentity(outDir: string): Promise<{
   commit: string;
   peekCount: number;
 }> {
-  const manifest = JSON.parse(
-    await readFile(
-      path.join(outDir, ".bundle", "software-map", "manifest.json"),
-      "utf8",
+  const manifest = jsonObject(
+    parseJsonText(
+      await readFile(
+        path.join(outDir, ".bundle", "software-map", "manifest.json"),
+        "utf8",
+      ),
     ),
-  ) as { baseCommit?: unknown; headCommit?: unknown };
-  if (
-    typeof manifest.baseCommit !== "string" ||
-    typeof manifest.headCommit !== "string"
-  ) {
+  );
+  const baseCommit = jsonString(manifest?.baseCommit);
+  const headCommit = jsonString(manifest?.headCommit);
+  if (baseCommit === undefined || headCommit === undefined) {
     throw new Error("Tutorial software-map manifest commits are invalid.");
   }
-  return {
-    baseCommit: manifest.baseCommit,
-    commit: manifest.headCommit,
-    peekCount: 0,
-  };
+  return { baseCommit, commit: headCommit, peekCount: 0 };
 }
 
 async function checkRuntimeManifest(outDir: string): Promise<void> {
-  const manifest = JSON.parse(
-    await readFile(path.join(tutorialRoot, "runtime-manifest.json"), "utf8"),
-  ) as {
-    version?: unknown;
-    reviewFiles?: unknown;
-    requiredPaths?: unknown;
-  };
-  if (
-    manifest.version !== 1 ||
-    !Array.isArray(manifest.reviewFiles) ||
-    !Array.isArray(manifest.requiredPaths) ||
-    manifest.reviewFiles.length === 0 ||
-    manifest.requiredPaths.length === 0 ||
-    !manifest.reviewFiles.every((entry) =>
-      isSafeManifestPath(entry, manifest.requiredPaths as unknown[]),
-    ) ||
-    !manifest.requiredPaths.every((entry) => isSafeManifestPath(entry))
-  ) {
-    throw new Error("Tutorial runtime manifest is invalid.");
-  }
+  const manifest = await readTutorialRuntimeManifest(tutorialRoot);
   for (const entry of manifest.requiredPaths) {
-    if (typeof entry !== "string") {
-      throw new Error("Tutorial runtime manifest contains an invalid path.");
-    }
     const generated = path.join(outDir, entry);
     const source = path.join(tutorialRoot, entry);
     const exists = await stat(generated)
@@ -187,19 +170,6 @@ async function checkRuntimeManifest(outDir: string): Promise<void> {
       throw new Error(`Tutorial runtime manifest references missing ${entry}.`);
     }
   }
-}
-
-function isSafeManifestPath(
-  entry: unknown,
-  requiredPaths?: unknown[],
-): entry is string {
-  return (
-    typeof entry === "string" &&
-    entry.length > 0 &&
-    !path.isAbsolute(entry) &&
-    !entry.split(/[\\/]/u).includes("..") &&
-    (!requiredPaths || requiredPaths.includes(entry))
-  );
 }
 
 function checkSampleTypeScript(repositoryRoot: string): void {

--- a/packages/progressive-review/src/agent-fff.ts
+++ b/packages/progressive-review/src/agent-fff.ts
@@ -10,6 +10,7 @@ import {
   type ReviewFffManagedRegistration,
   isJsonArray,
   isJsonObject,
+  jsonString,
   parseJsonText,
 } from "@dev.fast/review-protocol";
 
@@ -228,13 +229,13 @@ function findStdioConfig(
   value: JsonValue,
 ): { command: string; args: string[] } | null {
   if (!isJsonObject(value)) return null;
-  const { command, args } = value;
-  if (
-    typeof command === "string" &&
-    isJsonArray(args) &&
-    args.every((arg): arg is string => typeof arg === "string")
-  ) {
-    return { command, args };
+  const command = jsonString(value.command);
+  const args = isJsonArray(value.args) ? value.args : undefined;
+  if (command !== undefined && args !== undefined) {
+    const argStrings = args.flatMap((arg) => jsonString(arg) ?? []);
+    if (argStrings.length === args.length) {
+      return { command, args: argStrings };
+    }
   }
   for (const child of Object.values(value)) {
     const found = findStdioConfig(child);

--- a/packages/progressive-review/src/agent-trace-hooks.ts
+++ b/packages/progressive-review/src/agent-trace-hooks.ts
@@ -8,6 +8,7 @@ import {
   type JsonValue,
   isJsonArray,
   isJsonObject,
+  jsonString,
   parseJsonText,
 } from "@dev.fast/review-protocol";
 
@@ -316,12 +317,11 @@ function shellCommand(command: string): string {
     : `'${command.replaceAll("'", `'"'"'`)}'`;
 }
 
-function isReviewTraceHookCommand(command: unknown): boolean {
-  if (typeof command !== "string") return false;
+function isReviewTraceHookCommand(command: JsonValue | undefined): boolean {
+  const text = jsonString(command);
+  if (text === undefined) return false;
   const match =
-    /^(.*) trace hook (SessionStart|UserPromptSubmit|SessionEnd)$/.exec(
-      command,
-    );
+    /^(.*) trace hook (SessionStart|UserPromptSubmit|SessionEnd)$/.exec(text);
   if (!match) return false;
   return match[1] === "review" || match[1].endsWith("/review'");
 }

--- a/packages/progressive-review/src/agent-trace-parser.ts
+++ b/packages/progressive-review/src/agent-trace-parser.ts
@@ -2,9 +2,17 @@ import path from "node:path";
 
 import {
   type JsonObject,
+  type JsonValue,
   type ReviewAgentTraceEvent,
   type ReviewAgentTraceSession,
+  isJsonArray,
   isJsonObject,
+  jsonArray,
+  jsonBoolean,
+  jsonNumber,
+  jsonObject,
+  jsonString,
+  parseJsonText,
 } from "@dev.fast/review-protocol";
 
 export const AGENT_TRACE_PARSER_VERSION = "1";
@@ -78,9 +86,9 @@ export function sniffAgentTraceHarness(
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
-      const record = JSON.parse(trimmed) as { type?: unknown };
-      if (record.type === "session_meta") return "codex";
-      if (record.type === "session") return "pi";
+      const type = jsonObject(parseJsonText(trimmed))?.type;
+      if (type === "session_meta") return "codex";
+      if (type === "session") return "pi";
       return "claude-code";
     } catch {
       continue;
@@ -93,21 +101,21 @@ export function parseAgentTraceJsonl(
   jsonl: string,
   options?: { isSubagent?: boolean },
 ): AgentTraceParseResult {
-  const records: unknown[] = [];
+  const records: JsonValue[] = [];
   for (const line of jsonl.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
-      records.push(JSON.parse(trimmed));
+      records.push(parseJsonText(trimmed));
     } catch {
       // Partial trailing writes are expected in live transcripts.
     }
   }
-  const first = records[0] as { type?: unknown } | undefined;
+  const firstType = jsonObject(records[0])?.type;
   const parsed =
-    first?.type === "session_meta"
+    firstType === "session_meta"
       ? parseCodexRecords(records)
-      : first?.type === "session"
+      : firstType === "session"
         ? parsePiRecords(records)
         : parseClaudeRecords(records, options);
   parsed.activeMs = computeActiveMs(parsed.events);
@@ -154,9 +162,9 @@ interface ClaudeContentBlock {
   thinking?: string;
   id?: string;
   name?: string;
-  input?: unknown;
+  input?: JsonValue;
   tool_use_id?: string;
-  content?: unknown;
+  content?: JsonValue;
   is_error?: boolean;
 }
 
@@ -168,17 +176,56 @@ interface ClaudeRecord {
   cwd?: string;
   aiTitle?: string;
   customTitle?: string;
-  message?: { role?: string; content?: unknown };
-  toolUseResult?: {
-    filePath?: string;
-    structuredPatch?: Array<{ lines?: string[] }>;
+  message?: { role?: string; content?: JsonValue };
+  toolUseResult?: { filePath?: string; structuredPatch?: JsonValue };
+}
+
+function claudeRecord(value: JsonObject): ClaudeRecord {
+  const message = jsonObject(value.message);
+  const toolUseResult = jsonObject(value.toolUseResult);
+  return {
+    type: jsonString(value.type),
+    isSidechain: jsonBoolean(value.isSidechain),
+    isMeta: jsonBoolean(value.isMeta),
+    timestamp: jsonString(value.timestamp),
+    cwd: jsonString(value.cwd),
+    aiTitle: jsonString(value.aiTitle),
+    customTitle: jsonString(value.customTitle),
+    message: message && {
+      role: jsonString(message.role),
+      content: message.content,
+    },
+    toolUseResult: toolUseResult && {
+      filePath: jsonString(toolUseResult.filePath),
+      structuredPatch: toolUseResult.structuredPatch,
+    },
   };
 }
 
-function claudeContentBlocks(content: unknown): ClaudeContentBlock[] {
-  if (typeof content === "string") return [{ type: "text", text: content }];
-  if (Array.isArray(content)) return content as ClaudeContentBlock[];
-  return [];
+function claudeContentBlock(value: JsonValue): ClaudeContentBlock | undefined {
+  if (!isJsonObject(value)) return undefined;
+  return {
+    type: jsonString(value.type),
+    text: jsonString(value.text),
+    thinking: jsonString(value.thinking),
+    id: jsonString(value.id),
+    name: jsonString(value.name),
+    input: value.input,
+    tool_use_id: jsonString(value.tool_use_id),
+    content: value.content,
+    is_error: jsonBoolean(value.is_error),
+  };
+}
+
+function claudeContentBlocks(
+  content: JsonValue | undefined,
+): ClaudeContentBlock[] {
+  const text = jsonString(content);
+  if (text !== undefined) return [{ type: "text", text }];
+  return (
+    jsonArray(content)?.flatMap((block) => claudeContentBlock(block) ?? []) ??
+    []
+  );
 }
 
 const CLAUDE_NOISE_PATTERNS = [
@@ -216,14 +263,14 @@ function cleanClaudeUserText(text: string): string | null {
   return cleaned;
 }
 
-function claudeResultText(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
+function claudeResultText(content: JsonValue | undefined): string {
+  const text = jsonString(content);
+  if (text !== undefined) return text;
   const parts: string[] = [];
-  for (const block of content as ClaudeContentBlock[]) {
-    if (block?.type === "text" && typeof block.text === "string") {
+  for (const block of claudeContentBlocks(content)) {
+    if (block.type === "text" && block.text !== undefined) {
       parts.push(block.text);
-    } else if (block?.type === "image") {
+    } else if (block.type === "image") {
       parts.push("[image]");
     }
   }
@@ -231,15 +278,18 @@ function claudeResultText(content: unknown): string {
 }
 
 function patchCounts(
-  patch: Array<{ lines?: string[] }> | undefined,
+  patch: JsonValue | undefined,
 ): { additions: number; deletions: number } | null {
-  if (!patch) return null;
+  const hunks = jsonArray(patch);
+  if (!hunks) return null;
   let additions = 0;
   let deletions = 0;
-  for (const hunk of patch) {
-    for (const line of hunk.lines ?? []) {
-      if (line.startsWith("+")) additions += 1;
-      else if (line.startsWith("-")) deletions += 1;
+  for (const hunk of hunks) {
+    for (const line of jsonArray(jsonObject(hunk)?.lines) ?? []) {
+      const text = jsonString(line);
+      if (text === undefined) continue;
+      if (text.startsWith("+")) additions += 1;
+      else if (text.startsWith("-")) deletions += 1;
     }
   }
   return { additions, deletions };
@@ -259,10 +309,8 @@ function claudeToolEvent(
     title: name,
     at,
   };
-  const inputText = (key: string): string | null => {
-    const value = input[key];
-    return typeof value === "string" ? value : null;
-  };
+  const inputText = (key: string): string | null =>
+    jsonString(input[key]) ?? null;
   const filePath =
     inputText("file_path") ?? inputText("path") ?? inputText("notebook_path");
   switch (name) {
@@ -341,7 +389,7 @@ function claudeToolEvent(
 }
 
 function parseClaudeRecords(
-  records: unknown[],
+  records: readonly JsonValue[],
   options?: { isSubagent?: boolean },
 ): AgentTraceParseResult {
   const events: AgentTraceEvent[] = [];
@@ -354,15 +402,13 @@ function parseClaudeRecords(
   let toolCalls = 0;
 
   for (const raw of records) {
-    const record = raw as ClaudeRecord;
-    if (record.type === "ai-title" && typeof record.aiTitle === "string") {
+    if (!isJsonObject(raw)) continue;
+    const record = claudeRecord(raw);
+    if (record.type === "ai-title" && record.aiTitle !== undefined) {
       title ??= record.aiTitle;
       continue;
     }
-    if (
-      record.type === "custom-title" &&
-      typeof record.customTitle === "string"
-    ) {
+    if (record.type === "custom-title" && record.customTitle !== undefined) {
       title = record.customTitle;
       continue;
     }
@@ -378,7 +424,7 @@ function parseClaudeRecords(
     if (record.type === "user") {
       let sawToolResult = false;
       for (const block of blocks) {
-        if (block?.type !== "tool_result") continue;
+        if (block.type !== "tool_result") continue;
         sawToolResult = true;
         const pending = block.tool_use_id
           ? pendingTools.get(block.tool_use_id)
@@ -399,10 +445,9 @@ function parseClaudeRecords(
       }
       if (sawToolResult || record.isMeta) continue;
       const text = blocks
-        .filter(
-          (block) => block?.type === "text" && typeof block.text === "string",
+        .flatMap((block) =>
+          block.type === "text" && block.text !== undefined ? [block.text] : [],
         )
-        .map((block) => block.text as string)
         .join("\n");
       const cleaned = cleanClaudeUserText(text);
       if (!cleaned) continue;
@@ -411,7 +456,7 @@ function parseClaudeRecords(
       continue;
     }
     for (const block of blocks) {
-      if (block?.type === "thinking" && typeof block.thinking === "string") {
+      if (block.type === "thinking" && block.thinking !== undefined) {
         const trimmed = block.thinking.trim();
         if (trimmed) {
           events.push({
@@ -421,10 +466,10 @@ function parseClaudeRecords(
             at,
           });
         }
-      } else if (block?.type === "text" && typeof block.text === "string") {
+      } else if (block.type === "text" && block.text !== undefined) {
         const trimmed = block.text.trim();
         if (trimmed) events.push({ kind: "assistant", markdown: trimmed, at });
-      } else if (block?.type === "tool_use") {
+      } else if (block.type === "tool_use") {
         const event = claudeToolEvent(block, at, cwd);
         toolCalls += 1;
         events.push(event);
@@ -447,33 +492,31 @@ function parseClaudeRecords(
 
 // --- Codex rollouts --------------------------------------------------------
 
+interface CodexTextBlock {
+  type?: string;
+  text?: string;
+}
+
 interface CodexPayload {
   type?: string;
   role?: string;
-  content?: Array<{ type?: string; text?: string }>;
+  content?: CodexTextBlock[];
   name?: string;
-  arguments?: unknown;
-  input?: unknown;
+  arguments?: JsonValue;
+  input?: JsonValue;
   call_id?: string;
-  output?: unknown;
-  action?: { query?: string };
+  output?: JsonValue;
   cwd?: string;
   timestamp?: string;
   message?: string;
   query?: string;
   stdout?: string;
   success?: boolean;
-  changes?: Record<
-    string,
-    { type?: string; unified_diff?: string; content?: string }
-  >;
-  invocation?: {
-    server?: string;
-    tool?: string;
-    arguments?: unknown;
-  };
-  result?: unknown;
-  command?: unknown;
+  /** File path → change record (`type`, `unified_diff`, `content`). */
+  changes?: JsonObject;
+  invocation?: JsonObject;
+  result?: JsonValue;
+  command?: JsonValue;
   aggregated_output?: string;
   exit_code?: number;
 }
@@ -482,6 +525,51 @@ interface CodexRecord {
   type?: string;
   timestamp?: string;
   payload?: CodexPayload;
+}
+
+function codexTextBlocks(value: JsonValue | undefined): CodexTextBlock[] {
+  return (
+    jsonArray(value)?.flatMap((block) => {
+      const record = jsonObject(block);
+      return record
+        ? [{ type: jsonString(record.type), text: jsonString(record.text) }]
+        : [];
+    }) ?? []
+  );
+}
+
+function codexPayload(value: JsonObject): CodexPayload {
+  return {
+    type: jsonString(value.type),
+    role: jsonString(value.role),
+    content: codexTextBlocks(value.content),
+    name: jsonString(value.name),
+    arguments: value.arguments,
+    input: value.input,
+    call_id: jsonString(value.call_id),
+    output: value.output,
+    cwd: jsonString(value.cwd),
+    timestamp: jsonString(value.timestamp),
+    message: jsonString(value.message),
+    query: jsonString(value.query),
+    stdout: jsonString(value.stdout),
+    success: jsonBoolean(value.success),
+    changes: jsonObject(value.changes),
+    invocation: jsonObject(value.invocation),
+    result: value.result,
+    command: value.command,
+    aggregated_output: jsonString(value.aggregated_output),
+    exit_code: jsonNumber(value.exit_code),
+  };
+}
+
+function codexRecord(value: JsonObject): CodexRecord {
+  const payload = jsonObject(value.payload);
+  return {
+    type: jsonString(value.type),
+    timestamp: jsonString(value.timestamp),
+    payload: payload && codexPayload(payload),
+  };
 }
 
 const CODEX_USER_NOISE_PREFIXES = [
@@ -519,12 +607,12 @@ const CODEX_USER_NOISE_PREFIXES = [
 
 function codexText(payload: CodexPayload): string {
   return (payload.content ?? [])
-    .filter(
-      (block) =>
-        (block?.type === "input_text" || block?.type === "output_text") &&
-        typeof block.text === "string",
+    .flatMap((block) =>
+      (block.type === "input_text" || block.type === "output_text") &&
+      block.text !== undefined
+        ? [block.text]
+        : [],
     )
-    .map((block) => block.text as string)
     .join("\n")
     .trim();
 }
@@ -559,14 +647,11 @@ function unifiedDiffCounts(diff: string) {
   return { additions, deletions };
 }
 
-function codexValueText(value: unknown): string {
-  if (typeof value === "string") return value;
+function codexValueText(value: JsonValue | undefined): string {
+  const text = jsonString(value);
+  if (text !== undefined) return text;
   if (value === null || value === undefined) return "";
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
+  return JSON.stringify(value);
 }
 
 function codexPatchEvent(
@@ -581,18 +666,20 @@ function codexPatchEvent(
   let deletions = 0;
   const relativePaths = paths.map((filePath) => relativizePath(filePath, cwd));
   for (const filePath of paths) {
-    const change = changes[filePath] ?? {};
-    if (change.type === "add" && typeof change.content === "string") {
-      additions += change.content.split("\n").length;
-    } else if (change.type === "delete" && typeof change.content === "string") {
-      deletions += change.content.split("\n").length;
-    } else if (typeof change.unified_diff === "string") {
-      const counts = unifiedDiffCounts(change.unified_diff);
+    const change = jsonObject(changes[filePath]) ?? {};
+    const content = jsonString(change.content);
+    const unifiedDiff = jsonString(change.unified_diff);
+    if (change.type === "add" && content !== undefined) {
+      additions += content.split("\n").length;
+    } else if (change.type === "delete" && content !== undefined) {
+      deletions += content.split("\n").length;
+    } else if (unifiedDiff !== undefined) {
+      const counts = unifiedDiffCounts(unifiedDiff);
       additions += counts.additions;
       deletions += counts.deletions;
     }
   }
-  const single = paths.length === 1 ? changes[paths[0]] : null;
+  const single = paths.length === 1 ? jsonObject(changes[paths[0]]) : null;
   const verb =
     single?.type === "add"
       ? "Added"
@@ -609,9 +696,9 @@ function codexPatchEvent(
     deletions,
     at,
   };
-  const diffs = paths
-    .map((filePath) => changes[filePath]?.unified_diff)
-    .filter((diff): diff is string => typeof diff === "string");
+  const diffs = paths.flatMap(
+    (filePath) => jsonString(jsonObject(changes[filePath])?.unified_diff) ?? [],
+  );
   if (diffs.length > 0) event.input = truncate(diffs.join("\n"), INPUT_LIMIT);
   if (payload.stdout) event.output = truncate(payload.stdout, OUTPUT_LIMIT);
   if (payload.success === false) event.error = true;
@@ -623,16 +710,13 @@ function codexMcpEvent(
   at: string | undefined,
 ): AgentTraceToolEvent {
   const invocation = payload.invocation ?? {};
-  const server =
-    typeof invocation.server === "string" ? invocation.server : "mcp";
-  const tool = typeof invocation.tool === "string" ? invocation.tool : "tool";
-  const argumentsValue = invocation.arguments as
-    | { title?: unknown }
-    | undefined;
+  const server = jsonString(invocation.server) ?? "mcp";
+  const tool = jsonString(invocation.tool) ?? "tool";
+  const argumentsTitle = jsonString(jsonObject(invocation.arguments)?.title);
   const title =
-    argumentsValue && typeof argumentsValue.title === "string"
-      ? `${server} · ${tool} — ${argumentsValue.title}`
-      : `${server} · ${tool}`;
+    argumentsTitle === undefined
+      ? `${server} · ${tool}`
+      : `${server} · ${tool} — ${argumentsTitle}`;
   const event: AgentTraceToolEvent = {
     kind: "tool",
     tool: `${server}.${tool}`,
@@ -642,25 +726,17 @@ function codexMcpEvent(
   };
   const input = codexValueText(invocation.arguments);
   if (input && input !== "{}") event.input = truncate(input, INPUT_LIMIT);
-  const result = payload.result as
-    | {
-        Ok?: {
-          content?: Array<{ type?: string; text?: string }>;
-          isError?: boolean;
-        };
-        Err?: unknown;
-      }
-    | undefined;
-  if (result?.Ok?.content) {
-    const text = result.Ok.content
-      .filter(
-        (block) => block?.type === "text" && typeof block.text === "string",
+  const result = jsonObject(payload.result);
+  const ok = jsonObject(result?.Ok);
+  if (ok?.content) {
+    const text = codexTextBlocks(ok.content)
+      .flatMap((block) =>
+        block.type === "text" && block.text !== undefined ? [block.text] : [],
       )
-      .map((block) => block.text as string)
       .join("\n")
       .trim();
     if (text) event.output = truncate(text, OUTPUT_LIMIT);
-    if (result.Ok.isError) event.error = true;
+    if (ok.isError) event.error = true;
   } else if (result && "Err" in result) {
     event.error = true;
     event.output = truncate(codexValueText(result.Err), OUTPUT_LIMIT);
@@ -739,18 +815,12 @@ function codexToolEvent(
     }
     let command = source;
     try {
-      const parsed = JSON.parse(source || "{}") as {
-        cmd?: string;
-        command?: string[] | string;
-      };
+      const parsed = jsonObject(parseJsonText(source || "{}"));
       command =
-        typeof parsed.cmd === "string"
-          ? parsed.cmd
-          : Array.isArray(parsed.command)
-            ? parsed.command.join(" ")
-            : typeof parsed.command === "string"
-              ? parsed.command
-              : command;
+        jsonString(parsed?.cmd) ??
+        jsonArray(parsed?.command)?.join(" ") ??
+        jsonString(parsed?.command) ??
+        command;
     } catch {
       // Keep the raw arguments string.
     }
@@ -776,25 +846,27 @@ function codexToolEvent(
   return event;
 }
 
-function codexOutputText(output: unknown): string {
-  if (typeof output === "string") {
+function codexOutputText(output: JsonValue | undefined): string {
+  const text = jsonString(output);
+  if (text !== undefined) {
     try {
-      const parsed = JSON.parse(output) as { output?: unknown };
-      if (typeof parsed.output === "string") return parsed.output;
+      const inner = jsonString(jsonObject(parseJsonText(text))?.output);
+      if (inner !== undefined) return inner;
     } catch {
       // Raw output string.
     }
-    return output;
+    return text;
   }
-  if (output && typeof output === "object") {
-    const inner = (output as { output?: unknown }).output;
-    if (typeof inner === "string") return inner;
-    return codexValueText(output);
-  }
-  return "";
+  const inner = jsonString(jsonObject(output)?.output);
+  if (inner !== undefined) return inner;
+  return isJsonObject(output) || isJsonArray(output)
+    ? codexValueText(output)
+    : "";
 }
 
-function parseCodexRecords(records: unknown[]): AgentTraceParseResult {
+function parseCodexRecords(
+  records: readonly JsonValue[],
+): AgentTraceParseResult {
   const events: AgentTraceEvent[] = [];
   const pendingTools = new Map<string, AgentTraceToolEvent>();
   let startedAt: string | null = null;
@@ -807,8 +879,10 @@ function parseCodexRecords(records: unknown[]): AgentTraceParseResult {
   let hasMessageEvents = false;
   let hasPatchEvents = false;
   let hasMcpEvents = false;
-  for (const raw of records) {
-    const record = raw as CodexRecord;
+  const codexRecords = records.flatMap((raw) =>
+    isJsonObject(raw) ? [codexRecord(raw)] : [],
+  );
+  for (const record of codexRecords) {
     if (record.type !== "event_msg") continue;
     const eventType = record.payload?.type;
     if (eventType === "user_message" || eventType === "agent_message") {
@@ -821,8 +895,7 @@ function parseCodexRecords(records: unknown[]): AgentTraceParseResult {
   }
   const flags = { hasPatchEvents, hasMcpEvents };
 
-  for (const raw of records) {
-    const record = raw as CodexRecord;
+  for (const record of codexRecords) {
     const payload = record.payload;
     if (record.type === "session_meta") {
       cwd = payload?.cwd ?? null;
@@ -882,9 +955,9 @@ function parseCodexRecords(records: unknown[]): AgentTraceParseResult {
           break;
         }
         case "exec_command_end": {
-          const command = Array.isArray(payload.command)
-            ? (payload.command as string[]).join(" ")
-            : codexValueText(payload.command);
+          const command =
+            jsonArray(payload.command)?.join(" ") ??
+            codexValueText(payload.command);
           if (!command) break;
           toolCalls += 1;
           const event: AgentTraceToolEvent = {
@@ -898,10 +971,7 @@ function parseCodexRecords(records: unknown[]): AgentTraceParseResult {
           if (payload.aggregated_output) {
             event.output = truncate(payload.aggregated_output, OUTPUT_LIMIT);
           }
-          if (
-            typeof payload.exit_code === "number" &&
-            payload.exit_code !== 0
-          ) {
+          if (payload.exit_code !== undefined && payload.exit_code !== 0) {
             event.error = true;
           }
           events.push(event);
@@ -998,15 +1068,52 @@ interface PiRecord {
   message?: {
     role?: string;
     toolCallId?: string;
-    content?: PiContentBlock[] | string;
+    /** Either plain text or an array of content blocks. */
+    content?: JsonValue;
   };
 }
 
-function piText(content: PiContentBlock[] | string | undefined): string {
-  if (typeof content === "string") return content;
-  return (content ?? [])
-    .filter((block) => block?.type === "text" && typeof block.text === "string")
-    .map((block) => block.text as string)
+function piRecord(value: JsonObject): PiRecord {
+  const message = jsonObject(value.message);
+  return {
+    type: jsonString(value.type),
+    timestamp: jsonString(value.timestamp),
+    cwd: jsonString(value.cwd),
+    message: message && {
+      role: jsonString(message.role),
+      toolCallId: jsonString(message.toolCallId),
+      content: message.content,
+    },
+  };
+}
+
+function piContentBlocks(content: JsonValue | undefined): PiContentBlock[] {
+  return (
+    jsonArray(content)?.flatMap((block) => {
+      const record = jsonObject(block);
+      return record
+        ? [
+            {
+              type: jsonString(record.type),
+              text: jsonString(record.text),
+              thinking: jsonString(record.thinking),
+              id: jsonString(record.id),
+              name: jsonString(record.name),
+              arguments: jsonObject(record.arguments),
+            },
+          ]
+        : [];
+    }) ?? []
+  );
+}
+
+function piText(content: JsonValue | undefined): string {
+  const text = jsonString(content);
+  if (text !== undefined) return text;
+  return piContentBlocks(content)
+    .flatMap((block) =>
+      block.type === "text" && block.text !== undefined ? [block.text] : [],
+    )
     .join("\n")
     .trim();
 }
@@ -1018,10 +1125,7 @@ function piToolEvent(
 ): AgentTraceToolEvent {
   const name = block.name ?? "tool";
   const args: JsonObject = block.arguments ?? {};
-  const argText = (key: string): string | null => {
-    const value = args[key];
-    return typeof value === "string" ? value : null;
-  };
+  const argText = (key: string): string | null => jsonString(args[key]) ?? null;
   const event: AgentTraceToolEvent = {
     kind: "tool",
     tool: name,
@@ -1058,9 +1162,8 @@ function piToolEvent(
         ? compactFileLine(relativizePath(pathValue, cwd))
         : name;
       if (pathValue) event.filePath = relativizePath(pathValue, cwd);
-      if (typeof args.content === "string") {
-        event.additions = (args.content as string).split("\n").length;
-      }
+      const content = argText("content");
+      if (content !== null) event.additions = content.split("\n").length;
       break;
     case "subagent":
       event.verb = "Ran agent";
@@ -1080,7 +1183,7 @@ function piToolEvent(
   return event;
 }
 
-function parsePiRecords(records: unknown[]): AgentTraceParseResult {
+function parsePiRecords(records: readonly JsonValue[]): AgentTraceParseResult {
   const events: AgentTraceEvent[] = [];
   const pendingTools = new Map<string, AgentTraceToolEvent>();
   let startedAt: string | null = null;
@@ -1091,7 +1194,8 @@ function parsePiRecords(records: unknown[]): AgentTraceParseResult {
   let firstUserText: string | null = null;
 
   for (const raw of records) {
-    const record = raw as PiRecord;
+    if (!isJsonObject(raw)) continue;
+    const record = piRecord(raw);
     if (record.type === "session") {
       cwd = record.cwd ?? null;
       startedAt ??= record.timestamp ?? null;
@@ -1121,15 +1225,14 @@ function parsePiRecords(records: unknown[]): AgentTraceParseResult {
       continue;
     }
     if (message.role === "assistant") {
-      if (typeof message.content === "string") {
-        const trimmed = message.content.trim();
+      const contentText = jsonString(message.content);
+      if (contentText !== undefined) {
+        const trimmed = contentText.trim();
         if (trimmed) events.push({ kind: "assistant", markdown: trimmed, at });
         continue;
       }
-      for (const block of Array.isArray(message.content)
-        ? message.content
-        : []) {
-        if (block?.type === "thinking" && typeof block.thinking === "string") {
+      for (const block of piContentBlocks(message.content)) {
+        if (block.type === "thinking" && block.thinking !== undefined) {
           const trimmed = block.thinking.trim();
           if (trimmed) {
             events.push({
@@ -1139,11 +1242,11 @@ function parsePiRecords(records: unknown[]): AgentTraceParseResult {
               at,
             });
           }
-        } else if (block?.type === "text" && typeof block.text === "string") {
+        } else if (block.type === "text" && block.text !== undefined) {
           const trimmed = block.text.trim();
           if (trimmed)
             events.push({ kind: "assistant", markdown: trimmed, at });
-        } else if (block?.type === "toolCall") {
+        } else if (block.type === "toolCall") {
           if (block.name === "subagent_wait") continue;
           const event = piToolEvent(block, at, cwd);
           toolCalls += 1;

--- a/packages/progressive-review/src/atomic-write.ts
+++ b/packages/progressive-review/src/atomic-write.ts
@@ -25,7 +25,7 @@ export function writeFileAtomic(
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileAtomicPackage.sync(
     filePath,
-    typeof contents === "string" ? contents : Buffer.from(contents),
+    contents instanceof Uint8Array ? Buffer.from(contents) : contents,
     {
       encoding,
       mode: options.mode,
@@ -42,7 +42,7 @@ export async function writeFileAtomicAsync(
   mkdirSync(path.dirname(filePath), { recursive: true });
   await writeFileAtomicPackage(
     filePath,
-    typeof contents === "string" ? contents : Buffer.from(contents),
+    contents instanceof Uint8Array ? Buffer.from(contents) : contents,
     options,
   );
 }

--- a/packages/progressive-review/src/authoring.ts
+++ b/packages/progressive-review/src/authoring.ts
@@ -1,3 +1,4 @@
+import { isObjectValue } from "@dev.fast/review-protocol";
 import type { ComponentType, ReactNode } from "react";
 import { z } from "zod";
 
@@ -158,6 +159,16 @@ export const anchorInputMapSchema = z.record(
 );
 export type AnchorInputMap = z.infer<typeof anchorInputMapSchema>;
 
+// The `key: "Title"` shorthand becomes `{ title }` at the parse boundary, so
+// definition code branches on one shape.
+const anchorDefinitionMapSchema = z.record(
+  nonEmptyStringSchema,
+  z.union([
+    nonEmptyStringSchema.transform((title): AnchorInput => ({ title })),
+    anchorInputSchema,
+  ]),
+);
+
 export const anchorRefSchema = z.strictObject({
   __kind: z.literal("db-anchor-ref"),
   id: nonEmptyStringSchema,
@@ -283,17 +294,24 @@ export interface AuthoredTargetRef {
 const resolvedTargetRefSchema = z.strictObject(targetRefShape);
 
 export const targetRefSchema = z.preprocess(
-  (value) => resolveTargetRef(value) ?? value,
+  (value) => (isAuthoredTargetRef(value) ? value[authoredTargetRefKey] : value),
   resolvedTargetRefSchema,
 );
 
-export function resolveTargetRef(value: unknown): TargetRef | null {
-  if (!value || typeof value !== "object") return null;
-  const authored = (value as Partial<AuthoredTargetRef>)[authoredTargetRefKey];
-  if (authored) return authored;
-  return (value as { __kind?: unknown }).__kind === "db-target-ref"
-    ? (value as TargetRef)
-    : null;
+// The handles defineStores returns carry their target under a private symbol;
+// an authored `from`/`to` prop is decoded here before the schema sees it.
+export function isAuthoredTargetRef(
+  value: unknown,
+): value is AuthoredTargetRef {
+  return isObjectValue(value) && authoredTargetRefKey in value;
+}
+
+export function resolveTargetRef(
+  value: AuthoredTargetRef | TargetRef | ActorRef | undefined,
+): TargetRef | null {
+  if (value === undefined) return null;
+  if (authoredTargetRefKey in value) return value[authoredTargetRefKey];
+  return value.__kind === "db-target-ref" ? value : null;
 }
 
 const dbOperationCommonShape = {
@@ -329,17 +347,20 @@ export const dbOperationPropsSchema = z.union([
 ]);
 export type DbOperationProps = z.infer<typeof dbOperationPropsSchema>;
 
+// Only the identifying fields are parsed: `z.custom` keeps the store handle's
+// identity, and with it the collection refs hanging off it.
+const storeRefIdentitySchema = z.object({
+  __kind: z.literal("db-store-ref"),
+  id: z.string(),
+  label: z.string(),
+});
+
 export const databaseLensPropsSchema = z.strictObject({
   title: optionalNonEmptyStringSchema,
   stores: z.record(
     nonEmptyStringSchema,
     z.custom<StoreRef>(
-      (value) =>
-        Boolean(value) &&
-        typeof value === "object" &&
-        (value as { __kind?: unknown }).__kind === "db-store-ref" &&
-        typeof (value as { id?: unknown }).id === "string" &&
-        typeof (value as { label?: unknown }).label === "string",
+      (value) => storeRefIdentitySchema.safeParse(value).success,
       "Must be a store reference returned by defineStores",
     ),
   ),
@@ -348,15 +369,18 @@ export const databaseLensPropsSchema = z.strictObject({
 });
 export type DatabaseLensProps = z.infer<typeof databaseLensPropsSchema>;
 
+// The model is the normalized structure defineSoftwareMap returns; `z.custom`
+// keeps it by identity and only its shape is parsed.
+const normalizedSoftwareModelSchema = z.object({
+  elements: z.array(z.unknown()),
+  elementsByPath: z.instanceof(Map),
+  relationships: z.array(z.unknown()),
+});
+
 export const softwareMapPropsSchema = z.strictObject({
   model: z
     .custom<NormalizedSoftwareModel>(
-      (value) =>
-        Boolean(value) &&
-        typeof value === "object" &&
-        Array.isArray((value as { elements?: unknown }).elements) &&
-        (value as { elementsByPath?: unknown }).elementsByPath instanceof Map &&
-        Array.isArray((value as { relationships?: unknown }).relationships),
+      (value) => normalizedSoftwareModelSchema.safeParse(value).success,
       "Must be a normalized software model",
     )
     .optional(),
@@ -688,14 +712,30 @@ type SoftwareStoreRefFor<T extends SoftwareStoreInput> = Omit<
     ? { documents: CollectionRefs<T["documents"]> }
     : Pick<StoreRef, "documents">);
 
+const softwareActorObjectInputSchema = z.strictObject({
+  path: nonEmptyStringSchema,
+  label: optionalNonEmptyStringSchema,
+});
+type SoftwareActorDefinition = z.infer<typeof softwareActorObjectInputSchema>;
+
 export const softwareActorInputSchema = z.union([
   nonEmptyStringSchema,
-  z.strictObject({
-    path: nonEmptyStringSchema,
-    label: optionalNonEmptyStringSchema,
-  }),
+  softwareActorObjectInputSchema,
 ]);
 export type SoftwareActorInput = z.infer<typeof softwareActorInputSchema>;
+
+// The `id: "path"` shorthand becomes `{ path }` at the parse boundary.
+const softwareActorDefinitionMapSchema = z.record(
+  nonEmptyStringSchema,
+  z.union([
+    nonEmptyStringSchema.transform(
+      (path): SoftwareActorDefinition => ({
+        path,
+      }),
+    ),
+    softwareActorObjectInputSchema,
+  ]),
+);
 
 export const softwareStoreInputSchema = z.strictObject({
   path: nonEmptyStringSchema,
@@ -820,13 +860,9 @@ function defineAnchors<T extends AnchorInputMap>(
   pending: Promise<void>[],
   reportMissingSoftwareMap: (context: { path: readonly PropertyKey[] }) => void,
 ): { [K in keyof T]: AnchorRefFor<T[K]> } {
-  anchorInputMapSchema.parse(input);
+  const anchors = anchorDefinitionMapSchema.parse(input);
   return Object.fromEntries(
-    Object.entries(input).map(([id, rawAnchor]) => {
-      const anchor =
-        typeof rawAnchor === "string"
-          ? { title: rawAnchor }
-          : (rawAnchor as AnchorInput);
+    Object.entries(anchors).map(([id, anchor]) => {
       requireDefinedSoftwareMapPath(
         environment,
         anchor.softwareMapPath,
@@ -854,10 +890,10 @@ function defineAnchors<T extends AnchorInputMap>(
               peek!.resolution = resolved;
               Object.freeze(peek);
             },
-            (error: unknown) => {
+            (cause: unknown) => {
               throwAuthoringIssue(
                 [id, "peek"],
-                `Code range could not be resolved in the pinned worktree: ${errorMessage(error)}`,
+                `Code range could not be resolved in the pinned worktree: ${errorMessage(cause)}`,
               );
             },
           );
@@ -929,7 +965,7 @@ function defineStores<T extends StoreInputMap>(
   ) as { [K in keyof T]: StoreRefFor<T[K]> };
 }
 
-export function validateCodePeekProps(input: unknown): CodePeekProps {
+export function validateCodePeekProps(input: CodePeekProps): CodePeekProps {
   return codePeekPropsSchema.parse(input);
 }
 
@@ -937,20 +973,16 @@ function defineSoftwareActors<T extends Record<string, SoftwareActorInput>>(
   model: NormalizedSoftwareModel,
   input: T,
 ): { [K in keyof T]: ActorRef } {
-  z.record(nonEmptyStringSchema, softwareActorInputSchema).parse(input);
+  const actors = softwareActorDefinitionMapSchema.parse(input);
   return Object.fromEntries(
-    Object.entries(input).map(([id, actor]) => {
-      const path = softwarePathFromInput(actor, [id, "path"]);
-      const element = softwareElementForPath(model, path, [id, "path"]);
+    Object.entries(actors).map(([id, actor]) => {
+      const element = softwareElementForPath(model, actor.path, [id, "path"]);
       return [
         id,
         Object.freeze({
           __kind: "db-actor-ref",
           id,
-          label:
-            typeof actor === "string"
-              ? element.label
-              : (actor.label ?? element.label),
+          label: actor.label ?? element.label,
           softwareMapPath: element.path,
         } satisfies ActorRef),
       ];
@@ -965,12 +997,11 @@ function defineSoftwareStores<T extends SoftwareStoreInputMap>(
   softwareStoreInputMapSchema.parse(input);
   const stores = Object.fromEntries(
     Object.entries(input).map(([id, store]) => {
-      const path = softwarePathFromInput(store, [id, "path"]);
-      const element = softwareElementForPath(model, path, [id, "path"]);
+      const element = softwareElementForPath(model, store.path, [id, "path"]);
       if (element.type !== "dataStore") {
         throwAuthoringIssue(
           [id, "path"],
-          `Software map element "${path}" must be a dataStore to back a DatabaseLens store`,
+          `Software map element "${store.path}" must be a dataStore to back a DatabaseLens store`,
         );
       }
       return [
@@ -1091,7 +1122,9 @@ function defineFieldTargets(
 function isNestedSchema(
   value: SoftwareDataStoreFieldSchema[string],
 ): value is SoftwareDataStoreFieldSchema {
-  return typeof (value as { type?: unknown }).type !== "string";
+  // A leaf's `type` is its column type; on a nested schema `type` can only be
+  // a field named "type".
+  return !z.string().safeParse(value.type).success;
 }
 
 function softwareElementForPath(
@@ -1123,22 +1156,6 @@ function requireDefinedSoftwareMapPath(
   softwareElementForPath(environment.softwareMap, path, propertyPath);
 }
 
-function softwarePathFromInput(
-  input: unknown,
-  propertyPath: PropertyKey[],
-): string {
-  const path =
-    typeof input === "string"
-      ? input
-      : input && typeof input === "object" && "path" in input
-        ? input.path
-        : undefined;
-  if (typeof path !== "string") {
-    throwAuthoringIssue(propertyPath, "Must be a software-map path string");
-  }
-  return path;
-}
-
 const DATA_STORE_KIND_MAP: Record<SoftwareDataStoreKind, StoreKind> = {
   artifactStore: "document",
   bucket: "document",
@@ -1160,8 +1177,7 @@ export function throwAuthoringIssue(
   throw new z.ZodError([{ code: "custom", path, message, input: undefined }]);
 }
 
-function errorMessage(error: unknown): string {
-  if (error instanceof Error && error.message.trim()) return error.message;
-  if (typeof error === "string" && error.trim()) return error;
-  return String(error);
+function errorMessage(cause: unknown): string {
+  if (cause instanceof Error && cause.message.trim()) return cause.message;
+  return String(cause);
 }

--- a/packages/progressive-review/src/cli-runner.ts
+++ b/packages/progressive-review/src/cli-runner.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 import type { Writable } from "node:stream";
 
 import { devfastPrepareCommands } from "@dev.fast/local-vcs";
-import type { ReviewView } from "@dev.fast/review-protocol";
+import {
+  type ReviewView,
+  jsonObject,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
 import { Argument, Command, CommanderError, Option } from "commander";
 
 import {
@@ -1187,9 +1192,14 @@ function installTargets(targets: readonly string[]): InstallTarget[] {
   ];
 }
 
+interface StopHookPayload {
+  cwd?: string;
+  transcriptPath?: string;
+}
+
 async function readStopHookPayload(
   input: ProgressiveReviewCliInput,
-): Promise<{ cwd?: string; transcriptPath?: string }> {
+): Promise<StopHookPayload> {
   const stdin = input.stdin ?? process.stdin;
   if (stdin.isTTY) return {};
   try {
@@ -1199,16 +1209,13 @@ async function readStopHookPayload(
     }
     const raw = Buffer.concat(chunks).toString("utf8").trim();
     if (!raw) return {};
-    const parsed = JSON.parse(raw) as {
-      cwd?: unknown;
-      transcript_path?: unknown;
-    };
-    return {
-      ...(typeof parsed.cwd === "string" ? { cwd: parsed.cwd } : {}),
-      ...(typeof parsed.transcript_path === "string"
-        ? { transcriptPath: parsed.transcript_path }
-        : {}),
-    };
+    const parsed = jsonObject(parseJsonText(raw));
+    const payload: StopHookPayload = {};
+    const cwd = jsonString(parsed?.cwd);
+    if (cwd !== undefined) payload.cwd = cwd;
+    const transcriptPath = jsonString(parsed?.transcript_path);
+    if (transcriptPath !== undefined) payload.transcriptPath = transcriptPath;
+    return payload;
   } catch {
     return {};
   }
@@ -1483,12 +1490,12 @@ async function finishActiveTelemetry(
       }
     | undefined,
   exitCode: number,
-  error?: unknown,
+  cause?: unknown,
   properties: Record<string, boolean | number | string | null | undefined> = {},
 ): Promise<void> {
   if (!active || active.finished) return;
   active.finished = true;
-  const classification = errorClassification(active.command, error);
+  const classification = errorClassification(active.command, cause);
   await attemptTelemetry(() =>
     exitCode === 0
       ? telemetry.captureCommandSucceeded({
@@ -1515,14 +1522,14 @@ async function captureOneOffCommand(
   telemetry: ProgressiveReviewCommandTelemetry,
   command: ProgressiveReviewCommandPath,
   exitCode: number,
-  error?: unknown,
+  cause?: unknown,
 ): Promise<void> {
   const commandRunId = telemetry.createCommandRunId();
   await attemptTelemetry(() => telemetry.captureInstallationCreated());
   await attemptTelemetry(() =>
     telemetry.captureCommandStarted({ command, commandRunId }),
   );
-  const classification = errorClassification(command, error);
+  const classification = errorClassification(command, cause);
   await attemptTelemetry(() =>
     exitCode === 0
       ? telemetry.captureCommandSucceeded({
@@ -1598,12 +1605,12 @@ interface ErrorClassification {
 
 function errorClassification(
   command: ProgressiveReviewCommandPath,
-  error: unknown,
+  cause: unknown,
 ): ErrorClassification {
-  if (error instanceof CommanderError || command === "invalid") {
+  if (cause instanceof CommanderError || command === "invalid") {
     return { errorName: "usage_error", errorCategory: "user_input" };
   }
-  const name = error instanceof Error ? error.name.toLowerCase() : "";
+  const name = cause instanceof Error ? cause.name.toLowerCase() : "";
   if (name.includes("notfound")) {
     return { errorName: "review_not_found", errorCategory: "local_state" };
   }
@@ -1628,7 +1635,7 @@ function errorClassification(
   if (command.startsWith("map.") || command.startsWith("cache.")) {
     return { errorName: "repository_error", errorCategory: "local_state" };
   }
-  if (error) {
+  if (cause) {
     return { errorName: "unexpected_error", errorCategory: "internal" };
   }
   return { errorName: "process_error", errorCategory: "dependency" };
@@ -1646,11 +1653,11 @@ function commanderErrorMessage(error: CommanderError): string {
   return error.message.replace(/^error:\s*/i, "");
 }
 
-function formatCliError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.stack || `${error.name}: ${error.message}`;
+function formatCliError(cause: unknown): string {
+  if (cause instanceof Error) {
+    return cause.stack || `${cause.name}: ${cause.message}`;
   }
-  return String(error);
+  return String(cause);
 }
 
 function ensureTrailingNewline(value: string): string {

--- a/packages/progressive-review/src/cli.ts
+++ b/packages/progressive-review/src/cli.ts
@@ -6,6 +6,12 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  jsonObject,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
 // A standalone build (npx/global install) defers to the CLI bundled with a
 // running Review Desktop so the CLI can never skew from the server it talks
 // to. Checkout runs execute src/cli.ts via tsx and therefore never delegate.
@@ -62,18 +68,20 @@ function maybeDelegateToDesktopCli(argv: string[]): number | null {
   let cliPath: string;
   let runtimePath: string | undefined;
   try {
-    const discovery = JSON.parse(
-      readFileSync(path.join(devHome, "review-desktop", "server.json"), "utf8"),
-    ) as { cliPath?: unknown; cliRuntimePath?: unknown };
-    if (typeof discovery.cliPath !== "string" || !discovery.cliPath)
-      return null;
-    cliPath = discovery.cliPath;
-    if (
-      typeof discovery.cliRuntimePath === "string" &&
-      discovery.cliRuntimePath &&
-      existsSync(discovery.cliRuntimePath)
-    ) {
-      runtimePath = discovery.cliRuntimePath;
+    const discovery = jsonObject(
+      parseJsonText(
+        readFileSync(
+          path.join(devHome, "review-desktop", "server.json"),
+          "utf8",
+        ),
+      ),
+    );
+    const discoveredCliPath = jsonString(discovery?.cliPath);
+    if (!discoveredCliPath) return null;
+    cliPath = discoveredCliPath;
+    const discoveredRuntimePath = jsonString(discovery?.cliRuntimePath);
+    if (discoveredRuntimePath && existsSync(discoveredRuntimePath)) {
+      runtimePath = discoveredRuntimePath;
     }
   } catch {
     return null;

--- a/packages/progressive-review/src/codex-thread-wakeup.ts
+++ b/packages/progressive-review/src/codex-thread-wakeup.ts
@@ -7,6 +7,8 @@ import { join } from "node:path";
 import {
   type JsonObject,
   isJsonObject,
+  jsonObject,
+  jsonString,
   parseJsonText,
 } from "@dev.fast/review-protocol";
 
@@ -261,8 +263,7 @@ function framedMessages(socket: Socket): FramedMessages {
   };
 
   const dispatch = (message: JsonObject): void => {
-    const requestId =
-      typeof message.requestId === "string" ? message.requestId : undefined;
+    const requestId = jsonString(message.requestId);
     if (requestId === undefined) {
       queued.push(message);
       return;
@@ -364,13 +365,13 @@ function initializedClientId(message: JsonObject): string {
   if (message.resultType !== "success" || message.method !== "initialize") {
     throw responseError("initialize", message);
   }
-  const result = message.result;
-  if (!isJsonObject(result) || typeof result.clientId !== "string") {
+  const clientId = jsonString(jsonObject(message.result)?.clientId);
+  if (clientId === undefined) {
     throw new CodexIpcProtocolError(
       "Codex IPC returned a malformed initialize response.",
     );
   }
-  return result.clientId;
+  return clientId;
 }
 
 function assertSuccessfulWake(message: JsonObject): void {
@@ -383,7 +384,8 @@ function assertSuccessfulWake(message: JsonObject): void {
 }
 
 function responseError(method: string, message: JsonObject): Error {
-  const detail = typeof message.error === "string" ? `: ${message.error}` : "";
+  const error = jsonString(message.error);
+  const detail = error === undefined ? "" : `: ${error}`;
   return new CodexIpcProtocolError(
     `Codex IPC request "${method}" failed${detail}.`,
   );

--- a/packages/progressive-review/src/compiler/remark-review-anchor-links.ts
+++ b/packages/progressive-review/src/compiler/remark-review-anchor-links.ts
@@ -1,4 +1,4 @@
-import type { Link, Root } from "mdast";
+import type { Link, Nodes, Root } from "mdast";
 
 const ANCHOR_LINK = /^anchors\.([A-Za-z_$][A-Za-z0-9_$]*)$/;
 
@@ -7,7 +7,7 @@ interface ParentNode {
 }
 
 interface VFileLike {
-  fail(message: string, node?: unknown): never;
+  fail(message: string, node?: Nodes): never;
 }
 
 /** Compile Markdown `[label](anchors.key)` into a typed AnchorLink. */

--- a/packages/progressive-review/src/compiler/review-document-compiler.ts
+++ b/packages/progressive-review/src/compiler/review-document-compiler.ts
@@ -4,6 +4,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 
 import { compile } from "@mdx-js/mdx";
+import type { Nodes as MdastNode, Root } from "mdast";
 import remarkMdx from "remark-mdx";
 import {
   type RawSourceMap,
@@ -11,6 +12,7 @@ import {
   SourceMapGenerator,
 } from "source-map";
 import ts from "typescript";
+import { z } from "zod";
 
 import {
   progressiveReviewAppSourcePath,
@@ -19,6 +21,7 @@ import {
 import { maskReviewFrontmatter } from "../review-frontmatter";
 import {
   type ReviewMdxDocument,
+  isMdxAttributeValueExpression,
   parseReviewMdxDocument,
 } from "../review-mdx-ast";
 import { reviewTypescriptEstreeParser } from "../review-mdx-typescript-parser";
@@ -413,28 +416,46 @@ async function composeRuntimeSourceMap(input: {
   }
 }
 
+// The mdast nodes that carry authored JavaScript: ESM blocks, expressions in
+// flow or text position, and JSX attribute value expressions.
+type AuthoredMdxNode = { value: string } & Pick<MdastNode, "position">;
+
 function collectAuthoredTypescript(regions: AuthoredTypescriptRegion[]) {
-  return () => (tree: unknown) => {
-    walkUnknownTree(tree, (node) => {
-      const kind =
-        node.type === "mdxjsEsm"
-          ? "esm"
-          : node.type === "mdxFlowExpression" ||
-              node.type === "mdxTextExpression" ||
-              node.type === "mdxJsxAttributeValueExpression"
-            ? "expression"
-            : null;
-      if (!kind || typeof node.value !== "string" || !node.value.trim()) return;
-      const position = node.position as
-        | { start?: { line?: number; column?: number } }
-        | undefined;
-      regions.push({
-        kind,
-        value: node.value,
-        sourceStartLine: position?.start?.line ?? 1,
-        sourceStartColumn:
-          (position?.start?.column ?? 1) + (kind === "expression" ? 1 : 0),
-      });
+  const collect = (
+    kind: AuthoredTypescriptRegion["kind"],
+    node: AuthoredMdxNode,
+  ): void => {
+    if (!node.value.trim()) return;
+    regions.push({
+      kind,
+      value: node.value,
+      sourceStartLine: node.position?.start.line ?? 1,
+      sourceStartColumn:
+        (node.position?.start.column ?? 1) + (kind === "expression" ? 1 : 0),
+    });
+  };
+  return () => (tree: Root) => {
+    walkMdast(tree, (node) => {
+      if (node.type === "mdxjsEsm") {
+        collect("esm", node);
+      } else if (
+        node.type === "mdxFlowExpression" ||
+        node.type === "mdxTextExpression"
+      ) {
+        collect("expression", node);
+      } else if (
+        node.type === "mdxJsxFlowElement" ||
+        node.type === "mdxJsxTextElement"
+      ) {
+        for (const attribute of node.attributes) {
+          if (
+            attribute.type === "mdxJsxAttribute" &&
+            isMdxAttributeValueExpression(attribute.value)
+          ) {
+            collect("expression", attribute.value);
+          }
+        }
+      }
     });
   };
 }
@@ -839,21 +860,19 @@ function countLines(value: string): number {
   return value.split(/\r\n|\n|\r/).length;
 }
 
-function walkUnknownTree(
-  value: unknown,
-  visit: (node: EstreeNode) => void,
-): void {
-  if (!value || typeof value !== "object") return;
-  if (Array.isArray(value)) {
-    for (const entry of value) walkUnknownTree(entry, visit);
-    return;
-  }
-  const node = value as EstreeNode;
+function walkMdast(node: MdastNode, visit: (node: MdastNode) => void): void {
   visit(node);
-  for (const [property, child] of Object.entries(node)) {
-    if (property === "position" || property === "data") continue;
-    walkUnknownTree(child, visit);
+  if ("children" in node) {
+    for (const child of node.children) walkMdast(child, visit);
   }
+}
+
+// Every estree node carries a string `type`; the other objects hanging off a
+// node (`loc`, a literal's `regex`, ...) do not.
+const estreeNodeSchema = z.object({ type: z.string() });
+
+function isEstreeNode(value: EstreeValue): value is EstreeNode {
+  return estreeNodeSchema.safeParse(value).success;
 }
 
 function eraseTypescriptRecma() {
@@ -864,12 +883,12 @@ function eraseTypescriptRecma() {
 }
 
 function eraseTypescriptNode(value: EstreeValue): EstreeValue {
-  if (!value || typeof value !== "object") return value;
   if (Array.isArray(value)) {
     return value
       .map((entry) => eraseTypescriptNode(entry))
       .filter((entry) => entry !== null);
   }
+  if (!isEstreeNode(value)) return value;
 
   const node = value;
   if (
@@ -888,9 +907,7 @@ function eraseTypescriptNode(value: EstreeValue): EstreeValue {
     if (Array.isArray(node.specifiers)) {
       node.specifiers = node.specifiers.filter(
         (specifier) =>
-          !specifier ||
-          typeof specifier !== "object" ||
-          (specifier as EstreeNode).importKind !== "type",
+          !isEstreeNode(specifier) || specifier.importKind !== "type",
       );
     }
   }
@@ -925,9 +942,9 @@ function eraseTypescriptNode(value: EstreeValue): EstreeValue {
 
 function mdxDiagnostic(
   filePath: string,
-  error: unknown,
+  cause: unknown,
 ): ReviewDocumentDiagnostic {
-  const candidate = error as {
+  const candidate = cause as {
     message?: string;
     line?: number;
     column?: number;
@@ -937,7 +954,7 @@ function mdxDiagnostic(
     source: "mdx",
     severity: "error",
     code: "MDX_PARSE_ERROR",
-    message: candidate?.message ?? String(error),
+    message: candidate?.message ?? String(cause),
     filePath,
     line: candidate?.line ?? candidate?.place?.start?.line,
     column: candidate?.column ?? candidate?.place?.start?.column,

--- a/packages/progressive-review/src/desktop-discovery.ts
+++ b/packages/progressive-review/src/desktop-discovery.ts
@@ -1,8 +1,13 @@
 import { readFile } from "node:fs/promises";
 
 import {
+  type JsonValue,
   REVIEW_DESKTOP_DISCOVERY_VERSION,
   type ReviewDesktopDiscovery,
+  isJsonObject,
+  jsonNumber,
+  jsonProperty,
+  parseJsonText,
   parseReviewDesktopDiscovery,
 } from "@dev.fast/review-protocol";
 
@@ -41,22 +46,23 @@ export async function readReviewDesktopDiscovery(
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
     throw new ReviewDesktopDiscoveryUnreadableError(filePath, String(error));
   }
-  let value: unknown;
+  let value: JsonValue;
   try {
-    value = JSON.parse(source);
+    value = parseJsonText(source);
   } catch (error) {
     throw new ReviewDesktopDiscoveryUnreadableError(filePath, String(error));
   }
   try {
     return parseReviewDesktopDiscovery(value);
   } catch (error) {
-    const version =
-      typeof value === "object" &&
-      value !== null &&
-      Number.isInteger((value as { version?: unknown }).version)
-        ? (value as { version: number }).version
-        : undefined;
-    if (version !== undefined && version !== REVIEW_DESKTOP_DISCOVERY_VERSION) {
+    const version = isJsonObject(value)
+      ? jsonNumber(jsonProperty(value, "version"))
+      : undefined;
+    if (
+      version !== undefined &&
+      Number.isInteger(version) &&
+      version !== REVIEW_DESKTOP_DISCOVERY_VERSION
+    ) {
       throw new ReviewDesktopProtocolMismatchError(version);
     }
     throw new ReviewDesktopDiscoveryUnreadableError(filePath, String(error));
@@ -82,16 +88,11 @@ export async function readHealthyReviewDesktopDiscovery(
       signal: AbortSignal.timeout(1_500),
     });
     if (!response.ok) return null;
-    const health: unknown = await response.json();
+    const health = await response.json();
     if (
-      !health ||
-      typeof health !== "object" ||
-      Array.isArray(health) ||
-      !("ok" in health) ||
+      !isJsonObject(health) ||
       health.ok !== true ||
-      !("instanceId" in health) ||
       health.instanceId !== discovery.instanceId ||
-      !("desktopAttached" in health) ||
       health.desktopAttached !== true
     ) {
       return null;

--- a/packages/progressive-review/src/error-message.ts
+++ b/packages/progressive-review/src/error-message.ts
@@ -1,3 +1,3 @@
-export function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+export function errorMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
 }

--- a/packages/progressive-review/src/error-telemetry.ts
+++ b/packages/progressive-review/src/error-telemetry.ts
@@ -17,7 +17,12 @@
 
 import { createHash } from "node:crypto";
 
-import type { JsonObject } from "@dev.fast/review-protocol";
+import {
+  type JsonObject,
+  type JsonValue,
+  isJsonObject,
+  jsonString,
+} from "@dev.fast/review-protocol";
 
 import { cleanTelemetryText } from "./telemetry-clean-text";
 import {
@@ -25,13 +30,6 @@ import {
   BUNDLE_FRAME_SEPARATOR,
   isReportableCleanedMessage,
 } from "./ui-telemetry-events";
-
-/** The raw error envelope a client may attach beside its event properties. */
-export interface RawErrorReport {
-  readonly name?: unknown;
-  readonly message?: unknown;
-  readonly stack?: unknown;
-}
 
 export interface DerivedErrorTelemetryProperties {
   error_name?: string;
@@ -66,17 +64,21 @@ const BUNDLE_ANCHORS = ["/out/", "/assets/", "/review-runtime/"];
 /** `at fn (url:line:col)`, `at url:line:col`, and the bare `url:line:col`. */
 const STACK_FRAME_PATTERN = /(?:\(|\bat\s+|^\s*)([^()\s]+?):(\d+):(\d+)\)?\s*$/;
 
+/**
+ * `cause` is the raw error envelope a client attached beside its event
+ * properties: `{ name, message, stack }` as JSON, or anything else a hostile
+ * client sent, which derives nothing.
+ */
 export function deriveErrorTelemetryProperties(
-  raw: unknown,
+  cause: unknown,
 ): DerivedErrorTelemetryProperties {
   const derived: DerivedErrorTelemetryProperties = {};
   try {
-    if (!raw || typeof raw !== "object") return derived;
-    const report = raw as RawErrorReport;
+    if (!isJsonObject(cause)) return derived;
 
-    const name = report.name;
+    const name = jsonString(cause.name);
     if (
-      typeof name === "string" &&
+      name !== undefined &&
       name.length > 0 &&
       name.length <= MAX_ERROR_NAME_LENGTH &&
       ERROR_NAME_PATTERN.test(name)
@@ -84,8 +86,8 @@ export function deriveErrorTelemetryProperties(
       derived.error_name = name;
     }
 
-    const message = report.message;
-    if (typeof message === "string" && message.length > 0) {
+    const message = jsonString(cause.message);
+    if (message !== undefined && message.length > 0) {
       // The digest goes on every report, cleaned message or not. It is what
       // groups the reports whose message does not survive the checks below.
       derived.message_hash = hashErrorMessage(message);
@@ -98,7 +100,7 @@ export function deriveErrorTelemetryProperties(
       }
     }
 
-    const frames = packBundleFrames(report.stack);
+    const frames = packBundleFrames(cause.stack);
     if (frames) derived.frames = frames;
   } catch {
     // Telemetry must never break the request that carried it.
@@ -131,11 +133,11 @@ const SERVER_DERIVED_PROPERTIES = [
  */
 export function mergeErrorTelemetryProperties(
   clientProperties: JsonObject,
-  rawError: unknown,
+  cause: unknown,
 ): JsonObject {
   const merged = { ...clientProperties };
   for (const key of SERVER_DERIVED_PROPERTIES) delete merged[key];
-  if (rawError) Object.assign(merged, deriveErrorTelemetryProperties(rawError));
+  if (cause) Object.assign(merged, deriveErrorTelemetryProperties(cause));
   return merged;
 }
 
@@ -174,12 +176,10 @@ export function hashErrorMessage(message: string): string {
  * Rewrite a stack into bundle-relative `file:line:col` frames joined by "|".
  * Returns undefined when no frame resolves inside the bundle.
  */
-export function packBundleFrames(stack: unknown): string | undefined {
-  const text = Array.isArray(stack)
-    ? stack.join("\n")
-    : typeof stack === "string"
-      ? stack
-      : undefined;
+export function packBundleFrames(
+  stack: JsonValue | undefined,
+): string | undefined {
+  const text = Array.isArray(stack) ? stack.join("\n") : jsonString(stack);
   if (!text) return undefined;
 
   const frames: string[] = [];

--- a/packages/progressive-review/src/map-cli-entry.test.ts
+++ b/packages/progressive-review/src/map-cli-entry.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { Writable } from "node:stream";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 
 import { collectingWritable } from "./cli-output";
 
@@ -143,9 +144,9 @@ function writableOutput(output: string[]): Writable {
 function lastCaptureBody(fetchMock: {
   mock: { calls: Array<Parameters<typeof fetch>> };
 }) {
-  const body = fetchMock.mock.calls.at(-1)?.[1]?.body;
-  if (typeof body !== "string") throw new Error("Expected JSON string body");
-  const parsed = JSON.parse(body) as {
+  const body = z.string().safeParse(fetchMock.mock.calls.at(-1)?.[1]?.body);
+  if (!body.success) throw new Error("Expected JSON string body");
+  const parsed = JSON.parse(body.data) as {
     batch: Array<{
       event: string;
       properties: Record<string, string | number | boolean | undefined>;

--- a/packages/progressive-review/src/map-cli.ts
+++ b/packages/progressive-review/src/map-cli.ts
@@ -289,9 +289,7 @@ export function parseSoftwareMapCliArgs(
   return {
     ok: true,
     command,
-    positionals: commandModel.processedArgs.filter(
-      (arg): arg is string => typeof arg === "string",
-    ),
+    positionals: commandModel.args,
     force: options.force ?? false,
     diffRefs: {},
     review: options.review,

--- a/packages/progressive-review/src/migrate.ts
+++ b/packages/progressive-review/src/migrate.ts
@@ -18,6 +18,8 @@ import { promisify } from "node:util";
 import {
   type JsonObject,
   isJsonObject,
+  jsonBoolean,
+  jsonString,
   parseJsonText,
 } from "@dev.fast/review-protocol";
 
@@ -518,9 +520,9 @@ function isLegacyDesktopCatalogRecord(
   ];
   return (
     record.reviewKey === reviewKey &&
-    requiredStrings.every(
-      (value) => typeof value === "string" && value.length > 0,
-    ) &&
+    requiredStrings
+      .map(jsonString)
+      .every((value) => value !== undefined && value.length > 0) &&
     ["git", "jj", "none"].includes(String(repository.kind)) &&
     Number.isSafeInteger(record.startedAt) &&
     Number(record.startedAt) > 0 &&
@@ -529,8 +531,9 @@ function isLegacyDesktopCatalogRecord(
     ["active", "completed", "dismissed", "unavailable"].includes(
       String(record.state),
     ) &&
-    typeof record.available === "boolean" &&
-    (record.headRef === undefined || typeof record.headRef === "string") &&
+    jsonBoolean(record.available) !== undefined &&
+    (record.headRef === undefined ||
+      jsonString(record.headRef) !== undefined) &&
     (record.pullRequestNumber === undefined ||
       (Number.isSafeInteger(record.pullRequestNumber) &&
         Number(record.pullRequestNumber) > 0)) &&

--- a/packages/progressive-review/src/native-agent/claude-transcript.ts
+++ b/packages/progressive-review/src/native-agent/claude-transcript.ts
@@ -3,10 +3,13 @@ import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
+import { jsonString } from "@dev.fast/review-protocol";
+
 import type { NativeReviewMessage } from "./native-session";
 import {
   type JsonRecord,
   isJsonRecord,
+  isMissingFileError,
   readJsonLines,
   textBlocks,
 } from "./transcript-json";
@@ -49,14 +52,7 @@ async function findTranscript(
       withFileTypes: true,
     });
   } catch (error) {
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
-      return undefined;
-    }
+    if (isMissingFileError(error)) return undefined;
     throw error;
   }
   for (const entry of entries) {
@@ -128,7 +124,6 @@ function assistantText(entry: JsonRecord): string {
 }
 
 function entryTimestamp(entry: JsonRecord): string[] {
-  return typeof entry.timestamp === "string" && entry.timestamp
-    ? [entry.timestamp]
-    : [];
+  const timestamp = jsonString(entry.timestamp);
+  return timestamp ? [timestamp] : [];
 }

--- a/packages/progressive-review/src/native-agent/codex-app-server.ts
+++ b/packages/progressive-review/src/native-agent/codex-app-server.ts
@@ -2,10 +2,18 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { once } from "node:events";
 import { createInterface } from "node:readline";
 
+import {
+  type JsonValue,
+  jsonObject,
+  jsonProperty,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
 import { isJsonRecord } from "./transcript-json";
 
 interface PendingRequest {
-  resolve(value: unknown): void;
+  resolve(value: JsonValue | undefined): void;
   reject(error: Error): void;
   timeout: ReturnType<typeof setTimeout>;
 }
@@ -64,10 +72,13 @@ export class CodexAppServerClient {
     }
   }
 
-  async request(method: string, params: unknown): Promise<unknown> {
+  async request(
+    method: string,
+    params: JsonValue,
+  ): Promise<JsonValue | undefined> {
     if (this.#closed) throw new Error("The Codex app-server is closed.");
     const id = String(this.#nextId++);
-    const response = new Promise<unknown>((resolve, reject) => {
+    const response = new Promise<JsonValue | undefined>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.#pending.delete(id);
         reject(new Error(`Codex request "${method}" timed out.`));
@@ -81,7 +92,7 @@ export class CodexAppServerClient {
     return response;
   }
 
-  notify(method: string, params: unknown): void {
+  notify(method: string, params: JsonValue): void {
     if (this.#closed) return;
     this.#child.stdin.write(`${JSON.stringify({ method, params })}\n`);
   }
@@ -100,9 +111,9 @@ export class CodexAppServerClient {
   }
 
   #receive(line: string): void {
-    let value: unknown;
+    let value: JsonValue;
     try {
-      value = JSON.parse(line);
+      value = parseJsonText(line);
     } catch {
       this.#fail(new Error("Codex app-server wrote malformed JSON."));
       return;
@@ -112,17 +123,16 @@ export class CodexAppServerClient {
     if (!pending) return;
     this.#pending.delete(String(value.id));
     clearTimeout(pending.timeout);
-    if (isJsonRecord(value.error)) {
+    const error = jsonObject(value.error);
+    if (error) {
       pending.reject(
         new Error(
-          typeof value.error.message === "string"
-            ? value.error.message
-            : "Codex app-server request failed.",
+          jsonString(error.message) ?? "Codex app-server request failed.",
         ),
       );
       return;
     }
-    pending.resolve(value.result);
+    pending.resolve(jsonProperty(value, "result"));
   }
 
   #fail(error: Error): void {
@@ -148,15 +158,9 @@ export async function forkCodexThread(input: {
       ephemeral: false,
       excludeTurns: true,
     });
-    if (
-      !isJsonRecord(result) ||
-      !isJsonRecord(result.thread) ||
-      typeof result.thread.id !== "string" ||
-      result.thread.id.length === 0
-    ) {
-      throw new Error("Codex returned an invalid forked thread.");
-    }
-    return result.thread.id;
+    const threadId = codexThreadId(result);
+    if (!threadId) throw new Error("Codex returned an invalid forked thread.");
+    return threadId;
   } finally {
     await client.close();
   }
@@ -171,16 +175,15 @@ export async function startCodexThread(input: {
       cwd: input.cwd,
       ephemeral: false,
     });
-    if (
-      !isJsonRecord(result) ||
-      !isJsonRecord(result.thread) ||
-      typeof result.thread.id !== "string" ||
-      result.thread.id.length === 0
-    ) {
-      throw new Error("Codex returned an invalid new thread.");
-    }
-    return result.thread.id;
+    const threadId = codexThreadId(result);
+    if (!threadId) throw new Error("Codex returned an invalid new thread.");
+    return threadId;
   } finally {
     await client.close();
   }
+}
+
+/** The non-empty thread id in a thread/start or thread/fork result. */
+function codexThreadId(result: JsonValue | undefined): string | undefined {
+  return jsonString(jsonObject(jsonObject(result)?.thread)?.id) || undefined;
 }

--- a/packages/progressive-review/src/native-agent/codex-transcript.ts
+++ b/packages/progressive-review/src/native-agent/codex-transcript.ts
@@ -3,10 +3,13 @@ import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join, resolve } from "node:path";
 
+import { type JsonValue, jsonString } from "@dev.fast/review-protocol";
+
 import type { NativeReviewMessage } from "./native-session";
 import {
   type JsonRecord,
   isJsonRecord,
+  isMissingFileError,
   readJsonLines,
 } from "./transcript-json";
 
@@ -72,8 +75,7 @@ export function projectCodexReviewMessages(
     if (entry.type !== "event_msg" || payload.type !== "task_complete") {
       continue;
     }
-    const turnId =
-      typeof payload.turn_id === "string" ? payload.turn_id : undefined;
+    const turnId = jsonString(payload.turn_id);
     const candidates = turnId
       ? (assistantEntriesByTurn.get(turnId) ?? unscopedAssistantEntries)
       : unscopedAssistantEntries;
@@ -120,26 +122,27 @@ function codexMessageEntry(
   return {
     body,
     timestamp: timestamp(entry) ?? new Date(0).toISOString(),
-    ...(typeof payload.phase === "string" ? { phase: payload.phase } : {}),
-    ...(typeof metadata?.turn_id === "string"
-      ? { turnId: metadata.turn_id }
-      : {}),
+    phase: jsonString(payload.phase),
+    turnId: jsonString(metadata?.turn_id),
   };
 }
 
-function codexContentText(value: unknown): string[] {
-  if (typeof value === "string") return value.trim() ? [value] : [];
+function codexContentText(value: JsonValue | undefined): string[] {
+  const text = jsonString(value);
+  if (text !== undefined) return text.trim() ? [text] : [];
   if (!Array.isArray(value)) return [];
-  return value.flatMap((block) =>
-    isJsonRecord(block) &&
-    (block.type === "input_text" ||
-      block.type === "output_text" ||
-      block.type === "text") &&
-    typeof block.text === "string" &&
-    block.text.trim()
-      ? [block.text]
-      : [],
-  );
+  return value.flatMap((block) => {
+    if (
+      !isJsonRecord(block) ||
+      (block.type !== "input_text" &&
+        block.type !== "output_text" &&
+        block.type !== "text")
+    ) {
+      return [];
+    }
+    const blockText = jsonString(block.text);
+    return blockText?.trim() ? [blockText] : [];
+  });
 }
 
 function finalAssistantEntry(
@@ -152,9 +155,7 @@ function finalAssistantEntry(
 }
 
 function timestamp(entry: JsonRecord): string | undefined {
-  return typeof entry.timestamp === "string" && entry.timestamp
-    ? entry.timestamp
-    : undefined;
+  return jsonString(entry.timestamp) || undefined;
 }
 
 async function findFile(
@@ -181,13 +182,4 @@ async function findFile(
     }
   }
   return undefined;
-}
-
-function isMissingFileError(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    error.code === "ENOENT"
-  );
 }

--- a/packages/progressive-review/src/native-agent/native-message-mirror.ts
+++ b/packages/progressive-review/src/native-agent/native-message-mirror.ts
@@ -16,7 +16,7 @@ import type {
 interface NativeMessageMirrorOptions {
   observe(binding: ReviewThreadAgentBinding): ObservedNativeSession;
   service: ReviewThreadsService;
-  onError?: (error: unknown) => void;
+  onError?: (cause: unknown) => void;
 }
 
 interface SessionWatcher {
@@ -31,14 +31,14 @@ interface SessionWatcher {
 export class NativeMessageMirror {
   readonly #observe: NativeMessageMirrorOptions["observe"];
   readonly #service: ReviewThreadsService;
-  readonly #onError: (error: unknown) => void;
+  readonly #onError: (cause: unknown) => void;
   readonly #watchers = new Map<string, SessionWatcher>();
   #closed = false;
 
   constructor(options: NativeMessageMirrorOptions) {
     this.#observe = options.observe;
     this.#service = options.service;
-    this.#onError = options.onError ?? ((error) => console.error(error));
+    this.#onError = options.onError ?? ((cause) => console.error(cause));
   }
 
   start(): void {

--- a/packages/progressive-review/src/native-agent/native-observer.ts
+++ b/packages/progressive-review/src/native-agent/native-observer.ts
@@ -1,5 +1,11 @@
-import type { JsonObject } from "@dev.fast/review-protocol";
+import {
+  type JsonObject,
+  type JsonValue,
+  isJsonObject,
+  jsonString,
+} from "@dev.fast/review-protocol";
 
+import { errorMessage } from "../error-message";
 import { AsyncQueue } from "./async-queue";
 import { readClaudeReviewMessages } from "./claude-transcript";
 import { readCodexReviewMessages } from "./codex-transcript";
@@ -16,7 +22,7 @@ import type {
   UpdatePipe,
 } from "./native-session";
 import { readPiReviewMessages } from "./pi-transcript";
-import { isJsonRecord } from "./transcript-json";
+import { isMissingFileError } from "./transcript-json";
 
 interface SessionState {
   binding: ReviewThreadAgentBinding;
@@ -73,9 +79,9 @@ export class NativeSessionObserverRegistry {
     };
   }
 
-  acceptEvent(launchId: string, payload: unknown): void {
+  acceptEvent(launchId: string, payload: JsonValue): void {
     const launch = this.#launches.get(launchId);
-    if (!launch || launch.detached || !isJsonRecord(payload)) return;
+    if (!launch || launch.detached || !isJsonObject(payload)) return;
     const event = nativeHookEvent(payload);
     const actualSessionId =
       event.sessionId ?? launch.acceptedSessionId ?? launch.expectedSessionId;
@@ -127,10 +133,10 @@ export class NativeSessionObserverRegistry {
     }
   }
 
-  observerFailed(launchId: string, error: unknown): void {
+  observerFailed(launchId: string, cause: unknown): void {
     const launch = this.#launches.get(launchId);
     if (!launch || launch.detached) return;
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(cause);
     launch.events.push({ type: "observer.failed", error: message });
     if (!launch.acceptedSessionId) launch.rejectAccepted(new Error(message));
     launch.detached = true;
@@ -265,15 +271,12 @@ function sessionKey(ref: NativeSessionRef): string {
   return `${ref.harness}:${ref.sessionId}`;
 }
 
-function isMissingTranscript(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  if (
-    "code" in error &&
-    (error as Error & { code?: unknown }).code === "ENOENT"
-  ) {
-    return true;
-  }
-  return / has no (?:rollout|transcript) file\.$/u.test(error.message);
+function isMissingTranscript(cause: unknown): boolean {
+  if (!(cause instanceof Error)) return false;
+  return (
+    isMissingFileError(cause) ||
+    / has no (?:rollout|transcript) file\.$/u.test(cause.message)
+  );
 }
 
 interface NativeHookEvent {
@@ -312,8 +315,10 @@ function wakeSession(state: SessionState): void {
   for (const listener of state.listeners) listener();
 }
 
-function firstString(...values: unknown[]): string | undefined {
-  return values.find(
-    (value): value is string => typeof value === "string" && value.length > 0,
-  );
+function firstString(...values: (JsonValue | undefined)[]): string | undefined {
+  for (const value of values) {
+    const text = jsonString(value);
+    if (text) return text;
+  }
+  return undefined;
 }

--- a/packages/progressive-review/src/native-agent/native-turn-launcher.ts
+++ b/packages/progressive-review/src/native-agent/native-turn-launcher.ts
@@ -8,6 +8,7 @@ import {
   type JsonValue,
   type ReviewVerbRequest,
   isJsonObject,
+  jsonString,
 } from "@dev.fast/review-protocol";
 
 import { DEV_REVIEW_HOME_ENV, devReviewHome } from "../review-storage";
@@ -378,10 +379,6 @@ function shellQuote(value: string): string {
 }
 
 function tomlInline(value: JsonValue): string {
-  if (typeof value === "boolean" || typeof value === "number") {
-    return String(value);
-  }
-  if (typeof value === "string") return JSON.stringify(value);
   if (Array.isArray(value)) {
     return `[${value.map(tomlInline).join(", ")}]`;
   }
@@ -393,5 +390,9 @@ function tomlInline(value: JsonValue): string {
       })
       .join(", ")} }`;
   }
-  throw new TypeError("Codex hook configuration contains an invalid value.");
+  if (value === null) {
+    throw new TypeError("Codex hook configuration contains an invalid value.");
+  }
+  const text = jsonString(value);
+  return text === undefined ? String(value) : JSON.stringify(text);
 }

--- a/packages/progressive-review/src/native-agent/pi-observer-extension.ts
+++ b/packages/progressive-review/src/native-agent/pi-observer-extension.ts
@@ -6,10 +6,11 @@ interface PiObserverContext {
 }
 
 interface PiObserverApi {
-  on(
+  /** The event payload passes through untouched; only the context is read. */
+  on<Event>(
     event: "agent_settled" | "message_end" | "session_start",
     listener: (
-      event: unknown,
+      event: Event,
       context: PiObserverContext,
     ) => void | Promise<void>,
   ): void;

--- a/packages/progressive-review/src/native-agent/pi-transcript.ts
+++ b/packages/progressive-review/src/native-agent/pi-transcript.ts
@@ -3,10 +3,13 @@ import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
+import { jsonNumber, jsonObject, jsonString } from "@dev.fast/review-protocol";
+
 import type { NativeReviewMessage } from "./native-session";
 import {
   type JsonRecord,
   isJsonRecord,
+  isMissingFileError,
   readJsonLines,
   textBlocks,
 } from "./transcript-json";
@@ -57,33 +60,31 @@ export function projectPiReviewMessages(
 }
 
 function activeBranch(entries: readonly JsonRecord[]): JsonRecord[] {
-  const byId = new Map(
-    entries.flatMap((entry) =>
-      typeof entry.id === "string" && entry.id
-        ? [[entry.id, entry] as const]
-        : [],
-    ),
-  );
+  const byId = new Map<string, JsonRecord>();
+  for (const entry of entries) {
+    const id = entryId(entry);
+    if (id !== undefined) byId.set(id, entry);
+  }
   const leaf = [...entries]
     .reverse()
-    .find((entry) => typeof entry.id === "string" && entry.id);
-  if (!leaf || typeof leaf.id !== "string") return [];
+    .find((entry) => entryId(entry) !== undefined);
   const branch: JsonRecord[] = [];
   const visited = new Set<string>();
   let current: JsonRecord | undefined = leaf;
-  while (
-    current &&
-    typeof current.id === "string" &&
-    !visited.has(current.id)
-  ) {
+  while (current) {
+    const id = entryId(current);
+    if (id === undefined || visited.has(id)) break;
     branch.push(current);
-    visited.add(current.id);
-    current =
-      typeof current.parentId === "string"
-        ? byId.get(current.parentId)
-        : undefined;
+    visited.add(id);
+    const parentId = jsonString(current.parentId);
+    current = parentId === undefined ? undefined : byId.get(parentId);
   }
   return branch.reverse();
+}
+
+/** The entry's non-empty id, or undefined when it has none. */
+function entryId(entry: JsonRecord): string | undefined {
+  return jsonString(entry.id) || undefined;
 }
 
 function projectMessage(
@@ -91,13 +92,10 @@ function projectMessage(
   role: NativeReviewMessage["role"],
   body: string,
 ): NativeReviewMessage {
-  const message = isJsonRecord(entry.message) ? entry.message : {};
+  const messageTimestamp = jsonNumber(jsonObject(entry.message)?.timestamp);
   const timestamp =
-    typeof entry.timestamp === "string"
-      ? entry.timestamp
-      : typeof message.timestamp === "number"
-        ? new Date(message.timestamp).toISOString()
-        : new Date(0).toISOString();
+    jsonString(entry.timestamp) ??
+    new Date(messageTimestamp ?? 0).toISOString();
   return {
     role,
     body,
@@ -160,13 +158,4 @@ async function findFile(
     }
   }
   return undefined;
-}
-
-function isMissingFileError(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    error.code === "ENOENT"
-  );
 }

--- a/packages/progressive-review/src/native-agent/transcript-json.ts
+++ b/packages/progressive-review/src/native-agent/transcript-json.ts
@@ -2,7 +2,10 @@ import { readFile } from "node:fs/promises";
 
 import {
   type JsonObject,
+  type JsonValue,
   isJsonObject,
+  jsonArray,
+  jsonString,
   parseJsonText,
 } from "@dev.fast/review-protocol";
 
@@ -27,15 +30,19 @@ export async function readJsonLines(path: string): Promise<JsonRecord[]> {
   });
 }
 
-export function textBlocks(value: unknown): string[] {
-  if (typeof value === "string") return value.trim() ? [value] : [];
-  if (!Array.isArray(value)) return [];
-  return value.flatMap((block) =>
-    isJsonRecord(block) &&
-    block.type === "text" &&
-    typeof block.text === "string" &&
-    block.text.trim()
-      ? [block.text]
-      : [],
-  );
+export function textBlocks(value: JsonValue | undefined): string[] {
+  const text = jsonString(value);
+  if (text !== undefined) return text.trim() ? [text] : [];
+  const blocks = jsonArray(value);
+  if (!blocks) return [];
+  return blocks.flatMap((block) => {
+    if (!isJsonRecord(block) || block.type !== "text") return [];
+    const blockText = jsonString(block.text);
+    return blockText?.trim() ? [blockText] : [];
+  });
+}
+
+/** Whether a thrown filesystem error reports a missing file (ENOENT). */
+export function isMissingFileError(cause: unknown): boolean {
+  return cause instanceof Error && "code" in cause && cause.code === "ENOENT";
 }

--- a/packages/progressive-review/src/package-paths.ts
+++ b/packages/progressive-review/src/package-paths.ts
@@ -2,6 +2,12 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import {
+  jsonObject,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
 const MODEL_SOURCE_FILES = new Set([
   "software-map-model.ts",
   "tolerant-software-map-model.ts",
@@ -49,15 +55,18 @@ export function readProgressiveReviewPackageVersion(
   moduleUrl: string = import.meta.url,
 ): string {
   try {
-    const packageJson = JSON.parse(
-      readFileSync(
-        path.join(findProgressiveReviewPackageRoot(moduleUrl), "package.json"),
-        "utf8",
+    const packageJson = jsonObject(
+      parseJsonText(
+        readFileSync(
+          path.join(
+            findProgressiveReviewPackageRoot(moduleUrl),
+            "package.json",
+          ),
+          "utf8",
+        ),
       ),
-    ) as { version?: unknown };
-    return typeof packageJson.version === "string"
-      ? packageJson.version
-      : "unknown";
+    );
+    return jsonString(packageJson?.version) ?? "unknown";
   } catch {
     return "unknown";
   }

--- a/packages/progressive-review/src/posthog-capture-client.ts
+++ b/packages/progressive-review/src/posthog-capture-client.ts
@@ -2,6 +2,9 @@ import { randomUUID } from "node:crypto";
 import { readFile, readdir, rm } from "node:fs/promises";
 import path from "node:path";
 
+import { parseJsonText } from "@dev.fast/review-protocol";
+import { z } from "zod";
+
 import { writeFileAtomic } from "./atomic-write";
 import { EMBEDDED_PROGRESSIVE_REVIEW_POSTHOG_KEY } from "./embedded-posthog-key";
 import { DEV_REVIEW_HOME_ENV, devReviewHome } from "./review-storage";
@@ -426,23 +429,29 @@ function droppedEvents(
     }));
 }
 
+/** A queued event as this module wrote it to disk. */
+const QueuedPostHogEventSchema = z.object({
+  event: z.string(),
+  distinctId: z.string(),
+  properties: z
+    .record(
+      z.string(),
+      z.union([z.boolean(), z.number(), z.string(), z.null()]),
+    )
+    .optional(),
+  createdAt: z.number(),
+  attempts: z.number(),
+  nextAttemptAt: z.number(),
+});
+
 async function readQueuedEvent(
   filePath: string,
 ): Promise<QueuedPostHogEvent | undefined> {
   try {
-    const parsed = JSON.parse(
-      await readFile(filePath, "utf8"),
-    ) as QueuedPostHogEvent;
-    if (
-      typeof parsed.event !== "string" ||
-      typeof parsed.distinctId !== "string" ||
-      typeof parsed.createdAt !== "number" ||
-      typeof parsed.attempts !== "number" ||
-      typeof parsed.nextAttemptAt !== "number"
-    ) {
-      return undefined;
-    }
-    return parsed;
+    const parsed = QueuedPostHogEventSchema.safeParse(
+      parseJsonText(await readFile(filePath, "utf8")),
+    );
+    return parsed.success ? parsed.data : undefined;
   } catch {
     return undefined;
   }

--- a/packages/progressive-review/src/progressive-review-telemetry.test.ts
+++ b/packages/progressive-review/src/progressive-review-telemetry.test.ts
@@ -506,7 +506,9 @@ function storedConfig(
 
 async function writeStoredConfig(
   configPath: string,
-  config: unknown,
+  config:
+    | Partial<ProgressiveReviewTelemetryInstallConfig>
+    | { installId: string },
 ): Promise<void> {
   await mkdir(path.dirname(configPath), { recursive: true });
   await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");

--- a/packages/progressive-review/src/progressive-review-telemetry.ts
+++ b/packages/progressive-review/src/progressive-review-telemetry.ts
@@ -2,6 +2,11 @@ import { createHmac, randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
+import {
+  jsonObject,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
 import { valid as validSemver } from "semver";
 
 import { writeFileAtomic } from "./atomic-write";
@@ -553,12 +558,12 @@ export class ProgressiveReviewTelemetry {
 
   private async readLegacyInstallId(): Promise<string | undefined> {
     try {
-      const parsed = JSON.parse(
-        await readFile(this.legacyInstallConfigPath, "utf8"),
-      ) as { installId?: unknown };
-      return typeof parsed.installId === "string" && parsed.installId.length > 0
-        ? parsed.installId
-        : undefined;
+      const installId = jsonString(
+        jsonObject(
+          parseJsonText(await readFile(this.legacyInstallConfigPath, "utf8")),
+        )?.installId,
+      );
+      return installId ? installId : undefined;
     } catch {
       return undefined;
     }
@@ -720,12 +725,12 @@ function reviewAppVersion(env: NodeJS.ProcessEnv): string | undefined {
 async function readProgressiveReviewPackageVersion(): Promise<string> {
   try {
     const packageRoot = findProgressiveReviewPackageRoot(import.meta.url);
-    const packageJson = JSON.parse(
-      await readFile(path.join(packageRoot, "package.json"), "utf8"),
-    ) as { version?: unknown };
-    return typeof packageJson.version === "string"
-      ? packageJson.version
-      : "unknown";
+    const packageJson = jsonObject(
+      parseJsonText(
+        await readFile(path.join(packageRoot, "package.json"), "utf8"),
+      ),
+    );
+    return jsonString(packageJson?.version) ?? "unknown";
   } catch {
     return "unknown";
   }

--- a/packages/progressive-review/src/review-agent-traces.ts
+++ b/packages/progressive-review/src/review-agent-traces.ts
@@ -20,6 +20,10 @@ import {
   type SessionMeta,
   byCommitSchema,
   commitShaSchema,
+  isStringValue,
+  jsonNumber,
+  jsonObject,
+  parseJsonText,
   sessionIdSchema,
   sessionMetaSchema,
 } from "@dev.fast/review-protocol";
@@ -402,7 +406,7 @@ function readNormalizedTrace(filePath: string): NormalizedTrace | null {
       metadata.type !== "metadata" ||
       metadata.version !== 1 ||
       metadata.parserVersion !== AGENT_TRACE_PARSER_VERSION ||
-      typeof metadata.source?.bytes !== "number"
+      !Number.isFinite(metadata.source?.bytes)
     ) {
       return null;
     }
@@ -513,11 +517,15 @@ export async function pullReviewTraceCorpus(input: {
   };
 }
 
-function normalizeRepo(repo: string | { owner: string; repo: string }): {
-  owner: string;
-  repo: string;
-} {
-  return typeof repo === "string" ? parseRepo(repo) : repo;
+type RepoInput = string | { owner: string; repo: string };
+
+function normalizeRepo(repo: RepoInput): { owner: string; repo: string } {
+  return isRepoSlug(repo) ? parseRepo(repo) : repo;
+}
+
+/** Whether a repo input is the "owner/repo" slug form. */
+function isRepoSlug(repo: RepoInput): repo is string {
+  return isStringValue(repo);
 }
 
 function normalizedTracePath(
@@ -1543,10 +1551,9 @@ export async function r2HeadObjectSize(key: string): Promise<number | null> {
         },
       },
     );
-    const parsed = JSON.parse(proc.stdout) as { ContentLength?: number };
-    return typeof parsed.ContentLength === "number"
-      ? parsed.ContentLength
-      : null;
+    return (
+      jsonNumber(jsonObject(parseJsonText(proc.stdout))?.ContentLength) ?? null
+    );
   } catch {
     return null;
   }
@@ -1908,18 +1915,15 @@ async function addSessionsFromR2Index(
       if (!entry) continue;
       if (!Array.isArray(entry.sessions)) continue;
       for (const value of entry.sessions) {
-        if (
-          typeof value !== "string" ||
-          !sessionIdSchema.safeParse(value).success
-        ) {
-          continue;
-        }
-        const existing = sessions.get(value);
+        const parsed = sessionIdSchema.safeParse(value);
+        if (!parsed.success) continue;
+        const sessionId = parsed.data;
+        const existing = sessions.get(sessionId);
         if (existing) {
           existing.commits.push({ sha: commit.sha, subject: commit.subject });
         } else {
-          sessions.set(value, {
-            sessionId: value,
+          sessions.set(sessionId, {
+            sessionId,
             commits: [{ sha: commit.sha, subject: commit.subject }],
           });
         }

--- a/packages/progressive-review/src/review-app.ts
+++ b/packages/progressive-review/src/review-app.ts
@@ -1,6 +1,11 @@
 import type { Writable } from "node:stream";
 
-import type { ReviewView } from "@dev.fast/review-protocol";
+import {
+  type JsonValue,
+  type ReviewView,
+  jsonObject,
+  jsonString,
+} from "@dev.fast/review-protocol";
 
 import { readReviewDesktopDiscovery } from "./desktop-discovery";
 import { runReviewAppLaunch } from "./review-app-launcher";
@@ -80,7 +85,7 @@ export async function runReviewAppPick(
       body: JSON.stringify(input.view ? { view: input.view } : {}),
     },
   );
-  const payload: unknown = await response.json();
+  const payload: JsonValue = await response.json();
   if (!response.ok) {
     throw new Error(reviewAppResponseError(payload, response.status));
   }
@@ -144,15 +149,9 @@ async function pickAppReview(
   return resolveAppReview(reviews, picked.uuid);
 }
 
-function reviewAppResponseError(payload: unknown, status: number): string {
-  if (
-    payload &&
-    typeof payload === "object" &&
-    !Array.isArray(payload) &&
-    "error" in payload &&
-    typeof payload.error === "string"
-  ) {
-    return payload.error;
-  }
-  return `Review Desktop returned ${status} for app open.`;
+function reviewAppResponseError(payload: JsonValue, status: number): string {
+  return (
+    jsonString(jsonObject(payload)?.error) ??
+    `Review Desktop returned ${status} for app open.`
+  );
 }

--- a/packages/progressive-review/src/review-bundle.ts
+++ b/packages/progressive-review/src/review-bundle.ts
@@ -2,6 +2,9 @@ import crypto from "node:crypto";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import { type JsonValue, parseJsonText } from "@dev.fast/review-protocol";
+import { z } from "zod";
+
 import type { ReviewDocumentBundle } from "./server/doc-bundler";
 
 // `review publish` writes the built document bundle into the review dir and
@@ -16,11 +19,12 @@ const BUNDLE_CODE_FILE = "review-document.js";
 const BUNDLE_MANIFEST_FILE = "manifest.json";
 const BUNDLE_MANIFEST_VERSION = 1;
 
-interface ReviewBundleManifest {
-  version: number;
-  routePath: string;
-  sourcePath: string;
-}
+const reviewBundleManifestSchema = z.object({
+  version: z.literal(BUNDLE_MANIFEST_VERSION),
+  routePath: z.string(),
+  sourcePath: z.string(),
+});
+type ReviewBundleManifest = z.infer<typeof reviewBundleManifestSchema>;
 
 export async function writeReviewDocumentBundle(
   reviewDir: string,
@@ -80,20 +84,12 @@ export async function readReviewDocumentBundle(
 }
 
 function parseManifest(raw: string): ReviewBundleManifest | null {
-  let value: unknown;
+  let value: JsonValue;
   try {
-    value = JSON.parse(raw);
+    value = parseJsonText(raw);
   } catch {
     return null;
   }
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const manifest = value as Partial<ReviewBundleManifest>;
-  if (
-    manifest.version !== BUNDLE_MANIFEST_VERSION ||
-    typeof manifest.routePath !== "string" ||
-    typeof manifest.sourcePath !== "string"
-  ) {
-    return null;
-  }
-  return manifest as ReviewBundleManifest;
+  const manifest = reviewBundleManifestSchema.safeParse(value);
+  return manifest.success ? manifest.data : null;
 }

--- a/packages/progressive-review/src/review-code-target-migration.ts
+++ b/packages/progressive-review/src/review-code-target-migration.ts
@@ -7,33 +7,45 @@ import {
   type GitLabDiffPosition,
   type GitLabTextDiffRow,
   type JsonObject,
+  type JsonValue,
   createGitLabTextDiffPosition,
   isJsonObject,
+  jsonObject,
+  parseJsonText,
 } from "@dev.fast/review-protocol";
+import { z } from "zod";
 
 import { type DiffHunk, parseUnifiedPatch } from "./unified-diff";
 
-interface LegacyCodeSpan {
-  startLine: number;
-  endLine: number;
-}
+const LegacyCodeSpanSchema = z
+  .object({
+    startLine: z.number().int().positive(),
+    endLine: z.number().int().positive(),
+  })
+  .refine((span) => span.endLine >= span.startLine);
 
-interface LegacyCodeTarget {
-  kind: "code";
-  path: string;
-  side: "base" | "head";
-  commit: string;
-  span: LegacyCodeSpan;
-}
+type LegacyCodeSpan = z.infer<typeof LegacyCodeSpanSchema>;
 
-interface LegacyCodeChangePosition {
-  fromCommit: string;
-  toCommit: string;
-  oldPath: string;
-  newPath: string | null;
-  oldSpan: LegacyCodeSpan;
-  newSpan: LegacyCodeSpan | null;
-}
+const LegacyCodeTargetSchema = z.object({
+  kind: z.literal("code"),
+  path: z.string(),
+  side: z.enum(["base", "head"]),
+  commit: z.string(),
+  span: LegacyCodeSpanSchema,
+});
+
+type LegacyCodeTarget = z.infer<typeof LegacyCodeTargetSchema>;
+
+const LegacyCodeChangePositionSchema = z.object({
+  fromCommit: z.string(),
+  toCommit: z.string(),
+  oldPath: z.string(),
+  newPath: z.string().nullable(),
+  oldSpan: LegacyCodeSpanSchema,
+  newSpan: LegacyCodeSpanSchema.nullable(),
+});
+
+type LegacyCodeChangePosition = z.infer<typeof LegacyCodeChangePositionSchema>;
 
 interface ReviewCodeMigrationContext {
   rootPath: string;
@@ -56,10 +68,10 @@ export type LegacyCodeRecordKind = "comment" | "comment-draft";
 
 export function createLegacyCodeRecordMigrator(
   context: ReviewCodeMigrationContext,
-): (record: unknown, kind: LegacyCodeRecordKind) => Promise<unknown> {
+): (record: JsonValue, kind: LegacyCodeRecordKind) => Promise<JsonValue> {
   const fileDiffs = new Map<string, Promise<FileDiff>>();
 
-  const migrateThread = async (value: unknown): Promise<unknown> => {
+  const migrateThread = async (value: JsonValue): Promise<JsonValue> => {
     const thread = objectRecord(value, "legacy code comment thread");
     if (!isLegacyCodeTarget(thread.target)) return value;
     const target = parseLegacyCodeTarget(thread.target);
@@ -69,18 +81,18 @@ export function createLegacyCodeRecordMigrator(
     const change = parseLegacyChangePosition(thread.changePosition);
     const originalPosition = await positionForTarget(original);
     const position = await positionForTarget(target);
-    const nextTarget = {
+    const nextTarget: JsonObject = {
       kind: "code",
-      original_position: originalPosition,
-      position,
+      original_position: storedDiffPosition(originalPosition),
+      position: storedDiffPosition(position),
       ...(change?.newSpan === null
         ? {
-            change_position: {
+            change_position: storedDiffPosition({
               ...position,
               base_sha: context.baseCommit,
               start_sha: context.baseCommit,
               head_sha: context.headCommit,
-            },
+            }),
           }
         : {}),
     };
@@ -236,79 +248,37 @@ function diffRowForLine(
     : { old_line: oldCursor + line - newCursor, new_line: line };
 }
 
-function parseLegacyCodeTarget(value: unknown): LegacyCodeTarget {
-  if (!isLegacyCodeTarget(value)) {
-    throw new Error("Legacy code target is malformed.");
-  }
-  const span = objectRecord(value.span, "legacy code target span");
-  if (
-    typeof value.path !== "string" ||
-    (value.side !== "base" && value.side !== "head") ||
-    typeof value.commit !== "string" ||
-    !positiveInteger(span.startLine) ||
-    !positiveInteger(span.endLine) ||
-    span.endLine < span.startLine
-  ) {
-    throw new Error("Legacy code target is malformed.");
-  }
-  return {
-    kind: "code",
-    path: value.path,
-    side: value.side,
-    commit: value.commit,
-    span: { startLine: span.startLine, endLine: span.endLine },
-  };
+function parseLegacyCodeTarget(value: JsonValue): LegacyCodeTarget {
+  const parsed = LegacyCodeTargetSchema.safeParse(value);
+  if (!parsed.success) throw new Error("Legacy code target is malformed.");
+  return parsed.data;
 }
 
 function parseLegacyChangePosition(
-  value: unknown,
+  value: JsonValue | undefined,
 ): LegacyCodeChangePosition | null {
   if (value === undefined) return null;
-  const change = objectRecord(value, "legacy code change position");
-  const oldSpan = parseLegacySpan(change.oldSpan);
-  const newSpan =
-    change.newSpan === null ? null : parseLegacySpan(change.newSpan);
-  if (
-    typeof change.fromCommit !== "string" ||
-    typeof change.toCommit !== "string" ||
-    typeof change.oldPath !== "string" ||
-    (change.newPath !== null && typeof change.newPath !== "string")
-  ) {
+  const parsed = LegacyCodeChangePositionSchema.safeParse(value);
+  if (!parsed.success) {
     throw new Error("Legacy code change position is malformed.");
   }
-  return {
-    fromCommit: change.fromCommit,
-    toCommit: change.toCommit,
-    oldPath: change.oldPath,
-    newPath: change.newPath,
-    oldSpan,
-    newSpan,
-  };
+  return parsed.data;
 }
 
-function parseLegacySpan(value: unknown): LegacyCodeSpan {
-  const span = objectRecord(value, "legacy code span");
-  if (
-    !positiveInteger(span.startLine) ||
-    !positiveInteger(span.endLine) ||
-    span.endLine < span.startLine
-  ) {
-    throw new Error("Legacy code span is malformed.");
-  }
-  return { startLine: span.startLine, endLine: span.endLine };
+/** A diff position as review.db stores it: serialized, undefined optionals dropped. */
+function storedDiffPosition(position: GitLabDiffPosition): JsonObject {
+  const stored = jsonObject(parseJsonText(JSON.stringify(position)));
+  if (!stored) throw new Error("Diff position did not serialize to an object.");
+  return stored;
 }
 
-function isLegacyCodeTarget(value: unknown): value is JsonObject {
+function isLegacyCodeTarget(value: JsonValue | undefined): value is JsonObject {
   return isJsonObject(value) && value.kind === "code" && "path" in value;
 }
 
-function objectRecord(value: unknown, name: string): JsonObject {
+function objectRecord(value: JsonValue | undefined, name: string): JsonObject {
   if (!isJsonObject(value)) throw new Error(`${name} is malformed.`);
   return value;
-}
-
-function positiveInteger(value: unknown): value is number {
-  return Number.isInteger(value) && Number(value) > 0;
 }
 
 function isString(value: string | null): value is string {

--- a/packages/progressive-review/src/review-codex-wait-state.ts
+++ b/packages/progressive-review/src/review-codex-wait-state.ts
@@ -3,13 +3,20 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 
+import { type JsonValue, parseJsonText } from "@dev.fast/review-protocol";
+import { z } from "zod";
+
 import { writePrivateJsonAtomic } from "./server/desktop-paths";
 import { processIsAlive, withFileLock } from "./with-file-lock";
 
-type WaitState = {
-  delivered: string[];
-  waiter: { ownerToken: string; pid: number } | null;
-};
+const waitStateSchema = z.object({
+  delivered: z.array(z.string()),
+  waiter: z
+    .object({ ownerToken: z.string(), pid: z.int().positive() })
+    .nullable(),
+});
+
+type WaitState = z.infer<typeof waitStateSchema>;
 
 export type ReviewCodexWaitOwner = {
   env: NodeJS.ProcessEnv;
@@ -137,9 +144,9 @@ async function updateWaitState<T>(
 }
 
 async function readWaitState(statePath: string): Promise<WaitState> {
-  let value: unknown;
+  let value: JsonValue;
   try {
-    value = JSON.parse(await readFile(statePath, "utf8"));
+    value = parseJsonText(await readFile(statePath, "utf8"));
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return { waiter: null, delivered: [] };
@@ -148,26 +155,11 @@ async function readWaitState(statePath: string): Promise<WaitState> {
       cause: error,
     });
   }
-  if (!isWaitState(value)) {
+  const state = waitStateSchema.safeParse(value);
+  if (!state.success) {
     throw new Error(`Codex waiter state is invalid at ${statePath}.`);
   }
-  return value;
-}
-
-function isWaitState(value: unknown): value is WaitState {
-  if (typeof value !== "object" || value === null) return false;
-  const state = value as Partial<WaitState>;
-  const waiter = state.waiter;
-  return (
-    Array.isArray(state.delivered) &&
-    state.delivered.every((id) => typeof id === "string") &&
-    (waiter === null ||
-      (typeof waiter === "object" &&
-        typeof waiter.ownerToken === "string" &&
-        typeof waiter.pid === "number" &&
-        Number.isInteger(waiter.pid) &&
-        waiter.pid > 0))
-  );
+  return state.data;
 }
 
 function reviewCodexWaitStatePath(input: {

--- a/packages/progressive-review/src/review-diff-files.ts
+++ b/packages/progressive-review/src/review-diff-files.ts
@@ -172,11 +172,11 @@ function fileContentFromBytes(
   };
 }
 
-function isMissingFileError(error: unknown): boolean {
+function isMissingFileError(cause: unknown): boolean {
   return (
-    error instanceof Error &&
-    "code" in error &&
-    (error as NodeJS.ErrnoException).code === "ENOENT"
+    cause instanceof Error &&
+    "code" in cause &&
+    (cause as NodeJS.ErrnoException).code === "ENOENT"
   );
 }
 

--- a/packages/progressive-review/src/review-home.ts
+++ b/packages/progressive-review/src/review-home.ts
@@ -14,6 +14,7 @@ import { currentHead, listCommitRange } from "@dev.fast/local-vcs";
 import {
   DEFAULT_DISMISSED_RETENTION_DAYS,
   type JsonObject,
+  type JsonValue,
   REVIEW_SCHEMA_VERSION,
   type ReviewAgentSessionRole,
   type ReviewDescriptor,
@@ -21,6 +22,9 @@ import {
   ReviewRecordSchema,
   type ReviewSourceIdentity,
   isJsonObject,
+  jsonObject,
+  jsonString,
+  parseJsonText,
   summarizeReviewDiffFiles,
 } from "@dev.fast/review-protocol";
 
@@ -578,11 +582,11 @@ export async function readStoredReview(
 ): Promise<StoredReview | { error: ReviewHomeError }> {
   const reviewPath = path.join(dir, "review.json");
   try {
-    const value: unknown = JSON.parse(await readFile(reviewPath, "utf8"));
+    const value = parseJsonText(await readFile(reviewPath, "utf8"));
     const parsed = safeParseStoredReviewRecord(value);
     if (!parsed.success) {
       return {
-        error: reviewHomeError(dir, value, {
+        error: reviewHomeError(dir, jsonObject(value), {
           message: `Invalid review.json; run \`review migrate apply\`: ${parsed.error.issues.map((issue) => issue.message).join("; ")}`,
           code: "MIGRATION_REQUIRED",
         }),
@@ -600,14 +604,14 @@ export async function readStoredReview(
   }
 }
 
+/** `record` is the parsed review, or the raw review.json object when it failed to parse. */
 function reviewHomeError(
   reviewDir: string,
-  value: unknown,
+  record: StoredReviewRecord | JsonObject | undefined,
   error: { message: string; code?: string },
 ): ReviewHomeError {
-  const record = isJsonObject(value) ? value : undefined;
   const directoryUuid = path.basename(reviewDir);
-  const storedUuid = typeof record?.uuid === "string" ? record.uuid : null;
+  const storedUuid = jsonString(record?.uuid) ?? null;
   const reviewUuid = UUID_PATTERN.test(storedUuid ?? "")
     ? storedUuid
     : UUID_PATTERN.test(directoryUuid)
@@ -616,26 +620,20 @@ function reviewHomeError(
   return {
     reviewDir,
     reviewUuid,
-    title: typeof record?.title === "string" ? record.title : "",
-    worktreePath:
-      typeof record?.worktreePath === "string" && record.worktreePath
-        ? record.worktreePath
-        : reviewDir,
-    lastPublishedAt:
-      typeof record?.lastPublishedAt === "string"
-        ? record.lastPublishedAt
-        : null,
+    title: jsonString(record?.title) ?? "",
+    worktreePath: jsonString(record?.worktreePath) || reviewDir,
+    lastPublishedAt: jsonString(record?.lastPublishedAt) ?? null,
     message: error.message,
     ...(error.code ? { code: error.code } : {}),
   };
 }
 
-export function parseStoredReviewRecord(value: unknown): StoredReviewRecord {
+export function parseStoredReviewRecord(value: JsonValue): StoredReviewRecord {
   return StoredReviewRecordSchema.parse(stripLegacySoftwareMap(value));
 }
 
 export function parseStoredReviewRecordForMigration(
-  value: unknown,
+  value: JsonValue,
 ): StoredReviewRecord {
   if (!isJsonObject(value)) return parseStoredReviewRecord(value);
   const record = stripLegacySoftwareMap(value);
@@ -663,13 +661,13 @@ export function parseStoredReviewRecordForMigration(
   });
 }
 
-export function safeParseStoredReviewRecord(value: unknown) {
+export function safeParseStoredReviewRecord(value: JsonValue) {
   return StoredReviewRecordSchema.safeParse(stripLegacySoftwareMap(value));
 }
 
 function stripLegacySoftwareMap(value: JsonObject): JsonObject;
-function stripLegacySoftwareMap(value: unknown): unknown;
-function stripLegacySoftwareMap(value: unknown): unknown {
+function stripLegacySoftwareMap(value: JsonValue): JsonValue;
+function stripLegacySoftwareMap(value: JsonValue): JsonValue {
   if (!isJsonObject(value)) return value;
   const { softwareMap: _legacySoftwareMap, ...record } = value;
   return record;

--- a/packages/progressive-review/src/review-info.test.ts
+++ b/packages/progressive-review/src/review-info.test.ts
@@ -341,7 +341,7 @@ describe("review info", () => {
       expect(next.reviews[0]?.uuid).not.toBe(initial.reviews[0]?.uuid);
       const duplicateError = await runReviewScaffold({ cwd: root }).then(
         () => "",
-        (error: unknown) => String(error),
+        (cause: unknown) => String(cause),
       );
       expect(duplicateError).toContain(initial.reviews[0]!.uuid);
       expect(duplicateError).toContain(next.reviews[0]!.uuid);

--- a/packages/progressive-review/src/review-info.ts
+++ b/packages/progressive-review/src/review-info.ts
@@ -1,3 +1,11 @@
+import {
+  type JsonValue,
+  ReviewStatusSchema,
+  jsonObject,
+  jsonString,
+} from "@dev.fast/review-protocol";
+import { z } from "zod";
+
 import { requireHealthyReviewDesktop } from "./desktop-discovery";
 import type { StoredReview } from "./review-home";
 
@@ -22,6 +30,23 @@ export interface ReviewInfoEvent {
   }>;
 }
 
+const ReviewInfoEventSchema: z.ZodType<ReviewInfoEvent> = z.object({
+  event: z.literal("info"),
+  warnings: z.array(z.string()).optional(),
+  reviews: z.array(
+    z.object({
+      uuid: z.string(),
+      dir: z.string(),
+      change: z.string().nullable(),
+      inSync: z.boolean(),
+      matchesCheckout: z.boolean(),
+      unresolvedComments: z.number(),
+      status: ReviewStatusSchema,
+      title: z.string(),
+    }),
+  ),
+});
+
 export async function runReviewInfo(
   input: RunReviewInfoInput,
 ): Promise<ReviewInfoEvent> {
@@ -34,37 +59,24 @@ export async function runReviewInfo(
     },
     body: JSON.stringify(input),
   });
-  const payload: unknown = await response.json();
+  const payload: JsonValue = await response.json();
   if (!response.ok) {
     throw new Error(reviewInfoResponseError(payload, response.status));
   }
   return parseReviewInfoEvent(payload);
 }
 
-function parseReviewInfoEvent(value: unknown): ReviewInfoEvent {
-  if (
-    !value ||
-    typeof value !== "object" ||
-    Array.isArray(value) ||
-    !("event" in value) ||
-    value.event !== "info" ||
-    !("reviews" in value) ||
-    !Array.isArray(value.reviews)
-  ) {
+function parseReviewInfoEvent(value: JsonValue): ReviewInfoEvent {
+  const parsed = ReviewInfoEventSchema.safeParse(value);
+  if (!parsed.success) {
     throw new Error("Review Desktop returned an invalid info response.");
   }
-  return value as ReviewInfoEvent;
+  return parsed.data;
 }
 
-function reviewInfoResponseError(payload: unknown, status: number): string {
-  if (
-    payload &&
-    typeof payload === "object" &&
-    !Array.isArray(payload) &&
-    "error" in payload &&
-    typeof payload.error === "string"
-  ) {
-    return payload.error;
-  }
-  return `Review Desktop returned ${status} for info.`;
+function reviewInfoResponseError(payload: JsonValue, status: number): string {
+  return (
+    jsonString(jsonObject(payload)?.error) ??
+    `Review Desktop returned ${status} for info.`
+  );
 }

--- a/packages/progressive-review/src/review-logger.ts
+++ b/packages/progressive-review/src/review-logger.ts
@@ -1,3 +1,9 @@
+import {
+  type JsonValue,
+  isJsonObject,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
 import pino from "pino";
 import pretty from "pino-pretty";
 
@@ -75,54 +81,38 @@ export function emitReviewEvent(
   logger.event(event);
 }
 
-/** The fields a thrown non-Error value may carry that the log record keeps. */
-interface ThrownValueFields {
-  name?: unknown;
-  message?: unknown;
-  stack?: unknown;
-  component?: unknown;
-  propertyPath?: unknown;
-  expected?: unknown;
-  received?: unknown;
-}
-
-export function serializeReviewError(error: unknown): ReviewLifecycleError {
-  // SAFETY: every field is optional and re-checked with typeof/in below, so
-  // any non-null object satisfies the shape.
-  const value =
-    error && typeof error === "object" ? (error as ThrownValueFields) : null;
+export function serializeReviewError(cause: unknown): ReviewLifecycleError {
+  // A thrown object is read as the JSON record it is about to be logged as;
+  // each field the record keeps is decoded on its own below.
+  const fields = isJsonObject(cause) ? cause : undefined;
+  const stack = jsonString(fields?.stack);
+  const component = jsonString(fields?.component);
+  const propertyPath = jsonString(fields?.propertyPath);
   return {
     name:
-      error instanceof Error
-        ? error.name
-        : typeof value?.name === "string"
-          ? value.name
-          : "Error",
+      cause instanceof Error
+        ? cause.name
+        : (jsonString(fields?.name) ?? "Error"),
     message:
-      error instanceof Error
-        ? error.message
-        : typeof value?.message === "string"
-          ? value.message
-          : String(error),
-    ...(typeof value?.stack === "string" ? { stack: value.stack } : {}),
-    ...(typeof value?.component === "string"
-      ? { component: value.component }
+      cause instanceof Error
+        ? cause.message
+        : (jsonString(fields?.message) ?? String(cause)),
+    ...(stack === undefined ? {} : { stack }),
+    ...(component === undefined ? {} : { component }),
+    ...(propertyPath === undefined ? {} : { propertyPath }),
+    ...(fields && "expected" in fields
+      ? { expected: jsonSafeValue(fields.expected) }
       : {}),
-    ...(typeof value?.propertyPath === "string"
-      ? { propertyPath: value.propertyPath }
-      : {}),
-    ...(value && "expected" in value
-      ? { expected: jsonSafeValue(value.expected) }
-      : {}),
-    ...(value && "received" in value
-      ? { received: jsonSafeValue(value.received) }
+    ...(fields && "received" in fields
+      ? { received: jsonSafeValue(fields.received) }
       : {}),
   };
 }
 
-function jsonSafeValue(value: unknown): unknown {
+/** Round-trip through JSON so a value that cannot serialize still logs. */
+function jsonSafeValue(value: JsonValue): JsonValue {
   try {
-    return JSON.parse(JSON.stringify(value)) as unknown;
+    return parseJsonText(JSON.stringify(value));
   } catch {
     return String(value);
   }

--- a/packages/progressive-review/src/review-mdx-ast.ts
+++ b/packages/progressive-review/src/review-mdx-ast.ts
@@ -2,13 +2,21 @@ import type {
   CallExpression,
   Node as EstreeNode,
   Expression,
-  ObjectExpression,
+  Literal,
   Program,
-  Property,
 } from "estree";
+import type { Nodes as MdastNode } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
-import { mdxFromMarkdown } from "mdast-util-mdx";
+import {
+  type MdxJsxAttribute,
+  type MdxJsxAttributeValueExpression,
+  type MdxJsxExpressionAttribute,
+  type MdxJsxFlowElement,
+  type MdxJsxTextElement,
+  mdxFromMarkdown,
+} from "mdast-util-mdx";
 import { mdxjs } from "micromark-extension-mdxjs";
+import { z } from "zod";
 
 // One real MDX parse for every validator. The checks used to regex-scan raw
 // text — which cannot tell markup from a tag quoted in a string, an anchor
@@ -46,8 +54,13 @@ export interface ReviewMdxLink {
   line: number;
 }
 
+export interface ReviewMdxParseError {
+  message: string;
+  line: number;
+}
+
 export interface ReviewMdxDocument {
-  parseError: { message: string; line: number } | null;
+  parseError: ReviewMdxParseError | null;
   // Capitalized (component) JSX elements, in document order.
   components: MdxJsxElementHit[];
   // Every named JSX element with its attributes.
@@ -58,69 +71,73 @@ export interface ReviewMdxDocument {
   esmPrograms: Program[];
 }
 
-interface MdxParseErrorLike {
-  reason?: unknown;
-  message?: unknown;
-  line?: unknown;
-  place?: { line?: unknown } | null;
+// What micromark throws on a syntax error: a VFileMessage, whose `line` is the
+// failing line, `place` a point or position, and `reason` the message without
+// the file location.
+const mdxParseErrorSchema = z.object({
+  reason: z.string().optional(),
+  message: z.string().optional(),
+  line: z.number().optional(),
+  place: z.object({ line: z.number().optional() }).nullable().optional(),
+});
+
+function mdxParseError(cause: unknown): ReviewMdxParseError {
+  const parsed = mdxParseErrorSchema.safeParse(cause);
+  if (!parsed.success) return { message: String(cause), line: 1 };
+  const { reason, message, line, place } = parsed.data;
+  return {
+    message: reason ?? message ?? String(cause),
+    line: line ?? place?.line ?? 1,
+  };
 }
 
-interface MdastNodeLike {
-  type?: unknown;
-  name?: unknown;
-  url?: unknown;
-  children?: unknown;
-  attributes?: unknown;
-  value?: unknown;
-  data?: { estree?: unknown } | null;
-  position?: {
-    start?: { line?: unknown; offset?: unknown };
-    end?: { offset?: unknown };
-  } | null;
+function nodeLine(node: Pick<MdastNode, "position">): number {
+  return node.position?.start.line ?? 1;
 }
 
-function nodeLine(node: MdastNodeLike): number {
-  const line = node.position?.start?.line;
-  return typeof line === "number" ? line : 1;
+function estreeLine(node: EstreeNode): number {
+  return node.loc?.start.line ?? 1;
 }
 
-function estreeLine(node: EstreeNode | Property): number {
-  const line = (node as { loc?: { start?: { line?: number } } | null }).loc
-    ?.start?.line;
-  return typeof line === "number" ? line : 1;
-}
-
-function isSelfClosing(source: string, node: MdastNodeLike): boolean {
-  const start = node.position?.start?.offset;
-  const end = node.position?.end?.offset;
-  if (typeof start !== "number" || typeof end !== "number") return false;
+function isSelfClosing(
+  source: string,
+  node: MdxJsxFlowElement | MdxJsxTextElement,
+): boolean {
+  const start = node.position?.start.offset;
+  const end = node.position?.end.offset;
+  if (start === undefined || end === undefined) return false;
   return /\/\s*>$/.test(source.slice(start, end).trimEnd());
 }
 
+// A JSX attribute value is the quoted string or an expression node. TypeScript
+// cannot narrow that union with `in`, so the node shape is parsed once here.
+const attributeValueExpressionSchema = z.object({
+  type: z.literal("mdxJsxAttributeValueExpression"),
+});
+
+export function isMdxAttributeValueExpression(
+  value: MdxJsxAttribute["value"],
+): value is MdxJsxAttributeValueExpression {
+  return attributeValueExpressionSchema.safeParse(value).success;
+}
+
 function attributeFromNode(
-  attribute: MdastNodeLike,
+  attribute: MdxJsxAttribute | MdxJsxExpressionAttribute,
 ): ReviewMdxAttribute | null {
-  if (
-    attribute.type !== "mdxJsxAttribute" ||
-    typeof attribute.name !== "string"
-  ) {
-    // Spread attributes ({...props}) carry no static name to validate.
-    return null;
-  }
+  // Spread attributes ({...props}) carry no static name to validate.
+  if (attribute.type !== "mdxJsxAttribute") return null;
   const base: ReviewMdxAttribute = {
     name: attribute.name,
     line: nodeLine(attribute),
   };
-  if (typeof attribute.value === "string") {
-    return { ...base, stringValue: attribute.value };
+  const { value } = attribute;
+  if (value === null || value === undefined) return base;
+  if (!isMdxAttributeValueExpression(value)) {
+    return { ...base, stringValue: value };
   }
-  const value = attribute.value as MdastNodeLike | null;
-  if (value && value.type === "mdxJsxAttributeValueExpression") {
-    const program = value.data?.estree as Program | undefined;
-    const statement = program?.body?.[0];
-    if (statement && statement.type === "ExpressionStatement") {
-      return { ...base, expression: statement.expression };
-    }
+  const statement = value.data?.estree?.body[0];
+  if (statement?.type === "ExpressionStatement") {
+    return { ...base, expression: statement.expression };
   }
   return base;
 }
@@ -137,63 +154,44 @@ export function parseReviewMdxDocument(source: string): ReviewMdxDocument {
     esmPrograms: [],
   };
 
-  let tree: MdastNodeLike;
+  let tree: MdastNode;
   try {
     tree = fromMarkdown(source, {
       extensions: [mdxjs()],
       mdastExtensions: [mdxFromMarkdown()],
-    }) as MdastNodeLike;
-  } catch (error) {
-    const parseError = error as MdxParseErrorLike;
-    const line =
-      typeof parseError.line === "number"
-        ? parseError.line
-        : typeof parseError.place?.line === "number"
-          ? parseError.place.line
-          : 1;
-    const message =
-      typeof parseError.reason === "string"
-        ? parseError.reason
-        : typeof parseError.message === "string"
-          ? parseError.message
-          : String(error);
-    document.parseError = { message, line };
+    });
+  } catch (cause) {
+    document.parseError = mdxParseError(cause);
     return document;
   }
 
-  const visit = (node: MdastNodeLike): void => {
+  const visit = (node: MdastNode): void => {
     if (
       (node.type === "mdxJsxFlowElement" ||
         node.type === "mdxJsxTextElement") &&
-      typeof node.name === "string"
+      node.name !== null
     ) {
       const line = nodeLine(node);
       if (/^[A-Z]/.test(node.name)) {
         document.components.push({ name: node.name, line });
       }
-      const attributes = Array.isArray(node.attributes)
-        ? (node.attributes as MdastNodeLike[])
-            .map(attributeFromNode)
-            .filter((attribute): attribute is ReviewMdxAttribute =>
-              Boolean(attribute),
-            )
-        : [];
       document.elements.push({
         name: node.name,
         line,
         selfClosing: isSelfClosing(source, node),
-        attributes,
+        attributes: node.attributes
+          .map(attributeFromNode)
+          .filter((attribute) => attribute !== null),
       });
     }
-    if (node.type === "link" && typeof node.url === "string") {
+    if (node.type === "link") {
       document.links.push({ url: node.url, line: nodeLine(node) });
     }
-    if (node.type === "mdxjsEsm") {
-      const program = node.data?.estree as Program | undefined;
-      if (program) document.esmPrograms.push(program);
+    if (node.type === "mdxjsEsm" && node.data?.estree) {
+      document.esmPrograms.push(node.data.estree);
     }
-    if (Array.isArray(node.children)) {
-      for (const child of node.children) visit(child as MdastNodeLike);
+    if ("children" in node) {
+      for (const child of node.children) visit(child);
     }
   };
   visit(tree);
@@ -219,12 +217,12 @@ export function walkEstree(
   }
 }
 
+// Every estree node carries a string `type`; the other objects hanging off a
+// node (`loc`, a literal's `regex`, ...) do not.
+const estreeNodeSchema = z.object({ type: z.string() });
+
 function isEstreeNode(value: unknown): value is EstreeNode {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof (value as { type?: unknown }).type === "string"
-  );
+  return estreeNodeSchema.safeParse(value).success;
 }
 
 export function findCallExpressions(
@@ -256,14 +254,13 @@ export function objectLiteralProperties(
 ): EstreeObjectProperty[] {
   if (!node || node.type !== "ObjectExpression") return [];
   const properties: EstreeObjectProperty[] = [];
-  for (const property of (node as ObjectExpression).properties) {
+  for (const property of node.properties) {
     if (property.type !== "Property") continue;
     const name =
       property.key.type === "Identifier"
         ? property.key.name
-        : property.key.type === "Literal" &&
-            typeof property.key.value === "string"
-          ? property.key.value
+        : property.key.type === "Literal"
+          ? literalStringValue(property.key)
           : null;
     if (name === null) continue;
     if (property.value.type === "ObjectPattern") continue;
@@ -276,26 +273,33 @@ export function objectLiteralProperties(
   return properties;
 }
 
+// Only a string literal ({ "a": 1 }) names a property; numeric, boolean, and
+// regex literals do not.
+function literalStringValue(literal: Literal): string | null {
+  const value = z.string().safeParse(literal.value);
+  return value.success ? value.data : null;
+}
+
+// Absolute character offsets acorn and Babel record on every node beside the
+// optional estree `range`.
+export interface EstreeOffsets {
+  start: number;
+  end: number;
+}
+
+const estreeOffsetsSchema = z.object({ start: z.number(), end: z.number() });
+
+export function hasEstreeOffsets(
+  node: EstreeNode,
+): node is EstreeNode & EstreeOffsets {
+  return estreeOffsetsSchema.safeParse(node).success;
+}
+
 // Document-relative character offsets of an estree node — acorn (as run by
 // the MDX extension) records them on every node, positioned against the full
 // document. Lets a caller slice the original source for a node and hand it to
 // a different parser.
-export function estreeNodeRange(
-  node: EstreeNode,
-): { start: number; end: number } | null {
-  const withOffsets = node as {
-    range?: [number, number];
-    start?: number;
-    end?: number;
-  };
-  if (Array.isArray(withOffsets.range)) {
-    return { start: withOffsets.range[0], end: withOffsets.range[1] };
-  }
-  if (
-    typeof withOffsets.start === "number" &&
-    typeof withOffsets.end === "number"
-  ) {
-    return { start: withOffsets.start, end: withOffsets.end };
-  }
-  return null;
+export function estreeNodeRange(node: EstreeNode): EstreeOffsets | null {
+  if (node.range) return { start: node.range[0], end: node.range[1] };
+  return hasEstreeOffsets(node) ? { start: node.start, end: node.end } : null;
 }

--- a/packages/progressive-review/src/review-mdx-typescript-parser.ts
+++ b/packages/progressive-review/src/review-mdx-typescript-parser.ts
@@ -2,9 +2,7 @@ import type { ParserOptions } from "@babel/parser";
 import { parse, parseExpression } from "@babel/parser";
 import type { Comment, Expression, Program } from "estree";
 
-interface EstreeNode extends Record<string, unknown> {
-  type?: string;
-}
+import { hasEstreeOffsets, walkEstree } from "./review-mdx-ast";
 
 /**
  * What `@babel/parser` returns under the "estree" plugin. Its typings describe
@@ -13,6 +11,15 @@ interface EstreeNode extends Record<string, unknown> {
 interface EstreeParseResult {
   program: Program;
   comments: Comment[] | null;
+}
+
+/**
+ * The fields micromark reads off a failed parse, matching acorn's SyntaxError:
+ * Babel records the offset as `pos`; acorn callers expect `raisedAt`.
+ */
+interface AcornCompatibleError extends Error {
+  pos?: number;
+  raisedAt?: number;
 }
 
 const parserOptions = {
@@ -57,33 +64,23 @@ export const reviewTypescriptEstreeParser = {
 function withAcornCompatibleError<T>(run: () => T): T {
   try {
     return run();
-  } catch (error) {
-    if (error && typeof error === "object") {
-      const syntaxError = error as { pos?: number; raisedAt?: number };
+  } catch (cause) {
+    if (cause instanceof Error) {
+      const syntaxError: AcornCompatibleError = cause;
       syntaxError.raisedAt = (syntaxError.pos ?? 0) + 1;
     }
-    throw error;
+    throw cause;
   }
 }
 
-function offsetEstreeNode(value: unknown, offset: number): void {
-  if (!value || typeof value !== "object") return;
-  if (Array.isArray(value)) {
-    for (const entry of value) offsetEstreeNode(entry, offset);
-    return;
-  }
-  const node = value as EstreeNode;
-  if (typeof node.start === "number") node.start += offset;
-  if (typeof node.end === "number") node.end += offset;
-  if (
-    Array.isArray(node.range) &&
-    typeof node.range[0] === "number" &&
-    typeof node.range[1] === "number"
-  ) {
-    node.range = [node.range[0] + offset, node.range[1] + offset];
-  }
-  for (const [property, child] of Object.entries(node)) {
-    if (property === "loc" || property === "range") continue;
-    offsetEstreeNode(child, offset);
-  }
+function offsetEstreeNode(root: Expression, offset: number): void {
+  walkEstree(root, (node) => {
+    if (hasEstreeOffsets(node)) {
+      node.start += offset;
+      node.end += offset;
+    }
+    if (node.range) {
+      node.range = [node.range[0] + offset, node.range[1] + offset];
+    }
+  });
 }

--- a/packages/progressive-review/src/review-preferences.ts
+++ b/packages/progressive-review/src/review-preferences.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_DISMISSED_RETENTION_DAYS,
   type JsonValue,
   isJsonObject,
+  jsonNumber,
   parseJsonText,
 } from "@dev.fast/review-protocol";
 
@@ -63,16 +64,18 @@ function parseRetentionDays(raw: JsonValue): DismissedRetentionDays {
   }
   const value = raw.dismissedRetentionDays;
   if (value === null) return null;
-  return normalizeRetentionDays(typeof value === "number" ? value : undefined);
+  return normalizeRetentionDays(jsonNumber(value));
 }
 
 /**
  * Guards the reaper against a hand-edited file: a zero or negative window would
  * delete every dismissed review on the next scan.
  */
-function normalizeRetentionDays(value: unknown): DismissedRetentionDays {
+function normalizeRetentionDays(
+  value: number | null | undefined,
+): DismissedRetentionDays {
   if (value === null) return null;
-  if (typeof value !== "number" || !Number.isFinite(value) || value < 1) {
+  if (value === undefined || !Number.isFinite(value) || value < 1) {
     return DEFAULT_DISMISSED_RETENTION_DAYS;
   }
   return Math.floor(value);

--- a/packages/progressive-review/src/review-prepare.ts
+++ b/packages/progressive-review/src/review-prepare.ts
@@ -96,9 +96,9 @@ export async function prepareReviewPinnedCheckout(
       const runCommand = input.runCommand ?? runPrepareShellCommand;
       for (const command of input.commands) {
         const result = await runCommand(command, input.checkoutPath).catch(
-          (error: unknown) => ({
+          (cause: unknown) => ({
             exitCode: null,
-            output: error instanceof Error ? error.message : String(error),
+            output: cause instanceof Error ? cause.message : String(cause),
           }),
         );
         if (result.exitCode !== 0) {

--- a/packages/progressive-review/src/review-publish-element-audit.ts
+++ b/packages/progressive-review/src/review-publish-element-audit.ts
@@ -1,8 +1,10 @@
+import { isCallableValue, isObjectValue } from "@dev.fast/review-protocol";
 import { z } from "zod";
 
 import {
   type CallStackDiffProps,
   callStackDiffPropsSchema,
+  dbUseCasePropsSchema,
   reviewAuthoringPropsSchemas,
   traceQuotePropsSchema,
 } from "./authoring";
@@ -20,11 +22,17 @@ import { errorMessage } from "./error-message";
 const ELEMENT_MARKER = "__reviewPublishElement";
 const FRAGMENT = Symbol.for("react.fragment");
 
+// What `jsx` receives as an element type: an intrinsic tag name, a React
+// marker symbol (Fragment, Suspense, ...), or a component function.
+export type PublishAuditElementType = string | symbol | PublishAuditComponent;
+
+export type PublishAuditKey = string | number | null | undefined;
+
 export interface PublishAuditElement {
   [ELEMENT_MARKER]: true;
-  type: unknown;
+  type: PublishAuditElementType;
   props: PublishValidationProps;
-  key: unknown;
+  key: PublishAuditKey;
 }
 
 // The tree the audit walks: element records, text, and the values
@@ -52,13 +60,14 @@ export type PublishValidationPropValue =
 
 export interface PublishValidationProps {
   children?: PublishAuditNode;
+  key?: PublishAuditKey;
   [prop: string]: PublishValidationPropValue;
 }
 
 type AuthoringComponentName = keyof typeof reviewAuthoringPropsSchemas;
 
 function isAuditElement(value: PublishAuditNode): value is PublishAuditElement {
-  if (typeof value !== "object" || value === null) return false;
+  if (!isObjectValue(value)) return false;
   return (
     (ELEMENT_MARKER in value && value[ELEMENT_MARKER] === true) ||
     ("$$typeof" in value &&
@@ -67,10 +76,19 @@ function isAuditElement(value: PublishAuditNode): value is PublishAuditElement {
   );
 }
 
+// The document module's default export and every function-typed element are
+// components compiled against this runtime: they take a props record and
+// return the element tree their `jsx` calls built.
+export function isPublishAuditComponent(
+  value: unknown,
+): value is PublishAuditComponent {
+  return isCallableValue(value);
+}
+
 function makeElement(
-  type: unknown,
+  type: PublishAuditElementType,
   props: PublishValidationProps | null | undefined,
-  key: unknown,
+  key: PublishAuditKey,
 ): PublishAuditElement {
   return { [ELEMENT_MARKER]: true, type, props: props ?? {}, key };
 }
@@ -80,8 +98,14 @@ function makeElement(
 // Fragments do NOT flatten — React.Children treats a fragment as one child,
 // and the lens parsers in the app rely on that.
 function flattenChildren(children: PublishAuditNode): PublishAuditNode[] {
-  if (children === null || children === undefined) return [];
-  if (typeof children === "boolean") return [];
+  if (
+    children === null ||
+    children === undefined ||
+    children === true ||
+    children === false
+  ) {
+    return [];
+  }
   if (Array.isArray(children)) return children.flatMap(flattenChildren);
   return [children];
 }
@@ -104,14 +128,17 @@ export function createPublishValidationReact(): PublishValidationReact {
 
 function publishValidationReactMembers() {
   const noop = () => undefined;
-  const identity = (value: unknown) => value;
+  const identity = <T>(value: T) => value;
   // A plain function keeps `class X extends Component` working: unlike an
   // arrow function it has a prototype, and the stub is never instantiated.
   function StubComponent(): void {}
-  const jsx = (type: unknown, props?: PublishValidationProps, key?: unknown) =>
-    makeElement(type, props, key);
+  const jsx = (
+    type: PublishAuditElementType,
+    props?: PublishValidationProps,
+    key?: PublishAuditKey,
+  ) => makeElement(type, props, key);
   const createElement = (
-    type: unknown,
+    type: PublishAuditElementType,
     props?: PublishValidationProps | null,
     ...children: PublishAuditNode[]
   ) =>
@@ -211,11 +238,8 @@ export interface PublishAuditTraceQuote {
 }
 
 export function extractAuditText(node: PublishAuditNode): string {
-  if (node === null || node === undefined || typeof node === "boolean") {
+  if (node === null || node === undefined || node === true || node === false) {
     return "";
-  }
-  if (typeof node === "string" || typeof node === "number") {
-    return String(node);
   }
   if (Array.isArray(node)) {
     return node.map(extractAuditText).join("");
@@ -223,11 +247,11 @@ export function extractAuditText(node: PublishAuditNode): string {
   if (isAuditElement(node)) {
     return extractAuditText(node.props.children);
   }
-  return "";
+  return String(node);
 }
 
 export function auditReviewDocumentComponent(input: {
-  Component: unknown;
+  Component: PublishAuditComponent;
   reportError: (message: string) => void;
   // Publish checks every CallStackDiff's -/+ rows against the change's
   // deleted and added lines; the audit is the one walk that sees each
@@ -235,9 +259,11 @@ export function auditReviewDocumentComponent(input: {
   collectCallStackDiff?: (props: CallStackDiffProps) => void;
   collectTraceQuote?: (quote: PublishAuditTraceQuote) => void;
 }): void {
-  if (typeof input.Component !== "function") return;
   const components = new Map<AuthoringComponentName, PublishAuditComponent>();
-  const componentNames = new Map<unknown, AuthoringComponentName>();
+  const componentNames = new Map<
+    PublishAuditElementType,
+    AuthoringComponentName
+  >();
   for (const name of Object.keys(
     reviewAuthoringPropsSchemas,
   ) as AuthoringComponentName[]) {
@@ -249,12 +275,7 @@ export function auditReviewDocumentComponent(input: {
 
   let tree: PublishAuditNode;
   try {
-    // SAFETY: the document component is the bundle's default export, compiled
-    // from MDX against this runtime's `jsx`; it takes a props record and
-    // returns the element tree those calls built.
-    tree = (input.Component as PublishAuditComponent)({
-      components: Object.fromEntries(components),
-    });
+    tree = input.Component({ components: Object.fromEntries(components) });
   } catch (error) {
     input.reportError(
       `Review document did not evaluate for validation: ${errorMessage(error)}`,
@@ -296,15 +317,13 @@ export function auditReviewDocumentComponent(input: {
         walk(child.props.children, name);
         continue;
       }
-      if (typeof child.type === "function") {
+      if (isPublishAuditComponent(child.type)) {
         // Best-effort expansion of document-local components: MDX-generated
         // helpers are hook-free and expand; anything that throws under the
         // stub hooks is skipped, exactly as inert as it was before the audit.
         let rendered: PublishAuditNode = null;
         try {
-          // SAFETY: a function-typed element is a document-local component
-          // compiled against this runtime; it renders to the same node tree.
-          rendered = (child.type as PublishAuditComponent)(child.props);
+          rendered = child.type(child.props);
         } catch {
           rendered = null;
         }
@@ -320,7 +339,7 @@ function auditElement(
   element: PublishAuditElement,
   name: AuthoringComponentName,
   parentName: AuthoringComponentName | null,
-  componentNames: ReadonlyMap<unknown, AuthoringComponentName>,
+  componentNames: ReadonlyMap<PublishAuditElementType, AuthoringComponentName>,
   reportError: (message: string) => void,
 ): void {
   const schema: z.ZodType = reviewAuthoringPropsSchemas[name];
@@ -357,14 +376,16 @@ function auditElement(
     for (const child of flattenChildren(element.props.children)) {
       if (!isAuditElement(child)) continue;
       if (componentNames.get(child.type) !== "DbUseCase") continue;
-      const label = child.props.label;
-      if (typeof label !== "string") continue;
-      if (labels.has(label)) {
+      const label = dbUseCasePropsSchema.shape.label.safeParse(
+        child.props.label,
+      );
+      if (!label.success) continue;
+      if (labels.has(label.data)) {
         reportError(
-          `<DbUseCase> label "${label}" must be unique within its <DatabaseLens>.`,
+          `<DbUseCase> label "${label.data}" must be unique within its <DatabaseLens>.`,
         );
       }
-      labels.add(label);
+      labels.add(label.data);
     }
   }
   if (

--- a/packages/progressive-review/src/review-publish-evaluate.ts
+++ b/packages/progressive-review/src/review-publish-evaluate.ts
@@ -27,6 +27,7 @@ import {
   type PublishAuditTraceQuote,
   auditReviewDocumentComponent,
   createPublishValidationReact,
+  isPublishAuditComponent,
 } from "./review-publish-element-audit";
 import { defineSoftwareMap } from "./software-map-model";
 import { resolveReviewSourceRange } from "./source-range-resolver";
@@ -433,7 +434,7 @@ function validationRuntimeExports(input: {
       return session;
     },
     createActiveReviewDocument: (document: { Component?: unknown }) => {
-      if (typeof document.Component !== "function") {
+      if (!isPublishAuditComponent(document.Component)) {
         throw new Error("Review document has no component export.");
       }
       auditReviewDocumentComponent({

--- a/packages/progressive-review/src/review-reopen-marker.ts
+++ b/packages/progressive-review/src/review-reopen-marker.ts
@@ -1,6 +1,12 @@
 import { mkdir, open, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import {
+  jsonObject,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
 import { reviewDir } from "./review-file";
 
 // A "pending reopen" marker records that the reviewer requested changes that
@@ -58,9 +64,10 @@ export async function readReopenMarker(
     return null;
   }
   try {
-    const parsed = JSON.parse(raw) as Partial<ReopenMarker> | null;
-    if (!parsed || typeof parsed.submittedAt !== "string") return null;
-    return { submittedAt: parsed.submittedAt, nudged: parsed.nudged === true };
+    const parsed = jsonObject(parseJsonText(raw));
+    const submittedAt = jsonString(parsed?.submittedAt);
+    if (parsed === undefined || submittedAt === undefined) return null;
+    return { submittedAt, nudged: parsed.nudged === true };
   } catch {
     return null;
   }

--- a/packages/progressive-review/src/review-source-agent-session.ts
+++ b/packages/progressive-review/src/review-source-agent-session.ts
@@ -156,17 +156,18 @@ async function createPiReviewSourceSession(input: {
     );
   } catch (error) {
     throw new Error(
-      `Pi could not create the Review source session: ${commandError(error)}`,
+      `Pi could not create the Review source session: ${commandFailure(error)}`,
       { cause: error },
     );
   }
   return { harness: "pi", sessionId };
 }
 
-function commandError(error: unknown): string {
-  if (typeof error === "object" && error !== null && "stderr" in error) {
-    const stderr = String(error.stderr).trim();
+/** The stderr a failed pi command reported, else its error message. */
+function commandFailure(cause: unknown): string {
+  if (cause instanceof Error && "stderr" in cause) {
+    const stderr = String(cause.stderr).trim();
     if (stderr) return stderr;
   }
-  return errorMessage(error);
+  return errorMessage(cause);
 }

--- a/packages/progressive-review/src/review-state-store.ts
+++ b/packages/progressive-review/src/review-state-store.ts
@@ -6,6 +6,7 @@ import { readFileAtRevisionSync } from "@dev.fast/local-vcs";
 import {
   CodeThreadTargetSchema,
   type GitLabDiffPosition,
+  type JsonObject,
   ReviewRecordSchema,
   gitLabDiffPositionRows,
   isJsonObject,
@@ -47,7 +48,12 @@ interface ReviewCodeTargetContext {
   headCommit: string | null;
 }
 
-function isLegacyCodeTarget(target: unknown): boolean {
+/**
+ * Code targets from before the `code` kind existed were text targets on a
+ * native or code-part surface; such a shape can still arrive as raw JSON from
+ * an older store.
+ */
+function isLegacyCodeTarget(target: ThreadTarget | JsonObject): boolean {
   if (!isJsonObject(target) || target.kind !== "text") return false;
   if (!isJsonObject(target.surface)) return false;
   if (target.surface.type === "native") return true;

--- a/packages/progressive-review/src/review-thread-store-backend.ts
+++ b/packages/progressive-review/src/review-thread-store-backend.ts
@@ -4,14 +4,17 @@ import { DatabaseSync } from "node:sqlite";
 
 import {
   type JsonObject,
+  type JsonValue,
   isJsonObject,
   parseJsonText,
 } from "@dev.fast/review-protocol";
 import {
+  ReviewCommentAgentSessionSchema,
   ReviewCommentDraftThreadMapSchema,
   parseReviewCommentThreadMap,
   parseStoredReviewCommentThreadMap,
 } from "@dev.fast/review-protocol";
+import { z } from "zod";
 
 import type {
   ReviewCommentDraftThreadMap,
@@ -163,9 +166,9 @@ export type ReviewThreadDbMigrationResult = "missing" | "current" | "upgraded";
 export interface ReviewThreadDbMigrationOptions {
   force?: boolean;
   migrateLegacyCodeRecord?: (
-    record: unknown,
+    record: JsonValue,
     kind: "comment" | "comment-draft",
-  ) => Promise<unknown>;
+  ) => Promise<JsonValue>;
   onDropLegacyCodeRecord?: (input: {
     threadId: string;
     kind: "comment" | "comment-draft";
@@ -256,7 +259,7 @@ function migrateNativeAgentSessionRecords(db: DatabaseSync): void {
       `UPDATE ${table} SET record_json = ? WHERE thread_id = ?`,
     );
     for (const row of rows) {
-      const value: unknown = JSON.parse(row.record_json);
+      const value = parseJsonText(row.record_json);
       const migrated = migrateNativeAgentSessionRecord(value, table);
       if (migrated !== value) {
         update.run(JSON.stringify(migrated), row.thread_id);
@@ -266,9 +269,9 @@ function migrateNativeAgentSessionRecords(db: DatabaseSync): void {
 }
 
 function migrateNativeAgentSessionRecord(
-  value: unknown,
+  value: JsonValue,
   table: "comments" | "comment_drafts",
-): unknown {
+): JsonValue {
   if (!isJsonObject(value)) return value;
   if (table === "comment_drafts") {
     if (!isJsonObject(value.thread)) return value;
@@ -277,6 +280,11 @@ function migrateNativeAgentSessionRecord(
   }
   return migrateNativeAgentSessionThread(value);
 }
+
+/** Pre-v6 records may carry extra agent-session keys; keep only the current ones. */
+const LegacyCommentAgentSessionSchema = z.object(
+  ReviewCommentAgentSessionSchema.shape,
+);
 
 function migrateNativeAgentSessionThread(thread: JsonObject): JsonObject {
   const originalMessages = Array.isArray(thread.messages)
@@ -303,24 +311,10 @@ function migrateNativeAgentSessionThread(thread: JsonObject): JsonObject {
     ? { ...thread, messages: migratedMessages }
     : thread;
   if (!("agentSession" in migratedThread)) return migratedThread;
-  const { agentSession: session, ...preserved } = migratedThread;
-  if (
-    !isJsonObject(session) ||
-    (session.harness !== "claude-code" &&
-      session.harness !== "codex" &&
-      session.harness !== "pi") ||
-    typeof session.sessionId !== "string" ||
-    !session.sessionId
-  ) {
-    return preserved;
-  }
-  return {
-    ...preserved,
-    agentSession: {
-      harness: session.harness,
-      sessionId: session.sessionId,
-    },
-  };
+  const { agentSession, ...preserved } = migratedThread;
+  const session = LegacyCommentAgentSessionSchema.safeParse(agentSession);
+  if (!session.success) return preserved;
+  return { ...preserved, agentSession: session.data };
 }
 
 async function migrateLegacyCodeRecords(
@@ -342,8 +336,8 @@ async function migrateLegacyCodeRecords(
       .prepare(`SELECT thread_id, record_json FROM ${table.name}`)
       .all() as Array<{ thread_id: string; record_json: string }>;
     for (const row of rows) {
-      const current = JSON.parse(row.record_json) as unknown;
-      let migrated: unknown;
+      const current = parseJsonText(row.record_json);
+      let migrated: JsonValue;
       try {
         migrated = await migrate(current, table.kind);
       } catch (error) {

--- a/packages/progressive-review/src/review-worktree-target.ts
+++ b/packages/progressive-review/src/review-worktree-target.ts
@@ -6,6 +6,7 @@ import {
   devfastPrepareCommands,
   resolveRevision,
 } from "@dev.fast/local-vcs";
+import { parseJsonText } from "@dev.fast/review-protocol";
 
 import { ensureReviewPinnedCheckout } from "./review-head-checkout";
 import {
@@ -194,7 +195,7 @@ export function readReviewStoreRecord(
 ): StoredReviewRecord {
   const storePath = path.resolve(reviewRootPath);
   try {
-    const value: unknown = JSON.parse(
+    const value = parseJsonText(
       fs.readFileSync(path.join(storePath, "review.json"), "utf8"),
     );
     const parsed = safeParseStoredReviewRecord(value);

--- a/packages/progressive-review/src/runtime.ts
+++ b/packages/progressive-review/src/runtime.ts
@@ -9,6 +9,14 @@ import {
   resolveRepoContext,
   resolveRevision,
 } from "@dev.fast/local-vcs";
+import {
+  type JsonValue,
+  isJsonObject,
+  jsonNumber,
+  jsonObject,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
 
 import { errorMessage } from "./error-message";
 import { reviewMdxPath } from "./review-file";
@@ -237,7 +245,8 @@ export async function resolvePullRequestReviewSubject(input: {
 
   if (!parsed) {
     try {
-      parsed = JSON.parse(stdout ?? "") as PullRequestMetadata;
+      const value = parseJsonText(stdout ?? "");
+      parsed = isJsonObject(value) ? value : {};
     } catch (error) {
       throw new Error(
         `Unable to parse gh pr view output for ${input.value}: ${errorMessage(
@@ -246,35 +255,32 @@ export async function resolvePullRequestReviewSubject(input: {
       );
     }
   }
-  if (typeof parsed.number !== "number") {
+  const number = jsonNumber(parsed.number);
+  if (number === undefined) {
     throw new Error(
       `Could not resolve pull request number for ${input.value}.`,
     );
   }
-  if (typeof parsed.baseRefName !== "string" || !parsed.baseRefName.trim()) {
-    throw new Error(`Could not resolve base branch for PR ${parsed.number}.`);
+  const baseRefName = jsonString(parsed.baseRefName);
+  if (!baseRefName?.trim()) {
+    throw new Error(`Could not resolve base branch for PR ${number}.`);
   }
 
-  const headRef = `refs/dev-fast/reviews/pr-${parsed.number}/head`;
+  const headRef = `refs/dev-fast/reviews/pr-${number}/head`;
   const preparedRefs = await preparePullRequestRefs({
     cwd: input.cwd,
-    baseRefName: parsed.baseRefName,
+    baseRefName,
     headRef,
-    pullRequestNumber: parsed.number,
-    baseRefOid:
-      typeof parsed.baseRefOid === "string" && parsed.baseRefOid
-        ? parsed.baseRefOid
-        : undefined,
+    pullRequestNumber: number,
+    baseRefOid: jsonString(parsed.baseRefOid) || undefined,
     repoContext,
     execFile,
   });
 
+  const title = jsonString(parsed.title)?.trim();
   return {
-    number: parsed.number,
-    title:
-      typeof parsed.title === "string" && parsed.title.trim()
-        ? parsed.title.trim()
-        : `PR ${parsed.number}`,
+    number,
+    title: title || `PR ${number}`,
     repo: repoSlug,
     baseRef: preparedRefs.baseRef,
     headRef: preparedRefs.headRef,
@@ -362,11 +368,12 @@ function parseGithubPullRequestRepoSlug(value: string): string | undefined {
   return undefined;
 }
 
+/** The `gh pr view --json` fields, before they are checked. */
 interface PullRequestMetadata {
-  number?: unknown;
-  title?: unknown;
-  baseRefName?: unknown;
-  baseRefOid?: unknown;
+  number?: JsonValue;
+  title?: JsonValue;
+  baseRefName?: JsonValue;
+  baseRefOid?: JsonValue;
 }
 
 function parseGithubPullRequestNumber(value: string): number | undefined {
@@ -408,16 +415,13 @@ async function fetchPublicGithubPullRequestMetadata(input: {
       `GitHub REST API returned HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`,
     );
   }
-  const metadata = (await response.json()) as {
-    number?: unknown;
-    title?: unknown;
-    base?: { ref?: unknown; sha?: unknown };
-  };
+  const metadata = jsonObject(await response.json());
+  const base = jsonObject(metadata?.base);
   return {
-    number: metadata.number,
-    title: metadata.title,
-    baseRefName: metadata.base?.ref,
-    baseRefOid: metadata.base?.sha,
+    number: metadata?.number,
+    title: metadata?.title,
+    baseRefName: base?.ref,
+    baseRefOid: base?.sha,
   };
 }
 

--- a/packages/progressive-review/src/server/bug-report-trace.test.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.test.ts
@@ -239,19 +239,15 @@ describe("readAuthoringTraceAttachment", () => {
   it("rejects malformed Codex history metadata", async () => {
     const childId = "45454545-4545-4545-8545-454545454545";
     const parentId = "56565656-5656-4656-8656-565656565656";
-    writeCodexTrace(
-      childId,
-      [
-        {
-          type: "session_meta",
-          payload: { id: childId, history_base: { thread_id: parentId } },
-          ordinal: 2,
-        },
-        { child: true, ordinal: 3 },
-      ]
-        .map(jsonLine)
-        .join(""),
-    );
+    const records: JsonObject[] = [
+      {
+        type: "session_meta",
+        payload: { id: childId, history_base: { thread_id: parentId } },
+        ordinal: 2,
+      },
+      { child: true, ordinal: 3 },
+    ];
+    writeCodexTrace(childId, records.map(jsonLine).join(""));
     writeReview("codex:" + childId);
 
     await expect(
@@ -665,6 +661,6 @@ function readPart(attachment: AuthoringTraceAttachment, index: number): string {
   return gunzipSync(readFileSync(part.path)).toString("utf8");
 }
 
-function jsonLine(value: unknown): string {
+function jsonLine(value: JsonObject): string {
   return JSON.stringify(value) + "\n";
 }

--- a/packages/progressive-review/src/server/bug-report-trace.ts
+++ b/packages/progressive-review/src/server/bug-report-trace.ts
@@ -9,7 +9,10 @@ import { createGzip } from "node:zlib";
 
 import {
   type JsonObject,
-  isJsonObject,
+  type JsonValue,
+  jsonNumber,
+  jsonObject,
+  jsonString,
   parseJsonText,
 } from "@dev.fast/review-protocol";
 
@@ -231,17 +234,17 @@ async function readCodexMetadata(
   if (first.type !== "session_meta") {
     throw new Error("Codex trace does not start with session metadata.");
   }
-  const payload = objectValue(first.payload);
+  const payload = jsonObject(first.payload);
   if (payload?.id !== sessionId) {
     throw new Error("Codex trace metadata does not match its session id.");
   }
-  const historyBaseValue = objectValue(payload.history_base);
+  const historyBaseValue = jsonObject(payload.history_base);
   let historyBase: CodexHistoryBase | undefined;
   if (payload.history_base !== undefined) {
     if (!historyBaseValue) {
       throw new Error("Codex history base is malformed.");
     }
-    const threadId = stringValue(historyBaseValue.thread_id);
+    const threadId = jsonString(historyBaseValue.thread_id);
     const endOrdinalExclusive = integerValue(
       historyBaseValue.end_ordinal_exclusive,
     );
@@ -488,22 +491,15 @@ function redactTraceText(contents: string): string {
 
 function parseJsonObject(line: string): JsonObject | undefined {
   try {
-    return objectValue(parseJsonText(line));
+    return jsonObject(parseJsonText(line));
   } catch {
     return undefined;
   }
 }
 
-function objectValue(value: unknown): JsonObject | undefined {
-  return isJsonObject(value) ? value : undefined;
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-function integerValue(value: unknown): number | undefined {
-  return Number.isSafeInteger(value) && (value as number) >= 0
-    ? (value as number)
+function integerValue(value: JsonValue | undefined): number | undefined {
+  const number = jsonNumber(value);
+  return number !== undefined && Number.isSafeInteger(number) && number >= 0
+    ? number
     : undefined;
 }

--- a/packages/progressive-review/src/server/bug-report.test.ts
+++ b/packages/progressive-review/src/server/bug-report.test.ts
@@ -475,10 +475,15 @@ function diagnostics(): BugReportPayload["diagnostics"] {
   };
 }
 
-interface CapturedPart {
-  name: string;
-  value: string | { filename: string; type: string; bytes: Buffer };
+interface CapturedFile {
+  filename: string;
+  type: string;
+  bytes: Buffer;
 }
+
+type CapturedPart =
+  | { name: string; text: string }
+  | { name: string; file: CapturedFile };
 
 interface CapturedFetch {
   fetchImpl: typeof fetch;
@@ -500,24 +505,25 @@ function captureFetch(): CapturedFetch {
     const form = init?.body;
     if (!(form instanceof FormData)) throw new Error("Expected FormData.");
     for (const [name, value] of form.entries()) {
-      capturedParts.push({
-        name,
-        value:
-          typeof value === "string"
-            ? value
-            : {
+      capturedParts.push(
+        value instanceof File
+          ? {
+              name,
+              file: {
                 filename: value.name,
                 type: value.type,
                 bytes: Buffer.from(await value.arrayBuffer()),
               },
-      });
+            }
+          : { name, text: value },
+      );
     }
     return successResponse();
   };
   const part = (name: string) => {
     const result = capturedParts.find((candidate) => candidate.name === name);
     if (!result) throw new Error(`Missing captured ${name} part.`);
-    return result.value;
+    return result;
   };
   return {
     fetchImpl,
@@ -525,23 +531,23 @@ function captureFetch(): CapturedFetch {
     headers: () => headers ?? new Headers(),
     parts: () => capturedParts,
     textPart: (name) => {
-      const value = part(name);
-      if (typeof value !== "string") throw new Error(`${name} is not text.`);
-      return value;
+      const captured = part(name);
+      if (!("text" in captured)) throw new Error(`${name} is not text.`);
+      return captured.text;
     },
     filePart: (name) => {
-      const value = part(name);
-      if (typeof value === "string") throw new Error(`${name} is not a file.`);
-      return value.bytes;
+      const captured = part(name);
+      if (!("file" in captured)) throw new Error(`${name} is not a file.`);
+      return captured.file.bytes;
     },
     fileParts: (name) =>
       capturedParts
         .filter((candidate) => candidate.name === name)
         .map((candidate) => {
-          if (typeof candidate.value === "string") {
+          if (!("file" in candidate)) {
             throw new Error(`${name} is not a file.`);
           }
-          return candidate.value.bytes;
+          return candidate.file.bytes;
         }),
   };
 }

--- a/packages/progressive-review/src/server/desktop-host-shutdown.ts
+++ b/packages/progressive-review/src/server/desktop-host-shutdown.ts
@@ -1,12 +1,20 @@
+import {
+  type JsonValue,
+  isJsonObject,
+  jsonBoolean,
+  jsonProperty,
+  jsonString,
+} from "@dev.fast/review-protocol";
+
 interface DesktopHostMessagePort {
-  on(event: "message", listener: (event: { data: unknown }) => void): void;
-  off(event: "message", listener: (event: { data: unknown }) => void): void;
+  on(event: "message", listener: (event: { data: JsonValue }) => void): void;
+  off(event: "message", listener: (event: { data: JsonValue }) => void): void;
 }
 
 interface DesktopHostProcess {
   parentPort?: DesktopHostMessagePort;
-  on(event: "message", listener: (message: unknown) => void): void;
-  off(event: "message", listener: (message: unknown) => void): void;
+  on(event: "message", listener: (message: JsonValue) => void): void;
+  off(event: "message", listener: (message: JsonValue) => void): void;
 }
 
 export function listenForDesktopHostShutdown(
@@ -15,37 +23,26 @@ export function listenForDesktopHostShutdown(
   onTelemetrySetting?: (enabled: boolean) => void,
   onStageRustAnalyzer?: (path: string) => void,
 ): () => void {
-  const handleMessage = (message: unknown) => {
-    if (
-      message &&
-      typeof message === "object" &&
-      (message as { type?: unknown }).type === "shutdown"
-    ) {
+  const handleMessage = (message: JsonValue) => {
+    if (!isJsonObject(message)) return;
+    const type = jsonProperty(message, "type");
+    if (type === "shutdown") {
       onShutdown();
       return;
     }
-    if (
-      message &&
-      typeof message === "object" &&
-      (message as { type?: unknown }).type === "telemetry-setting" &&
-      typeof (message as { enabled?: unknown }).enabled === "boolean"
-    ) {
-      onTelemetrySetting?.((message as { enabled: boolean }).enabled);
+    if (type === "telemetry-setting") {
+      const enabled = jsonBoolean(jsonProperty(message, "enabled"));
+      if (enabled !== undefined) onTelemetrySetting?.(enabled);
       return;
     }
-    if (
-      message &&
-      typeof message === "object" &&
-      (message as { type?: unknown }).type === "stage-rust-analyzer" &&
-      typeof (message as { path?: unknown }).path === "string" &&
-      (message as { path: string }).path.length > 0
-    ) {
-      onStageRustAnalyzer?.((message as { path: string }).path);
+    if (type === "stage-rust-analyzer") {
+      const path = jsonString(jsonProperty(message, "path"));
+      if (path) onStageRustAnalyzer?.(path);
     }
   };
 
   if (hostProcess.parentPort) {
-    const handleParentMessage = (event: { data: unknown }) => {
+    const handleParentMessage = (event: { data: JsonValue }) => {
       handleMessage(event.data);
     };
     hostProcess.parentPort.on("message", handleParentMessage);

--- a/packages/progressive-review/src/server/desktop-paths.ts
+++ b/packages/progressive-review/src/server/desktop-paths.ts
@@ -25,9 +25,9 @@ export function reviewDesktopStateDir(
   return path.join(reviewDesktopRoot(env), "state");
 }
 
-export async function writePrivateJsonAtomic(
+export async function writePrivateJsonAtomic<T>(
   filePath: string,
-  value: unknown,
+  value: T,
 ): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
   await writeFileAtomicAsync(filePath, `${JSON.stringify(value, null, 2)}\n`, {

--- a/packages/progressive-review/src/server/desktop-server-tutorial.test.ts
+++ b/packages/progressive-review/src/server/desktop-server-tutorial.test.ts
@@ -481,8 +481,8 @@ describe("Review Desktop tutorial preparation", () => {
         expect(stored?.review.status).toBe(
           action === "submit" ? "accepted" : "awaiting-review",
         );
-        expect(typeof stored?.review.dismissedAt).toBe(
-          action === "dismiss" ? "string" : "undefined",
+        expect(stored?.review.dismissedAt !== undefined).toBe(
+          action === "dismiss",
         );
       } finally {
         release();

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -2,11 +2,13 @@ import crypto from "node:crypto";
 import { existsSync } from "node:fs";
 import { readFile, readdir, rm, stat } from "node:fs/promises";
 import { type Server, createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import {
   type JsonObject,
+  type JsonValue,
   REVIEW_DESKTOP_DISCOVERY_VERSION,
   type ReviewDescriptor,
   type ReviewDesktopDiscovery,
@@ -18,6 +20,11 @@ import {
   type ReviewVerbRequest,
   type ReviewView,
   isJsonObject,
+  isObjectValue,
+  jsonBoolean,
+  jsonNumber,
+  jsonProperty,
+  jsonString,
   parseReviewCliInstallApplyRequest,
   parseReviewPublishReadyRequest,
   reviewViewSchema,
@@ -429,15 +436,12 @@ export function createGlobalReviewServer(
     /* A background open keeps the canvas where it is: the Source tab opens
        sessions purely to root its file tree. Body-less requests (the CLI)
        stay foreground. */
-    const openBody = (await readBoundedRequestJson(
+    const openBodyValue = await readBoundedRequestJson(
       context.req.raw,
       undefined,
       null,
-    )) as {
-      background?: unknown;
-      revision?: unknown;
-      view?: unknown;
-    } | null;
+    );
+    const openBody = isJsonObject(openBodyValue) ? openBodyValue : null;
     const background = openBody?.background === true;
     const parsedView = reviewViewSchema.safeParse(openBody?.view);
     if (openBody?.view !== undefined && !parsedView.success) {
@@ -471,10 +475,13 @@ export function createGlobalReviewServer(
         "review_unpublished",
       );
     }
+    const revisionValue = openBody
+      ? jsonProperty(openBody, "revision")
+      : undefined;
+    const revision = jsonString(revisionValue);
     if (
-      openBody?.revision !== undefined &&
-      (typeof openBody.revision !== "string" ||
-        !/^[0-9a-f]{40}$/.test(openBody.revision))
+      revisionValue !== undefined &&
+      (revision === undefined || !/^[0-9a-f]{40}$/.test(revision))
     ) {
       throw new ReviewServerError(
         "Review revision must be a 40-character hexadecimal commit ID.",
@@ -483,9 +490,9 @@ export function createGlobalReviewServer(
       );
     }
     const requestedRevision =
-      typeof openBody?.revision === "string" &&
-      openBody.revision !== review.review.presentedDocumentRevision
-        ? openBody.revision
+      revision !== undefined &&
+      revision !== review.review.presentedDocumentRevision
+        ? revision
         : undefined;
     if (requestedRevision) {
       return openHistoricalReviewSession(
@@ -663,19 +670,18 @@ export function createGlobalReviewServer(
     globalJson(200, await readReviewPreferences()),
   );
   app.put("/preferences", async (context) => {
-    const body = (await readBoundedRequestJson(context.req.raw)) as {
-      dismissedRetentionDays?: unknown;
-    };
-    const value = body.dismissedRetentionDays;
-    if (value !== null && typeof value !== "number") {
+    const body = await readBoundedRequestJson(context.req.raw);
+    const value = isJsonObject(body)
+      ? jsonProperty(body, "dismissedRetentionDays")
+      : undefined;
+    const dismissedRetentionDays = value === null ? null : jsonNumber(value);
+    if (dismissedRetentionDays === undefined) {
       throw new ReviewServerError(
         "dismissedRetentionDays must be a number or null.",
         400,
       );
     }
-    const saved = await writeReviewPreferences({
-      dismissedRetentionDays: value,
-    });
+    const saved = await writeReviewPreferences({ dismissedRetentionDays });
     broadcastGlobal({ event: "preferences-changed", preferences: saved });
     return globalJson(200, saved);
   });
@@ -2148,7 +2154,7 @@ function latestAgentSessionWithRole(
     )[0]?.[0];
 }
 
-function parseInfoRequest(input: unknown): RunReviewInfoInput {
+function parseInfoRequest(input: JsonValue): RunReviewInfoInput {
   if (!isJsonObject(input)) {
     throw new HttpJsonError("Info request must be an object.", 400);
   }
@@ -2156,27 +2162,29 @@ function parseInfoRequest(input: unknown): RunReviewInfoInput {
   if (Object.keys(input).some((key) => !allowed.has(key))) {
     throw new HttpJsonError("Info request has unexpected fields.", 400);
   }
-  if (typeof input.cwd !== "string" || !input.cwd.trim()) {
+  const cwd = jsonString(jsonProperty(input, "cwd"));
+  if (cwd === undefined || !cwd.trim()) {
     throw new HttpJsonError("Info request requires cwd.", 400);
   }
-  if (input.all !== undefined && typeof input.all !== "boolean") {
+  const all = jsonProperty(input, "all");
+  if (all !== undefined && jsonBoolean(all) === undefined) {
     throw new HttpJsonError("Info all must be boolean.", 400);
   }
+  const reviewUuidValue = jsonProperty(input, "reviewUuid");
+  const reviewUuid = jsonString(reviewUuidValue);
   if (
-    input.reviewUuid !== undefined &&
-    (typeof input.reviewUuid !== "string" || !input.reviewUuid.trim())
+    reviewUuidValue !== undefined &&
+    (reviewUuid === undefined || !reviewUuid.trim())
   ) {
     throw new HttpJsonError("Info reviewUuid must be a non-empty string.", 400);
   }
-  if (input.all === true && input.reviewUuid !== undefined) {
+  if (all === true && reviewUuidValue !== undefined) {
     throw new HttpJsonError("Info all and reviewUuid cannot be combined.", 400);
   }
   return {
-    cwd: input.cwd,
-    ...(input.all ? { all: true } : {}),
-    ...(typeof input.reviewUuid === "string"
-      ? { reviewUuid: input.reviewUuid.trim() }
-      : {}),
+    cwd,
+    ...(all ? { all: true } : {}),
+    ...(reviewUuid !== undefined ? { reviewUuid: reviewUuid.trim() } : {}),
   };
 }
 
@@ -2396,11 +2404,11 @@ async function setReviewStatus(
   return { ...stored, review };
 }
 
-function httpJsonStatus(error: unknown): number {
-  return error instanceof HttpJsonError ? error.statusCode : 400;
+function httpJsonStatus(cause: unknown): number {
+  return cause instanceof HttpJsonError ? cause.statusCode : 400;
 }
 
-function globalJson(status: number, body: unknown): Response {
+function globalJson<T>(status: number, body: T): Response {
   return jsonResponse(body, status as ContentfulStatusCode, {
     cacheControl: "no-store",
   });
@@ -2412,7 +2420,7 @@ function listen(server: Server, port: number): Promise<number> {
     server.listen(port, "127.0.0.1", () => {
       server.off("error", reject);
       const address = server.address();
-      if (typeof address !== "object" || address === null) {
+      if (!isTcpAddress(address)) {
         reject(new Error("The Review server did not bind a TCP port."));
         return;
       }
@@ -2451,6 +2459,13 @@ async function removeMatchingDiscovery(
   }
 }
 
-function toError(value: unknown): Error {
-  return value instanceof Error ? value : new Error(String(value));
+/** `server.address()` is a string for pipe and socket listeners. */
+function isTcpAddress(
+  address: string | AddressInfo | null,
+): address is AddressInfo {
+  return isObjectValue(address);
+}
+
+function toError(cause: unknown): Error {
+  return cause instanceof Error ? cause : new Error(String(cause));
 }

--- a/packages/progressive-review/src/server/doc-bundler.ts
+++ b/packages/progressive-review/src/server/doc-bundler.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { type Message, type Plugin, build } from "esbuild";
+import { type BuildFailure, type Plugin, build } from "esbuild";
 
 import {
   type ReviewDocumentDiagnostic,
@@ -250,21 +250,24 @@ function entryModuleSource(input: {
   ].join("\n");
 }
 
+function isBuildFailure(cause: unknown): cause is BuildFailure {
+  return (
+    cause instanceof Error && "errors" in cause && Array.isArray(cause.errors)
+  );
+}
+
 function esbuildDiagnostics(
-  error: unknown,
+  cause: unknown,
   fallbackFilePath: string,
 ): ReviewDocumentDiagnostic[] {
-  const messages =
-    error && typeof error === "object" && "errors" in error
-      ? (error.errors as Message[])
-      : [];
+  const messages = isBuildFailure(cause) ? cause.errors : [];
   if (messages.length === 0) {
     return [
       {
         source: "review",
         severity: "error",
         code: "bundle",
-        message: error instanceof Error ? error.message : String(error),
+        message: cause instanceof Error ? cause.message : String(cause),
         filePath: fallbackFilePath,
       },
     ];

--- a/packages/progressive-review/src/server/global-verb-relay.ts
+++ b/packages/progressive-review/src/server/global-verb-relay.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 
 import {
+  type JsonValue,
   type ReviewVerbRequest,
   type ReviewVerbResponse,
   parseReviewDesktopVerbResult,
@@ -41,7 +42,7 @@ export class GlobalReviewDesktopVerbRelay {
     return true;
   }
 
-  dispatch(sessionId: string, value: unknown): Promise<ReviewVerbResponse> {
+  dispatch(sessionId: string, value: JsonValue): Promise<ReviewVerbResponse> {
     const request: ReviewVerbRequest = parseReviewVerbRequest(value);
     const control = this.controlWriter;
     if (!control) {
@@ -69,7 +70,7 @@ export class GlobalReviewDesktopVerbRelay {
     });
   }
 
-  acceptResult(value: unknown): boolean {
+  acceptResult(value: JsonValue): boolean {
     const result = parseReviewDesktopVerbResult(value);
     const pending = this.pending.get(result.id);
     if (!pending || pending.sessionId !== result.sessionId) return false;

--- a/packages/progressive-review/src/server/hono-http.ts
+++ b/packages/progressive-review/src/server/hono-http.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 
+import { type JsonValue, parseJsonText } from "@dev.fast/review-protocol";
 import { type HttpBindings, getRequestListener } from "@hono/node-server";
 import type { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -18,8 +19,8 @@ export function createNodeRequestListener(
   return getRequestListener(app.fetch);
 }
 
-export function jsonResponse(
-  body: unknown,
+export function jsonResponse<T>(
+  body: T,
   status: ContentfulStatusCode,
   options: {
     cacheControl?: string;
@@ -93,9 +94,9 @@ export function isAuthorizedRequest(
 export async function readBoundedRequestJson(
   request: Request,
   maxBytes = DEFAULT_MAX_REQUEST_BYTES,
-  emptyValue?: unknown,
+  emptyValue?: JsonValue,
   options: { allowTextPlain?: boolean } = {},
-): Promise<unknown> {
+): Promise<JsonValue> {
   assertJsonContentType(request, options);
   const contentLength = Number(request.headers.get("content-length"));
   if (Number.isFinite(contentLength) && contentLength > maxBytes) {
@@ -125,7 +126,7 @@ export async function readBoundedRequestJson(
   const body = Buffer.concat(chunks).toString("utf8");
   if (!body && emptyValue !== undefined) return emptyValue;
   try {
-    return JSON.parse(body) as unknown;
+    return parseJsonText(body);
   } catch {
     throw new HttpJsonError("Invalid JSON body.", 400);
   }

--- a/packages/progressive-review/src/server/review-api-parsers.test.ts
+++ b/packages/progressive-review/src/server/review-api-parsers.test.ts
@@ -1,3 +1,4 @@
+import type { JsonValue } from "@dev.fast/review-protocol";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -82,7 +83,7 @@ describe("parseReviewBugReportInput", () => {
   });
 });
 
-function expectBugReportStatus(value: unknown, statusCode: number) {
+function expectBugReportStatus(value: JsonValue, statusCode: number) {
   let thrown: unknown;
   try {
     parseReviewBugReportInput(value);

--- a/packages/progressive-review/src/server/review-api-parsers.ts
+++ b/packages/progressive-review/src/server/review-api-parsers.ts
@@ -1,5 +1,6 @@
 import {
   CreateReviewCommentInputSchema,
+  type JsonValue,
   ReviewBugReportRequestSchema,
   ReviewDiffFilesRequestSchema,
   ReviewThreadsCommandSchema,
@@ -52,7 +53,7 @@ export const SoftwareMapLineRangeInputSchema = z
   .strictObject(softwareMapLineRangeShape)
   .superRefine(validateSoftwareMapLineRange);
 
-export function parseReviewBugReportInput(value: unknown) {
+export function parseReviewBugReportInput(value: JsonValue) {
   const parsed = ReviewBugReportRequestSchema.parse(value);
   if (
     Buffer.byteLength(parsed.description, "utf8") >
@@ -168,15 +169,15 @@ export const UpdateReviewCommentInputSchema = z.strictObject({
   messageId: nonEmptyStringSchema.optional(),
 });
 
-export function requestJsonErrorStatus(error: unknown): number {
-  return error instanceof HttpJsonError ? error.statusCode : 400;
+export function requestJsonErrorStatus(cause: unknown): number {
+  return cause instanceof HttpJsonError ? cause.statusCode : 400;
 }
 
-export function parseCodePeekRoot(value: unknown) {
+export function parseCodePeekRoot(value: JsonValue) {
   return parseZod(CodePeekRootInputSchema, value, "CodePeek root");
 }
 
-export function parseSoftwareMapCodeElements(value: unknown) {
+export function parseSoftwareMapCodeElements(value: JsonValue) {
   if (!Array.isArray(value)) {
     throw new Error("SoftwareMap codeElements must be an array");
   }
@@ -187,7 +188,7 @@ export function parseSoftwareMapCodeElements(value: unknown) {
   );
 }
 
-export function parseSoftwareMapCoverageClaims(value: unknown) {
+export function parseSoftwareMapCoverageClaims(value: JsonValue | undefined) {
   if (value === undefined) return [];
   if (!Array.isArray(value)) {
     throw new Error("SoftwareMap coverageClaims must be an array");
@@ -200,13 +201,13 @@ export function parseSoftwareMapCoverageClaims(value: unknown) {
 }
 
 export function parseReviewSubmissionInput(
-  value: unknown,
+  value: JsonValue,
 ): CreateReviewSubmissionInput {
   return parseZod(ReviewSubmissionInputSchema, value, "Review submission");
 }
 
 export function parseReviewTabTelemetryInput(
-  value: unknown,
+  value: JsonValue,
 ): ReviewTabTelemetryEvent {
   return parseZod(
     ReviewTabTelemetryInputSchema,
@@ -215,7 +216,7 @@ export function parseReviewTabTelemetryInput(
   );
 }
 
-export function parseReviewDiffFilesInput(value: unknown) {
+export function parseReviewDiffFilesInput(value: JsonValue) {
   const input = parseZod(ReviewDiffFilesRequestSchema, value);
   return {
     includePatch: input.includePatch !== false,
@@ -225,17 +226,17 @@ export function parseReviewDiffFilesInput(value: unknown) {
 }
 
 export function parseReviewCommentInput(
-  value: unknown,
+  value: JsonValue,
 ): CreateReviewCommentInput {
   return parseZod(CreateReviewCommentInputSchema, value, "Review comment");
 }
 
-export function parseReviewThreadsCommand(value: unknown) {
+export function parseReviewThreadsCommand(value: JsonValue) {
   return parseZod(ReviewThreadsCommandSchema, value, "Review thread command");
 }
 
 export function parseUpdateReviewCommentInput(
-  value: unknown,
+  value: JsonValue,
 ): UpdateReviewCommentInput {
   return parseZod(UpdateReviewCommentInputSchema, value, "Comment update");
 }
@@ -253,6 +254,9 @@ export function parseReviewCommentMessagePath(
   };
 }
 
-export function parseThreadTarget(value: unknown, label: string): ThreadTarget {
+export function parseThreadTarget(
+  value: JsonValue,
+  label: string,
+): ThreadTarget {
   return parseZod(ThreadTargetSchema, value, label, true);
 }

--- a/packages/progressive-review/src/server/review-api.ts
+++ b/packages/progressive-review/src/server/review-api.ts
@@ -11,11 +11,13 @@ import {
 } from "@dev.fast/local-vcs";
 import {
   type JsonObject,
+  type JsonValue,
   type ReviewCommentThreadRecord,
   type ReviewSessionWire,
   type ReviewThreadsCommit,
   type ReviewVerbRequest,
   isJsonObject,
+  jsonString,
   parseReviewFileContentRequest,
 } from "@dev.fast/review-protocol";
 import { type Context, Hono } from "hono";
@@ -110,9 +112,9 @@ function recordClientError(
   event: ReturnType<typeof sanitizeUiTelemetryEvent>,
 ): void {
   if (event?.event !== "review_client_error") return;
-  const sessionId = event.properties.app_session_id;
-  const errorName = event.properties.error_name;
-  if (typeof sessionId !== "string" || typeof errorName !== "string") return;
+  const sessionId = jsonString(event.properties.app_session_id);
+  const errorName = jsonString(event.properties.error_name);
+  if (sessionId === undefined || errorName === undefined) return;
   const names = clientErrorsBySession.get(sessionId) ?? [];
   names.push(errorName);
   if (names.length > MAX_CLIENT_ERRORS_PER_SESSION) names.shift();
@@ -120,7 +122,7 @@ function recordClientError(
   clientErrorsBySession.set(sessionId, names);
   while (clientErrorsBySession.size > MAX_CLIENT_ERROR_SESSIONS) {
     const oldest = clientErrorsBySession.keys().next().value;
-    if (typeof oldest !== "string") break;
+    if (oldest === undefined) break;
     clientErrorsBySession.delete(oldest);
   }
 }
@@ -154,8 +156,8 @@ export interface ReviewTelemetryCapture {
 export async function captureSanitizedUiTelemetry(
   telemetry: ReviewTelemetryCapture,
   request: Request,
-  name: unknown,
-  properties: unknown,
+  name: JsonValue,
+  properties: JsonValue,
   onSanitized?: (
     event: NonNullable<ReturnType<typeof sanitizeUiTelemetryEvent>>,
   ) => void,
@@ -166,7 +168,7 @@ export async function captureSanitizedUiTelemetry(
    * the original message, and bundle-relative frames. The allowlist re-checks
    * all of it. Never merge this into `properties`.
    */
-  rawError?: unknown,
+  rawError?: JsonValue,
 ): Promise<void> {
   const appSessionId =
     request.headers.get(REVIEW_APP_SESSION_ID_HEADER) ?? undefined;
@@ -928,11 +930,12 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     context: Context<ReviewHonoEnv>,
   ): Promise<Response> {
     const url = new URL(context.req.url);
-    const contentRequest = parseReviewFileContentRequest({
-      path: url.searchParams.get("path") ?? undefined,
-      side: url.searchParams.get("side") ?? undefined,
-      commit: url.searchParams.get("commit") ?? undefined,
-    });
+    const contentQuery: JsonObject = {};
+    for (const key of ["path", "side", "commit"]) {
+      const value = url.searchParams.get(key);
+      if (value !== null) contentQuery[key] = value;
+    }
+    const contentRequest = parseReviewFileContentRequest(contentQuery);
     const diffTarget = await resolveScopedDiffTarget(
       url,
       contentRequest.commit,
@@ -1018,11 +1021,23 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   };
 }
 
-function parseCodePeekGraph(value: unknown): "head" | "base" {
+function parseCodePeekGraph(value: JsonValue): "head" | "base" {
   return value === "base" ? "base" : "head";
 }
 
-function readJson(request: Request): Promise<unknown> {
+function parseCodePeekIncludeDiff(value: JsonValue): boolean {
+  return value === true;
+}
+
+function parseCodePeekIncludeDiffSummary(value: JsonValue): boolean {
+  return value === true;
+}
+
+function readReviewStatus(stateReviewPath: string): string {
+  return readReviewStoreRecord(path.dirname(stateReviewPath)).status;
+}
+
+function readJson(request: Request): Promise<JsonValue> {
   return readBoundedRequestJson(request, undefined, {});
 }
 

--- a/packages/progressive-review/src/server/session-handler.ts
+++ b/packages/progressive-review/src/server/session-handler.ts
@@ -10,6 +10,7 @@ import {
   type ReviewSessionWire,
   type ReviewThreadsCommit,
   type ReviewVerbRequest,
+  jsonString,
 } from "@dev.fast/review-protocol";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
@@ -142,10 +143,7 @@ export async function createReviewSessionHandler(
                 presentationSessionId: input.sessionId,
               },
               {
-                appSessionId:
-                  typeof properties.app_session_id === "string"
-                    ? properties.app_session_id
-                    : undefined,
+                appSessionId: jsonString(properties.app_session_id),
               },
             );
             return;

--- a/packages/progressive-review/src/server/tutorial-service.ts
+++ b/packages/progressive-review/src/server/tutorial-service.ts
@@ -13,6 +13,13 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 import { resolveRevision } from "@dev.fast/local-vcs";
+import {
+  type JsonValue,
+  isJsonObject,
+  jsonProperty,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
 
 import {
   type ReviewAgentHarness,
@@ -288,17 +295,16 @@ async function readShippedMapManifest(
     "software-map",
     "manifest.json",
   );
-  const value = JSON.parse(await readFile(manifestPath, "utf8")) as {
-    headCommit?: unknown;
-    baseCommit?: unknown;
-  };
-  if (
-    typeof value.headCommit !== "string" ||
-    typeof value.baseCommit !== "string"
-  ) {
+  const value = parseJsonText(await readFile(manifestPath, "utf8"));
+  const manifest = isJsonObject(value) ? value : undefined;
+  const headCommit =
+    manifest && jsonString(jsonProperty(manifest, "headCommit"));
+  const baseCommit =
+    manifest && jsonString(jsonProperty(manifest, "baseCommit"));
+  if (headCommit === undefined || baseCommit === undefined) {
     throw new Error("Tutorial software-map manifest is invalid.");
   }
-  return { headCommit: value.headCommit, baseCommit: value.baseCommit };
+  return { headCommit, baseCommit };
 }
 
 async function isValidTutorialReview(
@@ -342,13 +348,12 @@ async function readTutorialStamp(
   stampPath: string,
 ): Promise<TutorialStamp | null> {
   try {
-    const value = JSON.parse(await readFile(stampPath, "utf8")) as {
-      version?: unknown;
-      reviewUuid?: unknown;
-    };
-    return value.version === TUTORIAL_STAMP_VERSION &&
-      typeof value.reviewUuid === "string"
-      ? { version: TUTORIAL_STAMP_VERSION, reviewUuid: value.reviewUuid }
+    const value = parseJsonText(await readFile(stampPath, "utf8"));
+    if (!isJsonObject(value)) return null;
+    const reviewUuid = jsonString(jsonProperty(value, "reviewUuid"));
+    return jsonProperty(value, "version") === TUTORIAL_STAMP_VERSION &&
+      reviewUuid !== undefined
+      ? { version: TUTORIAL_STAMP_VERSION, reviewUuid }
       : null;
   } catch {
     return null;
@@ -382,32 +387,44 @@ interface TutorialRuntimeManifest {
 async function readTutorialRuntimeManifest(
   assetsRoot: string,
 ): Promise<TutorialRuntimeManifest> {
-  const value = JSON.parse(
+  const value = parseJsonText(
     await readFile(path.join(assetsRoot, "runtime-manifest.json"), "utf8"),
-  ) as Partial<TutorialRuntimeManifest>;
-  const validEntries = (entries: unknown): entries is string[] =>
-    Array.isArray(entries) &&
-    entries.length > 0 &&
-    entries.every(
-      (entry) =>
-        typeof entry === "string" &&
-        entry.length > 0 &&
-        !path.isAbsolute(entry) &&
-        !entry.split(/[\\/]/u).includes(".."),
-    );
+  );
+  const manifest = isJsonObject(value) ? value : undefined;
+  const reviewFiles = manifest && jsonProperty(manifest, "reviewFiles");
+  const requiredPaths = manifest && jsonProperty(manifest, "requiredPaths");
   if (
-    value.version !== 1 ||
-    !validEntries(value.reviewFiles) ||
-    !validEntries(value.requiredPaths) ||
-    value.reviewFiles.some((entry) => !value.requiredPaths!.includes(entry))
+    !manifest ||
+    jsonProperty(manifest, "version") !== 1 ||
+    !isRelativePathList(reviewFiles) ||
+    !isRelativePathList(requiredPaths) ||
+    reviewFiles.some((entry) => !requiredPaths.includes(entry))
   ) {
     throw new Error("Tutorial runtime manifest is invalid.");
   }
   return {
     version: 1,
-    reviewFiles: [...new Set(value.reviewFiles)],
-    requiredPaths: [...new Set(value.requiredPaths)],
+    reviewFiles: [...new Set(reviewFiles)],
+    requiredPaths: [...new Set(requiredPaths)],
   };
+}
+
+function isRelativePathList(
+  entries: JsonValue | undefined,
+): entries is string[] {
+  return (
+    Array.isArray(entries) &&
+    entries.length > 0 &&
+    entries.every((entry) => {
+      const relativePath = jsonString(entry);
+      return (
+        relativePath !== undefined &&
+        relativePath.length > 0 &&
+        !path.isAbsolute(relativePath) &&
+        !relativePath.split(/[\\/]/u).includes("..")
+      );
+    })
+  );
 }
 
 async function isManagedTutorialPath(

--- a/packages/progressive-review/src/software-map-bundle.ts
+++ b/packages/progressive-review/src/software-map-bundle.ts
@@ -3,9 +3,14 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { type JsonValue, parseJsonText } from "@dev.fast/review-protocol";
 import { init as initModuleLexer, parse as parseModule } from "es-module-lexer";
+import { z } from "zod";
 
-import type { NormalizedSoftwareModel } from "./software-map-model";
+import {
+  type NormalizedSoftwareModel,
+  isNormalizedSoftwareModel,
+} from "./software-map-model";
 
 export const REVIEW_SOFTWARE_MAP_BUNDLE_DIR = path.join(
   ".bundle",
@@ -16,11 +21,17 @@ const BASE_MAP_FILE = "base-map.js";
 const MANIFEST_FILE = "manifest.json";
 const MANIFEST_VERSION = 1;
 
-interface SoftwareMapBundleManifest {
-  version: number;
-  headCommit: string;
-  baseCommit: string;
-}
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+const SoftwareMapBundleManifestSchema = z.object({
+  version: z.literal(MANIFEST_VERSION),
+  headCommit: z.string().regex(COMMIT_SHA_PATTERN),
+  baseCommit: z.string().regex(COMMIT_SHA_PATTERN),
+});
+
+type SoftwareMapBundleManifest = z.infer<
+  typeof SoftwareMapBundleManifestSchema
+>;
 
 export interface ReviewSoftwareMapBundle {
   headCode: string;
@@ -154,8 +165,8 @@ export async function extractLegacyReviewSoftwareMapBundle(input: {
     defineActors: identity,
     defineAnchors: identity,
     defineStores: identity,
-    defineSoftwareActors: (_model: unknown, value: unknown) => value,
-    defineSoftwareStores: (_model: unknown, value: unknown) => value,
+    defineSoftwareActors: <M, T>(_model: M, value: T): T => value,
+    defineSoftwareStores: <M, T>(_model: M, value: T): T => value,
   };
   const runtime = {
     createActiveReviewDocument(value: typeof captured) {
@@ -245,34 +256,12 @@ function bundleHash(headCode: string, baseCode: string): string {
 }
 
 function parseManifest(raw: string): SoftwareMapBundleManifest | null {
-  let value: unknown;
+  let value: JsonValue;
   try {
-    value = JSON.parse(raw);
+    value = parseJsonText(raw);
   } catch {
     return null;
   }
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const manifest = value as Partial<SoftwareMapBundleManifest>;
-  if (
-    manifest.version !== MANIFEST_VERSION ||
-    typeof manifest.headCommit !== "string" ||
-    !/^[0-9a-f]{40}$/i.test(manifest.headCommit) ||
-    typeof manifest.baseCommit !== "string" ||
-    !/^[0-9a-f]{40}$/i.test(manifest.baseCommit)
-  ) {
-    return null;
-  }
-  return manifest as SoftwareMapBundleManifest;
-}
-
-function isNormalizedSoftwareModel(
-  value: unknown,
-): value is NormalizedSoftwareModel {
-  return Boolean(
-    value &&
-    typeof value === "object" &&
-    Array.isArray((value as NormalizedSoftwareModel).elements) &&
-    (value as NormalizedSoftwareModel).elementsByPath instanceof Map &&
-    Array.isArray((value as NormalizedSoftwareModel).relationships),
-  );
+  const manifest = SoftwareMapBundleManifestSchema.safeParse(value);
+  return manifest.success ? manifest.data : null;
 }

--- a/packages/progressive-review/src/software-map-health.ts
+++ b/packages/progressive-review/src/software-map-health.ts
@@ -16,7 +16,10 @@ import {
   writeFileIfChangedSync,
 } from "./software-map-artifact";
 import { collectSoftwareMapCoverageErrors } from "./software-map-coverage-validation";
-import type { NormalizedSoftwareModel } from "./software-map-model";
+import {
+  type NormalizedSoftwareModel,
+  isNormalizedSoftwareModel,
+} from "./software-map-model";
 
 export interface SoftwareMapSourceCheck {
   canonicalSource: string;
@@ -173,16 +176,12 @@ export async function loadSoftwareMap(
   source: string,
   mapPath: string,
 ): Promise<NormalizedSoftwareModel> {
-  const module = (await importWithLocalizedModelImport({
+  const model = await importWithLocalizedModelImport({
     rootPath,
     source,
     basename: path.basename(mapPath),
-  })) as {
-    default?: unknown;
-    softwareMap?: unknown;
-  };
-  const model = module.default ?? module.softwareMap;
-  if (!isNormalizedSoftwareModel(model)) {
+  });
+  if (!model) {
     throw new Error(`${mapPath} must default-export defineSoftwareMap({...}).`);
   }
   return model;
@@ -197,7 +196,7 @@ async function importWithLocalizedModelImport(input: {
   rootPath: string;
   source: string;
   basename: string;
-}): Promise<unknown> {
+}): Promise<NormalizedSoftwareModel | null> {
   const gitDir = gitCommonDirSync(input.rootPath);
   if (!gitDir) throw new Error(`No git repository found at ${input.rootPath}`);
   // The check copy lives in a per-invocation directory (pid + random): a
@@ -221,7 +220,11 @@ async function importWithLocalizedModelImport(input: {
     );
     const url = pathToFileURL(checkPath);
     url.searchParams.set("t", String(Date.now()));
-    return await import(url.href);
+    const module: { default?: unknown; softwareMap?: unknown } = await import(
+      url.href
+    );
+    const model = module.default ?? module.softwareMap;
+    return isNormalizedSoftwareModel(model) ? model : null;
   } finally {
     rmSync(checkDir, { recursive: true, force: true });
   }
@@ -273,16 +276,4 @@ function readCommitTreeFilesSync(
     offset = end + 1;
   }
   return contents;
-}
-
-function isNormalizedSoftwareModel(
-  value: unknown,
-): value is NormalizedSoftwareModel {
-  return (
-    !!value &&
-    typeof value === "object" &&
-    Array.isArray((value as NormalizedSoftwareModel).elements) &&
-    (value as NormalizedSoftwareModel).elementsByPath instanceof Map &&
-    Array.isArray((value as NormalizedSoftwareModel).relationships)
-  );
 }

--- a/packages/progressive-review/src/software-map-model.ts
+++ b/packages/progressive-review/src/software-map-model.ts
@@ -1,3 +1,6 @@
+import { isObjectValue } from "@dev.fast/review-protocol";
+import { z } from "zod";
+
 export type SoftwareElementType =
   | "person"
   | "softwareSystem"
@@ -525,11 +528,7 @@ function validateDataStoreCollectionRecord(
   errors: string[],
 ) {
   if (collections === undefined) return;
-  if (
-    !collections ||
-    typeof collections !== "object" ||
-    Array.isArray(collections)
-  ) {
+  if (!isAuthoredObject(collections)) {
     errors.push(`Data store "${path}" ${property} must be an object.`);
     return;
   }
@@ -538,11 +537,7 @@ function validateDataStoreCollectionRecord(
       errors.push(`Data store "${path}" ${property} contains an empty id.`);
       continue;
     }
-    if (
-      !collection ||
-      typeof collection !== "object" ||
-      Array.isArray(collection)
-    ) {
+    if (!isAuthoredObject(collection)) {
       errors.push(
         `Data store "${path}" ${property}.${collectionId} must be an object.`,
       );
@@ -577,7 +572,7 @@ function validateDataStoreFieldSchema(
   path: string,
   errors: string[],
 ) {
-  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+  if (!isAuthoredObject(schema)) {
     errors.push(`${path} must be an object.`);
     return;
   }
@@ -587,7 +582,7 @@ function validateDataStoreFieldSchema(
       continue;
     }
     const fieldPath = `${path}.${field}`;
-    if (!value || typeof value !== "object" || Array.isArray(value)) {
+    if (!isAuthoredObject(value)) {
       errors.push(`${fieldPath} must be a field object or nested schema.`);
       continue;
     }
@@ -608,15 +603,12 @@ function validateDataStoreFieldSchema(
   }
 }
 
+const DataStoreFieldLeafSchema = z.object({ type: z.string() });
+
 function isDataStoreFieldLeaf(
   value: SoftwareDataStoreFieldSchema[string],
 ): value is SoftwareDataStoreFieldLeaf {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    "type" in value &&
-    typeof value.type === "string"
-  );
+  return DataStoreFieldLeafSchema.safeParse(value).success;
 }
 
 function normalizeCoverage(
@@ -642,7 +634,7 @@ function normalizeCoverage(
     errors.push(`Element "${path}" coverage.files must be an array.`);
   }
   for (const [index, file] of (coverage.files ?? []).entries()) {
-    if (typeof file === "string") {
+    if (isAuthoredString(file)) {
       if (!file.trim()) {
         errors.push(`Element "${path}" coverage.files[${index}] is empty.`);
         continue;
@@ -650,7 +642,7 @@ function normalizeCoverage(
       files.push({ path: file, ranges: [] });
       continue;
     }
-    if (!file || typeof file !== "object" || !file.path) {
+    if (!isAuthoredObject(file) || !file.path) {
       errors.push(
         `Element "${path}" coverage.files[${index}] must be a file path or object with path.`,
       );
@@ -671,7 +663,7 @@ function normalizeCoverage(
     errors.push(`Element "${path}" coverage.globs must be an array.`);
   }
   for (const [index, glob] of (coverage.globs ?? []).entries()) {
-    if (typeof glob !== "string" || !glob.trim()) {
+    if (!isAuthoredString(glob) || !glob.trim()) {
       errors.push(`Element "${path}" coverage.globs[${index}] is empty.`);
       continue;
     }
@@ -890,7 +882,7 @@ function validateSourceRanges(
   errors: string[],
 ) {
   for (const [index, range] of (sourceRanges ?? []).entries()) {
-    if (typeof range.file !== "string" || range.file.trim().length === 0) {
+    if (!isAuthoredString(range.file) || range.file.trim().length === 0) {
       errors.push(`${label}[${index}].file must be a non-empty string.`);
     }
     if (
@@ -933,4 +925,35 @@ function parentPathFor(path: string) {
   const lastDot = path.lastIndexOf(".");
   if (lastDot === -1) return undefined;
   return path.slice(0, lastDot);
+}
+
+// software-map.ts is imported as a plain module, so authored values reach the
+// normalizer without type checking. These decode a value's representation once
+// before the normalizer reads its fields.
+const AuthoredObjectSchema = z.object({});
+const AuthoredStringSchema = z.string();
+
+function isAuthoredObject<T>(value: T | undefined): value is T {
+  return AuthoredObjectSchema.safeParse(value).success;
+}
+
+function isAuthoredString(
+  value: string | SoftwareCoverageFileInput,
+): value is string {
+  return AuthoredStringSchema.safeParse(value).success;
+}
+
+/** A normalized model as a software-map module exports it (holds a Map, so not JSON). */
+export function isNormalizedSoftwareModel(
+  value: unknown,
+): value is NormalizedSoftwareModel {
+  return (
+    isObjectValue(value) &&
+    "elements" in value &&
+    Array.isArray(value.elements) &&
+    "elementsByPath" in value &&
+    value.elementsByPath instanceof Map &&
+    "relationships" in value &&
+    Array.isArray(value.relationships)
+  );
 }

--- a/packages/progressive-review/src/stored-review-migration.ts
+++ b/packages/progressive-review/src/stored-review-migration.ts
@@ -5,8 +5,11 @@ import {
   type JsonObject,
   REVIEW_SCHEMA_VERSION,
   isJsonObject,
+  jsonObject,
+  jsonString,
+  parseJsonText,
 } from "@dev.fast/review-protocol";
-import type { Expression, Program } from "estree";
+import type { Node as EstreeNode, Expression, Program } from "estree";
 
 import {
   authoringSessionKey,
@@ -66,16 +69,13 @@ async function legacyJsonRecordCount(filePath: string): Promise<number> {
     throw error;
   }
   if (!source.trim()) return 0;
-  let parsed: unknown;
+  let records: JsonObject | undefined;
   try {
-    parsed = JSON.parse(source) as unknown;
+    records = jsonObject(parseJsonText(source));
   } catch {
     return 0;
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return 0;
-  }
-  return Object.keys(parsed).length;
+  return records ? Object.keys(records).length : 0;
 }
 
 async function dropLegacyReviewState(
@@ -325,11 +325,8 @@ function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function estreeLine(value: unknown): number {
-  if (!value || typeof value !== "object") return 1;
-  const line = (value as { loc?: { start?: { line?: unknown } } | null }).loc
-    ?.start?.line;
-  return typeof line === "number" ? line : 1;
+function estreeLine(node: EstreeNode | undefined): number {
+  return node?.loc?.start.line ?? 1;
 }
 
 export async function migrateStoredReviewData(input: {
@@ -365,20 +362,13 @@ export async function migrateStoredReviewData(input: {
     const reviewDir = path.join(reviewsRoot, entry.name);
     const reviewPath = path.join(reviewDir, "review.mdx");
     try {
-      const value: unknown = JSON.parse(
-        await readFile(path.join(reviewDir, "review.json"), "utf8"),
+      const value = jsonObject(
+        parseJsonText(
+          await readFile(path.join(reviewDir, "review.json"), "utf8"),
+        ),
       );
-      const schemaVersion =
-        value && typeof value === "object" && !Array.isArray(value)
-          ? (value as { schemaVersion?: unknown }).schemaVersion
-          : undefined;
-      const worktreePath =
-        value &&
-        typeof value === "object" &&
-        !Array.isArray(value) &&
-        typeof (value as { worktreePath?: unknown }).worktreePath === "string"
-          ? (value as { worktreePath: string }).worktreePath
-          : null;
+      const schemaVersion = value?.schemaVersion;
+      const worktreePath = jsonString(value?.worktreePath);
       if (worktreePath && !cleanedLegacyRoots.has(worktreePath)) {
         cleanedLegacyRoots.add(worktreePath);
         total.legacyCheckoutsRemoved += await removeLegacyReviewCheckouts({
@@ -387,7 +377,7 @@ export async function migrateStoredReviewData(input: {
         });
       }
       if (
-        !isJsonObject(value) ||
+        !value ||
         (schemaVersion !== REVIEW_SCHEMA_VERSION &&
           schemaVersion !== 3 &&
           schemaVersion !== 2)
@@ -408,9 +398,9 @@ export async function migrateStoredReviewData(input: {
       const migratedRecord =
         parseStoredReviewRecordForMigration(migrationValue);
       if (schemaVersion === 2) {
-        const legacyRevision = value.presentedRevision;
+        const legacyRevision = jsonString(value.presentedRevision);
         try {
-          if (typeof legacyRevision === "string") {
+          if (legacyRevision !== undefined) {
             await migrateLegacyPresentedArtifacts({
               reviewDir,
               review: migratedRecord,
@@ -499,20 +489,10 @@ async function migrateReviewSourceSession(input: {
   onWarning?: (message: string) => void;
   value: JsonObject;
 }): Promise<JsonObject> {
-  const source = parseAuthoringSessionKey(
-    typeof input.value.agentSession === "string"
-      ? input.value.agentSession
-      : undefined,
-  );
-  const uuid = typeof input.value.uuid === "string" ? input.value.uuid : null;
-  const worktreePath =
-    typeof input.value.worktreePath === "string"
-      ? input.value.worktreePath
-      : null;
-  const sourceCommit =
-    typeof input.value.sourceCommit === "string"
-      ? input.value.sourceCommit
-      : null;
+  const source = parseAuthoringSessionKey(jsonString(input.value.agentSession));
+  const uuid = jsonString(input.value.uuid) ?? null;
+  const worktreePath = jsonString(input.value.worktreePath) ?? null;
+  const sourceCommit = jsonString(input.value.sourceCommit) ?? null;
   const { agentSession: _agentSession, ...record } = input.value;
   if (!source || !uuid || !worktreePath || !sourceCommit) {
     input.onWarning?.(
@@ -537,12 +517,7 @@ async function migrateReviewSourceSession(input: {
     });
     const sourceSession = authoringSessionKey(frozen);
     const now = new Date().toISOString();
-    const priorAgentSessions =
-      record.agentSessions &&
-      typeof record.agentSessions === "object" &&
-      !Array.isArray(record.agentSessions)
-        ? record.agentSessions
-        : {};
+    const priorAgentSessions = jsonObject(record.agentSessions) ?? {};
     return {
       ...record,
       agentSessions: {

--- a/packages/progressive-review/src/telemetry-config.ts
+++ b/packages/progressive-review/src/telemetry-config.ts
@@ -1,6 +1,8 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 
+import { z } from "zod";
+
 import { findProgressiveReviewPackageRoot } from "./package-paths";
 import { DEV_REVIEW_HOME_ENV, devReviewHome } from "./review-storage";
 
@@ -60,25 +62,31 @@ export function isTelemetryOptedOut(
   ].some(isEnabledEnvValue);
 }
 
+/**
+ * The on-disk install config as a hand-edited or older file may hold it: only
+ * the installation id is required, and a malformed optional field reads as
+ * absent.
+ */
+const storedTelemetryInstallConfigSchema = z.looseObject({
+  installationId: z.string().min(1),
+  createdAt: z.string().optional().catch(undefined),
+  installationCreatedSent: z.boolean().optional().catch(undefined),
+  enabled: z.boolean().optional().catch(undefined),
+  internal: z.boolean().optional().catch(undefined),
+});
+
 export function normalizeTelemetryInstallConfig(
   parsed: Partial<ProgressiveReviewTelemetryInstallConfig>,
   now: () => Date,
 ): ProgressiveReviewTelemetryInstallConfig | undefined {
-  if (
-    typeof parsed.installationId !== "string" ||
-    parsed.installationId.length === 0
-  ) {
-    return undefined;
-  }
+  const stored = storedTelemetryInstallConfigSchema.safeParse(parsed);
+  if (!stored.success) return undefined;
   return {
-    installationId: parsed.installationId,
-    createdAt:
-      typeof parsed.createdAt === "string"
-        ? parsed.createdAt
-        : now().toISOString(),
-    installationCreatedSent: Boolean(parsed.installationCreatedSent),
-    enabled: parsed.enabled !== false,
-    internal: parsed.internal === true,
+    installationId: stored.data.installationId,
+    createdAt: stored.data.createdAt ?? now().toISOString(),
+    installationCreatedSent: stored.data.installationCreatedSent === true,
+    enabled: stored.data.enabled !== false,
+    internal: stored.data.internal === true,
   };
 }
 

--- a/packages/progressive-review/src/threads-cli.ts
+++ b/packages/progressive-review/src/threads-cli.ts
@@ -5,6 +5,7 @@ import type { Writable } from "node:stream";
 import {
   ReviewCommentThreadRecordSchema,
   isJsonObject,
+  jsonString,
 } from "@dev.fast/review-protocol";
 
 import { reviewUuidForManagedCheckout } from "./review-head-checkout";
@@ -97,12 +98,9 @@ async function readAttachedReviewThread(input: {
   if (!isJsonObject(record)) {
     throw new Error("Review Desktop returned an invalid thread response.");
   }
-  const review = record.review;
+  const review = jsonString(record.review);
   const state = record.state;
-  if (
-    typeof review !== "string" ||
-    (state !== "draft" && state !== "submitted")
-  ) {
+  if (review === undefined || (state !== "draft" && state !== "submitted")) {
     throw new Error("Review Desktop returned an invalid thread response.");
   }
   if (input.reviewUuid && input.reviewUuid !== review) {

--- a/packages/progressive-review/src/trace-git-hook-runner.ts
+++ b/packages/progressive-review/src/trace-git-hook-runner.ts
@@ -163,7 +163,7 @@ async function readStdin(
   if (!stdin) return "";
   const chunks: Buffer[] = [];
   for await (const chunk of stdin) {
-    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   }
   return Buffer.concat(chunks).toString("utf8");
 }

--- a/packages/progressive-review/src/trace-hook-runner.ts
+++ b/packages/progressive-review/src/trace-hook-runner.ts
@@ -50,7 +50,7 @@ export async function runReviewTraceHook(
     try {
       const chunks: Buffer[] = [];
       for await (const chunk of input.stdin) {
-        chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
       }
       const raw = Buffer.concat(chunks).toString("utf8").trim();
       if (raw) {

--- a/packages/progressive-review/src/trace-machine-setup.ts
+++ b/packages/progressive-review/src/trace-machine-setup.ts
@@ -4,6 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
+import { parseJsonText } from "@dev.fast/review-protocol";
+import { z } from "zod";
+
 import { writeFileAtomicAsync } from "./atomic-write";
 import { clearTraceEnvCache } from "./review-agent-traces";
 
@@ -33,13 +36,14 @@ export interface TraceMachineStatus {
   error?: string;
 }
 
-interface TraceMachineSettings {
-  version: 1;
-  enabled: boolean;
-  autoActivateRepositories: true;
-  verifiedAt?: string;
-  error?: string;
-}
+const traceMachineSettingsSchema = z.object({
+  version: z.literal(1),
+  enabled: z.boolean(),
+  autoActivateRepositories: z.literal(true),
+  verifiedAt: z.string().optional(),
+  error: z.string().optional(),
+});
+type TraceMachineSettings = z.infer<typeof traceMachineSettingsSchema>;
 
 export function traceEnvPath(
   homeDir = os.homedir(),
@@ -244,12 +248,10 @@ async function readSettings(
   filePath: string,
 ): Promise<TraceMachineSettings | null> {
   try {
-    const value = JSON.parse(
-      await readFile(filePath, "utf8"),
-    ) as Partial<TraceMachineSettings>;
-    return value.version === 1 && typeof value.enabled === "boolean"
-      ? (value as TraceMachineSettings)
-      : null;
+    const parsed = traceMachineSettingsSchema.safeParse(
+      parseJsonText(await readFile(filePath, "utf8")),
+    );
+    return parsed.success ? parsed.data : null;
   } catch {
     return null;
   }

--- a/packages/progressive-review/src/trace-repository-hooks.ts
+++ b/packages/progressive-review/src/trace-repository-hooks.ts
@@ -5,6 +5,12 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
+import {
+  jsonArray,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
 const execFileAsync = promisify(execFile);
 
 interface RepositoryHookState {
@@ -300,7 +306,7 @@ async function readState(
 
 async function writePrivateJson(
   filePath: string,
-  value: unknown,
+  value: RepositoryHookState | string[],
 ): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, {
@@ -315,12 +321,10 @@ function registryPath(homeDir: string): string {
 
 async function readRegistry(homeDir: string): Promise<string[]> {
   try {
-    const value = JSON.parse(
-      await readFile(registryPath(homeDir), "utf8"),
-    ) as unknown;
-    return Array.isArray(value)
-      ? value.filter((item): item is string => typeof item === "string")
-      : [];
+    const value = parseJsonText(await readFile(registryPath(homeDir), "utf8"));
+    return (jsonArray(value) ?? [])
+      .map(jsonString)
+      .filter((item) => item !== undefined);
   } catch {
     return [];
   }

--- a/packages/progressive-review/src/tutorial-authoring-session.ts
+++ b/packages/progressive-review/src/tutorial-authoring-session.ts
@@ -1,6 +1,13 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 
+import {
+  type JsonObject,
+  jsonObject,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
 import { type ReviewAgentHarness, type SessionRef } from "./authoring-session";
 
 const TUTORIAL_AUTHORING_TIMEOUT_MS = 120_000;
@@ -107,23 +114,15 @@ export async function createTutorialAuthoringSession(input: {
 function codexThreadId(output: string): string {
   for (const line of output.split("\n")) {
     if (!line.trim()) continue;
-    let value: unknown;
+    let record: JsonObject | undefined;
     try {
-      value = JSON.parse(line);
+      record = jsonObject(parseJsonText(line));
     } catch {
       continue;
     }
-    if (
-      typeof value === "object" &&
-      value !== null &&
-      "type" in value &&
-      value.type === "thread.started" &&
-      "thread_id" in value &&
-      typeof value.thread_id === "string" &&
-      value.thread_id
-    ) {
-      return value.thread_id;
-    }
+    if (record?.type !== "thread.started") continue;
+    const threadId = jsonString(record.thread_id);
+    if (threadId) return threadId;
   }
   throw new Error("Codex did not report the tutorial source thread ID.");
 }

--- a/packages/progressive-review/src/ui-telemetry-events.test.ts
+++ b/packages/progressive-review/src/ui-telemetry-events.test.ts
@@ -43,7 +43,7 @@ describe("sanitizeUiTelemetryEvent", () => {
   });
 
   it("accepts a message only when the cleaner finished the job", () => {
-    const message = (value: string): unknown =>
+    const message = (value: string) =>
       sanitizeUiTelemetryEvent({
         name: "client_error",
         properties: { error_source: "window", message: value },
@@ -105,7 +105,7 @@ describe("sanitizeUiTelemetryEvent", () => {
   });
 
   it("requires a message hash to be a truncated hex digest", () => {
-    const hashed = (message_hash: string): unknown =>
+    const hashed = (message_hash: string) =>
       sanitizeUiTelemetryEvent({
         name: "client_error",
         properties: { error_source: "window", message_hash },

--- a/packages/progressive-review/src/ui-telemetry-events.ts
+++ b/packages/progressive-review/src/ui-telemetry-events.ts
@@ -16,7 +16,14 @@
 // accepting the property. Either the cleaner finished the job or only the
 // digest goes; a wrong producer cannot put raw text on the wire through here.
 
-import { type JsonObject, isJsonObject } from "@dev.fast/review-protocol";
+import {
+  type JsonObject,
+  isJsonObject,
+  jsonBoolean,
+  jsonNumber,
+  jsonString,
+} from "@dev.fast/review-protocol";
+import { z } from "zod";
 
 import {
   containsFilePathShape,
@@ -456,10 +463,9 @@ export function sanitizeUiTelemetryEvent(input: {
   event: string;
   properties: Record<string, string | number | boolean>;
 } | null {
-  if (typeof input.name !== "string" || !isUiTelemetryEventName(input.name)) {
-    return null;
-  }
-  const spec: UiTelemetryEventSpec = UI_TELEMETRY_EVENTS[input.name];
+  const name = z.string().safeParse(input.name);
+  if (!name.success || !isUiTelemetryEventName(name.data)) return null;
+  const spec: UiTelemetryEventSpec = UI_TELEMETRY_EVENTS[name.data];
 
   const raw: JsonObject = isJsonObject(input.properties)
     ? input.properties
@@ -472,58 +478,57 @@ export function sanitizeUiTelemetryEvent(input: {
   for (const [key, propSpec] of Object.entries(propertySpecs)) {
     const value = raw[key];
     if (value === undefined || value === null) continue;
+    const text = jsonString(value);
     if (propSpec === "number") {
-      if (typeof value === "number" && Number.isFinite(value)) {
-        properties[key] = value;
-      }
+      const number = jsonNumber(value);
+      if (number !== undefined) properties[key] = number;
       continue;
     }
     if (propSpec === "boolean") {
-      if (typeof value === "boolean") properties[key] = value;
+      const boolean = jsonBoolean(value);
+      if (boolean !== undefined) properties[key] = boolean;
       continue;
     }
     if (propSpec === "opaque_id") {
-      if (isValidReviewAppSessionId(value)) {
-        properties[key] = value;
-      }
+      if (isValidReviewAppSessionId(text)) properties[key] = text;
       continue;
     }
     if (propSpec === "release_version") {
-      if (typeof value === "string" && RELEASE_VERSION_PATTERN.test(value)) {
-        properties[key] = value;
+      if (text !== undefined && RELEASE_VERSION_PATTERN.test(text)) {
+        properties[key] = text;
       }
       continue;
     }
     if (propSpec === "enum_free_short") {
       if (
-        typeof value === "string" &&
-        value.length <= MAX_FREE_STRING_LENGTH &&
-        FREE_STRING_PATTERN.test(value)
+        text !== undefined &&
+        text.length <= MAX_FREE_STRING_LENGTH &&
+        FREE_STRING_PATTERN.test(text)
       ) {
-        properties[key] = value;
+        properties[key] = text;
       }
       continue;
     }
     if (propSpec === "hash_hex") {
-      if (typeof value === "string" && HASH_HEX_PATTERN.test(value)) {
-        properties[key] = value;
+      if (text !== undefined && HASH_HEX_PATTERN.test(text)) {
+        properties[key] = text;
       }
       continue;
     }
     if (propSpec === "bundle_frames") {
-      const frames = sanitizeBundleFrames(value);
+      const frames = sanitizeBundleFrames(text);
       if (frames) properties[key] = frames;
       continue;
     }
     if (propSpec === "cleaned_message") {
-      if (typeof value === "string" && isReportableCleanedMessage(value)) {
-        properties[key] = value;
+      if (text !== undefined && isReportableCleanedMessage(text)) {
+        properties[key] = text;
       }
       continue;
     }
-    if (Array.isArray(propSpec) && typeof value === "string") {
-      if ((propSpec as readonly string[]).includes(value)) {
-        properties[key] = value;
+    if (Array.isArray(propSpec) && text !== undefined) {
+      if ((propSpec as readonly string[]).includes(text)) {
+        properties[key] = text;
       }
     }
   }
@@ -558,8 +563,8 @@ export function isReportableCleanedMessage(value: string): boolean {
  * normalized; this is the independent second check, so it never repairs a frame
  * — it drops it. Returns undefined when nothing survives.
  */
-function sanitizeBundleFrames(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
+function sanitizeBundleFrames(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
   const kept: string[] = [];
   let length = 0;
   for (const frame of value.split(BUNDLE_FRAME_SEPARATOR)) {
@@ -573,6 +578,8 @@ function sanitizeBundleFrames(value: unknown): string | undefined {
   return kept.length > 0 ? kept.join(BUNDLE_FRAME_SEPARATOR) : undefined;
 }
 
-export function isValidReviewAppSessionId(value: unknown): value is string {
-  return typeof value === "string" && OPAQUE_ID_PATTERN.test(value);
+export function isValidReviewAppSessionId(
+  value: string | undefined,
+): value is string {
+  return value !== undefined && OPAQUE_ID_PATTERN.test(value);
 }

--- a/packages/progressive-review/src/with-file-lock.ts
+++ b/packages/progressive-review/src/with-file-lock.ts
@@ -2,6 +2,12 @@ import { mkdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 
+import {
+  jsonNumber,
+  jsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
 const LOCK_OWNER_FILE = "owner.json";
 const DEFAULT_HEARTBEAT_MS = 30_000;
 
@@ -105,9 +111,9 @@ function startHeartbeat(lockPath: string, intervalMs: number): NodeJS.Timeout {
 
 async function readLockOwner(lockPath: string): Promise<number | null> {
   return readFile(path.join(lockPath, LOCK_OWNER_FILE), "utf8")
-    .then((contents) => {
-      const value = JSON.parse(contents) as { pid?: unknown };
-      return typeof value.pid === "number" ? value.pid : null;
-    })
+    .then(
+      (contents) =>
+        jsonNumber(jsonObject(parseJsonText(contents))?.pid) ?? null,
+    )
     .catch(() => null);
 }

--- a/packages/review-protocol/scripts/generate-native-source.mjs
+++ b/packages/review-protocol/scripts/generate-native-source.mjs
@@ -12,24 +12,40 @@ if (!outputPath || process.argv.length !== 3) {
   throw new Error("Usage: generate-native-source.mjs <output-path>");
 }
 
-const contracts = readFileSync(
-  path.join(packageRoot, "src/contracts.ts"),
+// json.ts and runtime-value.ts are inlined ahead of contracts.ts, so every
+// relative import between the protocol modules is dropped.
+const stripRelativeImports = (source) =>
+  source.replace(/^import (?:type )?\{[^}]*\} from "\.\/[^"]+";\n\n?/gm, "");
+const runtimeValue = readFileSync(
+  path.join(packageRoot, "src/runtime-value.ts"),
   "utf8",
+);
+const json = stripRelativeImports(
+  readFileSync(path.join(packageRoot, "src/json.ts"), "utf8"),
+);
+const contracts = stripRelativeImports(
+  readFileSync(path.join(packageRoot, "src/contracts.ts"), "utf8"),
 ).replace(
   'import { z } from "zod";',
   'import { z } from "zod/v4";\n\nz.config({ jitless: true });',
 );
 const index = readFileSync(path.join(packageRoot, "src/index.ts"), "utf8")
   .replace(/^import \{ z \} from "zod";\n\n/, "")
-  .replace(/import \{[\s\S]*?\} from "\.\/contracts\.js";\n\n/, "")
+  .replace(/import \{[\s\S]*?\} from "\.\/contracts\.js";\n/, "")
+  .replace('import type { JsonValue } from "./json.js";\n\n', "")
   .replace('export * from "./bug-report.js";\n', "")
   .replace('export * from "./json.js";\n', "")
+  .replace('export * from "./runtime-value.js";\n', "")
   .replace('export * from "./contracts.js";\n\n', "");
 
 writeFileSync(
   outputPath,
   [
     "// GENERATED from @dev.fast/review-protocol. Do not edit.",
+    runtimeValue.trimEnd(),
+    "",
+    json.trimEnd(),
+    "",
     contracts.trimEnd(),
     "",
     index.trimStart(),

--- a/packages/review-protocol/src/bug-report.ts
+++ b/packages/review-protocol/src/bug-report.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import type { JsonValue } from "./json.js";
+
 const requiredString = z
   .string({ error: "must be a string" })
   .refine((value) => value.trim().length > 0, "must be a string");
@@ -147,13 +149,13 @@ export type ReviewBugReportResponse = z.infer<
 >;
 
 export function parseReviewBugReportRequest(
-  value: unknown,
+  value: JsonValue,
 ): ReviewBugReportRequest {
   return ReviewBugReportRequestSchema.parse(value);
 }
 
 export function parseReviewBugReportResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewBugReportResponse {
   return ReviewBugReportResponseSchema.parse(value);
 }

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { type JsonValue, isJsonObject } from "./json.js";
+
 export const sessionIdSchema = z
   .string()
   .regex(/^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/);
@@ -567,15 +569,15 @@ export type ReviewCommentDraftThreadMap = z.infer<
 >;
 
 export function parseStoredReviewCommentThreadMap(
-  value: unknown,
+  value: JsonValue,
 ): ReviewCommentThreadMap {
   return ReviewCommentThreadMapSchema.parse(value);
 }
 
 export function parseReviewCommentThreadMap(
-  value: unknown,
+  value: JsonValue,
 ): ReviewCommentThreadMap {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  if (!isJsonObject(value)) return {};
   const comments: ReviewCommentThreadMap = {};
   for (const [threadId, candidate] of Object.entries(value)) {
     const parsed = ReviewCommentThreadRecordSchema.safeParse(candidate);

--- a/packages/review-protocol/src/index.ts
+++ b/packages/review-protocol/src/index.ts
@@ -40,113 +40,115 @@ import {
   type ReviewVerbResponse,
   ReviewVerbResponseSchema,
 } from "./contracts.js";
+import type { JsonValue } from "./json.js";
 
 export * from "./bug-report.js";
 export * from "./json.js";
+export * from "./runtime-value.js";
 export * from "./contracts.js";
 
 export function parseReviewDesktopDiscovery(
-  value: unknown,
+  value: JsonValue,
 ): ReviewDesktopDiscovery {
   return parseZod(ReviewDesktopDiscoverySchema, value);
 }
 
-export function parseReviewListResponse(value: unknown): ReviewListResponse {
+export function parseReviewListResponse(value: JsonValue): ReviewListResponse {
   return parseZod(ReviewListResponseSchema, value);
 }
 
 export function parseReviewCliInstallStatus(
-  value: unknown,
+  value: JsonValue,
 ): ReviewCliInstallStatus {
   return parseZod(ReviewCliInstallStatusSchema, value);
 }
 
 export function parseReviewCliInstallApplyRequest(
-  value: unknown,
+  value: JsonValue,
 ): ReviewCliInstallApplyRequest {
   return parseZod(ReviewCliInstallApplyRequestSchema, value);
 }
 
 export function parseReviewCliInstallApplyResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewCliInstallApplyResponse {
   return parseZod(ReviewCliInstallApplyResponseSchema, value);
 }
 
 export function parseReviewPublishReadyRequest(
-  value: unknown,
+  value: JsonValue,
 ): ReviewPublishReadyRequest {
   return parseZod(ReviewPublishReadyRequestSchema, value);
 }
 
-export function parseReviewOpenResponse(value: unknown): ReviewOpenResponse {
+export function parseReviewOpenResponse(value: JsonValue): ReviewOpenResponse {
   return parseZod(ReviewOpenResponseSchema, value);
 }
 
 export function parseReviewTutorialOpenResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewTutorialOpenResponse {
   return parseZod(ReviewTutorialOpenResponseSchema, value);
 }
 
 export function parseReviewDesktopGlobalEvent(
-  value: unknown,
+  value: JsonValue,
 ): ReviewDesktopGlobalEvent {
   return parseZod(ReviewDesktopGlobalEventSchema, value);
 }
 
 export function parseReviewDesktopVerbFrame(
-  value: unknown,
+  value: JsonValue,
 ): ReviewDesktopVerbFrame {
   return parseZod(ReviewDesktopVerbFrameSchema, value);
 }
 
 export function parseReviewDesktopVerbResult(
-  value: unknown,
+  value: JsonValue,
 ): ReviewDesktopVerbResult {
   return parseZod(ReviewDesktopVerbResultSchema, value);
 }
 
 export function parseReviewSessionResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewSessionResponse {
   return parseZod(ReviewSessionResponseSchema, value);
 }
 
 export function parseReviewDiffFilesResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewDiffFilesResponse {
   return parseZod(ReviewDiffFilesResponseSchema, value);
 }
 
 export function parseReviewFileContentResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewFileContentResponse {
   return parseZod(ReviewFileContentResponseSchema, value);
 }
 
 export function parseReviewFileContentRequest(
-  value: unknown,
+  value: JsonValue,
 ): ReviewFileContentRequest {
   return parseZod(ReviewFileContentRequestSchema, value);
 }
 
-export function parseReviewVerbRequest(value: unknown): ReviewVerbRequest {
+export function parseReviewVerbRequest(value: JsonValue): ReviewVerbRequest {
   return parseZod(ReviewVerbRequestSchema, value);
 }
 
-export function parseReviewVerbResponse(value: unknown): ReviewVerbResponse {
+export function parseReviewVerbResponse(value: JsonValue): ReviewVerbResponse {
   return parseZod(ReviewVerbResponseSchema, value);
 }
 
 export function parseReviewAgentTraceListResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewAgentTraceListResponse {
   return parseZod(ReviewAgentTraceListResponseSchema, value);
 }
 
 export function parseReviewAgentTraceResponse(
-  value: unknown,
+  value: JsonValue,
 ): ReviewAgentTraceResponse {
   return parseZod(ReviewAgentTraceResponseSchema, value);
 }
@@ -166,7 +168,7 @@ export function rewriteReviewDocumentRuntime(
 
 export function parseZod<T>(
   schema: z.ZodType<T>,
-  value: unknown,
+  value: JsonValue,
   label?: string,
   prefixPath = false,
 ): T {
@@ -188,8 +190,8 @@ export function parseZod<T>(
 function formatIssuePath(path: PropertyKey[]): string {
   let output = "";
   for (const segment of path) {
-    if (typeof segment === "number") {
-      output += `[${segment}]`;
+    if (Number.isInteger(segment)) {
+      output += `[${String(segment)}]`;
     } else {
       output += `${output ? "." : ""}${String(segment)}`;
     }

--- a/packages/review-protocol/src/json.ts
+++ b/packages/review-protocol/src/json.ts
@@ -1,3 +1,10 @@
+import {
+  isBooleanValue,
+  isNumberValue,
+  isObjectValue,
+  isStringValue,
+} from "./runtime-value.js";
+
 /**
  * JSON values as they come off the wire or out of a file. Parse into one of
  * these at the I/O boundary, then narrow into a domain type; never carry an
@@ -9,7 +16,7 @@ export type JsonArray = JsonValue[];
 export type JsonObject = { [key: string]: JsonValue };
 
 export function isJsonObject(value: unknown): value is JsonObject {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  return isObjectValue(value) && !Array.isArray(value);
 }
 
 export function isJsonArray(value: unknown): value is JsonArray {
@@ -29,4 +36,31 @@ export function jsonProperty(
   key: string,
 ): JsonValue | undefined {
   return Object.hasOwn(value, key) ? value[key] : undefined;
+}
+
+/** The string a JSON value holds, or undefined when it is not a string. */
+export function jsonString(value: JsonValue | undefined): string | undefined {
+  return isStringValue(value) ? value : undefined;
+}
+
+/** The finite number a JSON value holds, or undefined otherwise. */
+export function jsonNumber(value: JsonValue | undefined): number | undefined {
+  return isNumberValue(value) && Number.isFinite(value) ? value : undefined;
+}
+
+/** The boolean a JSON value holds, or undefined otherwise. */
+export function jsonBoolean(value: JsonValue | undefined): boolean | undefined {
+  return isBooleanValue(value) ? value : undefined;
+}
+
+/** The object a JSON value holds, or undefined otherwise. */
+export function jsonObject(
+  value: JsonValue | undefined,
+): JsonObject | undefined {
+  return isObjectValue(value) && !Array.isArray(value) ? value : undefined;
+}
+
+/** The array a JSON value holds, or undefined otherwise. */
+export function jsonArray(value: JsonValue | undefined): JsonArray | undefined {
+  return Array.isArray(value) ? value : undefined;
 }

--- a/packages/review-protocol/src/runtime-value.ts
+++ b/packages/review-protocol/src/runtime-value.ts
@@ -1,0 +1,28 @@
+/**
+ * Realm-safe primitive checks. This module is the one sanctioned home for
+ * `typeof`; every other decoder in the repo narrows through these predicates.
+ * `instanceof Object` is not a substitute: values created in another realm
+ * (a worker, a vm context, an iframe) fail it while `typeof` still answers.
+ */
+export function isStringValue(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+export function isNumberValue(value: unknown): value is number {
+  return typeof value === "number";
+}
+
+export function isBooleanValue(value: unknown): value is boolean {
+  return typeof value === "boolean";
+}
+
+/** A non-null object, arrays and functions excluded. */
+export function isObjectValue(value: unknown): value is object {
+  return typeof value === "object" && value !== null;
+}
+
+export function isCallableValue(
+  value: unknown,
+): value is (...args: never[]) => void {
+  return typeof value === "function";
+}


### PR DESCRIPTION
## Summary

Third anti-slop pass. Promotes `anti-slop/no-unknown-returns`, `anti-slop/no-unknown-parameters`, and `anti-slop/no-runtime-typeof` from `warn` to `error` and clears all 553 findings (23 + 180 + 350) across 136 files.

- **Boundary convention:** JSON that enters from a file, HTTP body/response, sqlite row, stdin, child-process output, or `postMessage` is a `JsonValue`. All `parseXxx(value)` functions in `@dev.fast/review-protocol` now take `JsonValue` instead of `unknown`; `readBoundedRequestJson` and the other readers return `JsonValue`.
- **Decoders:** `json.ts` gains `jsonString` / `jsonNumber` / `jsonBoolean` / `jsonObject` / `jsonArray`. A new `runtime-value.ts` (`isStringValue`, `isNumberValue`, `isBooleanValue`, `isObjectValue`, `isCallableValue`) is the single sanctioned home for `typeof`, exempted by a one-file `overrides` entry; `instanceof Object` was rejected because it fails across realms. Every other former `typeof` site now narrows through these helpers, `instanceof`, `in`, or a small zod schema.
- **Signatures:** thrown-value decoders name their parameter `cause`; internal helpers take their real input types or become generic (`jsonResponse<T>`, `ReviewModuleImporter<T>`, `PiObserverApi.on<Event>`).
- **Overlay:** the native-source generator inlines `json.ts` and `runtime-value.ts`; the Code OSS `reviewProtocol.ts` overlay is regenerated.

## Behavioral notes (invalid input only)

- JSON roots that are `null` or a primitive now read as "invalid"/"absent" in tutorial manifests, desktop discovery, and Claude hook settings instead of throwing a `TypeError`.
- `foreignKeyTarget` returns `undefined` rather than `null` on a malformed ref (its one caller uses a truthiness check).

## Verification

- `pnpm lint`: 0 errors (385 warnings left, all in the four style rules).
- `pnpm format:check`: clean. `protocol:check`: clean.
- Package typechecks: review-protocol, local-vcs, progressive-review all clean.
- Tests: progressive-review 147 files / 1,161 tests, local-vcs 57, review-protocol 94, desktop scripts 17, `check:tutorial` passing.
