### PR TITLE
Keep the review tab and its agent terminal through a republish

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewCanvasEditorTabsService.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewCanvasEditorTabsService.test.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Event } from "../../base/common/event.js";
+import type { ReviewDescriptor } from "../common/reviewProtocol.js";
+import { ReviewCanvasEditorTabsService } from "./reviewCanvasEditorTabsService.js";
+
+const uuid = "11111111-1111-4111-8111-111111111111";
+const review: ReviewDescriptor = {
+	uuid,
+	title: "Open once",
+	status: "awaiting-review",
+	worktreePath: "/tmp/review",
+	repoKey: "repo",
+	sourceBranch: "feature",
+	presentedDocumentRevision: "a".repeat(40),
+	presentedSoftwareMapRevision: null,
+	lastPublishedAt: "2026-09-03T00:00:00.000Z",
+	available: true,
+	viewedAt: null,
+	dismissedAt: null,
+	reapsAt: null,
+};
+
+interface FakeGroup {
+	readonly id: number;
+	contains(candidate: unknown): boolean;
+}
+
+function serviceWith(
+	groups: FakeGroup[],
+	activeGroup: FakeGroup,
+	opened: unknown[][],
+): { service: ReviewCanvasEditorTabsService; input: object } {
+	const input = { isDisposed: () => false, preferSession: () => undefined };
+	const service = new ReviewCanvasEditorTabsService(
+		{ createInstance: () => input } as never,
+		{
+			onDidCloseEditor: Event.None,
+			openEditor: async (...args: unknown[]) => {
+				opened.push(args);
+				return undefined;
+			},
+		} as never,
+		{ mainPart: { activeGroup, getGroups: () => groups } } as never,
+		{ reviews: [review], reviewErrors: [] } as never,
+	);
+	return { service, input };
+}
+
+test("a review that is open elsewhere is revealed in that group", async () => {
+	const opened: unknown[][] = [];
+	const focused: FakeGroup = { id: 1, contains: () => false };
+	const holder: FakeGroup = { id: 2, contains: () => true };
+	const { service, input } = serviceWith([focused, holder], focused, opened);
+
+	await service.openReview(uuid, true);
+
+	assert.deepEqual(opened, [[input, { pinned: true, inactive: false }, holder]]);
+	service.dispose();
+});
+
+test("a first open lands in the active group", async () => {
+	const opened: unknown[][] = [];
+	const focused: FakeGroup = { id: 1, contains: () => false };
+	const other: FakeGroup = { id: 2, contains: () => false };
+	const { service, input } = serviceWith([focused, other], focused, opened);
+
+	await service.openReview(uuid, false);
+
+	assert.deepEqual(opened, [[input, { pinned: true, inactive: true }, focused]]);
+	service.dispose();
+});

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewCanvasEditorTabsService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewCanvasEditorTabsService.ts
@@ -7,7 +7,10 @@ import { createDecorator } from "../../platform/instantiation/common/instantiati
 import { IInstantiationService } from "../../platform/instantiation/common/instantiation.js";
 import { Disposable } from "../../base/common/lifecycle.js";
 import type { EditorInput } from "../../workbench/common/editor/editorInput.js";
-import { IEditorGroupsService } from "../../workbench/services/editor/common/editorGroupsService.js";
+import {
+	GroupsOrder,
+	IEditorGroupsService,
+} from "../../workbench/services/editor/common/editorGroupsService.js";
 import { IEditorService } from "../../workbench/services/editor/common/editorService.js";
 import { ReviewCanvasEditorInput } from "../browser/parts/canvas/reviewCanvasEditorInput.js";
 import { IReviewSessionService } from "./reviewSessionService.js";
@@ -119,11 +122,7 @@ export class ReviewCanvasEditorTabsService
 			this.inputs.set(target.kind, input);
 		}
 		configure?.(input);
-		await this.editorService.openEditor(
-			input,
-			{ pinned: true, inactive: !active, revealIfVisible: true },
-			this.editorGroupsService.mainPart.activeGroup,
-		);
+		await this.openInput(input, active);
 		return input;
 	}
 
@@ -132,7 +131,7 @@ export class ReviewCanvasEditorTabsService
 		active: boolean,
 	): Promise<ReviewCanvasEditorInput> {
 		const input = this.reviewInput(reviewUuid);
-		await this.openReviewInput(input, active);
+		await this.openInput(input, active);
 		return input;
 	}
 
@@ -162,7 +161,7 @@ export class ReviewCanvasEditorTabsService
 			);
 			this.inputs.set(key, input);
 		}
-		await this.openReviewInput(input, active);
+		await this.openInput(input, active);
 		return input;
 	}
 
@@ -202,14 +201,24 @@ export class ReviewCanvasEditorTabsService
 		return input;
 	}
 
-	private async openReviewInput(
+	/* Reveal the tab where it already lives; only a first open lands in the
+	   active group. VS Code applies its own reveal-if-open logic only when
+	   the caller names no group, but a group-less open can also be routed
+	   into a modal overlay, so the group is chosen here and always named. */
+	private async openInput(
 		input: ReviewCanvasEditorInput,
 		active: boolean,
 	): Promise<void> {
+		const mainPart = this.editorGroupsService.mainPart;
+		const group =
+			mainPart
+				.getGroups(GroupsOrder.MOST_RECENTLY_ACTIVE)
+				.find((candidate) => candidate.contains(input)) ??
+			mainPart.activeGroup;
 		await this.editorService.openEditor(
 			input,
-			{ pinned: true, inactive: !active, revealIfVisible: true },
-			this.editorGroupsService.mainPart.activeGroup,
+			{ pinned: true, inactive: !active },
+			group,
 		);
 	}
 
@@ -301,7 +310,7 @@ export class ReviewCanvasEditorTabsService
 			)
 			: this.reviewInput(session.reviewUuid);
 		input.preferSession(sessionId);
-		await this.openReviewInput(input, active);
+		await this.openInput(input, active);
 		return input;
 	}
 }

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.test.ts
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Emitter, Event } from "../../base/common/event.js";
+import type { ReviewDescriptor } from "../common/reviewProtocol.js";
+import {
+	type ReviewDesktopSession,
+	ReviewSessionModel,
+} from "./reviewSessionModelService.js";
+import type { ReviewSessionClosedEvent } from "./reviewSessionService.js";
+
+const uuid = "11111111-1111-4111-8111-111111111111";
+const review: ReviewDescriptor = {
+	uuid,
+	title: "Republished",
+	status: "awaiting-review",
+	worktreePath: "/tmp/review",
+	repoKey: "repo",
+	sourceBranch: "feature",
+	presentedDocumentRevision: "a".repeat(40),
+	presentedSoftwareMapRevision: null,
+	lastPublishedAt: "2026-09-03T00:00:00.000Z",
+	available: true,
+	viewedAt: null,
+	dismissedAt: null,
+	reapsAt: null,
+};
+
+function sessionNamed(sessionId: string): ReviewDesktopSession {
+	return {
+		serverUrl: "http://127.0.0.1:5000",
+		sessionUrl: `http://127.0.0.1:5000/sessions/${sessionId}`,
+		token: "token",
+		descriptor: {
+			sessionId,
+			sessionUrl: `http://127.0.0.1:5000/sessions/${sessionId}`,
+			reviewUuid: uuid,
+			routePath: "/",
+			startedAt: 1,
+		},
+		review,
+		session: {
+			sessionId,
+			storageDir: "/tmp/review-home",
+		} as ReviewDesktopSession["session"],
+	};
+}
+
+function modelWith(successor: ReviewDesktopSession): {
+	model: ReviewSessionModel;
+	closeSession: Emitter<ReviewSessionClosedEvent>;
+	resolved: number;
+	changes: number;
+} {
+	const closeSession = new Emitter<ReviewSessionClosedEvent>();
+	const state = { resolved: 0, changes: 0 };
+	const model = new ReviewSessionModel(
+		uuid,
+		sessionNamed("session-1"),
+		async () => {
+			state.resolved += 1;
+			return successor;
+		},
+		Event.None,
+		Event.None,
+		closeSession.event,
+	);
+	model.onDidChange(() => {
+		state.changes += 1;
+	});
+	return {
+		model,
+		closeSession,
+		get resolved() {
+			return state.resolved;
+		},
+		get changes() {
+			return state.changes;
+		},
+	};
+}
+
+test("a replaced session moves to its successor without going unavailable", async () => {
+	const successor = sessionNamed("session-2");
+	const harness = modelWith(successor);
+
+	harness.closeSession.fire({
+		session: sessionNamed("session-1").descriptor,
+		review,
+		reason: "replaced",
+	});
+	await new Promise((resolve) => setTimeout(resolve, 0));
+
+	assert.equal(harness.model.state, "active");
+	assert.equal(harness.model.session.session.sessionId, "session-2");
+	assert.equal(harness.resolved, 1);
+	assert.equal(harness.changes, 1);
+	harness.model.dispose();
+});
+
+test("a closed session goes unavailable", () => {
+	const harness = modelWith(sessionNamed("session-2"));
+
+	harness.closeSession.fire({
+		session: sessionNamed("session-1").descriptor,
+		review,
+		reason: "closed",
+	});
+
+	assert.equal(harness.model.state, "unavailable");
+	assert.match(harness.model.unavailableMessage ?? "", /closed/);
+	assert.equal(harness.resolved, 0);
+	harness.model.dispose();
+});
+
+test("a close for another session is ignored", () => {
+	const harness = modelWith(sessionNamed("session-2"));
+
+	harness.closeSession.fire({
+		session: sessionNamed("session-9").descriptor,
+		review,
+		reason: "replaced",
+	});
+
+	assert.equal(harness.model.state, "active");
+	assert.equal(harness.model.session.session.sessionId, "session-1");
+	assert.equal(harness.resolved, 0);
+	harness.model.dispose();
+});

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.ts
@@ -146,6 +146,19 @@ export class ReviewSessionModel extends Disposable {
 				if (event.session.sessionId !== this._session.session.sessionId) {
 					return;
 				}
+				// A replaced session is a republish: its promoted successor for
+				// this review is already registered. Move to it directly. Going
+				// unavailable in between would make the canvas reset the
+				// workbench as if a different review had opened.
+				if (event.reason === "replaced") {
+					void this.refresh().catch((error) => {
+						console.error(
+							`[Review Desktop] failed to follow replaced session ${reviewUuid}`,
+							error,
+						);
+					});
+					return;
+				}
 				this._comments.dispose();
 				if (event.review) {
 					this._session = { ...this._session, review: event.review };


### PR DESCRIPTION
A document publish replaces the Review's desktop session: the server
mounts the new revision as a fresh session, promotes it, and closes the
old one as replaced. Two things in the app treated that swap as a change
of review.

The canvas model marked itself unavailable when its session closed, which
made the canvas reset the workbench as if a different review had opened:
every non-review editor closed, including the Ask Agent terminal the
reader was typing in. A replaced session always has a promoted successor
for the same review, so the model now refreshes to it instead.

The tabs service always opened the review input into the active editor
group, so a review that was open in another group got a second tab next
to whatever had focus. It now opens into the main-part group that already
holds the input and falls back to the active group only for a first open.
The group stays explicit: a group-less open would let VS Code route the
tab into its modal overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)