### PR TITLE
Send bug descriptions with report metadata

### DIFF
--- a/packages/progressive-review/src/server/bug-report.test.ts
+++ b/packages/progressive-review/src/server/bug-report.test.ts
@@ -217,6 +217,7 @@ describe("submitReviewBugReport", () => {
       has_trace: false,
       parts: [{ field: "payload" }],
     });
+    expect(meta).not.toHaveProperty("description");
     const payloadBytes = capture.filePart("payload");
     expect(JSON.parse(gunzipSync(payloadBytes).toString("utf8"))).toMatchObject(
       {
@@ -226,6 +227,42 @@ describe("submitReviewBugReport", () => {
     );
     expect(meta.parts[0].bytes).toBe(payloadBytes.byteLength);
     expect(meta.parts[0].sha256).toBe(sha256(payloadBytes));
+  });
+
+  it("includes a verbatim meaningful description in report metadata", async () => {
+    writeReview("disabled:review");
+    const description = "First line\nSnow: 雪\nLast line";
+    const capture = captureFetch();
+
+    await submitReviewBugReport({
+      report: report({ description }),
+      reviewDocumentPath: path.join(reviewRootPath, "review.mdx"),
+      reviewRootPath,
+      clientErrorNames: [],
+      fetchImpl: capture.fetchImpl,
+    });
+
+    expect(JSON.parse(capture.textPart("meta"))).toMatchObject({
+      description,
+      description_length: Buffer.byteLength(description),
+    });
+  });
+
+  it("omits a whitespace-only description from report metadata", async () => {
+    writeReview("disabled:review");
+    const capture = captureFetch();
+
+    await submitReviewBugReport({
+      report: report({ description: " \n\t " }),
+      reviewDocumentPath: path.join(reviewRootPath, "review.mdx"),
+      reviewRootPath,
+      clientErrorNames: [],
+      fetchImpl: capture.fetchImpl,
+    });
+
+    const meta = JSON.parse(capture.textPart("meta"));
+    expect(meta).not.toHaveProperty("description");
+    expect(meta.description_length).toBe(4);
   });
 
   it.each([503, 422])(

--- a/packages/progressive-review/src/server/bug-report.ts
+++ b/packages/progressive-review/src/server/bug-report.ts
@@ -356,6 +356,9 @@ export async function buildBugReportRequest(
       })),
     ],
   };
+  if (payload.description.trim().length > 0) {
+    meta.description = payload.description;
+  }
   if (payload.trace) meta.trace_harness = payload.trace.harness;
   const form = new FormData();
   form.append("meta", JSON.stringify(meta));

--- a/packages/review-protocol/src/bug-report.test.ts
+++ b/packages/review-protocol/src/bug-report.test.ts
@@ -62,6 +62,45 @@ describe("bug report protocol", () => {
     expect(ReviewBugReportMetaV2Schema.parse(baseMeta)).toEqual(baseMeta);
   });
 
+  it("accepts a verbatim Unicode and multiline description", () => {
+    const description = "First line\nSnowman: ☃️\nLast line";
+    const meta = {
+      ...baseMeta,
+      description,
+      description_length: new TextEncoder().encode(description).byteLength,
+    };
+
+    expect(ReviewBugReportMetaV2Schema.parse(meta)).toEqual(meta);
+  });
+
+  it("accepts the 64 KiB description boundary", () => {
+    const description = "😀".repeat(16_384);
+    const meta = {
+      ...baseMeta,
+      description,
+      description_length: 65_536,
+    };
+
+    expect(ReviewBugReportMetaV2Schema.parse(meta)).toEqual(meta);
+  });
+
+  it("rejects an oversized description or a byte-length mismatch", () => {
+    expect(() =>
+      ReviewBugReportMetaV2Schema.parse({
+        ...baseMeta,
+        description: "😀".repeat(16_384) + "a",
+        description_length: 65_536,
+      }),
+    ).toThrow(/65,536 UTF-8 bytes/);
+    expect(() =>
+      ReviewBugReportMetaV2Schema.parse({
+        ...baseMeta,
+        description: "Snow: 雪",
+        description_length: 7,
+      }),
+    ).toThrow(/must match the description UTF-8 byte length/);
+  });
+
   it("rejects skipped or reordered trace filenames", () => {
     expect(() =>
       ReviewBugReportMetaV2Schema.parse({

--- a/packages/review-protocol/src/bug-report.ts
+++ b/packages/review-protocol/src/bug-report.ts
@@ -52,6 +52,13 @@ export const ReviewBugReportMetaV2Schema = z
   .strictObject({
     schema_version: z.literal(2),
     description_length: z.number().int().nonnegative().max(65_536),
+    description: z
+      .string()
+      .refine(
+        (value) => new TextEncoder().encode(value).byteLength <= 65_536,
+        "must not exceed 65,536 UTF-8 bytes",
+      )
+      .optional(),
     has_review: z.boolean(),
     has_map: z.boolean(),
     has_diff: z.boolean(),
@@ -85,6 +92,17 @@ export const ReviewBugReportMetaV2Schema = z
     parts: z.array(ReviewBugReportPartSchema).min(1).max(34),
   })
   .superRefine((meta, context) => {
+    if (
+      meta.description !== undefined &&
+      new TextEncoder().encode(meta.description).byteLength !==
+        meta.description_length
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["description_length"],
+        message: "must match the description UTF-8 byte length",
+      });
+    }
     const [first, ...traces] = meta.parts;
     const validOrder =
       first?.field === "payload" &&


### PR DESCRIPTION
## Summary

- add the optional description field to V2 bug-report metadata
- send the original Unicode and multiline text only when it is not whitespace-only
- preserve the existing 64 KiB UTF-8 limit and omit empty descriptions
- keep existing payload storage and UI telemetry behavior unchanged

## Rollout

Do not merge or release this sender until https://github.com/Fix-Fast/dev/pull/1051 is merged and deployed to bug.dev.fast. The current production Worker rejects unknown metadata fields.

## Tests

- pnpm --filter @dev.fast/review-protocol test
- focused bug-report sender tests
- pnpm run ci
