### PR TITLE
Add stacked PR review navigation

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/contrib/verbs/reviewVerbs.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/verbs/reviewVerbs.ts
@@ -224,6 +224,12 @@ export class ReviewVerbsService
           }
           break;
         }
+        case "openReview":
+          await this.tabsService.openReview(
+            request.args.reviewUuid,
+            request.args.active,
+          );
+          break;
         case "showThreads":
           await this.showThreads();
           break;

--- a/packages/progressive-review/app/src/review-doc-meta.test.tsx
+++ b/packages/progressive-review/app/src/review-doc-meta.test.tsx
@@ -1,17 +1,24 @@
 // @vitest-environment jsdom
 
+import type { ReviewCanvasBridge } from "@dev.fast/review-protocol";
 import { act } from "react";
-import { type Root, hydrateRoot } from "react-dom/client";
+import { type Root, createRoot, hydrateRoot } from "react-dom/client";
 import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ReviewSessionProvider } from "./host/review-session";
+import {
+  ReviewSessionProvider,
+  createReviewSession,
+} from "./host/review-session";
 import { ReviewDocumentMetaLine } from "./review-doc-meta";
 import {
   type ReviewInitialData,
   ReviewInitialDataContext,
 } from "./review-initial-data-context";
-import { testReviewSession } from "./review-session-test-utils";
+import {
+  testReviewBridge,
+  testReviewSession,
+} from "./review-session-test-utils";
 
 const initialData: ReviewInitialData = {
   comments: {},
@@ -19,6 +26,10 @@ const initialData: ReviewInitialData = {
   documentMeta: { updatedAtMs: Date.UTC(2026, 6, 22, 12, 0) },
   diffStats: { files: [{ additions: 2, deletions: 1 }] },
   softwareMapResolvedData: [],
+};
+const stackInitialData: ReviewInitialData = {
+  ...initialData,
+  documentMeta: { pullRequestNumber: 20 },
 };
 
 let root: Root | null = null;
@@ -72,5 +83,94 @@ describe("ReviewDocumentMetaLine", () => {
       expect.arrayContaining([expect.stringContaining("Hydration failed")]),
     );
     expect(container.textContent).toContain("updated 5 min ago");
+  });
+
+  it("opens an available later Review in a background tab", async () => {
+    const post = vi.fn<ReviewCanvasBridge["post"]>(async () => ({ ok: true }));
+    const stackSession = createReviewSession(
+      testReviewBridge(
+        {},
+        {
+          request: async (url) => {
+            expect(url).toContain("/stack");
+            return Response.json({
+              layers: [
+                {
+                  branch: "feature-b",
+                  relation: "current",
+                  pullRequestNumber: 20,
+                  pullRequestUrl: "https://github.com/o/r/pull/20",
+                  reviewUuid: "22222222-2222-4222-8222-222222222222",
+                  reviewTitle: "Review B",
+                },
+                {
+                  branch: "feature-c",
+                  relation: "later",
+                  pullRequestNumber: 30,
+                  pullRequestUrl: "https://github.com/o/r/pull/30",
+                  reviewUuid: "11111111-1111-4111-8111-111111111111",
+                  reviewTitle: "Review C",
+                },
+                {
+                  branch: "feature-d",
+                  relation: "later",
+                  pullRequestNumber: 40,
+                  pullRequestUrl: "https://github.com/o/r/pull/40",
+                  reviewUuid: null,
+                  reviewTitle: null,
+                },
+              ],
+            });
+          },
+          post,
+        },
+      ),
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        <ReviewSessionProvider session={stackSession}>
+          <ReviewInitialDataContext.Provider value={stackInitialData}>
+            <ReviewDocumentMetaLine />
+          </ReviewInitialDataContext.Provider>
+        </ReviewSessionProvider>,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(container.textContent).toContain("1 of 3");
+    expect(container.textContent).toContain("current");
+    expect(
+      [...container.querySelectorAll(".review-stack-position-marker")].map(
+        (marker) => marker.textContent,
+      ),
+    ).toEqual(["1", "2", "3"]);
+    const unavailable = container.querySelector<HTMLButtonElement>(
+      ".review-stack-menu button:disabled",
+    );
+    expect(unavailable?.textContent).toContain("PR #40");
+    expect(unavailable?.textContent).toContain("No Review");
+    const layer = container.querySelector<HTMLButtonElement>(
+      '.review-stack-menu button[data-relation="later"]',
+    );
+    expect(layer?.textContent).toContain("PR #30");
+    await act(async () => {
+      layer?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, metaKey: true }),
+      );
+    });
+    expect(post).toHaveBeenCalledWith({
+      name: "openReview",
+      args: {
+        reviewUuid: "11111111-1111-4111-8111-111111111111",
+        active: false,
+      },
+    });
+    await act(async () => {
+      unavailable?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(post).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/progressive-review/app/src/review-doc-meta.tsx
+++ b/packages/progressive-review/app/src/review-doc-meta.tsx
@@ -1,12 +1,20 @@
 import {
   type JsonValue,
   type ReviewDiffStats,
+  type ReviewStackLayer,
   isJsonObject,
   jsonNumber,
   jsonString,
+  parseReviewStackResponse,
   summarizeReviewDiffFiles,
 } from "@dev.fast/review-protocol";
-import { type ReactElement, useEffect, useState } from "react";
+import {
+  type MouseEvent,
+  type ReactElement,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { useReviewSession } from "./host/review-session";
 import { useReviewDiffFiles } from "./review-diff-files-context";
@@ -38,6 +46,7 @@ export function ReviewDocumentMetaLine(): ReactElement | null {
   const [relativeTimeNowMs, setRelativeTimeNowMs] = useState<number | null>(
     null,
   );
+  const [stackLayers, setStackLayers] = useState<ReviewStackLayer[]>([]);
 
   useEffect(() => {
     setRelativeTimeNowMs(Date.now());
@@ -65,6 +74,21 @@ export function ReviewDocumentMetaLine(): ReactElement | null {
     return () => controller.abort();
   }, [initialDocumentMeta, reviewFetch]);
 
+  useEffect(() => {
+    const controller = new AbortController();
+    if (!meta?.pullRequestNumber) {
+      setStackLayers([]);
+      return () => controller.abort();
+    }
+    reviewFetch("/stack", { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) return;
+        setStackLayers(parseReviewStackResponse(await response.json()).layers);
+      })
+      .catch(() => {});
+    return () => controller.abort();
+  }, [meta?.pullRequestNumber, reviewFetch]);
+
   const diff =
     diffFiles.status === "loaded" ? reviewDiffStats(diffFiles) : initialDiff;
   const updatedLabel =
@@ -90,6 +114,9 @@ export function ReviewDocumentMetaLine(): ReactElement | null {
             PR #{meta.pullRequestNumber}
           </span>
         ))}
+      {stackLayers.length > 1 ? (
+        <ReviewStackSelector layers={stackLayers} />
+      ) : null}
       {diff && (
         <>
           <span>
@@ -101,6 +128,122 @@ export function ReviewDocumentMetaLine(): ReactElement | null {
       )}
       {updatedLabel && <span>updated {updatedLabel}</span>}
     </div>
+  );
+}
+
+function ReviewStackSelector({
+  layers,
+}: {
+  layers: readonly ReviewStackLayer[];
+}): ReactElement {
+  const session = useReviewSession();
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+  const currentIndex = layers.findIndex(
+    (layer) => layer.relation === "current",
+  );
+  const position = currentIndex < 0 ? 1 : currentIndex + 1;
+  const openLayer = (
+    layer: ReviewStackLayer,
+    event: Pick<MouseEvent, "metaKey" | "ctrlKey" | "shiftKey" | "button">,
+  ) => {
+    if (!layer.reviewUuid) return;
+    detailsRef.current?.removeAttribute("open");
+    void session.surface.post({
+      name: "openReview",
+      args: {
+        reviewUuid: layer.reviewUuid,
+        active: !(
+          event.metaKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.button === 1
+        ),
+      },
+    });
+  };
+
+  return (
+    <details className="review-stack-selector" ref={detailsRef}>
+      <summary>
+        <span className="review-stack-position">
+          {position} of {layers.length}
+        </span>
+        <span className="review-stack-label">stack</span>
+        <svg viewBox="0 0 12 12" aria-hidden="true">
+          <path d="m3 4.5 3 3 3-3" />
+        </svg>
+      </summary>
+      <div className="review-stack-menu">
+        {layers.map((layer, index) => (
+          <ReviewStackLayerRow
+            key={layer.pullRequestNumber}
+            layer={layer}
+            position={index + 1}
+            onOpen={openLayer}
+          />
+        ))}
+      </div>
+    </details>
+  );
+}
+
+function ReviewStackLayerRow({
+  layer,
+  position,
+  onOpen,
+}: {
+  layer: ReviewStackLayer;
+  position: number;
+  onOpen: (
+    layer: ReviewStackLayer,
+    event: Pick<MouseEvent, "metaKey" | "ctrlKey" | "shiftKey" | "button">,
+  ) => void;
+}): ReactElement {
+  const current = layer.relation === "current";
+  const content = (
+    <>
+      <span className="review-stack-indicator">
+        <span className="review-stack-position-marker">{position}</span>
+      </span>
+      <span className="review-stack-layer-copy">
+        <span className="review-stack-layer-title">
+          PR #{layer.pullRequestNumber}
+          {layer.reviewTitle ? ` · ${layer.reviewTitle}` : ""}
+        </span>
+        <span className="review-stack-branch">{layer.branch}</span>
+      </span>
+      <span className="review-stack-relation">
+        {!layer.reviewUuid && !current ? "No Review" : layer.relation}
+      </span>
+    </>
+  );
+
+  if (current) {
+    return (
+      <div className="review-stack-row is-current" aria-current="true">
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      className="review-stack-row"
+      type="button"
+      data-relation={layer.relation}
+      disabled={!layer.reviewUuid}
+      title={
+        layer.reviewUuid
+          ? "Open Review (Cmd/Ctrl-click to open in the background)"
+          : "No generated Review exists for this pull request"
+      }
+      onClick={(event) => onOpen(layer, event)}
+      onAuxClick={(event) => {
+        if (event.button === 1) onOpen(layer, event);
+      }}
+    >
+      {content}
+    </button>
   );
 }
 

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -6940,8 +6940,9 @@ button {
 
 .review-doc-meta {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 14px;
+  min-height: 26px;
   width: min(100%, var(--review-prose-max-width));
   margin: -6px auto 0;
   color: var(--ink-faint);
@@ -6957,6 +6958,198 @@ button {
 
 a.review-doc-meta-pr:hover {
   text-decoration: underline;
+}
+
+.review-stack-selector {
+  position: relative;
+  color: var(--ink-faint);
+}
+
+.review-stack-selector > summary {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  height: 26px;
+  padding: 0 8px;
+  border: 1px solid var(--rule-soft);
+  border-radius: 7px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--ink);
+  list-style: none;
+}
+
+.review-stack-selector > summary::-webkit-details-marker {
+  display: none;
+}
+
+.review-stack-selector > summary:hover {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--rule-soft));
+  background: var(--control-bg);
+}
+
+.review-stack-position-marker {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--ink-faint);
+  border-radius: 50%;
+  color: var(--ink-soft);
+  font-size: 9px;
+  font-weight: 500;
+}
+
+.review-stack-position {
+  color: var(--ink);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.review-stack-label {
+  color: var(--ink-faint);
+  font-size: 10px;
+  font-weight: 400;
+}
+
+.review-stack-selector > summary svg {
+  width: 12px;
+  height: 12px;
+  color: var(--ink-faint);
+  transition: transform 120ms ease-out;
+}
+
+.review-stack-selector > summary path {
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.25;
+}
+
+.review-stack-selector[open] > summary svg {
+  transform: rotate(180deg);
+}
+
+.review-stack-menu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 6px);
+  left: 0;
+  display: flex;
+  min-width: 340px;
+  padding: 7px;
+  flex-direction: column;
+  border: 1px solid var(--rule-soft);
+  border-radius: 9px;
+  background: var(--surface-raised);
+  box-shadow: 0 14px 32px var(--shadow-color);
+}
+
+.review-stack-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 48px;
+  padding: 7px 9px;
+  gap: 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ink);
+  font: inherit;
+  text-align: left;
+}
+
+.review-stack-row.is-current {
+  background: color-mix(in srgb, var(--accent) 8%, var(--surface-raised));
+}
+
+button.review-stack-row:not(:disabled) {
+  cursor: pointer;
+}
+
+button.review-stack-row:not(:disabled):hover {
+  background: var(--bg-2);
+}
+
+button.review-stack-row:disabled {
+  cursor: default;
+}
+
+button.review-stack-row:disabled .review-stack-layer-title,
+button.review-stack-row:disabled .review-stack-branch,
+button.review-stack-row:disabled .review-stack-position-marker,
+button.review-stack-row:disabled .review-stack-relation {
+  color: var(--ink-faint);
+}
+
+.review-stack-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  flex: 0 0 24px;
+}
+
+.review-stack-row.is-current .review-stack-position-marker {
+  border-color: color-mix(in srgb, var(--accent) 64%, var(--rule-soft));
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.review-stack-layer-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.review-stack-layer-title,
+.review-stack-branch {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.review-stack-layer-title {
+  color: var(--ink);
+  font-size: 11px;
+  line-height: 15px;
+}
+
+.review-stack-row.is-current .review-stack-layer-title {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.review-stack-branch {
+  color: var(--ink-faint);
+  font-size: 10px;
+  line-height: 14px;
+}
+
+.review-stack-row.is-current .review-stack-branch {
+  color: var(--ink-soft);
+}
+
+.review-stack-row.is-current .review-stack-relation {
+  color: var(--accent);
+}
+
+.review-stack-relation {
+  width: 54px;
+  flex: 0 0 54px;
+  color: var(--ink-faint);
+  font-size: 8px;
+  letter-spacing: 0.02em;
+  line-height: 13px;
+  text-align: right;
+  text-transform: uppercase;
 }
 
 .review-doc-meta-added {

--- a/packages/progressive-review/src/review-stack.test.ts
+++ b/packages/progressive-review/src/review-stack.test.ts
@@ -1,0 +1,123 @@
+import type { ReviewDescriptor } from "@dev.fast/review-protocol";
+import { describe, expect, it, vi } from "vitest";
+
+import { type RunGhStackView, resolveReviewStackLayers } from "./review-stack";
+
+const publishedReview = (input: {
+  uuid: string;
+  repoKey: string;
+  pullRequestNumber: number;
+  title: string;
+}): ReviewDescriptor => ({
+  ...input,
+  status: "awaiting-review",
+  worktreePath: "/repo",
+  sourceBranch: "feature",
+  presentedDocumentRevision: "a".repeat(40),
+  presentedSoftwareMapRevision: null,
+  lastPublishedAt: "2026-09-01T00:00:00.000Z",
+  available: true,
+});
+
+describe("resolveReviewStackLayers", () => {
+  it("returns PR layers on both sides of the reviewed PR and matches local reviews", async () => {
+    const run = vi.fn<RunGhStackView>(async () =>
+      JSON.stringify({
+        trunk: "main",
+        currentBranch: "b",
+        branches: [
+          {
+            name: "a",
+            pr: { number: 10, url: "https://github.com/o/r/pull/10" },
+          },
+          {
+            name: "b",
+            pr: { number: 20, url: "https://github.com/o/r/pull/20" },
+          },
+          {
+            name: "c",
+            pr: { number: 30, url: "https://github.com/o/r/pull/30" },
+          },
+          {
+            name: "d",
+            pr: { number: 40, url: "https://github.com/o/r/pull/40" },
+          },
+        ],
+      }),
+    );
+    const reviewA = publishedReview({
+      uuid: "11111111-1111-4111-8111-111111111111",
+      repoKey: "github.com/o/r",
+      pullRequestNumber: 10,
+      title: "Review A",
+    });
+    const reviewB = publishedReview({
+      uuid: "22222222-2222-4222-8222-222222222222",
+      repoKey: "github.com/o/r",
+      pullRequestNumber: 20,
+      title: "Review B",
+    });
+
+    await expect(
+      resolveReviewStackLayers(
+        {
+          repoKey: "github.com/o/r",
+          worktreePath: "/repo",
+          pullRequestNumber: 20,
+        },
+        [reviewA, reviewB],
+        run,
+      ),
+    ).resolves.toEqual([
+      {
+        branch: "a",
+        pullRequestNumber: 10,
+        pullRequestUrl: "https://github.com/o/r/pull/10",
+        reviewUuid: reviewA.uuid,
+        reviewTitle: "Review A",
+        relation: "earlier",
+      },
+      {
+        branch: "b",
+        pullRequestNumber: 20,
+        pullRequestUrl: "https://github.com/o/r/pull/20",
+        reviewUuid: reviewB.uuid,
+        reviewTitle: "Review B",
+        relation: "current",
+      },
+      {
+        branch: "c",
+        pullRequestNumber: 30,
+        pullRequestUrl: "https://github.com/o/r/pull/30",
+        reviewUuid: null,
+        reviewTitle: null,
+        relation: "later",
+      },
+      {
+        branch: "d",
+        pullRequestNumber: 40,
+        pullRequestUrl: "https://github.com/o/r/pull/40",
+        reviewUuid: null,
+        reviewTitle: null,
+        relation: "later",
+      },
+    ]);
+    expect(run).toHaveBeenCalledWith("/repo");
+  });
+
+  it("fails closed when stack discovery is unavailable or malformed", async () => {
+    const subject = {
+      repoKey: "github.com/o/r",
+      worktreePath: "/repo",
+      pullRequestNumber: 30,
+    };
+    await expect(
+      resolveReviewStackLayers(subject, [], async () => {
+        throw new Error("not in a stack");
+      }),
+    ).resolves.toEqual([]);
+    await expect(
+      resolveReviewStackLayers(subject, [], async () => "{}"),
+    ).resolves.toEqual([]);
+  });
+});

--- a/packages/progressive-review/src/review-stack.ts
+++ b/packages/progressive-review/src/review-stack.ts
@@ -1,0 +1,98 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import type { ReviewStackLayer } from "@dev.fast/review-protocol";
+import { z } from "zod";
+
+const execFileAsync = promisify(execFile);
+
+const GhStackViewSchema = z.object({
+  branches: z.array(
+    z.object({
+      name: z.string().min(1),
+      pr: z
+        .object({
+          number: z.number().int().positive(),
+          url: z.string().url().optional(),
+        })
+        .optional(),
+    }),
+  ),
+});
+
+export interface ReviewStackSubject {
+  repoKey: string;
+  worktreePath: string;
+  pullRequestNumber?: number | null;
+}
+
+export interface ReviewStackCandidate {
+  uuid: string;
+  title: string;
+  repoKey: string;
+  pullRequestNumber?: number | null;
+  presentedDocumentRevision: string | null;
+}
+
+export type RunGhStackView = (cwd: string) => Promise<string>;
+
+export async function resolveReviewStackLayers(
+  subject: ReviewStackSubject,
+  reviews: readonly ReviewStackCandidate[],
+  runGhStackView: RunGhStackView = defaultRunGhStackView,
+): Promise<ReviewStackLayer[]> {
+  if (!subject.pullRequestNumber) return [];
+
+  let parsed: z.infer<typeof GhStackViewSchema>;
+  try {
+    parsed = GhStackViewSchema.parse(
+      JSON.parse(await runGhStackView(subject.worktreePath)),
+    );
+  } catch {
+    // Stack support is an enhancement. Missing gh-stack, an unrelated
+    // checkout, authentication failures, and preview-schema changes must not
+    // make the Review itself unavailable.
+    return [];
+  }
+
+  const currentIndex = parsed.branches.findIndex(
+    (branch) => branch.pr?.number === subject.pullRequestNumber,
+  );
+  if (currentIndex < 0) return [];
+
+  return parsed.branches.flatMap((branch, index) => {
+    if (!branch.pr) return [];
+    const review = reviews.find(
+      (candidate) =>
+        candidate.repoKey === subject.repoKey &&
+        candidate.pullRequestNumber === branch.pr?.number &&
+        candidate.presentedDocumentRevision,
+    );
+    return [
+      {
+        branch: branch.name,
+        pullRequestNumber: branch.pr.number,
+        pullRequestUrl: branch.pr.url ?? null,
+        reviewUuid: review?.uuid ?? null,
+        reviewTitle: review?.title ?? null,
+        relation:
+          index < currentIndex
+            ? "earlier"
+            : index === currentIndex
+              ? "current"
+              : "later",
+      },
+    ];
+  });
+}
+
+async function defaultRunGhStackView(cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync("gh", ["stack", "view", "--json"], {
+    cwd,
+    env: { ...process.env, GH_PROMPT_DISABLED: "1" },
+    encoding: "utf8",
+    timeout: 10_000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  return stdout;
+}

--- a/packages/progressive-review/src/server/review-api.ts
+++ b/packages/progressive-review/src/server/review-api.ts
@@ -14,6 +14,7 @@ import {
   type JsonValue,
   type ReviewCommentThreadRecord,
   type ReviewSessionWire,
+  type ReviewStackResponse,
   type ReviewThreadsCommit,
   type ReviewVerbRequest,
   isJsonObject,
@@ -53,10 +54,12 @@ import {
   resolveReviewDiffFiles,
   resolveReviewFileContent,
 } from "../review-diff-files";
+import { listReviews } from "../review-home";
 import {
   normalizeReviewRoutePath,
   resolveReviewDocumentFilePath,
 } from "../review-paths";
+import { resolveReviewStackLayers } from "../review-stack";
 import { saveReviewSubmissionAudit } from "../review-state-store";
 import { ReviewThreadsService } from "../review-threads-service";
 import {
@@ -379,6 +382,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     route(softwareMapArtifactsRefresh),
   );
   app.get("/document-meta", route(documentMeta));
+  app.get("/stack", route(reviewStack));
   app.post("/diff-files", route(diffFiles));
   app.get("/file-content", route(fileContent));
   app.get("/agent-traces", route(agentTraces));
@@ -896,6 +900,24 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     });
   }
 
+  async function reviewStack(): Promise<Response> {
+    const current = readReviewStoreRecord(reviewRootPath);
+    if (!current.pullRequestNumber) {
+      return reviewApiJsonResponse(200, { layers: [] });
+    }
+    const listed = await listReviews();
+    const reviews = listed.reviews.map((stored) => stored.review);
+    reviews.sort(
+      (left, right) =>
+        (right.lastPublishedAt ?? "").localeCompare(
+          left.lastPublishedAt ?? "",
+        ) || left.uuid.localeCompare(right.uuid),
+    );
+    return reviewApiJsonResponse(200, {
+      layers: await resolveReviewStackLayers(current, reviews),
+    });
+  }
+
   async function diffFiles(context: Context<ReviewHonoEnv>): Promise<Response> {
     const url = new URL(context.req.url);
     const body = parseReviewDiffFilesInput(await readJson(context.req.raw));
@@ -1051,7 +1073,10 @@ interface ReviewApiThreadBody {
   comment: ReviewCommentThreadRecord;
 }
 
-type ReviewApiResponseBody = ReviewApiStatusBody | ReviewApiThreadBody;
+type ReviewApiResponseBody =
+  | ReviewApiStatusBody
+  | ReviewApiThreadBody
+  | ReviewStackResponse;
 
 function reviewApiJsonResponse<T extends ReviewApiResponseBody>(
   status: number,

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1324,6 +1324,21 @@ export const ReviewListResponseSchema = z.strictObject({
 export type ReviewListResponse = z.infer<typeof ReviewListResponseSchema>;
 export type ReviewListError = ReviewListResponse["errors"][number];
 
+export const ReviewStackLayerSchema = z.strictObject({
+  branch: requiredString,
+  pullRequestNumber: positiveInteger,
+  pullRequestUrl: absoluteUrlSchema.nullable(),
+  reviewUuid: z.uuid({ error: "must be a UUID" }).nullable(),
+  reviewTitle: stringAllowEmpty.nullable(),
+  relation: z.enum(["earlier", "current", "later"]),
+});
+export type ReviewStackLayer = z.infer<typeof ReviewStackLayerSchema>;
+
+export const ReviewStackResponseSchema = z.strictObject({
+  layers: z.array(ReviewStackLayerSchema),
+});
+export type ReviewStackResponse = z.infer<typeof ReviewStackResponseSchema>;
+
 export const ReviewCliInstallTargetSchema = z.enum(
   ["claude", "codex", "cursor", "pi"],
   { error: "must be claude, codex, cursor, or pi" },
@@ -1901,6 +1916,13 @@ export const ReviewVerbRequestSchema = z.discriminatedUnion("name", [
         .regex(/^[0-9a-f]{40}$/)
         .optional(),
       sealedAt: positiveInteger.optional(),
+    }),
+  }),
+  z.strictObject({
+    name: z.literal("openReview"),
+    args: z.strictObject({
+      reviewUuid: z.uuid({ error: "must be a UUID" }),
+      active: z.boolean(),
     }),
   }),
   z.strictObject({ name: z.literal("showThreads"), args: z.strictObject({}) }),

--- a/packages/review-protocol/src/index.ts
+++ b/packages/review-protocol/src/index.ts
@@ -33,6 +33,8 @@ import {
   ReviewPublishReadyRequestSchema,
   type ReviewSessionResponse,
   ReviewSessionResponseSchema,
+  type ReviewStackResponse,
+  ReviewStackResponseSchema,
   type ReviewTutorialOpenResponse,
   ReviewTutorialOpenResponseSchema,
   type ReviewVerbRequest,
@@ -55,6 +57,12 @@ export function parseReviewDesktopDiscovery(
 
 export function parseReviewListResponse(value: JsonValue): ReviewListResponse {
   return parseZod(ReviewListResponseSchema, value);
+}
+
+export function parseReviewStackResponse(
+  value: JsonValue,
+): ReviewStackResponse {
+  return parseZod(ReviewStackResponseSchema, value);
 }
 
 export function parseReviewCliInstallStatus(


### PR DESCRIPTION
## Summary

- discover the full pull request stack with `gh stack view --json` and validate its output with Zod
- match stack entries to generated Reviews and expose navigation through the Review API and native tab bridge
- add a themed stack selector with foreground/background tab opening and disabled `No Review` states

## Screenshots

Collapsed selector:

![Collapsed stack selector showing the current PR position](https://raw.githubusercontent.com/milanb17/review/pr-assets/pr-assets/104/stack-selector-collapsed.png)

Expanded selector, including an unavailable Review:

![Expanded stack selector showing available and unavailable Reviews](https://raw.githubusercontent.com/milanb17/review/pr-assets/pr-assets/104/stack-selector-expanded.png)

## Testing

- `../../node_modules/.bin/vitest run --config vitest.config.ts src/review-stack.test.ts app/src/review-doc-meta.test.tsx`
- `../../node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/oxlint --disable-nested-config .`
- `./node_modules/.bin/oxfmt --check` on all changed source files
- production Review canvas build
