### PR TITLE
perf(review): ~20% improvement on warm runs from skill improvements

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
@@ -176,13 +176,6 @@ function isTutorialStepId(step: unknown): step is TutorialStepId {
 		REVIEW_TUTORIAL_STEP_IDS.includes(step as TutorialStepId)
 	);
 }
-// First commit is not proof of document health: effect-driven errors land
-// just after it. Mount validation holds its success signal for this settle
-// window so an error diagnostic reported from an effect still fails the
-// publish. Interaction-driven errors (for example a tour opened later) are
-// out of reach for any window.
-const mountValidationSettleMs = 2_000;
-
 function embeddedSelectionChangeReason(
 	event: ICursorPositionChangedEvent,
 ): EditorPaneSelectionChangeReason {
@@ -1494,7 +1487,6 @@ export class ReviewCanvasEditorPane extends EditorPane {
 		let handle: ReviewCanvasHandle | undefined;
 		let comments: ReviewCommentStore | undefined;
 		let loadTimeout: ReturnType<typeof setTimeout> | undefined;
-		let settleTimeout: ReturnType<typeof setTimeout> | undefined;
 		// Each step of the off-screen mount reports its wall-clock interval back
 		// to the server, which folds it into the publish timings the CLI shows.
 		const timings: { name: string; startEpochMs: number; endEpochMs: number }[] = [];
@@ -1563,15 +1555,15 @@ export class ReviewCanvasEditorPane extends EditorPane {
 				subscribe: () => ({ dispose: () => undefined }),
 				currentTheme: () => this.colorScheme(),
 				onDidChangeTheme: () => ({ dispose: () => undefined }),
+				// First commit is the success signal. Errors reported from effects
+				// that run before it still fail the mount via reportDiagnostic;
+				// later ones are the visible pane's problem, not publish's.
 				ready: () => {
-					if (finished || settleTimeout) {
+					if (finished) {
 						return;
 					}
 					timings.push({ name: "first commit", startEpochMs: mountedAt, endEpochMs: Date.now() });
-					settleTimeout = setTimeout(
-						() => finishMount(null),
-						mountValidationSettleMs,
-					);
+					finishMount(null);
 				},
 				reportDiagnostic: (diagnostic) => {
 					if (diagnostic.level === "error") {
@@ -1624,7 +1616,6 @@ export class ReviewCanvasEditorPane extends EditorPane {
 			};
 		} finally {
 			if (loadTimeout) clearTimeout(loadTimeout);
-			if (settleTimeout) clearTimeout(settleTimeout);
 			handle?.dispose();
 			container?.remove();
 			comments?.dispose();

--- a/packages/progressive-review/skills/dev-review/SKILL.md
+++ b/packages/progressive-review/skills/dev-review/SKILL.md
@@ -106,11 +106,9 @@ If no sub-agent facility exists, publish the document. Report that the map is no
 
 Read [Document authoring](references/document-authoring.md) before you edit `review.mdx` or `data.ts`.
 
-Use the materialized files in `traces.paths` from the scaffold event. When that array is non-empty, read [Trace quoting](references/trace-quoting.md) and complete its intent pass before authoring. Use FFF for candidate discovery.
+Use the materialized files in `traces.paths` from the scaffold event. When that array is non-empty, read [Trace quoting](references/trace-quoting.md) and complete its intent pass before authoring. Use FFF for trace search candidate discovery.
 
-Use the smallest document that explains the important change. Default to `AnchorLink` for source evidence, and use this to hyperlink any text in the review that refers to a specific piece of code. Use `CodePeek` only when readers must see the code inline to understand the main claim.
-
-Read every referenced range from the correct pinned checkout before you add it. Use the `checkouts` paths from the scaffold event: the head checkout for a head range, the base checkout for a base range.
+Use the `checkouts` paths from the scaffold event: the head checkout for a head range, the base checkout for a base range.
 
 ### 5. Publish the document
 
@@ -184,3 +182,11 @@ Complete the authoring turn only when all applicable conditions are true:
 - All document diagnostics are resolved.
 - Both map checks passed before map publication.
 - The Review is waiting on the reviewer, the reader dismissed it, or the Review was deleted.
+
+## Errata
+
+Do not run typechecks, compilation checks, lints, or tests of any sort until you get explicit instructions from the user.
+
+You do not need ANY of this information to write a good review and it is a complete waste of time.
+
+The point is to help the user understand the code; it does not relevant if CI is or is going to be green.

--- a/packages/progressive-review/skills/dev-review/references/document-authoring.md
+++ b/packages/progressive-review/skills/dev-review/references/document-authoring.md
@@ -4,32 +4,42 @@
 
 The reader sees the original user request and the Review document. The reader does not see agent reasoning or the implementation session.
 
-The H1 is the review's display title in Review Desktop tabs and Home. Write a short, specific title for the change (for example, "Publish pipeline: single mount"), not a generic one. Publishing syncs the title. Use progressive disclosure: short prose first, then details that earn their cost. Typical useful sections are interface change, lifecycle/data flow, state/storage, and testing evidence. Write in ASD-STE100 Simplified Technical English (STE).
+The H1 is the review's display title in Review Desktop tabs and Home. Write a short, specific title for the change (for example, "Publish pipeline: single mount"), not a generic one. Use progressive disclosure: short prose first, then details that earn their cost. Write in ASD-STE100 Simplified Technical English (STE).
 
-Assume raw prose will confuse the reader. Spend substantial reasoning effort deciding what to omit, rather than what to include; deep analysis followed by a small amount of clear output text is the correct tradeoff. Start brief and add resolution only where it earns the reader's attention; the reader's time and attention are incredibly expensive and thus every word you put out taxes and pains them. Your job is to not waste that time. Think about the style of RFCs from great tech leaders like Russ Cox, Dave Cheney, and the early React RFCs.
+Assume raw prose will confuse the reader. Think about the style of RFCs from great tech leaders like Russ Cox, Dave Cheney, and the early React RFCs.
 
 Remember that the reader can ONLY see the 'user' prompts _before_ coding started and the document you write to explain what changed. This means jargon in the middle - references to specific parts of code, especially any and all abstractions, changes, and code referenced _during_ the editing process - is confusing and not helpful. More words do not help. Progressive disclosure of complexity is key.
 
-Open the document with a landing section after the H1 and before the first H2. Be concise.
+If you have context on the change already in previous chat history, there's almost no reason to do extra exploration - go straight into authoring. Just make sure to attach examples to your claims.
 
-**Summary** 
-- short bullet points that summarize the change, for example:
-- comment peeks now open in the real diff editor, not a stitched-together fake buffer
-- both diff sides are actual files on disk, so imports and go-to-definition just work
-- comments stick to real lines — deleted ones included
+Open the document with a landing section after the H1 and before the first H2. Be concise; this section should just be *quotes from the prompt behind the change* (either through associated agent trace sessions, or your own context window, if you have the implementation session in context.)
+
+**Summary** - *What* behavior was changed
+- keep max ~5 bullet points. 1 is best and indicates a clean PR.
 
 **Why**
-A couple short sentences about: What problem does this change solve? (What problem(s) is this change not trying to solve?) For a bugfix, this can be what was wrong before; for a new feature, this can be what this adds. Capture the intent behind the pr using the developer's own prompts, if those are available to you (either through associated agent trace sessions, or your own context window, if you have the implementation session in context.)
+A couple short sentences about: What problem does this change solve? (What problem(s) is this change not trying to solve?) For a bugfix, this can be what was wrong before; for a new feature, this can be what this adds. 
 
 After the landing section, use fewer than five further sections when practical. Choose the sections that fit this change. Good section choices are:
 
 - requirements
+  - best expressed via links to trace
 - design
+  - best expressed via decision log w/ diagram or code examples w/ links to trace
 - interface change
+  - best expressed through links to code w/ example usage
 - lifecycle or data flow
+  - obviously best expressed via diagram (sequence + state diagram)
 - state or storage
+  - database diagram
 - testing evidence
-- decision log
+  - do:
+    - reference what is tested via integration-style or E2E tests via pseudocode.
+      - generally, it is wise here to skip noting unit tests
+    - add links to decisions etc. that are relevant here (e.g. explicit user guidance on what to test)
+  - do not:
+    - run tests or linters.
+    - "xxx/yyy tests are passing" (overwhelming without giving information; CI being green is enough).
 
 Add implementation detail only when it helps the reader check an important claim.
 
@@ -54,12 +64,20 @@ Do not import runtime values from source repository files. Put document data in 
 
 Scaffold creates one pinned checkout per pinned commit and prints both paths in its JSON event, under `checkouts.head` and `checkouts.base`. Read the paths from that output. Do not derive them from the repository layout. When you have no scaffold output, the layout is `<git-common-dir>/dev-fast/reviews/<review-uuid>/{head,base}/<full-commit>/`; resolve the common dir with `git rev-parse --git-common-dir` in the source worktree.
 
-Read each range from the correct pinned checkout before you add it:
+1. **Load the change into your context window**:
+   - *IMPORTANT*: THIS STEP IS OPTIONAL; SKIP to #2 IF THIS IS THE SAME SESSION THAT AUTHORED THE CHANGE
+   - Typically involves batched commands; utilize code mode + parallel subagents to minimize the number of tool calls.
+   - infer if "this is the same session that authored the change" via the user's messages.
+2. **Decide on the evidence that you want to show**
+3. **For locations where you can't remember specific line numbers, search for code locations to match your chosen examples/anchors.**
 
-- Use the head checkout (`sourceCommit`) for a head range.
-- Use the base checkout (`baseCommit`) for a base range.
+Default to `AnchorLink` or `CodePeek` for source evidence (prefer `AnchorLink`, with `CodePeek` superior for examples which are best demonstrated via inline code, e.g. an API change).
 
-Use the smallest range that proves the claim. Default to `AnchorLink` for source evidence. Use `CodePeek` only when readers must see the code inline to understand the main claim. A path outside the pinned checkout or an invalid line range blocks document publication.
+A path outside the pinned checkout blocks document publication.
+
+Remember that a review has two pinned checkouts (base checkout, or `baseCommit`, and head checkout, or `sourceCommit`). Depending on the anchor/code ref you may need to be specific about one side or the other.
+
+If code context is already in your context window (e.g. file/symbols), leverage that information to avoid extraneous searches.
 
 ## Authoring API (data.ts)
 
@@ -146,4 +164,4 @@ See <AnchorLink anchor={anchors.publish}>the publish implementation</AnchorLink>
 
 ## Publication checks
 
-Run `review publish --review <uuid> --json`. Do not run `npm test` against the private Review directory. The publish command supplies the correct private test command and returns document diagnostics as NDJSON events.
+Run `review publish --review <uuid> --json` to publish.


### PR DESCRIPTION
Stacked on the instrumentation + harness PR (#157). Two things: the mount settle timer removal, and the authoring guidance. Embedding code peeks at publish is its own PR above this one (#184); the source-range tooling guidance is above that (#183).

Taken together, on a 4–5.5 minute run: ~2s at publish from the timer (measured on `main`, below) and roughly 16–40s of exploration from the skill edits (measured on the pre-#84 lineage). The skill part depends on warm context, which is the normal case: the review request usually lands in the session that made the change.

## What it saves, per run (review#83 replay, warm)

| change | saving | when |
|---|---|---|
| mount settle timer removed | ~2s | every publish |
| skill edits taken together (no build checks in `SKILL.md`, author-from-context step, harness stash removed) | ~16–40s of exploration on warm runs | the run after these edits was 252s against 307–343s before, but 36s of that gap is a desktop `show` outlier in the 317s run, and four things changed at once (n=1 each). The build checks alone were 26–170s of calls when they fired. |

The one-minute saving from `--effort low` mentioned at the end is a harness finding, not a change in this PR.

## Publish path

The off-screen mount validation held success for a hard-coded `mountValidationSettleMs = 2_000` after first commit. Removed; first commit is the signal, and errors reported from effects before it still fail the mount. This is a behavior change as well as a saving: effect-driven errors that land after first commit no longer fail the publish. On `main`, warm review#83: `validate canvas mount` 7.67s → 5.6s with this alone (the remaining 5.5s is the per-peek fetch that #184 removes).

## Skill guidance

Ten warm-context runs of the same replay, one change at a time. What held:

- **No build checks while authoring.** Warm runs re-ran typecheck and the test suite every time (up to 150s) because the implementation session's own "keep it green" contract carried over. The rule works only in `SKILL.md`, which is in context when the reflex fires; the same sentence in a reference file did nothing because that file is opened later.
- Step 1 (load the change into context) is explicitly optional for the authoring session.

What did not move wall-clock: the agent still reads the files it wrote before choosing anchors (3–4 `cat` calls).

![Root causes ranked by seconds per run; the top two are CLI primitives](https://github.com/user-attachments/assets/0dd8fe6c-9d3c-4114-bcdf-92899691ea8c)

## The lever that is left

All runs above are `opus @ high`. The same replay at `--effort low` (3 runs) came in at a median of 270s versus 330s at high, with thinking tokens down ~30% and the document's shape unchanged (anchors, diagrams, size). `medium` was indistinguishable from `high`. That is the first knob that moved time without moving the document, and it is where the next measurement goes.

![Dependency graph of the remaining work; the blue path is the critical one](https://github.com/user-attachments/assets/2250b58e-392a-4f39-bf9b-2c201d2f379e)

## Notes for review

- Commits are split by concern; the tree typechecks and tests at the tip of the stack (1124 tests in `packages/progressive-review`, 104 in `review-protocol`).
- The renderer change was type-checked and exercised through the dev desktop under the harness.

https://claude.ai/code/session_01N2M3zTuiQh2z9WKiwpWqs3
