### PR TITLE
Keep the Resolved section in view when no threads are open

### DIFF
--- a/packages/progressive-review/app/src/review-components.tsx
+++ b/packages/progressive-review/app/src/review-components.tsx
@@ -1649,6 +1649,14 @@ function ThreadPanelInner({
             onSelect={selectListThread}
             onResumeInTerminal={resumeInTerminal}
             readOnly={Boolean(review.historicalRevision)}
+            emptyState={
+              resolvedThreads.length > 0
+                ? {
+                    title: "No open threads",
+                    description: "Resolved threads are listed below.",
+                  }
+                : undefined
+            }
           />
           {resolvedThreads.length > 0 && (
             <details className="thread-resolved-section">
@@ -1750,19 +1758,25 @@ function ThreadPanelList({
   onSelect,
   onResumeInTerminal,
   readOnly,
+  emptyState,
 }: {
   threads: ThreadView[];
   activeLocator: string | null;
   onSelect: (thread: ThreadView) => void;
   onResumeInTerminal: (thread: ThreadView) => Promise<void>;
   readOnly: boolean;
+  /** Copy for the empty list; the default assumes no threads exist at all. */
+  emptyState?: { title: string; description: string };
 }) {
   if (threads.length === 0) {
     return (
       <div className="question-sidebar-list question-sidebar-list--empty">
         <CommentIcon />
-        <strong>No threads yet</strong>
-        <p>Comment on or ask about highlighted review text.</p>
+        <strong>{emptyState?.title ?? "No threads yet"}</strong>
+        <p>
+          {emptyState?.description ??
+            "Comment on or ask about highlighted review text."}
+        </p>
       </div>
     );
   }

--- a/packages/progressive-review/app/src/review-panel.test.tsx
+++ b/packages/progressive-review/app/src/review-panel.test.tsx
@@ -233,6 +233,41 @@ describe("Review panel host", () => {
     expect(container.querySelector(".thread-chat-reopen-hint")).toBeNull();
   });
 
+  it("lists only-resolved threads under a compact empty state", async () => {
+    await session.bridge.comments.saveComment({
+      threadId: "thread-1",
+      messageId: "message-1",
+      target: { kind: "document" },
+      body: "is this anchor still right?",
+    });
+    await session.bridge.comments.setCommentResolved("thread-1", true);
+    const container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      renderWithSession(
+        <ReviewDebugSettingsProvider>
+          <ReviewProvider>
+            <ReviewPanelProvider>
+              <OpenThreadsPanel />
+              <ReviewPanelHost />
+            </ReviewPanelProvider>
+          </ReviewProvider>
+        </ReviewDebugSettingsProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    const body = container.querySelector(".review-panel-body")!;
+    expect(
+      body.querySelector(".question-sidebar-list--empty strong")?.textContent,
+    ).toBe("No open threads");
+    const resolved = body.querySelector(".thread-resolved-section");
+    expect(resolved).not.toBeNull();
+    expect(resolved!.querySelectorAll(".question-thread-row")).toHaveLength(1);
+  });
+
   it("replaces Threads when a document peek opens", async () => {
     const addEventListener = vi.spyOn(document, "addEventListener");
     const container = document.createElement("div");

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -3535,6 +3535,13 @@ button {
   text-align: center;
 }
 
+/* With only resolved threads, the empty state must not fill the body, or the
+   Resolved section after it lands below the fold. */
+.review-panel-body:has(.thread-resolved-section) .question-sidebar-list--empty {
+  height: auto;
+  padding: 36px 0 22px;
+}
+
 .question-sidebar-list--empty .ui-icon {
   width: 34px;
   height: 34px;


### PR DESCRIPTION
With only resolved threads, the Threads panel's empty state filled the
whole body, so the Resolved section rendered below the fold and looked
missing. The empty state now shrinks when a Resolved section follows it,
and its copy says there are no open threads rather than none at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)