### PR TITLE
Fork the Review source session at publish instead of scaffold

### DIFF
--- a/packages/progressive-review/src/review-comment-draft-reply.test.ts
+++ b/packages/progressive-review/src/review-comment-draft-reply.test.ts
@@ -108,7 +108,6 @@ async function makeOutdatedReview(): Promise<{ reviewPath: string }> {
     baseCommit: originalCommit,
     sourceCommit: movedCommit,
     sourceIdentity: { kind: "git-branch", name: "main" },
-    sourceSession: created.review.sourceSession,
   });
 
   await writeFile(
@@ -123,7 +122,6 @@ async function makeOutdatedReview(): Promise<{ reviewPath: string }> {
     baseCommit: originalCommit,
     sourceCommit: changedCommit,
     sourceIdentity: { kind: "git-branch", name: "main" },
-    sourceSession: movedReview.review.sourceSession,
   });
 
   const outdated = readReviewComments(reviewPath)["thread-1"]!;

--- a/packages/progressive-review/src/review-home.test.ts
+++ b/packages/progressive-review/src/review-home.test.ts
@@ -20,6 +20,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   ReviewHomeScanError,
+  bindPublishedSourceSession,
   bindReviewAuthorSession,
   computeSync,
   createReviewDir,
@@ -449,7 +450,6 @@ describe("review home", () => {
         baseCommit: originalCommit,
         sourceCommit: movedCommit,
         sourceIdentity: { kind: "git-branch", name: "main" },
-        sourceSession: created.review.sourceSession,
       });
       const moved = readReviewComments(reviewPath)["thread-1"]!;
       if (moved.target.kind !== "code")
@@ -476,7 +476,6 @@ describe("review home", () => {
         baseCommit: originalCommit,
         sourceCommit: changedCommit,
         sourceIdentity: { kind: "git-branch", name: "main" },
-        sourceSession: movedReview.review.sourceSession,
       });
       const outdated = readReviewComments(reviewPath)["thread-1"]!;
       if (outdated.target.kind !== "code") {
@@ -500,7 +499,6 @@ describe("review home", () => {
         baseCommit: originalCommit,
         sourceCommit: restoredCommit,
         sourceIdentity: { kind: "git-branch", name: "main" },
-        sourceSession: outdatedReview.review.sourceSession,
       });
       const stillOutdated = readReviewComments(reviewPath)["thread-1"]!;
       if (stillOutdated.target.kind !== "code") {
@@ -726,3 +724,75 @@ async function git(root: string, args: string[]): Promise<string> {
   });
   return stdout.trim();
 }
+
+describe("bindPublishedSourceSession", () => {
+  const record = parseStoredReviewRecord({
+    schemaVersion: 4,
+    uuid: "11111111-1111-4111-8111-111111111111",
+    repoKey: "repo",
+    worktreePath: "/repo",
+    baseRef: "main",
+    baseCommit: "a".repeat(40),
+    sourceCommit: "b".repeat(40),
+    sourceIdentity: { kind: "git-branch", name: "feature" },
+    pullRequestNumber: null,
+    pullRequestUrl: null,
+    title: "Progressive Review",
+    sourceSession: "disabled:review",
+    status: "draft",
+    presentedDocumentRevision: null,
+    presentedSoftwareMapRevision: null,
+    createdAt: "2026-09-03T10:00:00.000Z",
+    lastPublishedAt: null,
+    agentSessions: {
+      "claude-code:live": {
+        roles: ["publisher"],
+        firstSeenAt: "2026-09-03T10:00:00.000Z",
+        lastSeenAt: "2026-09-03T10:00:00.000Z",
+      },
+    },
+  });
+
+  it("replaces the source session and attributes the frozen fork as author", () => {
+    const bound = bindPublishedSourceSession(
+      record,
+      "claude-code:frozen-1",
+      "2026-09-03T11:00:00.000Z",
+    );
+    expect(bound.sourceSession).toBe("claude-code:frozen-1");
+    expect(bound.agentSessions).toEqual({
+      "claude-code:live": record.agentSessions!["claude-code:live"],
+      "claude-code:frozen-1": {
+        roles: ["author"],
+        firstSeenAt: "2026-09-03T11:00:00.000Z",
+        lastSeenAt: "2026-09-03T11:00:00.000Z",
+      },
+    });
+    expect(record.sourceSession).toBe("disabled:review");
+  });
+
+  it("moves a republished Review to the newest fork", () => {
+    const first = bindPublishedSourceSession(
+      record,
+      "codex:frozen-1",
+      "2026-09-03T11:00:00.000Z",
+    );
+    const second = bindPublishedSourceSession(
+      first,
+      "codex:frozen-2",
+      "2026-09-03T12:00:00.000Z",
+    );
+    expect(second.sourceSession).toBe("codex:frozen-2");
+    expect(Object.keys(second.agentSessions!)).toEqual([
+      "claude-code:live",
+      "codex:frozen-1",
+      "codex:frozen-2",
+    ]);
+  });
+
+  it("rejects a key that is not an agent session", () => {
+    expect(() => bindPublishedSourceSession(record, "fresh:codex")).toThrow(
+      /invalid/,
+    );
+  });
+});

--- a/packages/progressive-review/src/review-home.ts
+++ b/packages/progressive-review/src/review-home.ts
@@ -308,6 +308,38 @@ export async function sealReviewCandidate(
   return reviewVcs.seal(dir, message);
 }
 
+/** Binds a freshly frozen source session to a Review record. The frozen
+    copy is the authoring snapshot every new thread forks from, so it carries
+    the author role. Publish writes the result together with the promoted
+    revision, so a reader never sees one without the other. */
+export function bindPublishedSourceSession(
+  record: StoredReviewRecord,
+  sessionKey: string,
+  now = new Date().toISOString(),
+): StoredReviewRecord {
+  if (!parseAuthoringSessionKey(sessionKey)) {
+    throw new Error(`Review source session key is invalid: ${sessionKey}`);
+  }
+  const prior = record.agentSessions?.[sessionKey];
+  const roles = prior?.roles.includes("author")
+    ? prior.roles
+    : [...(prior?.roles ?? []), "author" as const];
+  return {
+    ...record,
+    sourceSession: sessionKey,
+    agentSessions: {
+      ...record.agentSessions,
+      [sessionKey]: {
+        roles,
+        firstSeenAt: prior?.firstSeenAt ?? now,
+        lastSeenAt: now,
+      },
+    },
+  };
+}
+
+/** Moves the pinned range. The source session stays as it is: publish
+    forks a fresh one for the new pins. */
 export async function updateReviewPins(
   review: StoredReview,
   pins: {
@@ -315,37 +347,20 @@ export async function updateReviewPins(
     baseCommit: string;
     sourceCommit: string;
     sourceIdentity: ReviewSourceIdentity;
-    sourceSession: string;
   },
 ): Promise<StoredReview> {
   if (
     review.review.baseRef === pins.baseRef &&
     review.review.baseCommit === pins.baseCommit &&
     review.review.sourceCommit === pins.sourceCommit &&
-    review.review.sourceSession === pins.sourceSession &&
     review.review.sourceIdentity?.kind === pins.sourceIdentity.kind &&
     review.review.sourceIdentity.name === pins.sourceIdentity.name
   ) {
     return review;
   }
-  const now = new Date().toISOString();
-  const sourceAttribution = parseAuthoringSessionKey(pins.sourceSession)
-    ? {
-        agentSessions: {
-          ...review.review.agentSessions,
-          [pins.sourceSession]: {
-            roles: ["updater" as const],
-            firstSeenAt:
-              review.review.agentSessions?.[pins.sourceSession]?.firstSeenAt ??
-              now,
-            lastSeenAt: now,
-          },
-        },
-      }
-    : {};
   const refreshed: StoredReview = {
     ...review,
-    review: { ...review.review, ...pins, ...sourceAttribution },
+    review: { ...review.review, ...pins },
   };
   const threadStore = reviewThreadStoreBackend(
     path.join(refreshed.dir, "review.mdx"),

--- a/packages/progressive-review/src/review-info.test.ts
+++ b/packages/progressive-review/src/review-info.test.ts
@@ -15,12 +15,8 @@ import { promisify } from "node:util";
 import { describe, expect, it, vi } from "vitest";
 
 import { createReviewDir } from "./review-home";
-import { runReviewRebind as rebindReview } from "./review-rebind";
-import {
-  type RunReviewScaffoldInput,
-  runReviewScaffold as scaffoldReview,
-} from "./review-scaffold";
-import type { createReviewSourceAgentSession } from "./review-source-agent-session";
+import { runReviewRebind } from "./review-rebind";
+import { runReviewScaffold } from "./review-scaffold";
 import { reviewSourceHeadRef } from "./review-source-ref";
 import { appendReviewComment, updateReviewComment } from "./review-state-store";
 import { closeAllReviewThreadStores } from "./review-thread-store-backend";
@@ -28,23 +24,6 @@ import { prepareReviewPublish } from "./server/publish-preparation";
 import { resolveReviewInfo } from "./server/review-info";
 
 const execFilePromise = promisify(execFile);
-
-// The native fork needs a live harness transcript; stand in a deterministic
-// fork so scaffold and rebind can bind a source session from env alone.
-const createSourceAgentSession = vi.fn<typeof createReviewSourceAgentSession>(
-  async ({ agent }) => ({
-    harness: agent.harness,
-    sessionId: `${agent.sessionId}-fork`,
-  }),
-);
-
-function runReviewScaffold(input: RunReviewScaffoldInput) {
-  return scaffoldReview({ ...input, createSourceAgentSession });
-}
-
-function runReviewRebind(input: Parameters<typeof rebindReview>[0]) {
-  return rebindReview({ ...input, createSourceAgentSession });
-}
 
 describe("review info", () => {
   it("returns an empty list without creating a review", async () => {
@@ -105,7 +84,9 @@ describe("review info", () => {
           "utf8",
         ),
       );
-      expect(reviewJson.sourceSession).toBe("codex:thread-1-fork");
+      // Publish forks the source session; a draft has none yet.
+      expect(reviewJson.sourceSession).toBe("disabled:review");
+      expect(reviewJson.agentSessions).toBeUndefined();
       expect(reviewJson.baseRef).toEqual(expect.any(String));
       expect(created.reviews[0]?.change).toBe(reviewJson.sourceIdentity?.name);
       await expect(
@@ -481,7 +462,10 @@ describe("review info", () => {
       expect(reviewJson.sourceCommit).toBe(movedHead);
       expect(reviewJson.baseCommit).toBe(forkPoint);
       expect(reviewJson.baseRef).toBe("main");
-      expect(reviewJson.sourceSession).toBe("claude-code:update-1-fork");
+      expect(reviewJson.sourceSession).toBe("disabled:review");
+      expect(reviewJson.agentSessions["claude-code:update-1"].roles).toEqual([
+        "updater",
+      ]);
 
       const rebased = await runReviewScaffold({
         cwd: root,
@@ -815,7 +799,10 @@ describe("review info", () => {
         name: "other",
       });
       expect(reviewJson.sourceCommit).toBe(otherTip);
-      expect(reviewJson.sourceSession).toBe("codex:rebind-1-fork");
+      expect(reviewJson.sourceSession).toBe("disabled:review");
+      expect(reviewJson.agentSessions["codex:rebind-1"].roles).toEqual([
+        "updater",
+      ]);
     } finally {
       vi.unstubAllEnvs();
       await rm(home, { recursive: true, force: true });
@@ -877,67 +864,6 @@ describe("review info", () => {
       expect(prepared.sourceCommit).toBe(featureTip);
       expect(prepared.sourceBranch).toBe("feature");
       expect(prepared).not.toHaveProperty("warnings");
-    } finally {
-      vi.unstubAllEnvs();
-      closeAllReviewThreadStores();
-      await rm(home, { recursive: true, force: true });
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("rebind failure leaves review.json untouched when agent session creation fails", async () => {
-    const root = await makeGitRepository();
-    const home = await mkdtemp(path.join(os.tmpdir(), "review-info-home-"));
-    vi.stubEnv("DEV_REVIEW_HOME", home);
-
-    try {
-      await git(root, ["checkout", "-b", "feature"]);
-      await writeFile(path.join(root, "README.md"), "# Feature\n", "utf8");
-      await git(root, ["commit", "-am", "feature"]);
-      const featureTip = await git(root, ["rev-parse", "feature"]);
-      const mainTip = await git(root, ["rev-parse", "main"]);
-      const created = await runReviewScaffold({
-        cwd: root,
-        baseRef: "main",
-        headRef: "feature",
-      });
-      const uuid = created.reviews[0]!.uuid;
-      const reviewDir = created.reviews[0]!.dir;
-      const before = JSON.parse(
-        await readFile(path.join(reviewDir, "review.json"), "utf8"),
-      );
-
-      await git(root, ["checkout", "main"]);
-      await git(root, ["checkout", "-b", "other"]);
-      await writeFile(path.join(root, "other.txt"), "other\n", "utf8");
-      await git(root, ["add", "."]);
-      await git(root, ["commit", "-m", "other"]);
-
-      createSourceAgentSession.mockRejectedValueOnce(
-        new Error("agent session creation failed"),
-      );
-
-      await expect(
-        runReviewRebind({
-          cwd: root,
-          change: "other",
-          reviewUuid: uuid,
-          env: { CODEX_THREAD_ID: "rebind-fail-session" },
-          stdout: nullStream(),
-        }),
-      ).rejects.toThrow(/agent session creation failed/);
-
-      const after = JSON.parse(
-        await readFile(path.join(reviewDir, "review.json"), "utf8"),
-      );
-      expect(after.sourceIdentity).toEqual({
-        kind: "git-branch",
-        name: "feature",
-      });
-      expect(after.sourceCommit).toBe(before.sourceCommit);
-      expect(after.baseCommit).toBe(before.baseCommit);
-      expect(after.sourceCommit).toBe(featureTip);
-      expect(after.baseCommit).toBe(mainTip);
     } finally {
       vi.unstubAllEnvs();
       closeAllReviewThreadStores();

--- a/packages/progressive-review/src/review-rebind.ts
+++ b/packages/progressive-review/src/review-rebind.ts
@@ -5,7 +5,7 @@ import {
   resolveRevision,
 } from "@dev.fast/local-vcs";
 
-import { type RunReviewScaffoldInput, repinReview } from "./review-scaffold";
+import { repinReview } from "./review-scaffold";
 import { resolveReviewRoot } from "./runtime";
 import { resolvePublishReview } from "./server/publish-preparation";
 
@@ -30,7 +30,6 @@ export async function runReviewRebind(input: {
   progress?: (message: string) => void;
   env?: NodeJS.ProcessEnv;
   stdout: Writable;
-  createSourceAgentSession?: RunReviewScaffoldInput["createSourceAgentSession"];
 }): Promise<number> {
   const reviewRoot = await resolveReviewRoot(input.cwd);
   const review = await resolvePublishReview(reviewRoot, input.reviewUuid);
@@ -58,7 +57,6 @@ export async function runReviewRebind(input: {
       toolingRoot: input.toolingRoot,
       progress: input.progress,
       env: input.env,
-      createSourceAgentSession: input.createSourceAgentSession,
     },
   );
   const output: ReviewRebindJsonOutput = {

--- a/packages/progressive-review/src/review-scaffold.ts
+++ b/packages/progressive-review/src/review-scaffold.ts
@@ -27,16 +27,15 @@ import {
 import { isPositionalChangeIdentity } from "./review-change-scope";
 import { removeReviewManagedCheckouts } from "./review-head-checkout";
 import {
-  DISABLED_REVIEW_SOURCE_SESSION,
   type StoredReview,
   createReviewDir,
   createReviewUuid,
   listReviews,
+  touchReviewAgentSession,
   updateReviewPins,
 } from "./review-home";
 import type { ReviewInfoEvent } from "./review-info";
 import { evaluateReviewDocumentBundleForPublish } from "./review-publish-evaluate";
-import { createReviewSourceAgentSession } from "./review-source-agent-session";
 import {
   deleteReviewSourceHeadRef,
   pinReviewSourceHeadRef,
@@ -62,8 +61,6 @@ export interface RunReviewScaffoldInput {
   newReview?: boolean;
   background?: boolean;
   onReviewBound?: (uuid: string) => void | Promise<void>;
-  /** Forks the invoking agent session; defaults to the harness-native fork. */
-  createSourceAgentSession?: typeof createReviewSourceAgentSession;
 }
 
 // Scaffold's event carries pinned commits, managed checkouts, and normalized
@@ -173,28 +170,6 @@ async function createReview(
       background: input.background,
     }),
   );
-  const invokingAgent = resolveAuthoringSessionRef(input.env ?? process.env);
-  let sourceAgentSession: string | null = null;
-  if (invokingAgent) {
-    if (!setup.headRootPath) {
-      throw new Error(
-        "Review scaffold cannot create a source session without its managed head checkout.",
-      );
-    }
-    // Narrowing does not survive into the span callback; pin the path first.
-    const headRootPath = setup.headRootPath;
-    const frozen = await span(
-      "scaffold: fork agent session",
-      () =>
-        (input.createSourceAgentSession ?? createReviewSourceAgentSession)({
-          agent: invokingAgent,
-          reviewUuid: uuid,
-          rootPath: headRootPath,
-        }),
-      invokingAgent.harness,
-    );
-    sourceAgentSession = authoringSessionKey(frozen);
-  }
   let created: StoredReview;
   try {
     created = await span("scaffold: create review dir", () =>
@@ -208,7 +183,6 @@ async function createReview(
         pullRequestNumber: source.subject.pullRequestNumber ?? null,
         pullRequestUrl: source.subject.pullRequestUrl ?? null,
         title: source.subject.pullRequestTitle ?? "Progressive Review",
-        sourceSession: sourceAgentSession ?? undefined,
       }),
     );
   } catch (error) {
@@ -307,41 +281,25 @@ export async function repinReview(
       background: input.background,
     }),
   );
-  const invokingAgent = resolveAuthoringSessionRef(input.env ?? process.env);
-  let sourceSession = DISABLED_REVIEW_SOURCE_SESSION;
-  if (invokingAgent) {
-    if (!setup.headRootPath) {
-      throw new Error(
-        "Review update cannot create a source session without its managed head checkout.",
-      );
-    }
-    // The fork belongs to the same unit of work as the pin. A Review whose
-    // Ask Agent cannot answer is not a usable Review, so a failure here fails
-    // the update and leaves the stored pins untouched.
-    // Narrowing does not survive into the span callback; pin the path first.
-    const headRootPath = setup.headRootPath;
-    const frozen = await span(
-      "scaffold: fork agent session",
-      () =>
-        (input.createSourceAgentSession ?? createReviewSourceAgentSession)({
-          agent: invokingAgent,
-          reviewUuid: uuid,
-          rootPath: headRootPath,
-        }),
-      invokingAgent.harness,
-    );
-    sourceSession = authoringSessionKey(frozen);
-  }
   await pinReviewSourceHeadRef(root, reviewSourceHeadRef(uuid), headCommit);
-  const updated = await span("scaffold: update review pins", () =>
+  let updated = await span("scaffold: update review pins", () =>
     updateReviewPins(review, {
       baseRef,
       baseCommit,
       sourceCommit,
       sourceIdentity,
-      sourceSession,
     }),
   );
+  const pinsMoved = updated !== review;
+  // Preserve the published source session until the next publish.
+  const invokingAgent = resolveAuthoringSessionRef(input.env ?? process.env);
+  if (invokingAgent) {
+    updated = await touchReviewAgentSession(
+      updated,
+      authoringSessionKey(invokingAgent),
+      "updater",
+    );
+  }
   await span("scaffold: report range staleness", () =>
     reportRangeStaleness({
       review: updated,
@@ -352,7 +310,7 @@ export async function repinReview(
       progress: input.progress,
     }),
   ).catch(() => undefined);
-  if (updated !== review && updated.review.status === "awaiting-review") {
+  if (pinsMoved && updated.review.status === "awaiting-review") {
     setup.warnings.push(
       "Pins moved under a published revision. Publish again to present the new commits.",
     );

--- a/packages/progressive-review/src/review-source-agent-session.ts
+++ b/packages/progressive-review/src/review-source-agent-session.ts
@@ -17,7 +17,9 @@ import { forkOpencodeSession } from "./native-agent/opencode";
 import { span } from "./startup-trace";
 
 /**
- * Fork the invoking session once and bind the frozen copy to the Review.
+ * Fork the invoking session at publish and bind the frozen copy to the
+ * Review. Every new thread forks that copy, so it must hold the finished
+ * authoring context: the change, the drafted document, and the publish.
  *
  * Each harness writes a native fork without sending a user message. No model
  * is ever named here, so the fork keeps the invoking session's model.

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -43,6 +43,7 @@ import {
   parseAuthoringSessionKey,
   parseFreshSourceSessionHarness,
 } from "../authoring-session";
+import { errorMessage } from "../error-message";
 import { preferredInstalledReviewAgent } from "../installed-review-agent";
 import * as claudeCode from "../native-agent/claude-code";
 import * as codex from "../native-agent/codex";
@@ -70,6 +71,7 @@ import {
 import {
   type StoredReview,
   type StoredReviewRecord,
+  bindPublishedSourceSession,
   bindReviewAuthorSession,
   countReviewComments,
   findReview,
@@ -90,6 +92,7 @@ import {
   requireClosedThreadsForRepublish,
 } from "../review-publish-thread-gate";
 import { clearReopenPending, markReopenPending } from "../review-reopen-marker";
+import { createReviewSourceAgentSession } from "../review-source-agent-session";
 import { devReviewHome } from "../review-storage";
 import { readReviewSoftwareMapBundle } from "../software-map-bundle";
 import { createTutorialAuthoringSession } from "../tutorial-authoring-session";
@@ -260,6 +263,8 @@ export interface GlobalReviewServerInput {
   tutorialAuthoringSessionFactory?: typeof createTutorialAuthoringSession;
   tutorialAuthorSessionBinder?: typeof bindReviewAuthorSession;
   tutorialAgentResolver?: () => Promise<ReviewAgentHarness | undefined>;
+  /** Forks the publishing agent session; defaults to the harness-native fork. */
+  sourceAgentSessionFactory?: typeof createReviewSourceAgentSession;
   publishRuntime?: {
     materializePublishRevision: typeof materializePublishRevision;
   };
@@ -289,6 +294,8 @@ export function createGlobalReviewServer(
     input.tutorialAuthoringSessionFactory ?? createTutorialAuthoringSession;
   const tutorialAuthorSessionBinder =
     input.tutorialAuthorSessionBinder ?? bindReviewAuthorSession;
+  const sourceAgentSessionFactory =
+    input.sourceAgentSessionFactory ?? createReviewSourceAgentSession;
   const tutorialAgentResolver =
     input.tutorialAgentResolver ??
     (async () =>
@@ -856,7 +863,12 @@ export function createGlobalReviewServer(
       }
       return globalJson(
         201,
-        await mountPublishedDocument(review, request.revision, request.view),
+        await mountPublishedDocument(
+          review,
+          request.revision,
+          request.view,
+          agent,
+        ),
       );
     } catch (error) {
       await telemetry.capturePublishGateRejected({ gate: "publish_ready" });
@@ -1026,6 +1038,7 @@ export function createGlobalReviewServer(
     review: StoredReview,
     revision: string,
     view?: ReviewView,
+    publisher?: SessionRef,
   ): Promise<{
     ok: true;
     revision: string;
@@ -1067,13 +1080,42 @@ export function createGlobalReviewServer(
         )
       : undefined;
     const documentPath = path.join(buildDir, "review.mdx");
+    // The publishing agent's transcript now holds the whole authoring
+    // context, so this is where the Review freezes its source session. The
+    // session registers with the frozen key so Ask Agent routes to it, and
+    // promotion persists it. A Review whose questions cannot be answered is
+    // not a usable Review, so a failed fork fails the publish.
+    const checkoutRoots = await ensureReviewCheckouts(review, sourceCommit);
+    let sourceSession: string | undefined;
+    if (publisher) {
+      try {
+        const frozen = await sourceAgentSessionFactory({
+          agent: publisher,
+          reviewUuid: review.review.uuid,
+          rootPath: checkoutRoots.headRootPath,
+        });
+        sourceSession = authoringSessionKey(frozen);
+      } catch (error) {
+        throw new ReviewServerError(
+          `Review source session could not be created: ${errorMessage(error)}`,
+          500,
+          "source_session_failed",
+        );
+      }
+    }
     const successor = await timed("register session", () =>
       registerSerialized({
-        review,
+        review: sourceSession
+          ? {
+              ...review,
+              review: bindPublishedSourceSession(review.review, sourceSession),
+            }
+          : review,
         documentPath,
         softwareMapRootPath,
         revision,
         source,
+        checkoutRoots,
         promoted: false,
       }),
     );
@@ -1119,6 +1161,7 @@ export function createGlobalReviewServer(
             successor.revision,
             successor.source,
             await reviewTitleFromDocument(documentPath),
+            sourceSession,
           );
           successor.promoted = true;
           await startSessionTelemetry(successor);
@@ -2408,13 +2451,17 @@ async function promoteReview(
   revision: string,
   source: { sourceCommit: string; sourceBranch: string },
   title: string | undefined,
+  sourceSession?: string,
 ): Promise<StoredReview> {
+  const now = new Date().toISOString();
   const review: StoredReviewRecord = {
-    ...stored.review,
+    ...(sourceSession
+      ? bindPublishedSourceSession(stored.review, sourceSession, now)
+      : stored.review),
     sourceCommit: source.sourceCommit,
     status: "awaiting-review",
     presentedDocumentRevision: revision,
-    lastPublishedAt: new Date().toISOString(),
+    lastPublishedAt: now,
     /* A publish is new work, so the review earns attention again and returns
        to Home as new. This also rescues a review that was dismissed and then
        updated rather than dropped. */


### PR DESCRIPTION
Comment threads inherit the authoring chat through the Review's frozen
source session. Scaffold used to take that snapshot, so every thread
started from a transcript that ended on the `review scaffold` call: the
agent had not drafted or published anything yet, and often tried to
resume the authoring checklist instead of answering the question.

The desktop server now forks the invoking session when it receives
publish-ready, binds the frozen copy as the Review's `sourceSession` in
the same `review.json` write that promotes the revision, and fails the
publish when the fork fails. Scaffold and update no longer fork; update
attributes the invoking session as an updater without touching the
source session. New threads on a republished Review start from the
latest publish, while threads that already have a session keep it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)