### PR TITLE
Centralize Review state in one database

### DIFF
--- a/packages/progressive-review/src/migrate.ts
+++ b/packages/progressive-review/src/migrate.ts
@@ -35,6 +35,7 @@ import {
   parseStoredReviewRecord,
   parseStoredReviewRecordForMigration,
 } from "./review-home";
+import { putReviewRecord } from "./review-state-db";
 import { devReviewHome } from "./review-storage";
 import { reviewVcs } from "./review-vcs";
 import { writePrivateJsonAtomic } from "./server/desktop-paths";
@@ -378,6 +379,15 @@ export async function migrateJjReviewRepositories(input: {
         recordSource,
         force: input.force,
       });
+      putReviewRecord(
+        reviewDir,
+        parseStoredReviewRecord(
+          JSON.parse(
+            await readFile(path.join(reviewDir, "review.json"), "utf8"),
+          ),
+        ),
+        input.reviewHome,
+      );
       input.log?.(`Converted jj Review repository ${reviewDir} to plain Git.`);
       result.migrated += 1;
     } catch (error) {

--- a/packages/progressive-review/src/review-attention.ts
+++ b/packages/progressive-review/src/review-attention.ts
@@ -1,9 +1,10 @@
-import path from "node:path";
-
 import type { ReviewRecord } from "@dev.fast/review-protocol";
 
-import type { StoredReview, StoredReviewRecord } from "./review-home";
-import { writePrivateJsonAtomic } from "./server/desktop-paths";
+import {
+  type StoredReview,
+  type StoredReviewRecord,
+  persistStoredReviewRecord,
+} from "./review-home";
 
 /**
  * The reader-facing lifecycle: new -> viewed -> dismissed. It is a separate
@@ -23,7 +24,7 @@ export async function writeReviewRecord(
   patch: Partial<StoredReviewRecord>,
 ): Promise<StoredReview> {
   const review: StoredReviewRecord = { ...stored.review, ...patch };
-  await writePrivateJsonAtomic(path.join(stored.dir, "review.json"), review);
+  await persistStoredReviewRecord(stored.dir, review);
   return { ...stored, review };
 }
 

--- a/packages/progressive-review/src/review-home.test.ts
+++ b/packages/progressive-review/src/review-home.test.ts
@@ -161,7 +161,8 @@ describe("review home", () => {
       await expect(
         readFile(path.join(created.dir, "package.json"), "utf8"),
       ).resolves.toContain('"test": "node review-test.mjs"');
-      expect(existsSync(path.join(created.dir, "review.db"))).toBe(true);
+      expect(existsSync(path.join(home, "review.db"))).toBe(true);
+      expect(existsSync(path.join(created.dir, "review.db"))).toBe(false);
       expect(existsSync(path.join(created.dir, "comments.json"))).toBe(false);
       expect(existsSync(path.join(created.dir, "questions.json"))).toBe(false);
       await expect(

--- a/packages/progressive-review/src/review-home.ts
+++ b/packages/progressive-review/src/review-home.ts
@@ -41,6 +41,11 @@ import {
   remapReviewCodeThreads,
 } from "./review-code-target-remap";
 import { resolveReviewDiffFiles } from "./review-diff-files";
+import {
+  deleteReviewState,
+  putReviewRecord,
+  readReviewRecord,
+} from "./review-state-db";
 import { readReviewComments } from "./review-state-store";
 import { devReviewHome } from "./review-storage";
 import {
@@ -125,7 +130,8 @@ export async function createReviewDir(
   if (!UUID_PATTERN.test(uuid)) {
     throw new Error(`Review UUID is invalid: ${uuid}`);
   }
-  const dir = path.join(reviewsHomeDir(binding.reviewsHomePath), uuid);
+  const reviewHome = binding.reviewsHomePath ?? devReviewHome();
+  const dir = path.join(reviewsHomeDir(reviewHome), uuid);
   const worktreePath = path.resolve(binding.worktreePath);
   const repository = await resolveReviewRepositoryIdentity(worktreePath);
   const createdAt = new Date().toISOString();
@@ -177,9 +183,10 @@ export async function createReviewDir(
       writeFile(path.join(dir, "review-test.mjs"), reviewTestShim, "utf8"),
       writeFile(path.join(dir, ".gitignore"), reviewGitignore, "utf8"),
     ]);
-    createReviewThreadDb(dir);
-    await writePrivateJsonAtomic(path.join(dir, "review.json"), review);
+    createReviewThreadDb(dir, reviewHome);
+    await persistStoredReviewRecord(dir, review, reviewHome);
   } catch (error) {
+    deleteReviewState(dir, reviewHome);
     await rm(dir, { recursive: true, force: true });
     throw error;
   }
@@ -204,14 +211,13 @@ export async function touchReviewAgentSession(
   if (!parseAuthoringSessionKey(sessionKey)) {
     throw new Error(`Review agent session key is invalid: ${sessionKey}`);
   }
-  const recordPath = path.join(review.dir, "review.json");
   const outcome = await withFileLock(
     path.join(review.dir, ".agent-sessions.lock"),
     AGENT_SESSION_LOCK_OPTIONS,
     async () => {
-      const current = parseStoredReviewRecord(
-        JSON.parse(await readFile(recordPath, "utf8")),
-      );
+      const loaded = await readStoredReview(review.dir);
+      if ("error" in loaded) throw new ReviewHomeScanError([loaded.error]);
+      const current = loaded.review;
       const prior = current.agentSessions?.[sessionKey];
       const roles = prior?.roles.includes(role)
         ? prior.roles
@@ -227,7 +233,7 @@ export async function touchReviewAgentSession(
           },
         },
       };
-      await writePrivateJsonAtomic(recordPath, updated);
+      await persistStoredReviewRecord(review.dir, updated);
       return { dir: review.dir, review: updated };
     },
   );
@@ -248,14 +254,13 @@ export async function bindReviewAuthorSession(
   now = new Date().toISOString(),
 ): Promise<StoredReview> {
   const sessionKey = authoringSessionKey(session);
-  const recordPath = path.join(review.dir, "review.json");
   const outcome = await withFileLock(
     path.join(review.dir, ".agent-sessions.lock"),
     AGENT_SESSION_LOCK_OPTIONS,
     async () => {
-      const current = parseStoredReviewRecord(
-        JSON.parse(await readFile(recordPath, "utf8")),
-      );
+      const loaded = await readStoredReview(review.dir);
+      if ("error" in loaded) throw new ReviewHomeScanError([loaded.error]);
+      const current = loaded.review;
       const freshHarness = parseFreshSourceSessionHarness(
         current.sourceSession,
       );
@@ -289,7 +294,7 @@ export async function bindReviewAuthorSession(
           },
         },
       };
-      await writePrivateJsonAtomic(recordPath, updated);
+      await persistStoredReviewRecord(review.dir, updated);
       return { dir: review.dir, review: updated };
     },
   );
@@ -371,10 +376,7 @@ export async function updateReviewPins(
       sourceCommit: refreshed.review.sourceCommit,
     },
   });
-  await writePrivateJsonAtomic(
-    path.join(refreshed.dir, "review.json"),
-    refreshed.review,
-  );
+  await persistStoredReviewRecord(refreshed.dir, refreshed.review);
   threadStore.writeCommentState(comments, remappedDrafts);
   return refreshed;
 }
@@ -579,9 +581,15 @@ export async function materializeReviewRevision(
 export async function readStoredReview(
   dir: string,
 ): Promise<StoredReview | { error: ReviewHomeError }> {
-  const reviewPath = path.join(dir, "review.json");
   try {
-    const value = parseJsonText(await readFile(reviewPath, "utf8"));
+    await access(dir);
+    const value = readReviewRecord(dir);
+    if (value === null) {
+      const error = Object.assign(new Error("Review record is missing."), {
+        code: "ENOENT",
+      });
+      throw error;
+    }
     const parsed = safeParseStoredReviewRecord(value);
     if (!parsed.success) {
       return {
@@ -603,6 +611,19 @@ export async function readStoredReview(
     if (code) detail.code = code;
     return { error: reviewHomeError(dir, undefined, detail) };
   }
+}
+
+/**
+ * Persist the authoritative record in SQLite, then refresh review.json as a
+ * compatibility mirror for older tooling and sealed historical revisions.
+ */
+export async function persistStoredReviewRecord(
+  dir: string,
+  review: StoredReviewRecord,
+  reviewHome?: string,
+): Promise<void> {
+  putReviewRecord(dir, review, reviewHome);
+  await writePrivateJsonAtomic(path.join(dir, "review.json"), review);
 }
 
 /** `record` is the parsed review, or the raw review.json object when it failed to parse. */

--- a/packages/progressive-review/src/review-info.test.ts
+++ b/packages/progressive-review/src/review-info.test.ts
@@ -16,7 +16,7 @@ import zlib from "node:zlib";
 import { describe, expect, it, vi } from "vitest";
 
 import { pullReviewTraceCorpus } from "./review-agent-traces";
-import { createReviewDir } from "./review-home";
+import { createReviewDir, persistStoredReviewRecord } from "./review-home";
 import { runReviewRebind as rebindReview } from "./review-rebind";
 import {
   type RunReviewScaffoldInput,
@@ -396,10 +396,10 @@ describe("review info", () => {
       expect(different.reviews[0]?.uuid).not.toBe(initial.reviews[0]?.uuid);
       const recordPath = path.join(different.reviews[0]!.dir, "review.json");
       const record = JSON.parse(await readFile(recordPath, "utf8"));
-      await writeFile(
-        recordPath,
-        `${JSON.stringify({ ...record, status: "accepted" }, null, 2)}\n`,
-      );
+      await persistStoredReviewRecord(different.reviews[0]!.dir, {
+        ...record,
+        status: "accepted",
+      });
       const afterTerminal = await runReviewScaffold({ cwd: root });
       expect(afterTerminal.reviews[0]?.uuid).not.toBe(
         different.reviews[0]?.uuid,
@@ -409,10 +409,10 @@ describe("review info", () => {
         "review.json",
       );
       const rejected = JSON.parse(await readFile(rejectedPath, "utf8"));
-      await writeFile(
-        rejectedPath,
-        `${JSON.stringify({ ...rejected, status: "rejected" }, null, 2)}\n`,
-      );
+      await persistStoredReviewRecord(afterTerminal.reviews[0]!.dir, {
+        ...rejected,
+        status: "rejected",
+      });
       await expect(runReviewScaffold({ cwd: root })).resolves.toMatchObject({
         reviews: [{ status: "draft" }],
       });
@@ -1132,7 +1132,7 @@ describe("review info", () => {
       const reviewJsonPath = path.join(created.reviews[0]!.dir, "review.json");
       const review = JSON.parse(await readFile(reviewJsonPath, "utf8"));
       review.status = "rejected";
-      await writeFile(reviewJsonPath, `${JSON.stringify(review, null, 2)}\n`);
+      await persistStoredReviewRecord(created.reviews[0]!.dir, review);
 
       await expect(resolveReviewInfo({ cwd: root })).resolves.toMatchObject({
         reviews: [],

--- a/packages/progressive-review/src/review-publish-thread-gate.test.ts
+++ b/packages/progressive-review/src/review-publish-thread-gate.test.ts
@@ -5,7 +5,7 @@ import { PassThrough } from "node:stream";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createReviewDir } from "./review-home";
+import { createReviewDir, persistStoredReviewRecord } from "./review-home";
 import { runReviewPublish } from "./review-publish";
 import {
   ReviewMissingAgentResponsesError,
@@ -84,14 +84,10 @@ describe("requireClosedThreadsForRepublish", () => {
   it("reports the blocked re-publish as an NDJSON publish error", async () => {
     const review = await createTestReview();
     addComment(review.dir, "thread-1");
-    await writeFile(
-      path.join(review.dir, "review.json"),
-      `${JSON.stringify({
-        ...review.review,
-        presentedDocumentRevision: "published-revision",
-      })}\n`,
-      "utf8",
-    );
+    await persistStoredReviewRecord(review.dir, {
+      ...review.review,
+      presentedDocumentRevision: "published-revision",
+    });
     const stdout = new PassThrough();
     let output = "";
     stdout.on("data", (chunk) => (output += String(chunk)));

--- a/packages/progressive-review/src/review-state-db.test.ts
+++ b/packages/progressive-review/src/review-state-db.test.ts
@@ -1,0 +1,166 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ReviewStateDbVersionError,
+  closeAllReviewStateDatabases,
+  deleteReviewState,
+  openReviewStateDb,
+  putReviewRecord,
+  readReviewRecord,
+  reviewStateDbPath,
+} from "./review-state-db";
+import { appendReviewComment, readReviewComments } from "./review-state-store";
+import {
+  closeAllReviewThreadStores,
+  createLegacyReviewThreadDb,
+  legacyReviewThreadDbPath,
+} from "./review-thread-store-backend";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  closeAllReviewThreadStores();
+  closeAllReviewStateDatabases();
+  vi.unstubAllEnvs();
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function setupHome(): string {
+  const home = mkdtempSync(path.join(tmpdir(), "review-state-db-"));
+  roots.push(home);
+  vi.stubEnv("DEV_REVIEW_HOME", home);
+  return home;
+}
+
+function reviewPath(home: string, reviewId: string): string {
+  const dir = path.join(home, "reviews", reviewId);
+  mkdirSync(dir, { recursive: true });
+  return path.join(dir, "review.mdx");
+}
+
+describe("global review state database", () => {
+  it("isolates comment rows for multiple reviews in one database", () => {
+    const home = setupHome();
+    const first = reviewPath(home, "review-a");
+    const second = reviewPath(home, "review-b");
+
+    appendReviewComment(first, {
+      threadId: "thread-a",
+      messageId: "message-a",
+      target: { kind: "document" },
+      body: "First review",
+      author: "Reviewer",
+    });
+    appendReviewComment(second, {
+      threadId: "thread-b",
+      messageId: "message-b",
+      target: { kind: "document" },
+      body: "Second review",
+      author: "Reviewer",
+    });
+
+    expect(Object.keys(readReviewComments(first))).toEqual(["thread-a"]);
+    expect(Object.keys(readReviewComments(second))).toEqual(["thread-b"]);
+    const db = new DatabaseSync(reviewStateDbPath(home), { readOnly: true });
+    expect(
+      db
+        .prepare("SELECT count(DISTINCT review_id) AS count FROM comments")
+        .get(),
+    ).toEqual({ count: 2 });
+    db.close();
+  });
+
+  it("treats the database record as authoritative over its JSON mirror", () => {
+    const home = setupHome();
+    const document = reviewPath(home, "review-a");
+    const dir = path.dirname(document);
+    putReviewRecord(dir, { uuid: "review-a", title: "Database" });
+    writeFileSync(
+      path.join(dir, "review.json"),
+      JSON.stringify({ uuid: "review-a", title: "Stale mirror" }),
+    );
+
+    expect(readReviewRecord(dir)).toEqual({
+      uuid: "review-a",
+      title: "Database",
+    });
+  });
+
+  it("imports legacy metadata and comments once without deleting the source", () => {
+    const home = setupHome();
+    const document = reviewPath(home, "review-a");
+    const dir = path.dirname(document);
+    writeFileSync(
+      path.join(dir, "review.json"),
+      JSON.stringify({ uuid: "review-a", title: "Legacy" }),
+    );
+    createLegacyReviewThreadDb(dir);
+    const legacy = new DatabaseSync(legacyReviewThreadDbPath(document));
+    legacy
+      .prepare("INSERT INTO comments (thread_id, record_json) VALUES (?, ?)")
+      .run(
+        "thread-a",
+        JSON.stringify({
+          threadId: "thread-a",
+          target: { kind: "document" },
+          status: "open",
+          messages: [
+            {
+              id: "message-a",
+              by: "Reviewer",
+              at: "2026-01-01T00:00:00.000Z",
+              body: "Imported",
+            },
+          ],
+        }),
+      );
+    legacy.close();
+
+    expect(readReviewRecord(dir)).toEqual({
+      uuid: "review-a",
+      title: "Legacy",
+    });
+    expect(Object.keys(readReviewComments(document))).toEqual(["thread-a"]);
+    expect(legacyReviewThreadDbPath(document)).not.toBe(
+      reviewStateDbPath(home),
+    );
+  });
+
+  it("cascades all review-owned state when a review is deleted", () => {
+    const home = setupHome();
+    const document = reviewPath(home, "review-a");
+    appendReviewComment(document, {
+      threadId: "thread-a",
+      messageId: "message-a",
+      target: { kind: "document" },
+      body: "Delete me",
+      author: "Reviewer",
+    });
+
+    deleteReviewState(path.dirname(document));
+    const db = openReviewStateDb(home);
+    expect(db.prepare("SELECT count(*) AS count FROM comments").get()).toEqual({
+      count: 0,
+    });
+    expect(db.prepare("SELECT count(*) AS count FROM reviews").get()).toEqual({
+      count: 0,
+    });
+  });
+
+  it("rejects an unsupported global schema version", () => {
+    const home = setupHome();
+    const db = openReviewStateDb(home);
+    db.prepare(
+      "UPDATE review_state_meta SET value = '999' WHERE key = 'schema_version'",
+    ).run();
+    closeAllReviewStateDatabases();
+    expect(() => openReviewStateDb(home)).toThrow(ReviewStateDbVersionError);
+  });
+});

--- a/packages/progressive-review/src/review-state-db.test.ts
+++ b/packages/progressive-review/src/review-state-db.test.ts
@@ -9,16 +9,23 @@ import {
   ReviewStateDbVersionError,
   closeAllReviewStateDatabases,
   deleteReviewState,
+  importLegacyReview,
   openReviewStateDb,
   putReviewRecord,
   readReviewRecord,
   reviewStateDbPath,
 } from "./review-state-db";
-import { appendReviewComment, readReviewComments } from "./review-state-store";
 import {
+  appendReviewComment,
+  readReviewCommentDrafts,
+  readReviewComments,
+} from "./review-state-store";
+import {
+  ReviewThreadDbVersionError,
   closeAllReviewThreadStores,
   createLegacyReviewThreadDb,
   legacyReviewThreadDbPath,
+  migrateReviewThreadDb,
 } from "./review-thread-store-backend";
 
 const roots: string[] = [];
@@ -46,6 +53,87 @@ function reviewPath(home: string, reviewId: string): string {
 }
 
 describe("global review state database", () => {
+  it("defers legacy comment and draft import until after migration, even after metadata reads and writes", async () => {
+    const home = setupHome();
+    const document = reviewPath(home, "review-a");
+    const dir = path.dirname(document);
+    writeFileSync(
+      path.join(dir, "review.json"),
+      JSON.stringify({ uuid: "review-a", title: "Legacy" }),
+    );
+    createLegacyReviewThreadDb(dir);
+    const legacy = new DatabaseSync(legacyReviewThreadDbPath(document));
+    const thread = {
+      threadId: "thread-a",
+      target: { kind: "document" },
+      status: "open",
+      agentSession: {
+        harness: "codex",
+        sessionId: "child",
+        sourceSessionId: "obsolete",
+      },
+      messages: [
+        {
+          id: "message-a",
+          by: "Reviewer",
+          at: "2026-01-01T00:00:00.000Z",
+          body: "Preserve me",
+        },
+      ],
+    };
+    legacy
+      .prepare("INSERT INTO comments(thread_id, record_json) VALUES (?, ?)")
+      .run("thread-a", JSON.stringify(thread));
+    legacy
+      .prepare(
+        "INSERT INTO comment_drafts(thread_id, record_json) VALUES (?, ?)",
+      )
+      .run(
+        "thread-a",
+        JSON.stringify({
+          thread,
+          inputs: [
+            {
+              threadId: "thread-a",
+              messageId: "message-a",
+              target: { kind: "document" },
+              body: "Preserve me",
+            },
+          ],
+        }),
+      );
+    legacy
+      .prepare("UPDATE meta SET value = '4' WHERE key = 'schema_version'")
+      .run();
+    legacy.close();
+    expect(readReviewRecord(dir)).toMatchObject({ title: "Legacy" });
+    putReviewRecord(dir, { uuid: "review-a", title: "Updated metadata" });
+    expect(() => importLegacyReview(dir)).toThrow(ReviewThreadDbVersionError);
+    expect(
+      openReviewStateDb()
+        .prepare("SELECT count(*) AS count FROM legacy_review_imports")
+        .get(),
+    ).toEqual({ count: 0 });
+    expect(
+      openReviewStateDb()
+        .prepare("SELECT count(*) AS count FROM comments")
+        .get(),
+    ).toEqual({ count: 0 });
+    expect(await migrateReviewThreadDb(document)).toBe("upgraded");
+    expect(readReviewComments(document)["thread-a"]).toMatchObject({
+      agentSession: { harness: "codex", sessionId: "child" },
+      messages: [{ body: "Preserve me" }],
+    });
+    expect(
+      readReviewCommentDrafts(document)["thread-a"].thread.messages[0].body,
+    ).toBe("Preserve me");
+    expect(readReviewRecord(dir)).toMatchObject({ title: "Updated metadata" });
+    expect(
+      openReviewStateDb()
+        .prepare("SELECT count(*) AS count FROM legacy_review_imports")
+        .get(),
+    ).toEqual({ count: 1 });
+  });
   it("isolates comment rows for multiple reviews in one database", () => {
     const home = setupHome();
     const first = reviewPath(home, "review-a");

--- a/packages/progressive-review/src/review-state-db.ts
+++ b/packages/progressive-review/src/review-state-db.ts
@@ -6,6 +6,7 @@ import type { JsonValue } from "@dev.fast/review-protocol";
 import { parseJsonText } from "@dev.fast/review-protocol";
 
 import { devReviewHome } from "./review-storage";
+import { requireCurrentThreadDbSchema } from "./review-thread-db-schema";
 
 export const REVIEW_STATE_DB_FILENAME = "review.db";
 export const REVIEW_STATE_DB_SCHEMA_VERSION = 1;
@@ -168,10 +169,6 @@ export function putReviewRecord(
          review_dir = excluded.review_dir,
          record_json = excluded.record_json`,
     ).run(reviewId, path.resolve(reviewDir), recordJson);
-    db.prepare(
-      `INSERT INTO legacy_review_imports (review_id, imported_at) VALUES (?, ?)
-       ON CONFLICT(review_id) DO NOTHING`,
-    ).run(reviewId, new Date().toISOString());
     db.exec("COMMIT");
   } catch (error) {
     db.exec("ROLLBACK");
@@ -183,16 +180,21 @@ export function readReviewRecord(
   reviewDir: string,
   home = defaultReviewHome(),
 ): JsonValue | null {
-  importLegacyReview(reviewDir, home);
   const dbPath = reviewStateDbPath(home);
-  if (!existsSync(dbPath)) return null;
+  const recordPath = path.join(reviewDir, "review.json");
+  if (!existsSync(dbPath) && !existsSync(recordPath)) return null;
   // SAFETY: reviews.record_json is a nullable TEXT column in the schema above.
   const row = openReviewStateDb(home)
     .prepare("SELECT record_json FROM reviews WHERE review_id = ?")
     .get(reviewIdForDir(reviewDir)) as
     | { record_json: string | null }
     | undefined;
-  return row?.record_json ? parseJsonText(row.record_json) : null;
+  if (row?.record_json) return parseJsonText(row.record_json);
+  if (!existsSync(recordPath)) return null;
+  // Discovery must not import comment records before their schema migration.
+  const record = parseJsonText(readFileSync(recordPath, "utf8"));
+  putReviewRecord(reviewDir, record, home);
+  return record;
 }
 
 export function importLegacyReview(
@@ -218,6 +220,12 @@ export function importLegacyReview(
   const legacy = existsSync(legacyDbPath)
     ? new DatabaseSync(legacyDbPath, { readOnly: true })
     : null;
+  try {
+    if (legacy) requireCurrentThreadDbSchema(legacy, legacyDbPath);
+  } catch (error) {
+    legacy?.close();
+    throw error;
+  }
   db.exec("BEGIN IMMEDIATE");
   try {
     db.prepare(

--- a/packages/progressive-review/src/review-state-db.ts
+++ b/packages/progressive-review/src/review-state-db.ts
@@ -1,0 +1,291 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import type { JsonValue } from "@dev.fast/review-protocol";
+import { parseJsonText } from "@dev.fast/review-protocol";
+
+import { devReviewHome } from "./review-storage";
+
+export const REVIEW_STATE_DB_FILENAME = "review.db";
+export const REVIEW_STATE_DB_SCHEMA_VERSION = 1;
+
+const REVIEW_STATE_DB_DDL = `
+CREATE TABLE IF NOT EXISTS review_state_meta (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+) STRICT;
+CREATE TABLE IF NOT EXISTS reviews (
+  review_id  TEXT PRIMARY KEY,
+  review_dir TEXT NOT NULL UNIQUE,
+  record_json TEXT CHECK (record_json IS NULL OR json_valid(record_json))
+) STRICT;
+CREATE TABLE IF NOT EXISTS documents (
+  review_id       TEXT NOT NULL REFERENCES reviews(review_id) ON DELETE CASCADE,
+  route_path      TEXT NOT NULL,
+  mode            TEXT NOT NULL CHECK (mode IN ('compiled', 'incremental')),
+  revision        INTEGER NOT NULL CHECK (revision >= 0),
+  source_hash     TEXT,
+  projection_json TEXT CHECK (projection_json IS NULL OR json_valid(projection_json)),
+  PRIMARY KEY (review_id, route_path)
+) STRICT;
+CREATE TABLE IF NOT EXISTS comments (
+  review_id   TEXT NOT NULL REFERENCES reviews(review_id) ON DELETE CASCADE,
+  route_path  TEXT NOT NULL,
+  thread_id   TEXT NOT NULL,
+  record_json TEXT NOT NULL CHECK (json_valid(record_json)),
+  status      TEXT GENERATED ALWAYS AS (json_extract(record_json, '$.status')) STORED,
+  PRIMARY KEY (review_id, route_path, thread_id)
+) STRICT;
+CREATE TABLE IF NOT EXISTS comment_drafts (
+  review_id   TEXT NOT NULL REFERENCES reviews(review_id) ON DELETE CASCADE,
+  route_path  TEXT NOT NULL,
+  thread_id   TEXT NOT NULL,
+  record_json TEXT NOT NULL CHECK (json_valid(record_json)),
+  PRIMARY KEY (review_id, route_path, thread_id)
+) STRICT;
+CREATE TABLE IF NOT EXISTS mutation_receipts (
+  review_id    TEXT NOT NULL REFERENCES reviews(review_id) ON DELETE CASCADE,
+  mutation_id  TEXT NOT NULL,
+  revision     INTEGER NOT NULL CHECK (revision >= 0),
+  response_json TEXT NOT NULL CHECK (json_valid(response_json)),
+  created_at   TEXT NOT NULL,
+  PRIMARY KEY (review_id, mutation_id)
+) STRICT;
+CREATE TABLE IF NOT EXISTS legacy_review_imports (
+  review_id  TEXT PRIMARY KEY REFERENCES reviews(review_id) ON DELETE CASCADE,
+  imported_at TEXT NOT NULL
+) STRICT;
+`;
+
+const connections = new Map<string, DatabaseSync>();
+
+export class ReviewStateDbVersionError extends Error {
+  override readonly name = "ReviewStateDbVersionError";
+
+  constructor(dbPath: string, found: string | null) {
+    super(
+      `Review state database ${dbPath} has schema version ` +
+        `${found ?? "(missing)"}; this version of Review supports ` +
+        `${REVIEW_STATE_DB_SCHEMA_VERSION}. Run \`review migrate apply\`.`,
+    );
+  }
+}
+
+export function defaultReviewHome(): string {
+  return devReviewHome();
+}
+
+export function reviewStateDbPath(home = defaultReviewHome()): string {
+  return path.join(path.resolve(home), REVIEW_STATE_DB_FILENAME);
+}
+
+export function reviewIdForDir(reviewDir: string): string {
+  const reviewId = path.basename(path.resolve(reviewDir));
+  if (!reviewId)
+    throw new Error(`Review directory has no identifier: ${reviewDir}`);
+  return reviewId;
+}
+
+export function openReviewStateDb(home = defaultReviewHome()): DatabaseSync {
+  const dbPath = reviewStateDbPath(home);
+  const cached = connections.get(dbPath);
+  if (cached) return cached;
+  mkdirSync(path.dirname(dbPath), { recursive: true, mode: 0o700 });
+  const existed = existsSync(dbPath);
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec(
+      "PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; " +
+        "PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;",
+    );
+    if (!existed) {
+      db.exec(REVIEW_STATE_DB_DDL);
+      db.prepare(
+        "INSERT INTO review_state_meta (key, value) VALUES ('schema_version', ?)",
+      ).run(String(REVIEW_STATE_DB_SCHEMA_VERSION));
+    } else {
+      const version = readReviewStateDbSchemaVersion(db);
+      if (version !== String(REVIEW_STATE_DB_SCHEMA_VERSION)) {
+        throw new ReviewStateDbVersionError(dbPath, version);
+      }
+      db.exec(REVIEW_STATE_DB_DDL);
+    }
+  } catch (error) {
+    db.close();
+    throw error;
+  }
+  connections.set(dbPath, db);
+  return db;
+}
+
+export function readReviewStateDbSchemaVersion(
+  db: DatabaseSync,
+): string | null {
+  // SAFETY: sqlite_master projects the integer literal `present`.
+  const hasMeta = db
+    .prepare(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'review_state_meta'",
+    )
+    .get() as { present: number } | undefined;
+  if (!hasMeta) return null;
+  // SAFETY: review_state_meta.value is declared TEXT NOT NULL above.
+  return (
+    (
+      db
+        .prepare(
+          "SELECT value FROM review_state_meta WHERE key = 'schema_version'",
+        )
+        .get() as { value: string } | undefined
+    )?.value ?? null
+  );
+}
+
+export function ensureReviewRegistration(
+  reviewDir: string,
+  home = defaultReviewHome(),
+): void {
+  const db = openReviewStateDb(home);
+  db.prepare(
+    `INSERT INTO reviews (review_id, review_dir, record_json) VALUES (?, ?, NULL)
+     ON CONFLICT(review_id) DO UPDATE SET review_dir = excluded.review_dir`,
+  ).run(reviewIdForDir(reviewDir), path.resolve(reviewDir));
+}
+
+export function putReviewRecord(
+  reviewDir: string,
+  record: JsonValue,
+  home = defaultReviewHome(),
+): void {
+  const db = openReviewStateDb(home);
+  const reviewId = reviewIdForDir(reviewDir);
+  const recordJson = JSON.stringify(record);
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.prepare(
+      `INSERT INTO reviews (review_id, review_dir, record_json) VALUES (?, ?, ?)
+       ON CONFLICT(review_id) DO UPDATE SET
+         review_dir = excluded.review_dir,
+         record_json = excluded.record_json`,
+    ).run(reviewId, path.resolve(reviewDir), recordJson);
+    db.prepare(
+      `INSERT INTO legacy_review_imports (review_id, imported_at) VALUES (?, ?)
+       ON CONFLICT(review_id) DO NOTHING`,
+    ).run(reviewId, new Date().toISOString());
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+export function readReviewRecord(
+  reviewDir: string,
+  home = defaultReviewHome(),
+): JsonValue | null {
+  importLegacyReview(reviewDir, home);
+  const dbPath = reviewStateDbPath(home);
+  if (!existsSync(dbPath)) return null;
+  // SAFETY: reviews.record_json is a nullable TEXT column in the schema above.
+  const row = openReviewStateDb(home)
+    .prepare("SELECT record_json FROM reviews WHERE review_id = ?")
+    .get(reviewIdForDir(reviewDir)) as
+    | { record_json: string | null }
+    | undefined;
+  return row?.record_json ? parseJsonText(row.record_json) : null;
+}
+
+export function importLegacyReview(
+  reviewDir: string,
+  home = defaultReviewHome(),
+): void {
+  const reviewId = reviewIdForDir(reviewDir);
+  const recordPath = path.join(reviewDir, "review.json");
+  const legacyDbPath = path.join(reviewDir, REVIEW_STATE_DB_FILENAME);
+  if (!existsSync(recordPath) && !existsSync(legacyDbPath)) return;
+  const db = openReviewStateDb(home);
+  if (
+    db
+      .prepare("SELECT 1 FROM legacy_review_imports WHERE review_id = ?")
+      .get(reviewId)
+  ) {
+    return;
+  }
+  const recordJson = existsSync(recordPath)
+    ? readFileSync(recordPath, "utf8")
+    : null;
+  if (recordJson !== null) JSON.parse(recordJson);
+  const legacy = existsSync(legacyDbPath)
+    ? new DatabaseSync(legacyDbPath, { readOnly: true })
+    : null;
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.prepare(
+      `INSERT INTO reviews (review_id, review_dir, record_json) VALUES (?, ?, ?)
+       ON CONFLICT(review_id) DO UPDATE SET
+         review_dir = excluded.review_dir,
+         record_json = COALESCE(reviews.record_json, excluded.record_json)`,
+    ).run(reviewId, path.resolve(reviewDir), recordJson);
+    if (legacy) importLegacyCommentRows(db, legacy, reviewId);
+    db.prepare(
+      "INSERT INTO legacy_review_imports (review_id, imported_at) VALUES (?, ?)",
+    ).run(reviewId, new Date().toISOString());
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  } finally {
+    legacy?.close();
+  }
+}
+
+function importLegacyCommentRows(
+  target: DatabaseSync,
+  legacy: DatabaseSync,
+  reviewId: string,
+): void {
+  // SAFETY: sqlite_master.name is TEXT for every table row.
+  const tables = new Set(
+    (
+      legacy
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+        .all() as Array<{ name: string }>
+    ).map((row) => row.name),
+  );
+  for (const table of ["comments", "comment_drafts"] as const) {
+    if (!tables.has(table)) continue;
+    const insert = target.prepare(
+      `INSERT OR IGNORE INTO ${table}
+       (review_id, route_path, thread_id, record_json) VALUES (?, '/', ?, ?)`,
+    );
+    // SAFETY: legacy Review v1-v6 tables declare both projected columns TEXT
+    // NOT NULL; callers validate the legacy schema version before import.
+    for (const row of legacy
+      .prepare(`SELECT thread_id, record_json FROM ${table}`)
+      .all() as Array<{ thread_id: string; record_json: string }>) {
+      insert.run(reviewId, row.thread_id, row.record_json);
+    }
+  }
+}
+
+export function deleteReviewState(
+  reviewDir: string,
+  home = defaultReviewHome(),
+): void {
+  const dbPath = reviewStateDbPath(home);
+  if (!existsSync(dbPath)) return;
+  openReviewStateDb(home)
+    .prepare("DELETE FROM reviews WHERE review_id = ?")
+    .run(reviewIdForDir(reviewDir));
+}
+
+export function closeAllReviewStateDatabases(): void {
+  for (const db of connections.values()) {
+    try {
+      db.close();
+    } catch {
+      // Already closed.
+    }
+  }
+  connections.clear();
+}

--- a/packages/progressive-review/src/review-state-store.test.ts
+++ b/packages/progressive-review/src/review-state-store.test.ts
@@ -8,7 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   appendReviewAgentMessage,
@@ -35,6 +35,7 @@ import type { ReviewSubmissionEvent, ThreadTarget } from "./types";
 const roots: string[] = [];
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   closeAllReviewThreadStores();
   for (const root of roots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
@@ -54,7 +55,9 @@ const target: ThreadTarget = {
 };
 
 function makeReviewPath(): string {
-  const reviewPath = path.join(tempRoot(), "current", "review.mdx");
+  const root = tempRoot();
+  vi.stubEnv("DEV_REVIEW_HOME", root);
+  const reviewPath = path.join(root, "reviews", "current", "review.mdx");
   return reviewPath;
 }
 

--- a/packages/progressive-review/src/review-thread-db-schema.ts
+++ b/packages/progressive-review/src/review-thread-db-schema.ts
@@ -1,0 +1,39 @@
+import type { DatabaseSync } from "node:sqlite";
+
+export const REVIEW_THREAD_DB_SCHEMA_VERSION = 6;
+
+export class ReviewThreadDbVersionError extends Error {
+  override readonly name = "ReviewThreadDbVersionError";
+
+  constructor(dbPath: string, found: string | null) {
+    super(
+      `Review thread database ${dbPath} has schema version ` +
+        `${found ?? "(missing)"}; this version of Review supports ` +
+        `${REVIEW_THREAD_DB_SCHEMA_VERSION}. Run \`review migrate apply\`.`,
+    );
+  }
+}
+
+export function readThreadDbSchemaVersion(db: DatabaseSync): string | null {
+  // SAFETY: the query projects the integer literal `present`.
+  const hasMeta = db
+    .prepare(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'meta'",
+    )
+    .get() as { present: number } | undefined;
+  if (!hasMeta) return null;
+  // SAFETY: the legacy meta table declares value TEXT NOT NULL.
+  const row = db
+    .prepare("SELECT value FROM meta WHERE key = 'schema_version'")
+    .get() as { value: string } | undefined;
+  return row?.value ?? null;
+}
+
+export function requireCurrentThreadDbSchema(
+  db: DatabaseSync,
+  dbPath: string,
+): void {
+  const version = readThreadDbSchemaVersion(db);
+  if (version !== String(REVIEW_THREAD_DB_SCHEMA_VERSION))
+    throw new ReviewThreadDbVersionError(dbPath, version);
+}

--- a/packages/progressive-review/src/review-thread-store-backend.test.ts
+++ b/packages/progressive-review/src/review-thread-store-backend.test.ts
@@ -16,7 +16,8 @@ import {
   REVIEW_THREAD_DB_SCHEMA_VERSION,
   ReviewThreadDbVersionError,
   closeAllReviewThreadStores,
-  createReviewThreadDb,
+  createLegacyReviewThreadDb,
+  legacyReviewThreadDbPath,
   migrateReviewThreadDb,
   reviewThreadDbPath,
 } from "./review-thread-store-backend";
@@ -25,6 +26,7 @@ const roots: string[] = [];
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   closeAllReviewThreadStores();
   for (const root of roots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
@@ -34,7 +36,8 @@ afterEach(() => {
 function makeReviewPath(): string {
   const root = mkdtempSync(path.join(tmpdir(), "review-thread-backend-"));
   roots.push(root);
-  const dir = path.join(root, "review");
+  vi.stubEnv("DEV_REVIEW_HOME", root);
+  const dir = path.join(root, "reviews", "review");
   mkdirSync(dir, { recursive: true });
   return path.join(dir, "review.mdx");
 }
@@ -94,8 +97,8 @@ describe("sqlite thread store", () => {
 
   it("rejects a database with an unsupported schema version", () => {
     const reviewPath = makeReviewPath();
-    const dbPath = reviewThreadDbPath(reviewPath);
-    createReviewThreadDb(path.dirname(reviewPath));
+    const dbPath = legacyReviewThreadDbPath(reviewPath);
+    createLegacyReviewThreadDb(path.dirname(reviewPath));
     const db = new DatabaseSync(dbPath);
     db.prepare(
       "UPDATE meta SET value = '999' WHERE key = 'schema_version'",
@@ -108,8 +111,8 @@ describe("sqlite thread store", () => {
 
   it("drops the question table through the managed v2 upgrade", async () => {
     const reviewPath = makeReviewPath();
-    const dbPath = reviewThreadDbPath(reviewPath);
-    createReviewThreadDb(path.dirname(reviewPath));
+    const dbPath = legacyReviewThreadDbPath(reviewPath);
+    createLegacyReviewThreadDb(path.dirname(reviewPath));
     closeAllReviewThreadStores();
     const db = new DatabaseSync(dbPath);
     db.exec(`
@@ -141,8 +144,8 @@ describe("sqlite thread store", () => {
 
   it("normalizes message markers and removes native provenance", async () => {
     const reviewPath = makeReviewPath();
-    const dbPath = reviewThreadDbPath(reviewPath);
-    createReviewThreadDb(path.dirname(reviewPath));
+    const dbPath = legacyReviewThreadDbPath(reviewPath);
+    createLegacyReviewThreadDb(path.dirname(reviewPath));
     closeAllReviewThreadStores();
     const db = new DatabaseSync(dbPath);
     db.prepare(
@@ -245,8 +248,8 @@ describe("sqlite thread store", () => {
 
   it("drops a malformed database record and emits a diagnostic", () => {
     const reviewPath = makeReviewPath();
-    const dbPath = reviewThreadDbPath(reviewPath);
-    createReviewThreadDb(path.dirname(reviewPath));
+    const dbPath = legacyReviewThreadDbPath(reviewPath);
+    createLegacyReviewThreadDb(path.dirname(reviewPath));
     const db = new DatabaseSync(dbPath);
     db.prepare(
       "INSERT INTO comments (thread_id, record_json) VALUES (?, ?)",
@@ -260,10 +263,15 @@ describe("sqlite thread store", () => {
     );
 
     closeAllReviewThreadStores();
-    const reopened = new DatabaseSync(dbPath);
+    const reopened = new DatabaseSync(reviewThreadDbPath(reviewPath));
     expect(
       reopened.prepare("SELECT count(*) AS count FROM comments").get(),
     ).toEqual({ count: 0 });
     reopened.close();
+    const legacy = new DatabaseSync(dbPath, { readOnly: true });
+    expect(
+      legacy.prepare("SELECT count(*) AS count FROM comments").get(),
+    ).toEqual({ count: 1 });
+    legacy.close();
   });
 });

--- a/packages/progressive-review/src/review-thread-store-backend.ts
+++ b/packages/progressive-review/src/review-thread-store-backend.ts
@@ -17,6 +17,17 @@ import {
 import { z } from "zod";
 
 import {
+  REVIEW_THREAD_DB_SCHEMA_VERSION,
+  ReviewThreadDbVersionError,
+  readThreadDbSchemaVersion,
+  requireCurrentThreadDbSchema,
+} from "./review-thread-db-schema";
+export {
+  REVIEW_THREAD_DB_SCHEMA_VERSION,
+  ReviewThreadDbVersionError,
+} from "./review-thread-db-schema";
+
+import {
   closeAllReviewStateDatabases,
   ensureReviewRegistration,
   importLegacyReview,
@@ -34,7 +45,6 @@ import type {
 // only as a legacy migration input.
 
 export const REVIEW_THREAD_DB_FILENAME = "review.db";
-export const REVIEW_THREAD_DB_SCHEMA_VERSION = 6;
 
 export function reviewStateDir(reviewMdxPath: string): string {
   return path.dirname(path.resolve(reviewMdxPath));
@@ -47,18 +57,6 @@ export function reviewThreadDbPath(reviewMdxPath: string): string {
 
 export function legacyReviewThreadDbPath(reviewMdxPath: string): string {
   return path.join(reviewStateDir(reviewMdxPath), REVIEW_THREAD_DB_FILENAME);
-}
-
-export class ReviewThreadDbVersionError extends Error {
-  override readonly name = "ReviewThreadDbVersionError";
-
-  constructor(dbPath: string, found: string | null) {
-    super(
-      `Review thread database ${dbPath} has schema version ` +
-        `${found ?? "(missing)"}; this version of Review supports ` +
-        `${REVIEW_THREAD_DB_SCHEMA_VERSION}. Run \`review migrate apply\`.`,
-    );
-  }
 }
 
 export interface ReviewThreadStoreBackend {
@@ -144,33 +142,12 @@ function openThreadDb(
   return db;
 }
 
-function readThreadDbSchemaVersion(db: DatabaseSync): string | null {
-  // SAFETY: the query projects the single integer column `present`.
-  const hasMeta = db
-    .prepare(
-      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'meta'",
-    )
-    .get() as { present: number } | undefined;
-  if (!hasMeta) return null;
-  // SAFETY: meta.value is a TEXT NOT NULL column (see REVIEW_THREAD_DB_DDL).
-  return (
-    (
-      db
-        .prepare("SELECT value FROM meta WHERE key = 'schema_version'")
-        .get() as { value: string } | undefined
-    )?.value ?? null
-  );
-}
-
 export function checkReviewThreadDbVersion(reviewMdxPath: string): void {
   const dbPath = legacyReviewThreadDbPath(reviewMdxPath);
   if (!existsSync(dbPath)) return;
   const db = new DatabaseSync(dbPath, { readOnly: true });
   try {
-    const version = readThreadDbSchemaVersion(db);
-    if (version !== String(REVIEW_THREAD_DB_SCHEMA_VERSION)) {
-      throw new ReviewThreadDbVersionError(dbPath, version);
-    }
+    requireCurrentThreadDbSchema(db, dbPath);
   } finally {
     db.close();
   }

--- a/packages/progressive-review/src/review-thread-store-backend.ts
+++ b/packages/progressive-review/src/review-thread-store-backend.ts
@@ -16,14 +16,22 @@ import {
 } from "@dev.fast/review-protocol";
 import { z } from "zod";
 
+import {
+  closeAllReviewStateDatabases,
+  ensureReviewRegistration,
+  importLegacyReview,
+  openReviewStateDb,
+  reviewIdForDir,
+  reviewStateDbPath,
+} from "./review-state-db";
 import type {
   ReviewCommentDraftThreadMap,
   ReviewCommentThreadMap,
 } from "./types";
 
-// The review thread store persists comments in a per-review SQLite database.
-// Its synchronous mutators rely on read-modify-write with no interleaving
-// await. See review-state-store.ts.
+// Comments for every review share the Review home database. All queries are
+// scoped by review_id and route_path; the per-review review.db name is retained
+// only as a legacy migration input.
 
 export const REVIEW_THREAD_DB_FILENAME = "review.db";
 export const REVIEW_THREAD_DB_SCHEMA_VERSION = 6;
@@ -33,6 +41,11 @@ export function reviewStateDir(reviewMdxPath: string): string {
 }
 
 export function reviewThreadDbPath(reviewMdxPath: string): string {
+  void reviewMdxPath;
+  return reviewStateDbPath();
+}
+
+export function legacyReviewThreadDbPath(reviewMdxPath: string): string {
   return path.join(reviewStateDir(reviewMdxPath), REVIEW_THREAD_DB_FILENAME);
 }
 
@@ -150,7 +163,7 @@ function readThreadDbSchemaVersion(db: DatabaseSync): string | null {
 }
 
 export function checkReviewThreadDbVersion(reviewMdxPath: string): void {
-  const dbPath = reviewThreadDbPath(reviewMdxPath);
+  const dbPath = legacyReviewThreadDbPath(reviewMdxPath);
   if (!existsSync(dbPath)) return;
   const db = new DatabaseSync(dbPath, { readOnly: true });
   try {
@@ -183,7 +196,7 @@ export async function migrateReviewThreadDb(
   reviewMdxPath: string,
   options: ReviewThreadDbMigrationOptions = {},
 ): Promise<ReviewThreadDbMigrationResult> {
-  const dbPath = reviewThreadDbPath(reviewMdxPath);
+  const dbPath = legacyReviewThreadDbPath(reviewMdxPath);
   if (!existsSync(dbPath)) return "missing";
   const cached = openDatabases.get(dbPath);
   if (cached) {
@@ -387,17 +400,25 @@ function hasLegacyCodeTargets(db: DatabaseSync): boolean {
 }
 
 function readThreadTable(
-  dbPath: string,
+  reviewDir: string,
   table: "comments" | "comment_drafts",
   keyColumn: "thread_id",
 ): JsonObject {
-  const db = openThreadDb(dbPath, { create: false });
-  if (!db) return {};
+  const dbPath = reviewStateDbPath();
+  const legacyDbPath = path.join(reviewDir, REVIEW_THREAD_DB_FILENAME);
+  if (!existsSync(dbPath) && !existsSync(legacyDbPath)) return {};
+  checkReviewThreadDbVersion(path.join(reviewDir, "review.mdx"));
+  importLegacyReview(reviewDir);
+  const db = openReviewStateDb();
+  const reviewId = reviewIdForDir(reviewDir);
   // SAFETY: the key column is the TEXT PRIMARY KEY and record_json is TEXT NOT
   // NULL in both tables, and every insert binds strings for them.
   const rows = db
-    .prepare(`SELECT ${keyColumn} AS key, record_json FROM ${table}`)
-    .all() as Array<{ key: string; record_json: string }>;
+    .prepare(
+      `SELECT ${keyColumn} AS key, record_json FROM ${table}
+       WHERE review_id = ? AND route_path = '/'`,
+    )
+    .all(reviewId) as Array<{ key: string; record_json: string }>;
   const result: JsonObject = {};
   for (const row of rows) {
     result[row.key] = parseJsonText(row.record_json);
@@ -406,21 +427,27 @@ function readThreadTable(
 }
 
 function writeThreadTable(
-  dbPath: string,
+  reviewDir: string,
   table: "comments" | "comment_drafts",
   keyColumn: "thread_id",
   value: ReviewCommentThreadMap | ReviewCommentDraftThreadMap,
 ): void {
-  const db = openThreadDb(dbPath, { create: true });
-  if (!db) throw new Error(`Could not open ${dbPath}.`);
+  checkReviewThreadDbVersion(path.join(reviewDir, "review.mdx"));
+  importLegacyReview(reviewDir);
+  ensureReviewRegistration(reviewDir);
+  const db = openReviewStateDb();
+  const reviewId = reviewIdForDir(reviewDir);
   const insert = db.prepare(
-    `INSERT INTO ${table} (${keyColumn}, record_json) VALUES (?, ?)`,
+    `INSERT INTO ${table}
+     (review_id, route_path, ${keyColumn}, record_json) VALUES (?, '/', ?, ?)`,
   );
   db.exec("BEGIN IMMEDIATE");
   try {
-    db.exec(`DELETE FROM ${table}`);
+    db.prepare(
+      `DELETE FROM ${table} WHERE review_id = ? AND route_path = '/'`,
+    ).run(reviewId);
     for (const [key, record] of Object.entries(value)) {
-      insert.run(key, JSON.stringify(record));
+      insert.run(reviewId, key, JSON.stringify(record));
     }
     db.exec("COMMIT");
   } catch (error) {
@@ -430,30 +457,38 @@ function writeThreadTable(
 }
 
 function writeCommentState(
-  dbPath: string,
+  reviewDir: string,
   comments: ReviewCommentThreadMap,
   drafts: ReviewCommentDraftThreadMap,
 ): void {
-  const db = openThreadDb(dbPath, { create: true });
-  if (!db) throw new Error(`Could not open ${dbPath}.`);
+  checkReviewThreadDbVersion(path.join(reviewDir, "review.mdx"));
+  importLegacyReview(reviewDir);
+  ensureReviewRegistration(reviewDir);
+  const db = openReviewStateDb();
+  const reviewId = reviewIdForDir(reviewDir);
   const insertComment = db.prepare(
-    "INSERT INTO comments (thread_id, record_json) VALUES (?, ?)",
+    "INSERT INTO comments (review_id, route_path, thread_id, record_json) VALUES (?, '/', ?, ?)",
   );
   const insertDraft = db.prepare(
-    "INSERT INTO comment_drafts (thread_id, record_json) VALUES (?, ?)",
+    "INSERT INTO comment_drafts (review_id, route_path, thread_id, record_json) VALUES (?, '/', ?, ?)",
   );
   db.exec("BEGIN IMMEDIATE");
   try {
-    db.exec("DELETE FROM comments; DELETE FROM comment_drafts;");
+    db.prepare(
+      "DELETE FROM comments WHERE review_id = ? AND route_path = '/'",
+    ).run(reviewId);
+    db.prepare(
+      "DELETE FROM comment_drafts WHERE review_id = ? AND route_path = '/'",
+    ).run(reviewId);
     for (const [threadId, record] of Object.entries(
       parseStoredReviewCommentThreadMap(comments),
     )) {
-      insertComment.run(threadId, JSON.stringify(record));
+      insertComment.run(reviewId, threadId, JSON.stringify(record));
     }
     for (const [threadId, record] of Object.entries(
       ReviewCommentDraftThreadMapSchema.parse(drafts),
     )) {
-      insertDraft.run(threadId, JSON.stringify(record));
+      insertDraft.run(reviewId, threadId, JSON.stringify(record));
     }
     db.exec("COMMIT");
   } catch (error) {
@@ -465,41 +500,41 @@ function writeCommentState(
 function sqliteThreadStoreBackend(
   reviewMdxPath: string,
 ): ReviewThreadStoreBackend {
-  const dbPath = reviewThreadDbPath(reviewMdxPath);
+  const reviewDir = reviewStateDir(reviewMdxPath);
   return {
-    readComments: () => readValidComments(dbPath),
+    readComments: () => readValidComments(reviewDir),
     writeComments: (comments) =>
       writeThreadTable(
-        dbPath,
+        reviewDir,
         "comments",
         "thread_id",
         parseStoredReviewCommentThreadMap(comments),
       ),
     readCommentDrafts: () =>
       ReviewCommentDraftThreadMapSchema.parse(
-        readThreadTable(dbPath, "comment_drafts", "thread_id"),
+        readThreadTable(reviewDir, "comment_drafts", "thread_id"),
       ),
     writeCommentDrafts: (drafts) =>
       writeThreadTable(
-        dbPath,
+        reviewDir,
         "comment_drafts",
         "thread_id",
         ReviewCommentDraftThreadMapSchema.parse(drafts),
       ),
     writeCommentState: (comments, drafts) =>
-      writeCommentState(dbPath, comments, drafts),
+      writeCommentState(reviewDir, comments, drafts),
   };
 }
 
-function readValidComments(dbPath: string): ReviewCommentThreadMap {
-  const stored = readThreadTable(dbPath, "comments", "thread_id");
+function readValidComments(reviewDir: string): ReviewCommentThreadMap {
+  const stored = readThreadTable(reviewDir, "comments", "thread_id");
   const comments = parseReviewCommentThreadMap(stored);
   const dropped = Object.keys(stored).filter((key) => !(key in comments));
   if (dropped.length === 0) return comments;
   console.error(
-    `[Review] Dropped ${dropped.length} malformed comment record${dropped.length === 1 ? "" : "s"} from ${dbPath}: ${dropped.join(", ")}`,
+    `[Review] Dropped ${dropped.length} malformed comment record${dropped.length === 1 ? "" : "s"} from ${reviewStateDbPath()}: ${dropped.join(", ")}`,
   );
-  writeThreadTable(dbPath, "comments", "thread_id", comments);
+  writeThreadTable(reviewDir, "comments", "thread_id", comments);
   return comments;
 }
 
@@ -508,7 +543,15 @@ function readValidComments(dbPath: string): ReviewCommentThreadMap {
  * so the database's presence marks the review sqlite-first from birth. Not
  * cached: the scaffold may be rolled back (rm -rf) on a later failure.
  */
-export function createReviewThreadDb(reviewDir: string): void {
+export function createReviewThreadDb(
+  reviewDir: string,
+  reviewHome?: string,
+): void {
+  ensureReviewRegistration(reviewDir, reviewHome);
+}
+
+/** Create the old per-review database shape for migration tests and tools. */
+export function createLegacyReviewThreadDb(reviewDir: string): void {
   const dbPath = path.join(reviewDir, REVIEW_THREAD_DB_FILENAME);
   const cached = openDatabases.get(dbPath);
   if (cached) {
@@ -532,4 +575,5 @@ export function closeAllReviewThreadStores(): void {
     }
   }
   openDatabases.clear();
+  closeAllReviewStateDatabases();
 }

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -75,6 +75,7 @@ import {
   findReview,
   listReviews,
   parseStoredReviewRecord,
+  persistStoredReviewRecord,
   reviewDescriptor,
   reviewTitleFromDocument,
   reviewsHomeDir,
@@ -90,6 +91,7 @@ import {
   requireClosedThreadsForRepublish,
 } from "../review-publish-thread-gate";
 import { clearReopenPending, markReopenPending } from "../review-reopen-marker";
+import { deleteReviewState } from "../review-state-db";
 import { devReviewHome } from "../review-storage";
 import { readReviewSoftwareMapBundle } from "../software-map-bundle";
 import { createTutorialAuthoringSession } from "../tutorial-authoring-session";
@@ -1634,6 +1636,7 @@ export function createGlobalReviewServer(
         open.map((session) => closeSession(session, "closed", false)),
       );
       await rm(dir, { recursive: true, force: true });
+      deleteReviewState(dir);
       const worktreePath = open[0]?.review.review.worktreePath;
       if (worktreePath) {
         await clearReopenPending(worktreePath).catch(() => undefined);
@@ -1662,6 +1665,7 @@ export function createGlobalReviewServer(
       reviewUuid: review.review.uuid,
     });
     await rm(review.dir, { recursive: true, force: true });
+    deleteReviewState(review.dir);
     await clearReopenPending(review.review.worktreePath).catch(() => undefined);
     broadcastGlobal({ event: "review-deleted", uuid: review.review.uuid });
   }
@@ -2422,7 +2426,7 @@ async function promoteReview(
     dismissedAt: null,
   };
   if (title) review.title = title;
-  await writePrivateJsonAtomic(path.join(stored.dir, "review.json"), review);
+  await persistStoredReviewRecord(stored.dir, review);
   return { ...stored, review };
 }
 
@@ -2434,7 +2438,7 @@ async function promoteSoftwareMap(
     ...stored.review,
     presentedSoftwareMapRevision: revision,
   };
-  await writePrivateJsonAtomic(path.join(stored.dir, "review.json"), review);
+  await persistStoredReviewRecord(stored.dir, review);
   return { ...stored, review };
 }
 
@@ -2495,7 +2499,7 @@ async function setReviewStatus(
   status: ReviewRecord["status"],
 ): Promise<StoredReview> {
   const review: StoredReviewRecord = { ...stored.review, status };
-  await writePrivateJsonAtomic(path.join(stored.dir, "review.json"), review);
+  await persistStoredReviewRecord(stored.dir, review);
   return { ...stored, review };
 }
 

--- a/packages/progressive-review/src/server/tutorial-service.ts
+++ b/packages/progressive-review/src/server/tutorial-service.ts
@@ -33,6 +33,7 @@ import {
   createReviewUuid,
   findReview,
   listReviews,
+  persistStoredReviewRecord,
   reviewTitleFromDocument,
   sealReviewCandidate,
 } from "../review-home";
@@ -40,6 +41,7 @@ import {
   pinReviewSourceHeadRef,
   reviewSourceHeadRef,
 } from "../review-source-ref";
+import { deleteReviewState } from "../review-state-db";
 import { devReviewHome } from "../review-storage";
 import { writePrivateJsonAtomic } from "./desktop-paths";
 
@@ -125,6 +127,7 @@ export function createTutorialService(input: {
     for (const review of listed.reviews) {
       if (await isManagedTutorialPath(review.review.worktreePath, sampleRoot)) {
         await input.deleteReview(review);
+        deleteReviewState(review.dir);
       }
     }
     await rm(tutorialRoot, { recursive: true, force: true });
@@ -209,10 +212,7 @@ export function createTutorialService(input: {
           lastPublishedAt: publishedAt,
         },
       };
-      await writePrivateJsonAtomic(
-        path.join(candidate.dir, "review.json"),
-        candidate.review,
-      );
+      await persistStoredReviewRecord(candidate.dir, candidate.review);
       const runtimeManifest = await readTutorialRuntimeManifest(assetsRoot);
       await Promise.all([
         ...runtimeManifest.reviewFiles.map((entry) =>
@@ -238,10 +238,7 @@ export function createTutorialService(input: {
           presentedSoftwareMapRevision: revision,
         },
       };
-      await writePrivateJsonAtomic(
-        path.join(review.dir, "review.json"),
-        review.review,
-      );
+      await persistStoredReviewRecord(review.dir, review.review);
       await writePrivateJsonAtomic(stampPath, {
         version: TUTORIAL_STAMP_VERSION,
         reviewUuid: review.review.uuid,

--- a/packages/progressive-review/src/stored-review-migration.ts
+++ b/packages/progressive-review/src/stored-review-migration.ts
@@ -483,6 +483,8 @@ export async function migrateStoredReviewData(input: {
         input.onBlocker?.(
           `Review ${entry.name} database migration failed: ${errorMessage(error)}`,
         );
+        // Keep recoverable legacy state intact; do not import or mark it done.
+        continue;
       }
       const result = await dropLegacyReviewState(reviewPath, input.log);
       importLegacyReview(reviewDir, input.reviewHome);

--- a/packages/progressive-review/src/stored-review-migration.ts
+++ b/packages/progressive-review/src/stored-review-migration.ts
@@ -38,6 +38,11 @@ import {
 import { reviewTypescriptEstreeParser } from "./review-mdx-typescript-parser";
 import { createReviewSourceAgentSession } from "./review-source-agent-session";
 import {
+  deleteReviewState,
+  importLegacyReview,
+  putReviewRecord,
+} from "./review-state-db";
+import {
   type ReviewThreadDbMigrationOptions,
   migrateReviewThreadDb,
 } from "./review-thread-store-backend";
@@ -387,6 +392,7 @@ export async function migrateStoredReviewData(input: {
           schemaVersion !== 2)
       ) {
         await rm(reviewDir, { recursive: true, force: true });
+        deleteReviewState(reviewDir, input.reviewHome);
         total.droppedReviews += 1;
         input.log?.(`Dropped old Review ${entry.name}.`);
         continue;
@@ -437,6 +443,7 @@ export async function migrateStoredReviewData(input: {
       const removedPeekKeys = await removedCodePeekKeys(reviewDir);
       if (removedPeekKeys.length > 0) {
         await rm(reviewDir, { recursive: true, force: true });
+        deleteReviewState(reviewDir, input.reviewHome);
         total.droppedLegacyPeekReviews += 1;
         total.droppedReviews += 1;
         input.log?.(
@@ -478,11 +485,14 @@ export async function migrateStoredReviewData(input: {
         );
       }
       const result = await dropLegacyReviewState(reviewPath, input.log);
+      importLegacyReview(reviewDir, input.reviewHome);
+      putReviewRecord(reviewDir, migratedRecord, input.reviewHome);
       total.droppedComments += result.droppedComments;
       total.droppedQuestions += result.droppedQuestions;
       total.documents += 1;
     } catch (error) {
       await rm(reviewDir, { recursive: true, force: true });
+      deleteReviewState(reviewDir, input.reviewHome);
       total.droppedReviews += 1;
       input.log?.(
         `Dropped malformed Review ${entry.name}: ${errorMessage(error)}`,


### PR DESCRIPTION
All reviews now store metadata, comments, and drafts in one `DEV_REVIEW_HOME/review.db`, with queries scoped by review and cascading deletion of review-owned state. `review.json` remains a compatibility and sealed-revision mirror; SQLite owns the current record.

Legacy databases remain recoverable on disk. Metadata discovery does not import comments or mark migration complete. Comment import validates the current legacy schema and runs only after migration; a failed migration preserves the review and reports a blocker. This prevents opening an old review before migration from importing obsolete comment targets that would later be dropped.

Validation: regression coverage for metadata reads and writes before migration, preservation of comments and drafts, and review isolation. The final stack passed all 1,186 progressive-review tests, protocol and desktop tests, TypeScript checks, lint, formatting, and diff checks.
