### PR TITLE
Scroll Threads panel focus to prose highlights

### DIFF
--- a/packages/progressive-review/app/src/thread-annotations.test.ts
+++ b/packages/progressive-review/app/src/thread-annotations.test.ts
@@ -2,12 +2,15 @@
 
 import { describe, expect, it, vi } from "vitest";
 
+import type { ThreadTarget } from "../../src/types";
+import { targetKey } from "./target-fingerprint";
 import {
   CARD_MAX_WIDTH,
   CARD_MIN_WIDTH,
   MARGIN_CARDS_MIN_GUTTER,
   annotationForThread,
   gutterForAvailable,
+  scrollTargetForThread,
   textNodeClientRects,
   threadFitsExpandedCard,
 } from "./thread-annotations";
@@ -18,6 +21,53 @@ function domRectList(...rects: DOMRect[]): DOMRectList {
     item: (index: number) => rects[index] ?? null,
   });
 }
+
+describe("scrollTargetForThread", () => {
+  const proseTarget: ThreadTarget = {
+    kind: "text",
+    surface: { type: "document", documentHash: "document-hash" },
+    selection: {
+      start: 0,
+      length: 5,
+      hash: "selection-hash",
+      quote: "hello",
+    },
+  };
+
+  function articleWith(html: string): HTMLElement {
+    document.body.innerHTML = `<article class="review-document">${html}</article>`;
+    return document.querySelector<HTMLElement>(".review-document")!;
+  }
+
+  it("prefers a real locator outside the annotation layer", () => {
+    const key = targetKey(proseTarget);
+    const article = articleWith(
+      `<p data-review-locator="${key}">real</p>` +
+        `<div class="review-annotations"><div class="review-highlight" data-review-locator="${key}"></div></div>`,
+    );
+
+    expect(scrollTargetForThread(article, proseTarget)?.tagName).toBe("P");
+  });
+
+  it("falls back to the thread's highlight for prose targets", () => {
+    const key = targetKey(proseTarget);
+    const article = articleWith(
+      `<p>prose</p>` +
+        `<div class="review-annotations"><div class="review-highlight" data-review-locator="${key}"></div></div>`,
+    );
+
+    const element = scrollTargetForThread(article, proseTarget);
+    expect(element?.classList.contains("review-highlight")).toBe(true);
+  });
+
+  it("returns null when neither a locator nor a highlight exists", () => {
+    const article = articleWith(
+      `<p>prose</p><div class="review-annotations"></div>`,
+    );
+
+    expect(scrollTargetForThread(article, proseTarget)).toBeNull();
+  });
+});
 
 describe("annotationForThread", () => {
   it("places a cross-paragraph comment pin in the selected prose margin", () => {

--- a/packages/progressive-review/app/src/thread-annotations.test.ts
+++ b/packages/progressive-review/app/src/thread-annotations.test.ts
@@ -9,6 +9,7 @@ import {
   CARD_MIN_WIDTH,
   MARGIN_CARDS_MIN_GUTTER,
   annotationForThread,
+  collapsedSectionForThread,
   gutterForAvailable,
   scrollTargetForThread,
   textNodeClientRects,
@@ -66,6 +67,18 @@ describe("scrollTargetForThread", () => {
     );
 
     expect(scrollTargetForThread(article, proseTarget)).toBeNull();
+  });
+
+  it("finds the collapsed section containing a prose target", () => {
+    const article = articleWith(
+      `<section class="review-section review-section--collapsed">` +
+        `<div class="review-section-body" hidden><p>hello</p></div>` +
+        `</section>`,
+    );
+
+    expect(collapsedSectionForThread(article, proseTarget)).toBe(
+      article.querySelector(".review-section"),
+    );
   });
 });
 

--- a/packages/progressive-review/app/src/thread-annotations.tsx
+++ b/packages/progressive-review/app/src/thread-annotations.tsx
@@ -1006,6 +1006,24 @@ function elementForThread(
   return null;
 }
 
+/**
+ * Element to scroll into view for a focus request. Unlike elementForThread,
+ * which must ignore the annotation overlays because it anchors measurement,
+ * scrolling may land on the thread's own highlight: for a prose selection
+ * that overlay is the only element marking where the thread lives.
+ */
+export function scrollTargetForThread(
+  article: HTMLElement,
+  target: ThreadTarget,
+): Element | null {
+  const anchored = elementForThread(article, target);
+  if (anchored && anchored !== article) return anchored;
+  const highlight = article.querySelector(
+    `.review-annotations .review-highlight[data-review-locator="${cssString(targetKey(target))}"]`,
+  );
+  return highlight ?? null;
+}
+
 function textRange(
   target: Extract<ThreadTarget, { kind: "text" }>,
   element: HTMLElement,

--- a/packages/progressive-review/app/src/thread-annotations.tsx
+++ b/packages/progressive-review/app/src/thread-annotations.tsx
@@ -219,6 +219,7 @@ export function ThreadAnnotations({
   const cardRefs = useRef(new Map<string, HTMLDivElement>());
   const rootRef = useRef<HTMLDivElement | null>(null);
   const draftHasTextRef = useRef(false);
+  const deferredFocusNonceRef = useRef<number | null>(null);
 
   // Recompute annotations when a draft opens/closes too, so the selected
   // text is highlighted while the comment is being written (not only after
@@ -510,7 +511,8 @@ export function ThreadAnnotations({
       const hiddenContainer = targetElement?.closest("[hidden]");
       const section =
         hiddenContainer?.closest(".review-section") ??
-        targetElement?.closest(".review-section--collapsed");
+        targetElement?.closest(".review-section--collapsed") ??
+        (target ? collapsedSectionForThread(article, target) : null);
       if (section) {
         section.dispatchEvent(new CustomEvent("review-section-expand"));
         await nextAnimationFrame();
@@ -521,6 +523,23 @@ export function ThreadAnnotations({
       }
 
       if (cancelled) return;
+      const scrollElement = target
+        ? scrollTargetForThread(article, target)
+        : null;
+      const isProseTarget =
+        target?.kind === "text" && target.surface.type === "document";
+      // A prose highlight is rendered one measurement cycle after the thread
+      // (or its section) appears. Wait exactly once for that cycle: keep the
+      // request pending and let the annotations dependency re-run this effect.
+      if (
+        request.scroll &&
+        !scrollElement &&
+        isProseTarget &&
+        deferredFocusNonceRef.current !== request.nonce
+      ) {
+        deferredFocusNonceRef.current = request.nonce;
+        return;
+      }
       setFocusPresentation(request.inline ? "inline" : "highlight");
       const preferred = preferredFocusedKey
         ? displayThreads.get(preferredFocusedKey)
@@ -529,8 +548,11 @@ export function ThreadAnnotations({
         setPreferredFocusedKey(request.inline ? (thread?.key ?? null) : null);
       }
       onThreadActivated?.(request.threadId);
-      if (request.scroll && targetElement) {
-        targetElement.scrollIntoView({ block: "center", behavior: "smooth" });
+      if (request.scroll) {
+        (scrollElement ?? targetElement ?? article).scrollIntoView({
+          block: "center",
+          behavior: "smooth",
+        });
       }
       // Thread detail lives in the side panel; a focus request only
       // highlights (and optionally scrolls to) the inline target.
@@ -541,6 +563,7 @@ export function ThreadAnnotations({
       cancelled = true;
     };
   }, [
+    annotations,
     articleRef,
     onThreadActivated,
     preferredFocusedKey,
@@ -1022,6 +1045,22 @@ export function scrollTargetForThread(
     `.review-annotations .review-highlight[data-review-locator="${cssString(targetKey(target))}"]`,
   );
   return highlight ?? null;
+}
+
+/** Find a collapsed section containing a document-text target. */
+export function collapsedSectionForThread(
+  article: HTMLElement,
+  target: ThreadTarget,
+): Element | null {
+  if (target.kind !== "text" || target.surface.type !== "document") {
+    return null;
+  }
+  const range = textRange(target, article);
+  return (
+    range?.startContainer.parentElement?.closest(
+      ".review-section--collapsed",
+    ) ?? null
+  );
 }
 
 function textRange(


### PR DESCRIPTION
## What this fixes

Clicking a prose thread in the Threads panel focused the thread, but did not scroll the review document to the highlighted text. The same problem could occur when the prose was inside a collapsed section.

## Fix

- Scroll to the prose highlight when the thread has no code or section locator.
- Retry once after annotations render so threads in collapsed sections are found.

## Testing

- Full pnpm run ci
- Manual checks for offscreen prose, prose in a collapsed section, and code-peek threads