### PR TITLE
Add a Resolve / Unresolve toggle to the Threads panel thread header

### DIFF
--- a/packages/progressive-review/app/src/review-components.tsx
+++ b/packages/progressive-review/app/src/review-components.tsx
@@ -44,7 +44,14 @@ import {
   useOptionalReviewSession,
   useReviewSession,
 } from "./host/review-session";
-import { CloseIcon, CommentIcon, MapPinIcon, TerminalIcon } from "./icons";
+import {
+  CloseIcon,
+  CommentIcon,
+  MapPinIcon,
+  RefreshIcon,
+  ResolveIcon,
+  TerminalIcon,
+} from "./icons";
 import { newTabLinkProps } from "./link-props";
 import { createClientId, useReview, useReviewActions } from "./review-context";
 import { useOptionalReviewPanelStore, useReviewPanel } from "./review-panel";
@@ -1588,16 +1595,36 @@ function ThreadPanelInner({
               + New ask
             </button>
           ) : undefined
-        ) : thread?.agentSession && !review.historicalRevision ? (
-          <button
-            type="button"
-            className="thread-resume-terminal"
-            aria-label="Resume in terminal"
-            title="Resume in terminal"
-            onClick={() => void resumeInTerminal(thread)}
-          >
-            <TerminalIcon />
-          </button>
+        ) : thread && !review.historicalRevision ? (
+          <>
+            <button
+              type="button"
+              className={`thread-resolve-toggle${
+                thread.resolved ? " thread-resolve-toggle--resolved" : ""
+              }`}
+              aria-pressed={thread.resolved}
+              onClick={() =>
+                void review.setCommentResolved(
+                  thread.threadId,
+                  !thread.resolved,
+                )
+              }
+            >
+              {thread.resolved ? <RefreshIcon /> : <ResolveIcon />}
+              <span>{thread.resolved ? "Unresolve" : "Resolve"}</span>
+            </button>
+            {thread.agentSession && (
+              <button
+                type="button"
+                className="thread-resume-terminal"
+                aria-label="Resume in terminal"
+                title="Resume in terminal"
+                onClick={() => void resumeInTerminal(thread)}
+              >
+                <TerminalIcon />
+              </button>
+            )}
+          </>
         ) : undefined
       }
     >
@@ -1693,7 +1720,7 @@ function ThreadChat({
           );
         })}
       </div>
-      {!readOnly && !thread?.resolved && (
+      {!readOnly && (
         <div className="thread-chat-composer">
           <ThreadComposer
             kind="new-thread"
@@ -1704,6 +1731,13 @@ function ThreadChat({
             onAskNow={onAskNow}
             onAddToReview={onAddToReview}
           />
+          {thread?.resolved && (
+            // A reply on a resolved thread reopens it (the comment store
+            // resets the status on append); say so before the reviewer types.
+            <p className="thread-chat-reopen-hint">
+              Submitting reopens this thread.
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/packages/progressive-review/app/src/review-panel.test.tsx
+++ b/packages/progressive-review/app/src/review-panel.test.tsx
@@ -159,6 +159,80 @@ describe("Review panel host", () => {
     });
   });
 
+  it("toggles a thread between resolved and open from its header", async () => {
+    await session.bridge.comments.saveComment({
+      threadId: "thread-1",
+      messageId: "message-1",
+      target: { kind: "document" },
+      body: "is this anchor still right?",
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      renderWithSession(
+        <ReviewDebugSettingsProvider>
+          <ReviewProvider>
+            <ReviewPanelProvider>
+              <OpenCommentPanel threadId="thread-1" />
+              <ReviewPanelHost />
+            </ReviewPanelProvider>
+          </ReviewProvider>
+        </ReviewDebugSettingsProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    const toggle = () =>
+      container.querySelector<HTMLButtonElement>(".thread-resolve-toggle");
+    expect(toggle()?.textContent).toBe("Resolve");
+    expect(toggle()?.getAttribute("aria-pressed")).toBe("false");
+
+    await act(async () => {
+      toggle()!.click();
+      await Promise.resolve();
+    });
+    expect(toggle()?.textContent).toBe("Unresolve");
+    expect(toggle()?.getAttribute("aria-pressed")).toBe("true");
+    expect(
+      toggle()?.classList.contains("thread-resolve-toggle--resolved"),
+    ).toBe(true);
+
+    // The composer stays available on a resolved thread and warns that a
+    // reply reopens it; submitting one flips the toggle back.
+    expect(
+      container.querySelector(".thread-chat-reopen-hint")?.textContent,
+    ).toBe("Submitting reopens this thread.");
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          ".thread-chat-composer .thread-reply-row",
+        )!
+        .click();
+    });
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      ".thread-chat-composer textarea",
+    );
+    expect(textarea).not.toBeNull();
+    await act(async () => {
+      const setValue = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )!.set!;
+      setValue.call(textarea, "one more thing");
+      textarea!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLFormElement>(".thread-compose")!
+        .requestSubmit();
+      await Promise.resolve();
+    });
+    expect(toggle()?.textContent).toBe("Resolve");
+    expect(container.querySelector(".thread-chat-reopen-hint")).toBeNull();
+  });
+
   it("replaces Threads when a document peek opens", async () => {
     const addEventListener = vi.spyOn(document, "addEventListener");
     const container = document.createElement("div");
@@ -425,6 +499,15 @@ function OpenReplacingPanel() {
 function OpenThreadsPanel() {
   const openThreads = useReviewPanel((state) => state.openThreads);
   useEffect(() => openThreads(), [openThreads]);
+  return null;
+}
+
+function OpenCommentPanel({ threadId }: { threadId: string }) {
+  const openThreads = useReviewPanel((state) => state.openThreads);
+  useEffect(
+    () => openThreads({ kind: "comment", threadId }),
+    [openThreads, threadId],
+  );
   return null;
 }
 

--- a/packages/progressive-review/app/src/review-session-test-utils.tsx
+++ b/packages/progressive-review/app/src/review-session-test-utils.tsx
@@ -107,8 +107,13 @@ function createTestCommentStore(): ReviewCommentStoreBridge {
       };
       local.set(input.threadId, {
         clientStatus: "draft",
+        // Like the desktop store, a reply reopens a resolved thread.
         thread: existing
-          ? { ...existing, messages: [...existing.messages, message] }
+          ? {
+              ...existing,
+              status: "open",
+              messages: [...existing.messages, message],
+            }
           : {
               threadId: input.threadId,
               target: input.target,

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -3688,6 +3688,49 @@ button {
   padding: 0;
 }
 
+/* Resolve / Unresolve, top-right of the opened thread. The resolved state is
+   drawn hollow and dashed to match the resolved pin in the document. */
+.thread-resolve-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 24px;
+  margin-left: auto;
+  padding: 0 9px;
+  border: 1px solid var(--rule-soft);
+  border-radius: 5px;
+  background: var(--control-bg);
+  color: var(--ink-soft);
+  font: 600 11px var(--font-mono);
+}
+
+.thread-resolve-toggle .ui-icon {
+  width: 11px;
+  height: 11px;
+}
+
+.thread-resolve-toggle:hover,
+.thread-resolve-toggle:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+
+.thread-resolve-toggle--resolved {
+  border-style: dashed;
+  border-color: var(--marker-resolved-rule);
+  background: transparent;
+  color: var(--marker-resolved-ink);
+}
+
+.thread-resolve-toggle--resolved:hover,
+.thread-resolve-toggle--resolved:focus-visible {
+  border-style: solid;
+  border-color: var(--ink-faint);
+  background: var(--highlight-resolved-bg-active);
+  color: var(--ink);
+}
+
 .thread-chat {
   display: flex;
   flex-direction: column;
@@ -3737,6 +3780,13 @@ button {
 
 .question-panel .thread-chat-composer .thread-compose {
   gap: 8px;
+}
+
+.thread-chat-reopen-hint {
+  margin: 6px 0 0;
+  color: var(--ink-faint);
+  font: 400 11px/15px var(--font-mono);
+  text-align: right;
 }
 
 .question-panel .thread-chat-composer .thread-compose textarea {


### PR DESCRIPTION
Resolving a thread was only possible from the code side peek's thread
card; the document's Threads panel had no control for it. The opened
thread's header now carries a Resolve chip beside the terminal button.
On a resolved thread it flips to Unresolve, drawn hollow and dashed to
match the resolved pin. Read-only historical revisions hide it.

A resolved thread keeps its composer. A short hint under it says that
submitting reopens the thread, which is what the comment store does on
append.

🤖 Generated with [Claude Code](https://claude.com/claude-code)