### PR TITLE
Keep the Threads panel closed after Ask now hands off to the terminal

### DIFF
--- a/packages/progressive-review/app/src/review-components.tsx
+++ b/packages/progressive-review/app/src/review-components.tsx
@@ -1467,6 +1467,7 @@ function ThreadPanelInner({
   const review = useReview();
   const session = useReviewSession();
   const openThreads = useReviewPanel((state) => state.openThreads);
+  const setThreadsPage = useReviewPanel((state) => state.setThreadsPage);
   const newAskTargetRef = useRef<{
     threadId: string;
     target: ThreadTarget;
@@ -1509,8 +1510,10 @@ function ThreadPanelInner({
       target: destination.target,
       body,
     });
+    // The native terminal may already have closed Threads by the time the
+    // ask resolves; only move within the panel if it is still open.
     if (panel.page.kind === "new-ask") {
-      openThreads({ kind: "comment", threadId: destination.threadId });
+      setThreadsPage({ kind: "comment", threadId: destination.threadId });
     }
   };
   const resumeInTerminal = async (item: ThreadView) => {
@@ -1533,11 +1536,11 @@ function ThreadPanelInner({
       target: destination.target,
       body,
     });
-    if (panel.page.kind === "new-ask") {
-      openThreads();
-    } else {
-      openThreads({ kind: "comment", threadId: destination.threadId });
-    }
+    setThreadsPage(
+      panel.page.kind === "new-ask"
+        ? { kind: "list" }
+        : { kind: "comment", threadId: destination.threadId },
+    );
   };
   const selectListThread = (item: ThreadView) => {
     // Scroll to and highlight the anchor, but keep the detail here in the

--- a/packages/progressive-review/app/src/review-panel-store.test.ts
+++ b/packages/progressive-review/app/src/review-panel-store.test.ts
@@ -77,6 +77,22 @@ describe("Review panel store", () => {
     });
   });
 
+  it("keeps Threads closed when a page change lands after the terminal took over", () => {
+    const store = createReviewPanelStore();
+
+    store.getState().openThreads({ kind: "new-ask" });
+    store.getState().closeForAgentTerminal();
+    store.getState().setThreadsPage({ kind: "comment", threadId: "comment-1" });
+    expect(store.getState().active).toBeNull();
+
+    store.getState().openThreads({ kind: "new-ask" });
+    store.getState().setThreadsPage({ kind: "comment", threadId: "comment-1" });
+    expect(store.getState().active).toEqual({
+      kind: "threads",
+      page: { kind: "comment", threadId: "comment-1" },
+    });
+  });
+
   it("distinguishes explicit tour reveals from focus-only activation", () => {
     const store = createReviewPanelStore();
     store.getState().openTour(tour, anchor.id);

--- a/packages/progressive-review/app/src/review-panel-store.ts
+++ b/packages/progressive-review/app/src/review-panel-store.ts
@@ -23,6 +23,9 @@ export interface ReviewPanelActions {
   restoreTour: (tour: GuidedTour, activeAnchor: string) => void;
   activateTourAnchor: (anchorId: string, options: { reveal: boolean }) => void;
   openThreads: (page?: ThreadsPage) => void;
+  /** Moves within Threads while it is active; a no-op once another surface
+   *  (such as the agent terminal) has closed it. */
+  setThreadsPage: (page: ThreadsPage) => void;
   restoreThreads: () => void;
   close: () => void;
   closeForAgentTerminal: () => void;
@@ -79,6 +82,12 @@ export function createReviewPanelStore() {
     },
     openThreads: (page = { kind: "list" }) =>
       set({ active: { kind: "threads", page }, motion: "live" }),
+    setThreadsPage: (page) =>
+      set((state) =>
+        state.active?.kind === "threads"
+          ? { active: { kind: "threads", page } }
+          : state,
+      ),
     restoreThreads: () =>
       set({
         active: { kind: "threads", page: { kind: "list" } },

--- a/packages/progressive-review/app/src/review-panel.test.tsx
+++ b/packages/progressive-review/app/src/review-panel.test.tsx
@@ -13,8 +13,10 @@ import { ReviewProvider } from "./review-context";
 import {
   ReviewPanelProvider,
   useReviewPanel,
+  useReviewPanelStore,
   useSuppressPanelMotionOnCanvasResume,
 } from "./review-panel";
+import type { ReviewPanelStore } from "./review-panel-store";
 import { testReviewSession } from "./review-session-test-utils";
 
 let root: ReturnType<typeof createRoot> | undefined;
@@ -102,6 +104,58 @@ describe("Review panel host", () => {
     expect(container.textContent).toContain("Threads");
     await vi.waitFor(() => {
       expect(container.querySelector(".threads-new-ask")).toBeNull();
+    });
+  });
+
+  it("stays closed when the agent terminal takes over during Ask now", async () => {
+    let panelStore: ReviewPanelStore | undefined;
+    const askAgent = vi.spyOn(session.bridge.comments, "askAgent");
+    askAgent.mockImplementation(async () => {
+      // The desktop fires agentTerminalOpening before the ask resolves.
+      panelStore!.getState().closeForAgentTerminal();
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      renderWithSession(
+        <ReviewDebugSettingsProvider>
+          <ReviewProvider>
+            <ReviewPanelProvider>
+              <CaptureStore onStore={(store) => (panelStore = store)} />
+              <OpenNewAskPanel />
+              <ReviewPanelHost />
+            </ReviewPanelProvider>
+          </ReviewProvider>
+        </ReviewDebugSettingsProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      ".thread-compose textarea",
+    );
+    expect(textarea).not.toBeNull();
+    await act(async () => {
+      const setValue = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )!.set!;
+      setValue.call(textarea, "hi");
+      textarea!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLFormElement>(".thread-compose")!
+        .requestSubmit();
+      await Promise.resolve();
+    });
+
+    expect(askAgent).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(panelStore!.getState().active).toBeNull();
+      expect(container.querySelectorAll(".side-panel")).toHaveLength(0);
     });
   });
 
@@ -371,6 +425,21 @@ function OpenReplacingPanel() {
 function OpenThreadsPanel() {
   const openThreads = useReviewPanel((state) => state.openThreads);
   useEffect(() => openThreads(), [openThreads]);
+  return null;
+}
+
+function OpenNewAskPanel() {
+  const openThreads = useReviewPanel((state) => state.openThreads);
+  useEffect(() => openThreads({ kind: "new-ask" }), [openThreads]);
+  return null;
+}
+
+function CaptureStore({
+  onStore,
+}: {
+  onStore: (store: ReviewPanelStore) => void;
+}) {
+  onStore(useReviewPanelStore());
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Ask now on the Threads panel's new-ask page awaited the agent run, then reopened the panel on the comment page. The native terminal launch fires `agentTerminalOpening` before the ask request resolves, so the panel closed for the terminal and immediately reappeared showing the running thread.
- Adds `setThreadsPage` to the panel store: it moves between pages only while Threads is still the active panel and is a no-op once another surface has closed it. The panel's Ask now and Add to review handlers use it; real entry points keep `openThreads`.

## Tests
- Store test: a page change after `closeForAgentTerminal` leaves the panel closed, and still navigates when Threads is open.
- Rendered panel test: Ask now on the new-ask page does not resurrect the panel when the terminal-opening close lands mid-request (verified failing before the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKPuiV9pRMsb9ojDNLu4eB