### PR TITLE
Add incremental Review canvas API and MCP tools

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
@@ -889,6 +889,9 @@ export class ReviewSessionService
 					this.removeReview(event.uuid);
 					return;
 				}
+				if (event.event !== "session-closed") {
+					return;
+				}
 				const closed = this._sessionRecords.find(
 					(item) => item.sessionId === event.sessionId,
 				);

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -87,6 +87,12 @@ $ review version --json
 | `review version` | Print the Review package version. |
 
 `review mcp` is intended for MCP client registration. It exposes explicit tools
+for reading and writing rich MDX inputs (`review_get_document_file` and
+`review_write_document_file`, limited to `review.mdx` and `data.ts`). Writes
+require the source hash from the preceding read; a null hash creates a missing
+input. Rich MDX retains its components and is rendered on publish. Document
+and comment authoring clients must use these APIs rather than disk or SQL.
+It also exposes tools
 to read or replace an incremental document, insert/update/delete/move stable
 nodes, and list/reply to/resolve comments. The process talks only to the
 authenticated Review Desktop API; it never opens the Review database or MDX

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -76,6 +76,7 @@ $ review version --json
 | `review rebind` | Move a Review to another branch, bookmark, or change ID. |
 | `review wait` | Wait for reviewer activity or an agent-action state. |
 | `review threads` | Read, reply to, and resolve Review threads. |
+| `review mcp` | Serve revision-checked Review document and comment tools over MCP stdio. |
 | `review map` | Author, validate, publish, and share experimental software maps. |
 | `review install` | Install Review skills for supported coding agents. |
 | `review login` | Log in to the hosted trace store with GitHub. |
@@ -84,6 +85,12 @@ $ review version --json
 | `review trace` | Manage agent traces in the hosted trace store. |
 | `review migrate apply` | Migrate supported legacy Review data. |
 | `review version` | Print the Review package version. |
+
+`review mcp` is intended for MCP client registration. It exposes explicit tools
+to read or replace an incremental document, insert/update/delete/move stable
+nodes, and list/reply to/resolve comments. The process talks only to the
+authenticated Review Desktop API; it never opens the Review database or MDX
+file itself.
 
 ## Desktop and discovery
 

--- a/docs/how-review-works.md
+++ b/docs/how-review-works.md
@@ -73,10 +73,16 @@ Authored Reviews are stored under:
 ${DEV_REVIEW_HOME:-~/.dev}/reviews/<uuid>/
 ```
 
-The directory contains the document, supporting TypeScript, pinned state,
-thread database, sealed revisions, and disposable build output. Review owns the
-infrastructure files; agents author `review.mdx` and `data.ts`, and use the CLI
-for publication and threads.
+The directory contains the MDX document, supporting TypeScript, a compatibility
+record mirror, sealed revisions, and disposable build output. One shared
+`${DEV_REVIEW_HOME:-~/.dev}/review.db` is authoritative for every Review's
+metadata and comments. Canvas and agent clients use the Review API instead of
+reading that database or the current document from disk.
+
+Existing rich MDX Reviews keep the compiled publication path. Incremental
+Reviews use stable `ReviewNode` IDs: MCP tools apply one revision-checked node
+operation at a time, Review Desktop writes the MDX, and the canvas receives a
+document-change event without replacing the whole session.
 
 Software maps are stored per commit in Git notes under
 `refs/notes/dev-fast/*`. They do not add generated map files to the reviewed

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -427,7 +427,7 @@ The report never sends these review files:
 
 - `review.json`, which holds a local directory path and the pull request URL
 - the compiled document in `.bundle/`, and the build output in `.build/`
-- `review.db`, which holds the comment threads and the questions
+- the shared `review.db`, which holds Review metadata and comment threads
 
 Trace attachment consent is independent of passive telemetry and trace sync.
 Neither setting enables trace attachment for a bug report. If the user opts in,

--- a/packages/progressive-review/skills/dev-review/SKILL.md
+++ b/packages/progressive-review/skills/dev-review/SKILL.md
@@ -104,9 +104,15 @@ If no sub-agent facility exists, publish the document. Report that the map is no
 
 ### 4. Author the document
 
-Read [Document authoring](references/document-authoring.md) before you edit `review.mdx` or `data.ts`.
+Read [Document authoring](references/document-authoring.md) before authoring the document. All document and comment reads and edits must go through the Review API; do not read or write `review.mdx`, `data.ts`, or comment databases directly. Register `review mcp` with your MCP client if its tools are not available.
 
-When the Review canvas MCP tools are available, use `review_get_document` and
+For rich MDX, use `review_get_document_file` and `review_write_document_file` with
+`name: "review.mdx"` or `name: "data.ts"`. Pass the returned `sourceHash` as
+`expectedSourceHash`; null creates a missing input. Keep built-in components and
+imports intact. Write each input through the API, then publish to compile and
+present the complete document.
+
+For incremental documents, use `review_get_document` and
 the revision-checked `review_replace_document`, `review_insert_node`,
 `review_update_node`, `review_delete_node`, and `review_move_node` tools. Keep
 the returned revision for the next mutation. Converting a compiled Review

--- a/packages/progressive-review/skills/dev-review/SKILL.md
+++ b/packages/progressive-review/skills/dev-review/SKILL.md
@@ -55,7 +55,7 @@ Pass resolved commit ids to `--base` and `--head`. Parent suffixes like `<rev>^`
 
 If scaffold warns that `devfast.prepare` is not configured, set up that command according to [Prepared worktrees](references/prepared-worktrees.md).
 
-Read the scaffold JSON event and `<review-dir>/review.json`. Together they carry these values; record them:
+Read the scaffold JSON event and `review info --json`. Together they carry these values; record them. Do not treat the compatibility `review.json` mirror as authoritative:
 
 - Review UUID and directory
 - source worktree
@@ -105,6 +105,13 @@ If no sub-agent facility exists, publish the document. Report that the map is no
 ### 4. Author the document
 
 Read [Document authoring](references/document-authoring.md) before you edit `review.mdx` or `data.ts`.
+
+When the Review canvas MCP tools are available, use `review_get_document` and
+the revision-checked `review_replace_document`, `review_insert_node`,
+`review_update_node`, `review_delete_node`, and `review_move_node` tools. Keep
+the returned revision for the next mutation. Converting a compiled Review
+requires the exact `sourceHash` returned by `review_get_document`. Never edit an
+incremental `review.mdx` directly.
 
 Use the materialized files in `traces.paths` from the scaffold event. When that array is non-empty, read [Trace quoting](references/trace-quoting.md) and complete its intent pass before authoring. Use FFF for trace search candidate discovery.
 

--- a/packages/progressive-review/skills/dev-review/references/document-authoring.md
+++ b/packages/progressive-review/skills/dev-review/references/document-authoring.md
@@ -53,8 +53,8 @@ Do not invent user-impact risks. Ask the user when risk depends on product usage
 
 Agents can edit only these Review files:
 
-- `review.mdx` is the presentation layer.
-- `data.ts` contains typed document inputs.
+- `review.mdx` is the presentation layer. Read and write it through `review_get_document_file` / `review_write_document_file`, never direct filesystem access.
+- `data.ts` contains typed document inputs. Use the same API tools with `name: "data.ts"`. Read first and pass its `sourceHash` as `expectedSourceHash` when writing (null for a missing input). Publish after all inputs are updated.
 
 Do not edit `review.json`, `review.db`, `.bundle/`, `.build/`, or the private Review `.git/` directory.
 

--- a/packages/progressive-review/skills/dev-review/references/lifecycle-and-storage.md
+++ b/packages/progressive-review/skills/dev-review/references/lifecycle-and-storage.md
@@ -77,7 +77,6 @@ ${DEV_REVIEW_HOME:-~/.dev}/reviews/<uuid>/
 ├── review.mdx
 ├── data.ts
 ├── review.json
-├── review.db
 ├── package.json
 ├── review-test.mjs
 ├── .gitignore
@@ -88,9 +87,9 @@ ${DEV_REVIEW_HOME:-~/.dev}/reviews/<uuid>/
 └── .git/
 ```
 
-`review.json` is schema 3 state. It contains the source worktree, binding, pinned commits, status, `presentedDocumentRevision`, and `presentedSoftwareMapRevision`.
+`review.json` is a compatibility mirror used by sealed historical revisions. The authoritative Review record and comment state live in `${DEV_REVIEW_HOME:-~/.dev}/review.db`, shared by every Review.
 
-`review.db` contains durable comment and question threads. Use only `review threads` to read or change it.
+Use only the Review API, MCP tools, or `review threads` to read or change documents and comments. Never query `review.db` or edit an incremental `review.mdx` directly.
 
 `.bundle/document/` contains the current document candidate. `.bundle/software-map/` contains the current map candidate when one exists. The private Review Git repository seals these candidates as revisions.
 

--- a/packages/progressive-review/src/cli-runner.ts
+++ b/packages/progressive-review/src/cli-runner.ts
@@ -56,6 +56,7 @@ import {
 import { runReviewInfo } from "./review-info";
 import { runReviewInternalTest } from "./review-internal-test";
 import { emitReviewEvent, serializeReviewError } from "./review-logger";
+import { runReviewMcp } from "./review-mcp";
 import { prepareReviewPinnedCheckout } from "./review-prepare";
 import { runReviewPublish } from "./review-publish";
 import { runReviewRebind } from "./review-rebind";
@@ -102,6 +103,7 @@ interface ProgressiveReviewCliRuntime {
   runReviewInfo: typeof runReviewInfo;
   runReviewScaffold: typeof runReviewScaffold;
   runReviewInternalTest: typeof runReviewInternalTest;
+  runReviewMcp: typeof runReviewMcp;
   runReviewPublish: typeof runReviewPublish;
   runReviewRebind: typeof runReviewRebind;
   runReviewThreadsGet: typeof runReviewThreadsGet;
@@ -299,6 +301,16 @@ export async function runProgressiveReviewCli(
     await runtime.runReviewInternalTest(reviewDir ?? cwd);
     state.exitCode = 0;
   });
+
+  program
+    .command("mcp")
+    .description("Serve the Review canvas MCP tools over stdio")
+    .action(async () => {
+      state.exitCode = await runtime.runReviewMcp({
+        stdin: input.stdin ?? process.stdin,
+        stdout: input.stdout,
+      });
+    });
 
   const writeAppEvent = (
     event: ReviewAppLaunchEvent | ReviewAppEvent,
@@ -1302,6 +1314,7 @@ function progressiveReviewCliRuntime(
     runReviewInfo,
     runReviewScaffold,
     runReviewInternalTest,
+    runReviewMcp,
     runReviewPublish,
     runReviewRebind,
     runReviewThreadsGet,

--- a/packages/progressive-review/src/incremental-review-document.test.ts
+++ b/packages/progressive-review/src/incremental-review-document.test.ts
@@ -1,0 +1,216 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { ReviewRecordSchema } from "@dev.fast/review-protocol";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ReviewDocumentApiError,
+  mutateReviewDocument,
+  parseIncrementalReviewDocument,
+  readReviewDocumentSnapshot,
+  serializeIncrementalReviewDocument,
+} from "./incremental-review-document";
+import type { StoredReview } from "./review-home";
+import { closeAllReviewStateDatabases } from "./review-state-db";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  closeAllReviewStateDatabases();
+  vi.unstubAllEnvs();
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("incremental Review documents", () => {
+  it("round-trips the restricted stable-node MDX format", () => {
+    const source = serializeIncrementalReviewDocument(7, [
+      { id: "intro", kind: "markdown", content: "# Hello\n\nWorld" },
+      {
+        id: "warning",
+        kind: "callout",
+        tone: "warning",
+        title: "Careful",
+        content: "Mind the edge.",
+      },
+    ]);
+
+    expect(parseIncrementalReviewDocument(source)).toEqual({
+      revision: 7,
+      nodes: [
+        { id: "intro", kind: "markdown", content: "# Hello\n\nWorld" },
+        {
+          id: "warning",
+          kind: "callout",
+          tone: "warning",
+          title: "Careful",
+          content: "Mind the edge.",
+        },
+      ],
+    });
+  });
+
+  it("converts a compiled document only with source-hash concurrency", async () => {
+    const review = await makeReview("# Existing rich MDX\n");
+    const compiled = await readReviewDocumentSnapshot(review);
+    expect(compiled).toMatchObject({ mode: "compiled", revision: 0 });
+
+    await expect(
+      mutateReviewDocument(review, {
+        mutationId: "replace-without-hash",
+        expectedRevision: 0,
+        operation: { type: "replace", nodes: [] },
+      }),
+    ).rejects.toMatchObject({
+      code: "source_hash_required",
+      statusCode: 409,
+    });
+
+    const replaced = await mutateReviewDocument(review, {
+      mutationId: "replace-1",
+      expectedRevision: 0,
+      expectedSourceHash: compiled.sourceHash,
+      operation: {
+        type: "replace",
+        nodes: [{ id: "intro", kind: "markdown", content: "# New" }],
+      },
+    });
+    expect(replaced.snapshot).toMatchObject({
+      mode: "incremental",
+      revision: 1,
+      nodes: [{ id: "intro", content: "# New" }],
+    });
+
+    const retried = await mutateReviewDocument(review, {
+      mutationId: "replace-1",
+      expectedRevision: 0,
+      expectedSourceHash: compiled.sourceHash,
+      operation: { type: "replace", nodes: [] },
+    });
+    expect(retried).toEqual(replaced);
+  });
+
+  it("applies insert, update, move, and delete by stable node ID", async () => {
+    const review = await makeReview(
+      serializeIncrementalReviewDocument(2, [
+        { id: "a", kind: "markdown", content: "A" },
+        { id: "b", kind: "markdown", content: "B" },
+      ]),
+    );
+    await mutateReviewDocument(review, {
+      mutationId: "insert-c",
+      expectedRevision: 2,
+      operation: {
+        type: "insert",
+        index: 1,
+        node: { id: "c", kind: "callout", content: "C" },
+      },
+    });
+    await mutateReviewDocument(review, {
+      mutationId: "update-c",
+      expectedRevision: 3,
+      operation: {
+        type: "update",
+        nodeId: "c",
+        patch: { title: "Changed", tone: "success" },
+      },
+    });
+    await mutateReviewDocument(review, {
+      mutationId: "move-b",
+      expectedRevision: 4,
+      operation: { type: "move", nodeId: "b", index: 0 },
+    });
+    const deleted = await mutateReviewDocument(review, {
+      mutationId: "delete-a",
+      expectedRevision: 5,
+      operation: { type: "delete", nodeId: "a" },
+    });
+
+    expect(deleted.snapshot.nodes).toEqual([
+      { id: "b", kind: "markdown", content: "B" },
+      {
+        id: "c",
+        kind: "callout",
+        content: "C",
+        title: "Changed",
+        tone: "success",
+      },
+    ]);
+  });
+
+  it("rejects stale mutations without changing the MDX file", async () => {
+    const source = serializeIncrementalReviewDocument(3, [
+      { id: "a", kind: "markdown", content: "A" },
+    ]);
+    const review = await makeReview(source);
+
+    await expect(
+      mutateReviewDocument(review, {
+        mutationId: "stale",
+        expectedRevision: 2,
+        operation: { type: "delete", nodeId: "a" },
+      }),
+    ).rejects.toBeInstanceOf(ReviewDocumentApiError);
+    await expect(
+      readFile(path.join(review.dir, "review.mdx"), "utf8"),
+    ).resolves.toBe(source);
+  });
+
+  it("recovers an idempotent receipt after the MDX write wins a crash", async () => {
+    const source = serializeIncrementalReviewDocument(
+      1,
+      [{ id: "a", kind: "markdown", content: "A" }],
+      "crash-window-mutation",
+    );
+    const review = await makeReview(source);
+
+    const recovered = await mutateReviewDocument(review, {
+      mutationId: "crash-window-mutation",
+      expectedRevision: 0,
+      operation: { type: "replace", nodes: [] },
+    });
+
+    expect(recovered.snapshot).toMatchObject({
+      revision: 1,
+      nodes: [{ id: "a" }],
+    });
+    await expect(
+      readFile(path.join(review.dir, "review.mdx"), "utf8"),
+    ).resolves.toBe(source);
+  });
+});
+
+async function makeReview(source: string): Promise<StoredReview> {
+  const home = await mkdtemp(path.join(os.tmpdir(), "incremental-review-"));
+  roots.push(home);
+  vi.stubEnv("DEV_REVIEW_HOME", home);
+  const uuid = "11111111-1111-4111-8111-111111111111";
+  const dir = path.join(home, "reviews", uuid);
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, "review.mdx"), source, "utf8");
+  return {
+    dir,
+    review: ReviewRecordSchema.parse({
+      schemaVersion: 4,
+      uuid,
+      repoKey: "repo",
+      worktreePath: home,
+      baseRef: "main",
+      baseCommit: "a".repeat(40),
+      sourceCommit: "b".repeat(40),
+      sourceIdentity: { kind: "git-branch", name: "main" },
+      pullRequestNumber: null,
+      pullRequestUrl: null,
+      title: "Incremental Review",
+      sourceSession: "disabled:review",
+      status: "draft",
+      presentedDocumentRevision: null,
+      presentedSoftwareMapRevision: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastPublishedAt: null,
+    }),
+  };
+}

--- a/packages/progressive-review/src/incremental-review-document.ts
+++ b/packages/progressive-review/src/incremental-review-document.ts
@@ -1,0 +1,350 @@
+import crypto from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  type ReviewDocumentMutationRequest,
+  type ReviewDocumentMutationResponse,
+  ReviewDocumentMutationResponseSchema,
+  type ReviewDocumentNode,
+  ReviewDocumentNodeSchema,
+  type ReviewDocumentSnapshot,
+  isJsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
+import { writeFileAtomicAsync } from "./atomic-write";
+import type { StoredReview } from "./review-home";
+import {
+  commitReviewDocumentMutation,
+  putReviewDocumentState,
+  readReviewDocumentState,
+  readReviewMutationReceipt,
+} from "./review-state-db";
+
+const INCREMENTAL_HEADER = "---\nreviewCanvas: incremental\nrevision: ";
+const INCREMENTAL_HEADER_PATTERN =
+  /^---\nreviewCanvas: incremental\nrevision: (\d+)\n(?:mutationId: ([A-Za-z0-9_-]+)\n)?---\n/u;
+const NODE_PATTERN =
+  /<ReviewNode data=\{(\{[^\n]+\})\}>\n([\s\S]*?)\n<\/ReviewNode>/gu;
+
+export class ReviewDocumentApiError extends Error {
+  override readonly name = "ReviewDocumentApiError";
+
+  constructor(
+    message: string,
+    readonly statusCode: number,
+    readonly code: string,
+  ) {
+    super(message);
+  }
+}
+
+export interface ParsedIncrementalReviewDocument {
+  revision: number;
+  mutationId?: string;
+  nodes: ReviewDocumentNode[];
+}
+
+export function parseIncrementalReviewDocument(
+  source: string,
+): ParsedIncrementalReviewDocument | null {
+  const normalized = source.replace(/\r\n?/gu, "\n");
+  const header = INCREMENTAL_HEADER_PATTERN.exec(normalized);
+  if (!header) return null;
+  const revision = Number(header[1]);
+  if (!Number.isSafeInteger(revision) || revision < 0) {
+    throw new ReviewDocumentApiError(
+      "The incremental Review revision is invalid.",
+      422,
+      "invalid_document",
+    );
+  }
+  const body = normalized.slice(header[0].length);
+  const nodes: ReviewDocumentNode[] = [];
+  const ids = new Set<string>();
+  let cursor = 0;
+  for (const match of body.matchAll(NODE_PATTERN)) {
+    const index = match.index;
+    if (body.slice(cursor, index).trim()) {
+      throw invalidDocument("Only top-level ReviewNode blocks are allowed.");
+    }
+    const metadata = parseJsonText(match[1]!);
+    if (!isJsonObject(metadata)) {
+      throw invalidDocument("Review node metadata must be an object.");
+    }
+    const parsed = ReviewDocumentNodeSchema.parse({
+      ...metadata,
+      content: match[2]!,
+    });
+    if (ids.has(parsed.id)) {
+      throw invalidDocument(`Duplicate Review node ID: ${parsed.id}`);
+    }
+    ids.add(parsed.id);
+    nodes.push(parsed);
+    cursor = index + match[0].length;
+  }
+  if (body.slice(cursor).trim()) {
+    throw invalidDocument("Only top-level ReviewNode blocks are allowed.");
+  }
+  const mutationId = header[2]
+    ? Buffer.from(header[2], "base64url").toString("utf8")
+    : undefined;
+  return mutationId ? { revision, mutationId, nodes } : { revision, nodes };
+}
+
+export function serializeIncrementalReviewDocument(
+  revision: number,
+  nodes: readonly ReviewDocumentNode[],
+  mutationId?: string,
+): string {
+  requireUniqueNodeIds(nodes);
+  const blocks = nodes.map((node) => {
+    if (node.content.includes("</ReviewNode>")) {
+      throw invalidDocument(
+        `Review node ${node.id} contains the reserved closing tag.`,
+      );
+    }
+    const { content, ...metadata } = ReviewDocumentNodeSchema.parse(node);
+    const data = JSON.stringify(metadata).replace(/</gu, "\\u003c");
+    return `<ReviewNode data={${data}}>\n${content}\n</ReviewNode>`;
+  });
+  const mutationLine = mutationId
+    ? `\nmutationId: ${Buffer.from(mutationId).toString("base64url")}`
+    : "";
+  return `${INCREMENTAL_HEADER}${revision}${mutationLine}\n---\n${blocks.join("\n\n")}${blocks.length ? "\n" : ""}`;
+}
+
+export async function readReviewDocumentSnapshot(
+  review: StoredReview,
+): Promise<ReviewDocumentSnapshot> {
+  const routePath = "/";
+  const documentPath = path.join(review.dir, "review.mdx");
+  const source = await readFile(documentPath, "utf8");
+  const sourceHash = hashSource(source);
+  const parsed = parseIncrementalReviewDocument(source);
+  const snapshot: ReviewDocumentSnapshot = parsed
+    ? {
+        reviewId: review.review.uuid,
+        routePath,
+        mode: "incremental",
+        revision: parsed.revision,
+        sourceHash,
+        source,
+        nodes: parsed.nodes,
+      }
+    : {
+        reviewId: review.review.uuid,
+        routePath,
+        mode: "compiled",
+        revision: 0,
+        sourceHash,
+        source,
+        nodes: null,
+      };
+  const stored = readReviewDocumentState(review.dir, routePath);
+  if (
+    !stored ||
+    stored.mode !== snapshot.mode ||
+    stored.revision !== snapshot.revision ||
+    stored.sourceHash !== sourceHash
+  ) {
+    putReviewDocumentState(review.dir, routePath, {
+      mode: snapshot.mode,
+      revision: snapshot.revision,
+      sourceHash,
+      projection: snapshot.nodes,
+    });
+  }
+  return snapshot;
+}
+
+export async function mutateReviewDocument(
+  review: StoredReview,
+  request: ReviewDocumentMutationRequest,
+): Promise<Extract<ReviewDocumentMutationResponse, { ok: true }>> {
+  const priorReceipt = readReviewMutationReceipt(
+    review.dir,
+    request.mutationId,
+  );
+  if (priorReceipt) {
+    const parsed = ReviewDocumentMutationResponseSchema.parse(priorReceipt);
+    if (!parsed.ok) {
+      throw new Error("Stored Review mutation receipt is not a success.");
+    }
+    return parsed;
+  }
+  const current = await readReviewDocumentSnapshot(review);
+  const parsedCurrent = parseIncrementalReviewDocument(current.source);
+  if (parsedCurrent?.mutationId === request.mutationId) {
+    const recovered: Extract<ReviewDocumentMutationResponse, { ok: true }> = {
+      ok: true,
+      mutationId: request.mutationId,
+      snapshot: current,
+    };
+    commitReviewDocumentMutation({
+      reviewDir: review.dir,
+      routePath: current.routePath,
+      mutationId: request.mutationId,
+      state: {
+        mode: current.mode,
+        revision: current.revision,
+        sourceHash: current.sourceHash,
+        projection: current.nodes,
+      },
+      response: recovered,
+      createdAt: new Date().toISOString(),
+    });
+    return recovered;
+  }
+  if (request.expectedRevision !== current.revision) {
+    throw new ReviewDocumentApiError(
+      `Review document revision changed from ${request.expectedRevision} to ${current.revision}.`,
+      409,
+      "revision_conflict",
+    );
+  }
+  if (
+    request.expectedSourceHash !== undefined &&
+    request.expectedSourceHash !== current.sourceHash
+  ) {
+    throw new ReviewDocumentApiError(
+      "Review document source changed before the mutation was applied.",
+      409,
+      "source_conflict",
+    );
+  }
+  if (current.mode === "compiled" && request.operation.type !== "replace") {
+    throw new ReviewDocumentApiError(
+      "A compiled Review must first be replaced with an incremental document.",
+      409,
+      "compiled_document",
+    );
+  }
+  if (current.mode === "compiled" && request.expectedSourceHash === undefined) {
+    throw new ReviewDocumentApiError(
+      "Replacing a compiled Review requires expectedSourceHash.",
+      409,
+      "source_hash_required",
+    );
+  }
+  const nodes = applyReviewDocumentOperation(
+    current.nodes ?? [],
+    request.operation,
+  );
+  const revision = current.revision + 1;
+  const source = serializeIncrementalReviewDocument(
+    revision,
+    nodes,
+    request.mutationId,
+  );
+  const sourceHash = hashSource(source);
+  const snapshot: ReviewDocumentSnapshot = {
+    reviewId: review.review.uuid,
+    routePath: "/",
+    mode: "incremental",
+    revision,
+    sourceHash,
+    source,
+    nodes,
+  };
+  const response: Extract<ReviewDocumentMutationResponse, { ok: true }> = {
+    ok: true,
+    mutationId: request.mutationId,
+    snapshot,
+  };
+  await writeFileAtomicAsync(path.join(review.dir, "review.mdx"), source, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  commitReviewDocumentMutation({
+    reviewDir: review.dir,
+    routePath: "/",
+    mutationId: request.mutationId,
+    state: {
+      mode: "incremental",
+      revision,
+      sourceHash,
+      projection: nodes,
+    },
+    response,
+    createdAt: new Date().toISOString(),
+  });
+  return response;
+}
+
+function applyReviewDocumentOperation(
+  current: readonly ReviewDocumentNode[],
+  operation: ReviewDocumentMutationRequest["operation"],
+): ReviewDocumentNode[] {
+  if (operation.type === "replace") {
+    requireUniqueNodeIds(operation.nodes);
+    return operation.nodes.map((node) => ({ ...node }));
+  }
+  const nodes = current.map((node) => ({ ...node }));
+  if (operation.type === "insert") {
+    if (nodes.some((node) => node.id === operation.node.id)) {
+      throw invalidMutation(`Review node already exists: ${operation.node.id}`);
+    }
+    if (operation.index > nodes.length) {
+      throw invalidMutation("Insert index is past the end of the document.");
+    }
+    nodes.splice(operation.index, 0, { ...operation.node });
+    return nodes;
+  }
+  const index = nodes.findIndex((node) => node.id === operation.nodeId);
+  if (index < 0) {
+    throw new ReviewDocumentApiError(
+      `Review node not found: ${operation.nodeId}`,
+      404,
+      "node_not_found",
+    );
+  }
+  if (operation.type === "delete") {
+    nodes.splice(index, 1);
+    return nodes;
+  }
+  if (operation.type === "move") {
+    const [node] = nodes.splice(index, 1);
+    if (operation.index > nodes.length) {
+      throw invalidMutation("Move index is past the end of the document.");
+    }
+    nodes.splice(operation.index, 0, node!);
+    return nodes;
+  }
+  const patch = operation.patch;
+  const next: ReviewDocumentNode = { ...nodes[index]! };
+  if (patch.kind !== undefined) next.kind = patch.kind;
+  if (patch.content !== undefined) next.content = patch.content;
+  if (patch.title === null) delete next.title;
+  else if (patch.title !== undefined) next.title = patch.title;
+  if (patch.tone === null) delete next.tone;
+  else if (patch.tone !== undefined) next.tone = patch.tone;
+  if (patch.language === null) delete next.language;
+  else if (patch.language !== undefined) next.language = patch.language;
+  nodes[index] = ReviewDocumentNodeSchema.parse(next);
+  return nodes;
+}
+
+function requireUniqueNodeIds(nodes: readonly ReviewDocumentNode[]): void {
+  const ids = new Set<string>();
+  for (const node of nodes) {
+    ReviewDocumentNodeSchema.parse(node);
+    if (ids.has(node.id)) {
+      throw invalidMutation(`Duplicate Review node ID: ${node.id}`);
+    }
+    ids.add(node.id);
+  }
+}
+
+function hashSource(source: string): string {
+  return crypto.createHash("sha256").update(source).digest("hex");
+}
+
+function invalidDocument(message: string): ReviewDocumentApiError {
+  return new ReviewDocumentApiError(message, 422, "invalid_document");
+}
+
+function invalidMutation(message: string): ReviewDocumentApiError {
+  return new ReviewDocumentApiError(message, 422, "invalid_mutation");
+}

--- a/packages/progressive-review/src/review-canvas-api-client.ts
+++ b/packages/progressive-review/src/review-canvas-api-client.ts
@@ -1,0 +1,155 @@
+import {
+  type JsonObject,
+  type JsonValue,
+  type ReviewDesktopDiscovery,
+  type ReviewDocumentMutationRequest,
+  type ReviewDocumentMutationResponse,
+  ReviewDocumentMutationResponseSchema,
+  type ReviewDocumentSnapshotResponse,
+  ReviewDocumentSnapshotResponseSchema,
+  type ReviewThreadsCommand,
+  type ReviewThreadsCommandResponse,
+  ReviewThreadsCommandResponseSchema,
+  type ReviewThreadsSnapshotResponse,
+  ReviewThreadsSnapshotResponseSchema,
+  isJsonObject,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
+import { requireHealthyReviewDesktop } from "./desktop-discovery";
+
+export interface ReviewCanvasApi {
+  getDocument(reviewId: string): Promise<ReviewDocumentSnapshotResponse>;
+  mutateDocument(
+    reviewId: string,
+    request: ReviewDocumentMutationRequest,
+  ): Promise<ReviewDocumentMutationResponse>;
+  getComments(reviewId: string): Promise<ReviewThreadsSnapshotResponse>;
+  command(
+    reviewId: string,
+    command: ReviewThreadsCommand,
+  ): Promise<ReviewThreadsCommandResponse>;
+  reply(input: {
+    reviewId: string;
+    threadId: string;
+    mutationId: string;
+    messageId: string;
+    body: string;
+    author?: string;
+  }): Promise<ReviewThreadsCommandResponse>;
+}
+
+export interface ReviewCanvasApiClientOptions {
+  discovery?: ReviewDesktopDiscovery;
+  fetch?: typeof globalThis.fetch;
+}
+
+export class ReviewCanvasApiClient implements ReviewCanvasApi {
+  private readonly fetch: typeof globalThis.fetch;
+
+  constructor(private readonly options: ReviewCanvasApiClientOptions = {}) {
+    this.fetch = options.fetch ?? globalThis.fetch;
+  }
+
+  async getDocument(reviewId: string): Promise<ReviewDocumentSnapshotResponse> {
+    return ReviewDocumentSnapshotResponseSchema.parse(
+      await this.request(`/reviews/${encodeURIComponent(reviewId)}/document`),
+    );
+  }
+
+  async mutateDocument(
+    reviewId: string,
+    request: ReviewDocumentMutationRequest,
+  ): Promise<ReviewDocumentMutationResponse> {
+    return ReviewDocumentMutationResponseSchema.parse(
+      await this.request(
+        `/reviews/${encodeURIComponent(reviewId)}/document/mutations`,
+        request,
+      ),
+    );
+  }
+
+  async getComments(reviewId: string): Promise<ReviewThreadsSnapshotResponse> {
+    return ReviewThreadsSnapshotResponseSchema.parse(
+      await this.request(`/reviews/${encodeURIComponent(reviewId)}/comments`),
+    );
+  }
+
+  async command(
+    reviewId: string,
+    command: ReviewThreadsCommand,
+  ): Promise<ReviewThreadsCommandResponse> {
+    return ReviewThreadsCommandResponseSchema.parse(
+      await this.request(
+        `/reviews/${encodeURIComponent(reviewId)}/thread-commands`,
+        command,
+      ),
+    );
+  }
+
+  async reply(input: {
+    reviewId: string;
+    threadId: string;
+    mutationId: string;
+    messageId: string;
+    body: string;
+    author?: string;
+  }): Promise<ReviewThreadsCommandResponse> {
+    const body: JsonObject = {
+      mutationId: input.mutationId,
+      messageId: input.messageId,
+      body: input.body,
+    };
+    if (input.author) body.author = input.author;
+    return ReviewThreadsCommandResponseSchema.parse(
+      await this.request(
+        `/reviews/${encodeURIComponent(input.reviewId)}/comments/${encodeURIComponent(input.threadId)}/replies`,
+        body,
+      ),
+    );
+  }
+
+  private async request(
+    pathname: string,
+    body?: JsonValue,
+  ): Promise<JsonValue> {
+    const discovery =
+      this.options.discovery ??
+      (await requireHealthyReviewDesktop("review mcp"));
+    let response: Response;
+    try {
+      const headers = new Headers({
+        "x-review-token": discovery.token,
+      });
+      if (body !== undefined) headers.set("content-type", "application/json");
+      response = await this.fetch(`${discovery.url}${pathname}`, {
+        method: body === undefined ? "GET" : "POST",
+        headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+    } catch (error) {
+      throw new Error("Review Desktop API is unavailable.", { cause: error });
+    }
+    const value = parseJsonText(await response.text());
+    if (!response.ok) {
+      const detail = isJsonObject(value)
+        ? (jsonString(value.error) ??
+          `Review Desktop returned ${response.status}.`)
+        : `Review Desktop returned ${response.status}.`;
+      throw new ReviewCanvasApiError(detail, response.status);
+    }
+    return value;
+  }
+}
+
+export class ReviewCanvasApiError extends Error {
+  override readonly name = "ReviewCanvasApiError";
+
+  constructor(
+    message: string,
+    readonly statusCode: number,
+  ) {
+    super(message);
+  }
+}

--- a/packages/progressive-review/src/review-canvas-api-client.ts
+++ b/packages/progressive-review/src/review-canvas-api-client.ts
@@ -2,6 +2,10 @@ import {
   type JsonObject,
   type JsonValue,
   type ReviewDesktopDiscovery,
+  type ReviewDocumentFileName,
+  type ReviewDocumentFileResponse,
+  ReviewDocumentFileResponseSchema,
+  type ReviewDocumentFileWrite,
   type ReviewDocumentMutationRequest,
   type ReviewDocumentMutationResponse,
   ReviewDocumentMutationResponseSchema,
@@ -20,6 +24,15 @@ import {
 import { requireHealthyReviewDesktop } from "./desktop-discovery";
 
 export interface ReviewCanvasApi {
+  getDocumentFile(
+    reviewId: string,
+    name: ReviewDocumentFileName,
+  ): Promise<ReviewDocumentFileResponse>;
+  writeDocumentFile(
+    reviewId: string,
+    name: ReviewDocumentFileName,
+    request: ReviewDocumentFileWrite,
+  ): Promise<ReviewDocumentFileResponse>;
   getDocument(reviewId: string): Promise<ReviewDocumentSnapshotResponse>;
   mutateDocument(
     reviewId: string,
@@ -50,6 +63,30 @@ export class ReviewCanvasApiClient implements ReviewCanvasApi {
 
   constructor(private readonly options: ReviewCanvasApiClientOptions = {}) {
     this.fetch = options.fetch ?? globalThis.fetch;
+  }
+
+  async getDocumentFile(
+    reviewId: string,
+    name: ReviewDocumentFileName,
+  ): Promise<ReviewDocumentFileResponse> {
+    return ReviewDocumentFileResponseSchema.parse(
+      await this.request(
+        `/reviews/${encodeURIComponent(reviewId)}/document/files/${encodeURIComponent(name)}`,
+      ),
+    );
+  }
+
+  async writeDocumentFile(
+    reviewId: string,
+    name: ReviewDocumentFileName,
+    request: ReviewDocumentFileWrite,
+  ): Promise<ReviewDocumentFileResponse> {
+    return ReviewDocumentFileResponseSchema.parse(
+      await this.request(
+        `/reviews/${encodeURIComponent(reviewId)}/document/files/${encodeURIComponent(name)}`,
+        request,
+      ),
+    );
   }
 
   async getDocument(reviewId: string): Promise<ReviewDocumentSnapshotResponse> {

--- a/packages/progressive-review/src/review-document-files.ts
+++ b/packages/progressive-review/src/review-document-files.ts
@@ -1,0 +1,69 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type {
+  ReviewDocumentFile,
+  ReviewDocumentFileName,
+  ReviewDocumentFileWrite,
+} from "@dev.fast/review-protocol";
+
+import { writeFileAtomicAsync } from "./atomic-write";
+import {
+  ReviewDocumentApiError,
+  parseIncrementalReviewDocument,
+} from "./incremental-review-document";
+import type { StoredReview } from "./review-home";
+
+export async function readReviewDocumentFile(
+  review: StoredReview,
+  name: ReviewDocumentFileName,
+): Promise<ReviewDocumentFile> {
+  try {
+    const source = await readFile(path.join(review.dir, name), "utf8");
+    return {
+      name,
+      source,
+      sourceHash: createHash("sha256").update(source).digest("hex"),
+    };
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return { name, source: null, sourceHash: null };
+    }
+    throw error;
+  }
+}
+
+/** Called under the same review lock as node mutations and publication. */
+export async function writeReviewDocumentFile(
+  review: StoredReview,
+  name: ReviewDocumentFileName,
+  request: ReviewDocumentFileWrite,
+): Promise<ReviewDocumentFile> {
+  const current = await readReviewDocumentFile(review, name);
+  if (
+    name === "review.mdx" &&
+    (parseIncrementalReviewDocument(current.source ?? "") ||
+      parseIncrementalReviewDocument(request.source))
+  ) {
+    throw new ReviewDocumentApiError(
+      "Use the node mutation API to author incremental documents.",
+      409,
+      "incremental_document",
+    );
+  }
+  // A retry after a lost response is safe if the requested contents already won.
+  if (current.source === request.source) return current;
+  if (current.sourceHash !== request.expectedSourceHash) {
+    throw new ReviewDocumentApiError(
+      "Document input changed; read it again before writing.",
+      409,
+      "source_conflict",
+    );
+  }
+  await writeFileAtomicAsync(path.join(review.dir, name), request.source, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  return readReviewDocumentFile(review, name);
+}

--- a/packages/progressive-review/src/review-mcp.test.ts
+++ b/packages/progressive-review/src/review-mcp.test.ts
@@ -1,0 +1,160 @@
+import { PassThrough } from "node:stream";
+
+import {
+  type JsonObject,
+  isJsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ReviewCanvasApi } from "./review-canvas-api-client";
+import { runReviewMcp } from "./review-mcp";
+
+describe("Review MCP server", () => {
+  it("negotiates and exposes explicit Review canvas tools", async () => {
+    const output = await exchange(fakeApi(), [
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+    ]);
+
+    expect(output[0]).toMatchObject({
+      id: 1,
+      result: { serverInfo: { name: "review-canvas" } },
+    });
+    expect(output[1]).toMatchObject({
+      id: 2,
+      result: {
+        tools: expect.arrayContaining([
+          expect.objectContaining({ name: "review_get_document" }),
+          expect.objectContaining({ name: "review_insert_node" }),
+          expect.objectContaining({ name: "review_reply_comment" }),
+        ]),
+      },
+    });
+  });
+
+  it("routes a node mutation through the Review API", async () => {
+    const api = fakeApi();
+    const mutate = vi.mocked(api.mutateDocument);
+    const output = await exchange(api, [
+      {
+        jsonrpc: "2.0",
+        id: "call-1",
+        method: "tools/call",
+        params: {
+          name: "review_insert_node",
+          arguments: {
+            reviewId: "11111111-1111-4111-8111-111111111111",
+            mutationId: "mutation-1",
+            expectedRevision: 4,
+            index: 1,
+            node: { id: "next", kind: "markdown", content: "Next" },
+          },
+        },
+      },
+    ]);
+
+    expect(mutate).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        mutationId: "mutation-1",
+        expectedRevision: 4,
+        operation: {
+          type: "insert",
+          index: 1,
+          node: { id: "next", kind: "markdown", content: "Next" },
+        },
+      }),
+    );
+    expect(output[0]).toMatchObject({
+      id: "call-1",
+      result: {
+        structuredContent: {
+          ok: true,
+          mutationId: "mutation-1",
+        },
+      },
+    });
+  });
+});
+
+async function exchange(
+  api: ReviewCanvasApi,
+  requests: JsonObject[],
+): Promise<JsonObject[]> {
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  let output = "";
+  stdout.on("data", (chunk) => (output += String(chunk)));
+  stdin.end(
+    `${requests.map((request) => JSON.stringify(request)).join("\n")}\n`,
+  );
+  await runReviewMcp({ api, stdin, stdout });
+  return output
+    .trim()
+    .split("\n")
+    .map((line) => {
+      const value = parseJsonText(line);
+      if (!isJsonObject(value))
+        throw new Error("MCP response is not an object.");
+      return value;
+    });
+}
+
+function fakeApi(): ReviewCanvasApi {
+  const snapshot = {
+    reviewId: "11111111-1111-4111-8111-111111111111",
+    routePath: "/",
+    mode: "incremental" as const,
+    revision: 5,
+    sourceHash: "hash",
+    source: "source",
+    nodes: [{ id: "next", kind: "markdown" as const, content: "Next" }],
+  };
+  const getDocument = vi.fn<ReviewCanvasApi["getDocument"]>(async () => ({
+    ok: true,
+    snapshot,
+  }));
+  const mutateDocument = vi.fn<ReviewCanvasApi["mutateDocument"]>(
+    async (_reviewId, request) => ({
+      ok: true,
+      mutationId: request.mutationId,
+      snapshot,
+    }),
+  );
+  const getComments = vi.fn<ReviewCanvasApi["getComments"]>(async () => ({
+    ok: true,
+    snapshot: { revision: 0, comments: {}, drafts: {} },
+  }));
+  const command = vi.fn<ReviewCanvasApi["command"]>(
+    async (_reviewId, command) => ({
+      ok: true,
+      commit: {
+        mutationId: command.mutationId,
+        revision: 1,
+        upsertedThreads: [],
+        deletedThreadIds: [],
+        upsertedDrafts: [],
+        deletedDraftThreadIds: [],
+      },
+    }),
+  );
+  const reply = vi.fn<ReviewCanvasApi["reply"]>(async (input) => ({
+    ok: true,
+    commit: {
+      mutationId: input.mutationId,
+      revision: 1,
+      upsertedThreads: [],
+      deletedThreadIds: [],
+      upsertedDrafts: [],
+      deletedDraftThreadIds: [],
+    },
+  }));
+  return {
+    getDocument,
+    mutateDocument,
+    getComments,
+    command,
+    reply,
+  };
+}

--- a/packages/progressive-review/src/review-mcp.test.ts
+++ b/packages/progressive-review/src/review-mcp.test.ts
@@ -11,6 +11,55 @@ import type { ReviewCanvasApi } from "./review-canvas-api-client";
 import { runReviewMcp } from "./review-mcp";
 
 describe("Review MCP server", () => {
+  it("routes rich MDX input reads and writes through the API", async () => {
+    const api = fakeApi();
+    const reviewId = "11111111-1111-4111-8111-111111111111";
+    const source = "export const title = 'From MCP';";
+    const output = await exchange(api, [
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "review_get_document_file",
+          arguments: { reviewId, name: "data.ts" },
+        },
+      },
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "review_write_document_file",
+          arguments: {
+            reviewId,
+            name: "data.ts",
+            source,
+            expectedSourceHash: null,
+          },
+        },
+      },
+      {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: {
+          name: "review_write_document_file",
+          arguments: { reviewId, name: "data.ts", source },
+        },
+      },
+    ]);
+    expect(api.getDocumentFile).toHaveBeenCalledWith(reviewId, "data.ts");
+    expect(api.writeDocumentFile).toHaveBeenCalledExactlyOnceWith(
+      reviewId,
+      "data.ts",
+      { source, expectedSourceHash: null },
+    );
+    expect(output[1]).toMatchObject({
+      result: { structuredContent: { ok: true, file: { source } } },
+    });
+    expect(output[2]).toMatchObject({ result: { isError: true } });
+  });
   it("negotiates and exposes explicit Review canvas tools", async () => {
     const output = await exchange(fakeApi(), [
       { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
@@ -151,6 +200,18 @@ function fakeApi(): ReviewCanvasApi {
     },
   }));
   return {
+    getDocumentFile: vi.fn<ReviewCanvasApi["getDocumentFile"]>(
+      async (_reviewId, name) => ({
+        ok: true as const,
+        file: { name, source: null, sourceHash: null },
+      }),
+    ),
+    writeDocumentFile: vi.fn<ReviewCanvasApi["writeDocumentFile"]>(
+      async (_reviewId, name, request) => ({
+        ok: true as const,
+        file: { name, source: request.source, sourceHash: "new-hash" },
+      }),
+    ),
     getDocument,
     mutateDocument,
     getComments,

--- a/packages/progressive-review/src/review-mcp.ts
+++ b/packages/progressive-review/src/review-mcp.ts
@@ -5,6 +5,8 @@ import type { Readable, Writable } from "node:stream";
 import {
   type JsonObject,
   type JsonValue,
+  ReviewDocumentFileNameSchema,
+  ReviewDocumentFileWriteSchema,
   ReviewDocumentNodeSchema,
   isJsonObject,
   jsonNumber,
@@ -122,6 +124,26 @@ async function callReviewTool(
   args: JsonObject,
 ): Promise<JsonValue> {
   const reviewId = requireString(args, "reviewId");
+  if (name === "review_get_document_file") {
+    return requireOk(
+      await api.getDocumentFile(
+        reviewId,
+        ReviewDocumentFileNameSchema.parse(args.name),
+      ),
+    );
+  }
+  if (name === "review_write_document_file") {
+    return requireOk(
+      await api.writeDocumentFile(
+        reviewId,
+        ReviewDocumentFileNameSchema.parse(args.name),
+        ReviewDocumentFileWriteSchema.parse({
+          source: args.source,
+          expectedSourceHash: args.expectedSourceHash,
+        }),
+      ),
+    );
+  }
   if (name === "review_get_document") {
     return requireOk(await api.getDocument(reviewId));
   }
@@ -285,6 +307,30 @@ const MUTATION_PROPERTIES = {
 } as const;
 
 const REVIEW_MCP_TOOLS: JsonValue[] = [
+  tool(
+    "review_get_document_file",
+    "Read a rich MDX document input through the API. Returns source and sourceHash; both are null for a missing input.",
+    {
+      properties: {
+        reviewId: BASE_PROPERTIES.reviewId,
+        name: { type: "string", enum: ["review.mdx", "data.ts"] },
+      },
+      required: ["reviewId", "name"],
+    },
+  ),
+  tool(
+    "review_write_document_file",
+    "Write rich MDX or data.ts using the sourceHash from review_get_document_file (null creates a missing input). Preserves rich components. Publish after editing to compile and present changes. Use node tools for incremental documents.",
+    {
+      properties: {
+        reviewId: BASE_PROPERTIES.reviewId,
+        name: { type: "string", enum: ["review.mdx", "data.ts"] },
+        source: { type: "string" },
+        expectedSourceHash: { type: ["string", "null"] },
+      },
+      required: ["reviewId", "name", "source", "expectedSourceHash"],
+    },
+  ),
   tool("review_get_document", "Read the current Review document snapshot.", {
     properties: { reviewId: BASE_PROPERTIES.reviewId },
     required: ["reviewId"],

--- a/packages/progressive-review/src/review-mcp.ts
+++ b/packages/progressive-review/src/review-mcp.ts
@@ -1,0 +1,388 @@
+import { randomUUID } from "node:crypto";
+import { createInterface } from "node:readline";
+import type { Readable, Writable } from "node:stream";
+
+import {
+  type JsonObject,
+  type JsonValue,
+  ReviewDocumentNodeSchema,
+  isJsonObject,
+  jsonNumber,
+  jsonObject,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+
+import {
+  type ReviewCanvasApi,
+  ReviewCanvasApiClient,
+} from "./review-canvas-api-client";
+
+const MCP_PROTOCOL_VERSION = "2025-06-18";
+
+export interface RunReviewMcpInput {
+  api?: ReviewCanvasApi;
+  stdin: Readable;
+  stdout: Writable;
+}
+
+export async function runReviewMcp(input: RunReviewMcpInput): Promise<number> {
+  const api = input.api ?? new ReviewCanvasApiClient();
+  const lines = createInterface({ input: input.stdin, crlfDelay: Infinity });
+  for await (const line of lines) {
+    if (!line.trim()) continue;
+    let request: JsonValue;
+    try {
+      request = parseJsonText(line);
+    } catch {
+      writeRpc(input.stdout, null, undefined, rpcError(-32700, "Parse error"));
+      continue;
+    }
+    if (!isJsonObject(request)) {
+      writeRpc(
+        input.stdout,
+        null,
+        undefined,
+        rpcError(-32600, "Invalid request"),
+      );
+      continue;
+    }
+    const id = request.id;
+    const method = jsonString(request.method);
+    if (!method) {
+      writeRpc(
+        input.stdout,
+        rpcId(id),
+        undefined,
+        rpcError(-32600, "Invalid request"),
+      );
+      continue;
+    }
+    if (method.startsWith("notifications/")) continue;
+    try {
+      const result = await handleMcpRequest(api, method, request.params);
+      writeRpc(input.stdout, rpcId(id), result);
+    } catch (error) {
+      if (method === "tools/call") {
+        writeRpc(input.stdout, rpcId(id), {
+          content: [
+            {
+              type: "text",
+              text: error instanceof Error ? error.message : String(error),
+            },
+          ],
+          isError: true,
+        });
+      } else {
+        writeRpc(
+          input.stdout,
+          rpcId(id),
+          undefined,
+          rpcError(
+            -32602,
+            error instanceof Error ? error.message : String(error),
+          ),
+        );
+      }
+    }
+  }
+  return 0;
+}
+
+async function handleMcpRequest(
+  api: ReviewCanvasApi,
+  method: string,
+  paramsValue: JsonValue | undefined,
+): Promise<JsonValue> {
+  if (method === "initialize") {
+    return {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: { tools: { listChanged: false } },
+      serverInfo: { name: "review-canvas", version: "1.0.0" },
+    };
+  }
+  if (method === "ping") return {};
+  if (method === "tools/list") return { tools: REVIEW_MCP_TOOLS };
+  if (method !== "tools/call") {
+    throw new Error(`Unsupported MCP method: ${method}`);
+  }
+  const params = requireObject(paramsValue, "params");
+  const name = requireString(params, "name");
+  const args = requireObject(params.arguments, "arguments");
+  const value = await callReviewTool(api, name, args);
+  return {
+    content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+    structuredContent: value,
+  };
+}
+
+async function callReviewTool(
+  api: ReviewCanvasApi,
+  name: string,
+  args: JsonObject,
+): Promise<JsonValue> {
+  const reviewId = requireString(args, "reviewId");
+  if (name === "review_get_document") {
+    return requireOk(await api.getDocument(reviewId));
+  }
+  if (name === "review_list_comments") {
+    return requireOk(await api.getComments(reviewId));
+  }
+  if (name === "review_resolve_comment") {
+    return requireOk(
+      await api.command(reviewId, {
+        command: "comment.update",
+        mutationId: mutationId(args),
+        threadId: requireString(args, "threadId"),
+        update: { status: "resolved" },
+      }),
+    );
+  }
+  if (name === "review_reply_comment") {
+    return requireOk(
+      await api.reply({
+        reviewId,
+        threadId: requireString(args, "threadId"),
+        mutationId: mutationId(args),
+        messageId: jsonString(args.messageId) ?? randomUUID(),
+        body: requireString(args, "body"),
+        author: jsonString(args.author),
+      }),
+    );
+  }
+  const expectedRevision = requireNonNegativeInteger(args, "expectedRevision");
+  const common = {
+    mutationId: mutationId(args),
+    expectedRevision,
+    expectedSourceHash: jsonString(args.expectedSourceHash),
+  };
+  if (name === "review_replace_document") {
+    const nodesValue = args.nodes;
+    if (!Array.isArray(nodesValue)) throw new Error("nodes must be an array.");
+    return requireOk(
+      await api.mutateDocument(reviewId, {
+        ...common,
+        operation: {
+          type: "replace",
+          nodes: nodesValue.map((node) => ReviewDocumentNodeSchema.parse(node)),
+        },
+      }),
+    );
+  }
+  if (name === "review_insert_node") {
+    return requireOk(
+      await api.mutateDocument(reviewId, {
+        ...common,
+        operation: {
+          type: "insert",
+          index: requireNonNegativeInteger(args, "index"),
+          node: ReviewDocumentNodeSchema.parse(args.node),
+        },
+      }),
+    );
+  }
+  if (name === "review_update_node") {
+    return requireOk(
+      await api.mutateDocument(reviewId, {
+        ...common,
+        operation: {
+          type: "update",
+          nodeId: requireString(args, "nodeId"),
+          patch: requireObject(args.patch, "patch"),
+        },
+      }),
+    );
+  }
+  if (name === "review_delete_node") {
+    return requireOk(
+      await api.mutateDocument(reviewId, {
+        ...common,
+        operation: {
+          type: "delete",
+          nodeId: requireString(args, "nodeId"),
+        },
+      }),
+    );
+  }
+  if (name === "review_move_node") {
+    return requireOk(
+      await api.mutateDocument(reviewId, {
+        ...common,
+        operation: {
+          type: "move",
+          nodeId: requireString(args, "nodeId"),
+          index: requireNonNegativeInteger(args, "index"),
+        },
+      }),
+    );
+  }
+  throw new Error(`Unknown Review tool: ${name}`);
+}
+
+function requireOk<T extends { ok: boolean; error?: string }>(
+  response: T,
+): JsonValue {
+  if (!response.ok) throw new Error(response.error ?? "Review API failed.");
+  return parseJsonText(JSON.stringify(response));
+}
+
+function mutationId(args: JsonObject): string {
+  return jsonString(args.mutationId) ?? randomUUID();
+}
+
+function requireObject(
+  value: JsonValue | undefined,
+  label: string,
+): JsonObject {
+  const object = jsonObject(value);
+  if (!object) throw new Error(`${label} must be an object.`);
+  return object;
+}
+
+function requireString(value: JsonObject, key: string): string {
+  const string = jsonString(value[key]);
+  if (!string?.trim()) throw new Error(`${key} must be a non-empty string.`);
+  return string;
+}
+
+function requireNonNegativeInteger(value: JsonObject, key: string): number {
+  const number = jsonNumber(value[key]);
+  if (number === undefined || !Number.isInteger(number) || number < 0) {
+    throw new Error(`${key} must be a non-negative integer.`);
+  }
+  return number;
+}
+
+function rpcId(value: JsonValue | undefined): string | number | null {
+  return jsonString(value) ?? jsonNumber(value) ?? null;
+}
+
+function rpcError(code: number, message: string): JsonObject {
+  return { code, message };
+}
+
+function writeRpc(
+  stdout: Writable,
+  id: string | number | null,
+  result?: JsonValue,
+  error?: JsonObject,
+): void {
+  const response: JsonObject = { jsonrpc: "2.0", id };
+  if (error) response.error = error;
+  else response.result = result ?? null;
+  stdout.write(`${JSON.stringify(response)}\n`);
+}
+
+const BASE_PROPERTIES = {
+  reviewId: { type: "string", format: "uuid" },
+  mutationId: { type: "string" },
+} as const;
+
+const MUTATION_PROPERTIES = {
+  ...BASE_PROPERTIES,
+  expectedRevision: { type: "integer", minimum: 0 },
+  expectedSourceHash: { type: "string" },
+} as const;
+
+const REVIEW_MCP_TOOLS: JsonValue[] = [
+  tool("review_get_document", "Read the current Review document snapshot.", {
+    properties: { reviewId: BASE_PROPERTIES.reviewId },
+    required: ["reviewId"],
+  }),
+  tool(
+    "review_replace_document",
+    "Replace or initialize stable Review nodes.",
+    {
+      properties: {
+        ...MUTATION_PROPERTIES,
+        nodes: { type: "array", items: nodeSchema() },
+      },
+      required: ["reviewId", "expectedRevision", "nodes"],
+    },
+  ),
+  tool("review_insert_node", "Insert one stable node at an index.", {
+    properties: {
+      ...MUTATION_PROPERTIES,
+      index: { type: "integer", minimum: 0 },
+      node: nodeSchema(),
+    },
+    required: ["reviewId", "expectedRevision", "index", "node"],
+  }),
+  tool("review_update_node", "Update one node without replacing the canvas.", {
+    properties: {
+      ...MUTATION_PROPERTIES,
+      nodeId: { type: "string" },
+      patch: { type: "object" },
+    },
+    required: ["reviewId", "expectedRevision", "nodeId", "patch"],
+  }),
+  tool("review_delete_node", "Delete one node by stable ID.", {
+    properties: { ...MUTATION_PROPERTIES, nodeId: { type: "string" } },
+    required: ["reviewId", "expectedRevision", "nodeId"],
+  }),
+  tool("review_move_node", "Move one node to a new index.", {
+    properties: {
+      ...MUTATION_PROPERTIES,
+      nodeId: { type: "string" },
+      index: { type: "integer", minimum: 0 },
+    },
+    required: ["reviewId", "expectedRevision", "nodeId", "index"],
+  }),
+  tool("review_list_comments", "Read Review comment threads.", {
+    properties: { reviewId: BASE_PROPERTIES.reviewId },
+    required: ["reviewId"],
+  }),
+  tool("review_resolve_comment", "Resolve a Review comment thread.", {
+    properties: {
+      ...BASE_PROPERTIES,
+      threadId: { type: "string" },
+    },
+    required: ["reviewId", "threadId"],
+  }),
+  tool("review_reply_comment", "Reply to a Review comment as the agent.", {
+    properties: {
+      ...BASE_PROPERTIES,
+      threadId: { type: "string" },
+      messageId: { type: "string" },
+      body: { type: "string" },
+      author: { type: "string" },
+    },
+    required: ["reviewId", "threadId", "body"],
+  }),
+];
+
+function tool(
+  name: string,
+  description: string,
+  schema: { properties: JsonObject; required: string[] },
+): JsonObject {
+  return {
+    name,
+    description,
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: schema.properties,
+      required: schema.required,
+    },
+  };
+}
+
+function nodeSchema(): JsonObject {
+  return {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      id: { type: "string" },
+      kind: { type: "string", enum: ["markdown", "callout", "code"] },
+      content: { type: "string" },
+      title: { type: "string" },
+      tone: {
+        type: "string",
+        enum: ["info", "warning", "success", "danger"],
+      },
+      language: { type: "string" },
+    },
+    required: ["id", "kind", "content"],
+  };
+}

--- a/packages/progressive-review/src/review-state-db.ts
+++ b/packages/progressive-review/src/review-state-db.ts
@@ -287,6 +287,135 @@ export function deleteReviewState(
     .run(reviewIdForDir(reviewDir));
 }
 
+export interface StoredReviewDocumentState {
+  mode: "compiled" | "incremental";
+  revision: number;
+  sourceHash: string | null;
+  projection: JsonValue | null;
+}
+
+export function readReviewDocumentState(
+  reviewDir: string,
+  routePath: string,
+): StoredReviewDocumentState | null {
+  importLegacyReview(reviewDir);
+  // SAFETY: the selected columns use the exact TEXT/INTEGER schema declared
+  // above; projection_json and source_hash are the only nullable columns.
+  const row = openReviewStateDb()
+    .prepare(
+      `SELECT mode, revision, source_hash, projection_json
+       FROM documents WHERE review_id = ? AND route_path = ?`,
+    )
+    .get(reviewIdForDir(reviewDir), routePath) as
+    | {
+        mode: "compiled" | "incremental";
+        revision: number;
+        source_hash: string | null;
+        projection_json: string | null;
+      }
+    | undefined;
+  if (!row) return null;
+  return {
+    mode: row.mode,
+    revision: row.revision,
+    sourceHash: row.source_hash,
+    projection: row.projection_json ? parseJsonText(row.projection_json) : null,
+  };
+}
+
+export function putReviewDocumentState(
+  reviewDir: string,
+  routePath: string,
+  state: StoredReviewDocumentState,
+): void {
+  ensureReviewRegistration(reviewDir);
+  openReviewStateDb()
+    .prepare(
+      `INSERT INTO documents
+       (review_id, route_path, mode, revision, source_hash, projection_json)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(review_id, route_path) DO UPDATE SET
+         mode = excluded.mode,
+         revision = excluded.revision,
+         source_hash = excluded.source_hash,
+         projection_json = excluded.projection_json`,
+    )
+    .run(
+      reviewIdForDir(reviewDir),
+      routePath,
+      state.mode,
+      state.revision,
+      state.sourceHash,
+      state.projection === null ? null : JSON.stringify(state.projection),
+    );
+}
+
+export function readReviewMutationReceipt(
+  reviewDir: string,
+  mutationId: string,
+): JsonValue | null {
+  importLegacyReview(reviewDir);
+  // SAFETY: mutation_receipts.response_json is declared TEXT NOT NULL.
+  const row = openReviewStateDb()
+    .prepare(
+      "SELECT response_json FROM mutation_receipts WHERE review_id = ? AND mutation_id = ?",
+    )
+    .get(reviewIdForDir(reviewDir), mutationId) as
+    | { response_json: string }
+    | undefined;
+  return row ? parseJsonText(row.response_json) : null;
+}
+
+export function commitReviewDocumentMutation(input: {
+  reviewDir: string;
+  routePath: string;
+  mutationId: string;
+  state: StoredReviewDocumentState;
+  response: JsonValue;
+  createdAt: string;
+}): void {
+  ensureReviewRegistration(input.reviewDir);
+  const db = openReviewStateDb();
+  const reviewId = reviewIdForDir(input.reviewDir);
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.prepare(
+      `INSERT INTO documents
+       (review_id, route_path, mode, revision, source_hash, projection_json)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(review_id, route_path) DO UPDATE SET
+         mode = excluded.mode,
+         revision = excluded.revision,
+         source_hash = excluded.source_hash,
+         projection_json = excluded.projection_json`,
+    ).run(
+      reviewId,
+      input.routePath,
+      input.state.mode,
+      input.state.revision,
+      input.state.sourceHash,
+      input.state.projection === null
+        ? null
+        : JSON.stringify(input.state.projection),
+    );
+    db.prepare(
+      `INSERT INTO mutation_receipts
+       (review_id, mutation_id, revision, response_json, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      reviewId,
+      input.mutationId,
+      input.state.revision,
+      JSON.stringify(input.response),
+      input.createdAt,
+    );
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
+}
+
 export function closeAllReviewStateDatabases(): void {
   for (const db of connections.values()) {
     try {

--- a/packages/progressive-review/src/review-threads-service.ts
+++ b/packages/progressive-review/src/review-threads-service.ts
@@ -32,7 +32,7 @@ export interface ReviewThreadsServiceOptions {
 }
 
 /**
- * Session-owned command boundary for durable Review comment state.
+ * Review-owned command boundary for durable Review comment state.
  *
  * SQLite commits first. The service then updates its projection and publishes
  * the exact committed change to every connected Review surface.
@@ -41,6 +41,7 @@ export class ReviewThreadsService {
   private comments: ReviewCommentThreadMap;
   private drafts: ReviewCommentDraftThreadMap;
   private revision = 0;
+  private readonly listeners = new Set<(commit: ReviewThreadsCommit) => void>();
 
   constructor(private readonly options: ReviewThreadsServiceOptions) {
     this.comments = readReviewComments(options.reviewPath);
@@ -52,6 +53,13 @@ export class ReviewThreadsService {
       revision: this.revision,
       comments: this.comments,
       drafts: this.drafts,
+    };
+  }
+
+  subscribe(listener: (commit: ReviewThreadsCommit) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
     };
   }
 
@@ -301,6 +309,7 @@ export class ReviewThreadsService {
       deletedDraftThreadIds,
     } satisfies ReviewThreadsCommit;
     this.options.onCommit?.(commit);
+    for (const listener of this.listeners) listener(commit);
     return commit;
   }
 }

--- a/packages/progressive-review/src/server/desktop-server-review-api.test.ts
+++ b/packages/progressive-review/src/server/desktop-server-review-api.test.ts
@@ -28,6 +28,65 @@ afterEach(async () => {
 });
 
 describe("Review Desktop document and comment API", () => {
+  it("authors rich MDX and imported data through hash-checked API writes", async () => {
+    const { client, reviewId, server } = await setupServer();
+    try {
+      const missing = await client.getDocumentFile(reviewId, "data.ts");
+      expect(missing).toEqual({
+        ok: true,
+        file: { name: "data.ts", source: null, sourceHash: null },
+      });
+      const data = "export const title = 'Rich document';\n";
+      const created = await client.writeDocumentFile(reviewId, "data.ts", {
+        source: data,
+        expectedSourceHash: null,
+      });
+      expect(await client.getDocumentFile(reviewId, "data.ts")).toEqual(
+        created,
+      );
+      // Retrying a successful write after losing its response does not conflict.
+      expect(
+        await client.writeDocumentFile(reviewId, "data.ts", {
+          source: data,
+          expectedSourceHash: null,
+        }),
+      ).toEqual(created);
+      const initial = await client.getDocumentFile(reviewId, "review.mdx");
+      if (!initial.ok) throw new Error(initial.error);
+      const source =
+        'import { title } from "./data.ts";\n\n# {title}\n\n<AnchorLink anchor={anchors.example}>Evidence</AnchorLink>\n\n<CodePeek anchor={anchors.example} />\n';
+      const request = { source, expectedSourceHash: initial.file.sourceHash };
+      const written = await client.writeDocumentFile(
+        reviewId,
+        "review.mdx",
+        request,
+      );
+      expect(written).toMatchObject({ ok: true, file: { source } });
+      expect(await client.getDocument(reviewId)).toMatchObject({
+        ok: true,
+        snapshot: { mode: "compiled", source },
+      });
+      await expect(
+        client.writeDocumentFile(reviewId, "review.mdx", {
+          ...request,
+          source: "# Stale overwrite",
+        }),
+      ).rejects.toMatchObject({ statusCode: 409 });
+      // The allowlist is enforced by the server, not just TypeScript callers.
+      const unknown = await fetch(
+        `${server.url}/reviews/${reviewId}/document/files/review.json`,
+        { headers: { "x-review-token": "review-api-token" } },
+      );
+      expect(unknown.status).toBe(404);
+      const unauthenticated = await fetch(
+        `${server.url}/reviews/${reviewId}/document/files/review.mdx`,
+      );
+      expect(unauthenticated.status).toBe(401);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("updates the MDX document incrementally and rejects stale revisions", async () => {
     const { client, reviewId, server } = await setupServer();
     try {
@@ -51,6 +110,13 @@ describe("Review Desktop document and comment API", () => {
         ok: true,
         snapshot: { revision: 1, nodes: [{ id: "intro" }] },
       });
+
+      await expect(
+        client.writeDocumentFile(reviewId, "review.mdx", {
+          source: "# Bypass nodes",
+          expectedSourceHash: replaced.ok ? replaced.snapshot.sourceHash : null,
+        }),
+      ).rejects.toMatchObject({ statusCode: 409 });
 
       await expect(
         client.mutateDocument(reviewId, {

--- a/packages/progressive-review/src/server/desktop-server-review-api.test.ts
+++ b/packages/progressive-review/src/server/desktop-server-review-api.test.ts
@@ -1,0 +1,167 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ReviewRecordSchema } from "@dev.fast/review-protocol";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ReviewCanvasApiClient } from "../review-canvas-api-client";
+import {
+  closeAllReviewStateDatabases,
+  putReviewRecord,
+} from "../review-state-db";
+import { createGlobalReviewServer } from "./desktop-server";
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const roots: string[] = [];
+
+afterEach(async () => {
+  closeAllReviewStateDatabases();
+  vi.unstubAllEnvs();
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("Review Desktop document and comment API", () => {
+  it("updates the MDX document incrementally and rejects stale revisions", async () => {
+    const { client, reviewId, server } = await setupServer();
+    try {
+      const initial = await client.getDocument(reviewId);
+      expect(initial).toMatchObject({
+        ok: true,
+        snapshot: { mode: "compiled", revision: 0 },
+      });
+      if (!initial.ok) throw new Error(initial.error);
+
+      const replaced = await client.mutateDocument(reviewId, {
+        mutationId: "replace-1",
+        expectedRevision: 0,
+        expectedSourceHash: initial.snapshot.sourceHash,
+        operation: {
+          type: "replace",
+          nodes: [{ id: "intro", kind: "markdown", content: "# Hello" }],
+        },
+      });
+      expect(replaced).toMatchObject({
+        ok: true,
+        snapshot: { revision: 1, nodes: [{ id: "intro" }] },
+      });
+
+      await expect(
+        client.mutateDocument(reviewId, {
+          mutationId: "stale-1",
+          expectedRevision: 0,
+          operation: { type: "delete", nodeId: "intro" },
+        }),
+      ).rejects.toMatchObject({ statusCode: 409 });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("exposes comment reads and mutations without client database access", async () => {
+    const { client, reviewId, server } = await setupServer();
+    try {
+      await client.command(reviewId, {
+        command: "comment.create",
+        mutationId: "comment-1",
+        input: {
+          threadId: "thread-1",
+          messageId: "message-1",
+          target: { kind: "document" },
+          body: "Please clarify.",
+        },
+      });
+      await client.reply({
+        reviewId,
+        threadId: "thread-1",
+        mutationId: "reply-1",
+        messageId: "message-2",
+        body: "Clarified.",
+      });
+      await client.command(reviewId, {
+        command: "comment.update",
+        mutationId: "resolve-1",
+        threadId: "thread-1",
+        update: { status: "resolved" },
+      });
+
+      const comments = await client.getComments(reviewId);
+      expect(comments).toMatchObject({
+        ok: true,
+        snapshot: {
+          comments: {
+            "thread-1": {
+              status: "resolved",
+              messages: [
+                { body: "Please clarify." },
+                { body: "Clarified.", role: "agent" },
+              ],
+            },
+          },
+        },
+      });
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+async function setupServer() {
+  const home = await mkdtemp(path.join(os.tmpdir(), "review-api-server-"));
+  roots.push(home);
+  vi.stubEnv("DEV_REVIEW_HOME", home);
+  const reviewId = "11111111-1111-4111-8111-111111111111";
+  const reviewDir = path.join(home, "reviews", reviewId);
+  await mkdir(reviewDir, { recursive: true });
+  await writeFile(path.join(reviewDir, "review.mdx"), "# Existing\n", "utf8");
+  putReviewRecord(
+    reviewDir,
+    ReviewRecordSchema.parse({
+      schemaVersion: 4,
+      uuid: reviewId,
+      repoKey: "repo",
+      worktreePath: home,
+      baseRef: "main",
+      baseCommit: "a".repeat(40),
+      sourceCommit: "b".repeat(40),
+      sourceIdentity: { kind: "git-branch", name: "main" },
+      pullRequestNumber: null,
+      pullRequestUrl: null,
+      title: "API Review",
+      sourceSession: "disabled:review",
+      status: "draft",
+      presentedDocumentRevision: null,
+      presentedSoftwareMapRevision: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastPublishedAt: null,
+    }),
+  );
+  const token = "review-api-token";
+  const server = createGlobalReviewServer({
+    appPid: process.pid,
+    packageRoot,
+    toolingRoot: packageRoot,
+    port: 0,
+    token,
+    discoveryPath: path.join(home, "desktop.json"),
+  });
+  await server.listen();
+  const client = new ReviewCanvasApiClient({
+    discovery: {
+      version: 3,
+      instanceId: server.discovery.instanceId,
+      url: server.url,
+      appPid: process.pid,
+      serverPid: process.pid,
+      token,
+      startedAt: Date.now(),
+    },
+  });
+  return { client, reviewId, server };
+}

--- a/packages/progressive-review/src/server/desktop-server-review-api.test.ts
+++ b/packages/progressive-review/src/server/desktop-server-review-api.test.ts
@@ -133,7 +133,7 @@ describe("Review Desktop document and comment API", () => {
   it("exposes comment reads and mutations without client database access", async () => {
     const { client, reviewId, server } = await setupServer();
     try {
-      await client.command(reviewId, {
+      const created = await client.command(reviewId, {
         command: "comment.create",
         mutationId: "comment-1",
         input: {
@@ -143,14 +143,14 @@ describe("Review Desktop document and comment API", () => {
           body: "Please clarify.",
         },
       });
-      await client.reply({
+      const replied = await client.reply({
         reviewId,
         threadId: "thread-1",
         mutationId: "reply-1",
         messageId: "message-2",
         body: "Clarified.",
       });
-      await client.command(reviewId, {
+      const resolved = await client.command(reviewId, {
         command: "comment.update",
         mutationId: "resolve-1",
         threadId: "thread-1",
@@ -158,9 +158,13 @@ describe("Review Desktop document and comment API", () => {
       });
 
       const comments = await client.getComments(reviewId);
+      expect(created).toMatchObject({ ok: true, commit: { revision: 1 } });
+      expect(replied).toMatchObject({ ok: true, commit: { revision: 2 } });
+      expect(resolved).toMatchObject({ ok: true, commit: { revision: 3 } });
       expect(comments).toMatchObject({
         ok: true,
         snapshot: {
+          revision: 3,
           comments: {
             "thread-1": {
               status: "resolved",

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -316,6 +316,7 @@ export function createGlobalReviewServer(
   const relay = new GlobalReviewDesktopVerbRelay();
   const sessions = new Map<string, ActiveReviewSession>();
   const reviewLocks = new Map<string, Promise<void>>();
+  const reviewThreads = new Map<string, ReviewThreadsService>();
   const globalClients = new Set<ReviewDesktopEventClient>();
   const tutorial = createTutorialService({
     packageRoot: input.packageRoot,
@@ -1773,7 +1774,9 @@ export function createGlobalReviewServer(
   }
 
   function threadsForReview(review: StoredReview): ReviewThreadsService {
-    return new ReviewThreadsService({
+    const existing = reviewThreads.get(review.review.uuid);
+    if (existing) return existing;
+    const service = new ReviewThreadsService({
       reviewPath: path.join(review.dir, "review.mdx"),
       author: process.env.USER ?? "Reviewer",
       onCommit: (commit) => {
@@ -1787,6 +1790,8 @@ export function createGlobalReviewServer(
         });
       },
     });
+    reviewThreads.set(review.review.uuid, service);
+    return service;
   }
 
   async function deleteReviewByUuid(uuid: string): Promise<void> {
@@ -1810,6 +1815,7 @@ export function createGlobalReviewServer(
       );
       await rm(dir, { recursive: true, force: true });
       deleteReviewState(dir);
+      reviewThreads.delete(uuid);
       const worktreePath = open[0]?.review.review.worktreePath;
       if (worktreePath) {
         await clearReopenPending(worktreePath).catch(() => undefined);
@@ -1839,6 +1845,7 @@ export function createGlobalReviewServer(
     });
     await rm(review.dir, { recursive: true, force: true });
     deleteReviewState(review.dir);
+    reviewThreads.delete(review.review.uuid);
     await clearReopenPending(review.review.worktreePath).catch(() => undefined);
     broadcastGlobal({ event: "review-deleted", uuid: review.review.uuid });
   }
@@ -1945,6 +1952,7 @@ export function createGlobalReviewServer(
       reviewPath: registration.documentPath,
       softwareMapRootPath: registration.softwareMapRootPath,
       stateReviewPath: path.join(registration.review.dir, "review.mdx"),
+      threadsService: threadsForReview(registration.review),
       routePath: "/",
       token,
       sessionId,
@@ -1963,17 +1971,6 @@ export function createGlobalReviewServer(
           event: "review-data-changed",
           uuid: registration.review.review.uuid,
           sessionId,
-        });
-      },
-      onReviewThreadsCommit: (commit) => {
-        broadcastGlobal({
-          event: "review-threads-committed",
-          uuid: registration.review.review.uuid,
-          sessionId,
-          commit,
-          commentCount: countReviewComments(
-            path.join(registration.review.dir, "review.mdx"),
-          ),
         });
       },
       runReviewThreadMutation: (operation) =>
@@ -2376,6 +2373,7 @@ export function createGlobalReviewServer(
       await Promise.all(
         [...agentServers.values()].map((server) => server.close()),
       );
+      reviewThreads.clear();
       await closeHttpServer(httpServer);
       await telemetry.shutdown(1_500);
     },

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -14,6 +14,8 @@ import {
   type ReviewDescriptor,
   type ReviewDesktopDiscovery,
   type ReviewDesktopGlobalEvent,
+  ReviewDocumentFileNameSchema,
+  ReviewDocumentFileWriteSchema,
   type ReviewRecord,
   type ReviewSessionDescriptor,
   type ReviewSessionWire,
@@ -68,6 +70,10 @@ import {
   reviewReapsAt,
   selectReapableReviews,
 } from "../review-attention";
+import {
+  readReviewDocumentFile,
+  writeReviewDocumentFile,
+} from "../review-document-files";
 import { listReviewDocumentVersions } from "../review-document-versions";
 import {
   ensureReviewPinnedCheckout,
@@ -492,6 +498,47 @@ export function createGlobalReviewServer(
       mutationId: request.mutationId,
     });
     return globalJson(200, response);
+  });
+  app.get("/reviews/:uuid/document/files/:name", async (context) => {
+    const name = ReviewDocumentFileNameSchema.safeParse(
+      context.req.param("name"),
+    );
+    if (!name.success)
+      throw new ReviewServerError("Unknown document input.", 404);
+    const review = await requireStoredReview(context.req.param("uuid"));
+    return globalJson(200, {
+      ok: true,
+      file: await readReviewDocumentFile(review, name.data),
+    });
+  });
+  app.post("/reviews/:uuid/document/files/:name", async (context) => {
+    const uuid = context.req.param("uuid");
+    const name = ReviewDocumentFileNameSchema.safeParse(
+      context.req.param("name"),
+    );
+    const request = ReviewDocumentFileWriteSchema.safeParse(
+      await readBoundedRequestJson(context.req.raw),
+    );
+    if (!name.success)
+      throw new ReviewServerError("Unknown document input.", 404);
+    if (!request.success)
+      throw new ReviewServerError(request.error.message, 400);
+    const file = await withReviewLock(uuid, async () => {
+      const review = await requireStoredReview(uuid);
+      if (
+        review.review.status === "accepted" ||
+        review.review.status === "rejected"
+      ) {
+        throw new ReviewServerError(
+          `Review ${uuid} is frozen.`,
+          409,
+          "review_terminal",
+        );
+      }
+      return writeReviewDocumentFile(review, name.data, request.data);
+    });
+    // Rich MDX is compiled and presented by the existing publish operation.
+    return globalJson(200, { ok: true, file });
   });
   app.get("/reviews/:uuid/comments", async (context) => {
     const review = await requireStoredReview(context.req.param("uuid"));

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -28,6 +28,7 @@ import {
   jsonProperty,
   jsonString,
   parseReviewCliInstallApplyRequest,
+  parseReviewDocumentMutationRequest,
   parseReviewPublishReadyRequest,
   reviewViewSchema,
 } from "@dev.fast/review-protocol";
@@ -43,6 +44,11 @@ import {
   parseAuthoringSessionKey,
   parseFreshSourceSessionHarness,
 } from "../authoring-session";
+import {
+  ReviewDocumentApiError,
+  mutateReviewDocument,
+  readReviewDocumentSnapshot,
+} from "../incremental-review-document";
 import { preferredInstalledReviewAgent } from "../installed-review-agent";
 import * as claudeCode from "../native-agent/claude-code";
 import * as codex from "../native-agent/codex";
@@ -93,6 +99,7 @@ import {
 import { clearReopenPending, markReopenPending } from "../review-reopen-marker";
 import { deleteReviewState } from "../review-state-db";
 import { devReviewHome } from "../review-storage";
+import { ReviewThreadsService } from "../review-threads-service";
 import { readReviewSoftwareMapBundle } from "../software-map-bundle";
 import { createTutorialAuthoringSession } from "../tutorial-authoring-session";
 import type { ReviewSubmissionEvent } from "../types";
@@ -126,6 +133,7 @@ import {
 import { HttpJsonError } from "./http-json";
 import { materializePublishRevision } from "./publish-stage";
 import { captureSanitizedUiTelemetry } from "./review-api";
+import { parseReviewThreadsCommand } from "./review-api-parsers";
 import { resolveReviewInfo } from "./review-info";
 import {
   type ReviewSessionHandler,
@@ -449,6 +457,97 @@ export function createGlobalReviewServer(
         ) || left.uuid.localeCompare(right.uuid),
     );
     return globalJson(200, { reviews, errors: listed.errors });
+  });
+  app.get("/reviews/:uuid/document", async (context) => {
+    const review = await requireStoredReview(context.req.param("uuid"));
+    return globalJson(200, {
+      ok: true,
+      snapshot: await readReviewDocumentSnapshot(review),
+    });
+  });
+  app.post("/reviews/:uuid/document/mutations", async (context) => {
+    const uuid = context.req.param("uuid");
+    const review = await requireStoredReview(uuid);
+    if (
+      review.review.status === "accepted" ||
+      review.review.status === "rejected"
+    ) {
+      throw new ReviewServerError(
+        `Review ${uuid} is ${review.review.status}; its document is frozen.`,
+        409,
+        "review_terminal",
+      );
+    }
+    const request = parseReviewDocumentMutationRequest(
+      await readBoundedRequestJson(context.req.raw),
+    );
+    const response = await withReviewLock(uuid, () =>
+      mutateReviewDocument(review, request),
+    );
+    broadcastGlobal({
+      event: "review-document-changed",
+      uuid,
+      routePath: response.snapshot.routePath,
+      revision: response.snapshot.revision,
+      mutationId: request.mutationId,
+    });
+    return globalJson(200, response);
+  });
+  app.get("/reviews/:uuid/comments", async (context) => {
+    const review = await requireStoredReview(context.req.param("uuid"));
+    return globalJson(200, {
+      ok: true,
+      snapshot: threadsForReview(review).snapshot(),
+    });
+  });
+  app.post("/reviews/:uuid/thread-commands", async (context) => {
+    const uuid = context.req.param("uuid");
+    const review = await requireStoredReview(uuid);
+    const command = parseReviewThreadsCommand(
+      await readBoundedRequestJson(context.req.raw),
+    );
+    const commit = await withReviewLock(uuid, async () =>
+      threadsForReview(review).dispatch(command),
+    );
+    return globalJson(
+      commit ? 200 : 404,
+      commit
+        ? { ok: true, commit }
+        : { ok: false, error: "Comment thread not found." },
+    );
+  });
+  app.post("/reviews/:uuid/comments/:threadId/replies", async (context) => {
+    const uuid = context.req.param("uuid");
+    const review = await requireStoredReview(uuid);
+    const value = await readBoundedRequestJson(context.req.raw);
+    const body = isJsonObject(value) ? value : {};
+    const mutationId = jsonString(body.mutationId);
+    const messageId = jsonString(body.messageId);
+    const text = jsonString(body.body)?.trim();
+    const author = jsonString(body.author)?.trim() || "Agent";
+    if (!mutationId || !messageId || !text) {
+      throw new ReviewServerError(
+        "mutationId, messageId, and body are required.",
+        400,
+        "invalid_reply",
+      );
+    }
+    const commit = await withReviewLock(uuid, async () =>
+      threadsForReview(review).appendAgentMessage({
+        mutationId,
+        threadId: context.req.param("threadId"),
+        messageId,
+        author,
+        body: text,
+        format: "plain",
+      }),
+    );
+    return globalJson(
+      commit ? 200 : 404,
+      commit
+        ? { ok: true, commit }
+        : { ok: false, error: "Comment thread not found." },
+    );
   });
   app.get("/sessions", () =>
     globalJson(200, {
@@ -932,7 +1031,8 @@ export function createGlobalReviewServer(
   app.onError((error) => {
     const serverError =
       error instanceof ReviewServerError ||
-      error instanceof ReviewOpenThreadsError
+      error instanceof ReviewOpenThreadsError ||
+      error instanceof ReviewDocumentApiError
         ? error
         : undefined;
     const message = toError(error).message;
@@ -1614,6 +1714,32 @@ export function createGlobalReviewServer(
     await abortTutorialAuthoringStates();
     await closeTutorialSessions();
     await tutorial.cleanup();
+  }
+
+  async function requireStoredReview(uuid: string): Promise<StoredReview> {
+    if (!UUID_PATTERN.test(uuid)) {
+      throw new ReviewServerError("Review not found.", 404);
+    }
+    const review = await findReview(uuid);
+    if (!review) throw new ReviewServerError("Review not found.", 404);
+    return review;
+  }
+
+  function threadsForReview(review: StoredReview): ReviewThreadsService {
+    return new ReviewThreadsService({
+      reviewPath: path.join(review.dir, "review.mdx"),
+      author: process.env.USER ?? "Reviewer",
+      onCommit: (commit) => {
+        broadcastGlobal({
+          event: "review-threads-committed",
+          uuid: review.review.uuid,
+          commit,
+          commentCount: countReviewComments(
+            path.join(review.dir, "review.mdx"),
+          ),
+        });
+      },
+    });
   }
 
   async function deleteReviewByUuid(uuid: string): Promise<void> {

--- a/packages/progressive-review/src/server/review-api.ts
+++ b/packages/progressive-review/src/server/review-api.ts
@@ -197,6 +197,7 @@ interface ReviewApiOptions {
   reviewRootPath?: string;
   toolingRoot: string;
   stateReviewPath?: string;
+  threadsService?: ReviewThreadsService;
   telemetry?: ReviewTelemetryCapture;
   onSubmission?: (event: ReviewSubmissionEvent) => void | Promise<void>;
   onReviewDismiss?: () => void | Promise<void>;
@@ -283,11 +284,13 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   const threadsFor = (writableReviewPath: string): ReviewThreadsService => {
     let service = threadServices.get(writableReviewPath);
     if (!service) {
-      service = new ReviewThreadsService({
-        reviewPath: writableReviewPath,
-        author: process.env.USER ?? "Reviewer",
-        onCommit: onReviewThreadsCommit,
-      });
+      service =
+        options.threadsService ??
+        new ReviewThreadsService({
+          reviewPath: writableReviewPath,
+          author: process.env.USER ?? "Reviewer",
+          onCommit: onReviewThreadsCommit,
+        });
       threadServices.set(writableReviewPath, service);
       const snapshot = service.snapshot();
       const hasAgentSession =

--- a/packages/progressive-review/src/server/session-handler.test.ts
+++ b/packages/progressive-review/src/server/session-handler.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../progressive-review-telemetry";
 import { writeReviewDocumentBundle } from "../review-bundle";
 import { readReviewComments } from "../review-state-store";
+import { ReviewThreadsService } from "../review-threads-service";
 import {
   type ReviewSessionHandlerInput,
   createReviewSessionHandler,
@@ -341,6 +342,97 @@ describe("createReviewSessionHandler", () => {
       expect(onReviewThreadsCommit).toHaveBeenCalledTimes(1);
     } finally {
       await handler.close();
+    }
+  });
+
+  it("shares snapshots and revisions with external mutations across sessions", async () => {
+    rootPath = await mkdtemp(path.join(tmpdir(), "review-session-shared-"));
+    const reviewPath = path.join(rootPath, "review.mdx");
+    const threadsService = new ReviewThreadsService({
+      reviewPath,
+      author: "Reviewer",
+    });
+    const onCommit = vi.fn<(commit: ReviewThreadsCommit) => void>();
+    const options: ReviewSessionHandlerInput = {
+      ...unusedAgentServices,
+      rootPath,
+      toolingRoot: rootPath,
+      reviewPath,
+      routePath: "/",
+      token: "shared-token",
+      threadsService,
+      onReviewThreadsCommit: onCommit,
+      session: {
+        rootPath,
+        baseRef: "HEAD",
+        appUrl: "http://localhost/sessions/shared",
+        reviewPath,
+        startedAt: Date.now(),
+      },
+    };
+    const first = await createReviewSessionHandler(options);
+    const second = await createReviewSessionHandler(options);
+    const request = (suffix: string, body?: JsonObject) =>
+      new Request(`http://localhost/__progressive-review${suffix}`, {
+        method: body ? "POST" : "GET",
+        headers: {
+          "x-review-token": "shared-token",
+          "content-type": "application/json",
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+    try {
+      // Initialize both session projections before the external API mutation.
+      await first.handle(request("/comments"));
+      await second.handle(request("/comments"));
+      threadsService.dispatch({
+        command: "comment.create",
+        mutationId: "external",
+        input: {
+          threadId: "shared",
+          messageId: "one",
+          target: { kind: "document" },
+          body: "External comment",
+        },
+      });
+      for (const handler of [first, second]) {
+        const response = await handler.handle(request("/comments"));
+        expect(await response.json()).toMatchObject({
+          ok: true,
+          snapshot: {
+            revision: 1,
+            comments: { shared: { messages: [{ body: "External comment" }] } },
+          },
+        });
+      }
+      const response = await first.handle(
+        request("/thread-commands", {
+          command: "comment.update",
+          mutationId: "session",
+          threadId: "shared",
+          update: { status: "resolved" },
+        }),
+      );
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        commit: { revision: 2 },
+      });
+      expect(threadsService.snapshot()).toMatchObject({
+        revision: 2,
+        comments: { shared: { status: "resolved" } },
+      });
+      expect(onCommit).toHaveBeenCalledTimes(4);
+      await first.close();
+      onCommit.mockClear();
+      threadsService.dispatch({
+        command: "comment.delete",
+        mutationId: "delete",
+        threadId: "shared",
+      });
+      expect(onCommit).toHaveBeenCalledTimes(1);
+    } finally {
+      await first.close();
+      await second.close();
     }
   });
 

--- a/packages/progressive-review/src/server/session-handler.ts
+++ b/packages/progressive-review/src/server/session-handler.ts
@@ -18,6 +18,7 @@ import { streamSSE } from "hono/streaming";
 import type { ReviewAgentHarness, SessionRef } from "../authoring-session";
 import type { AgentServer } from "../native-agent/native-session";
 import { readReviewDocumentBundle } from "../review-bundle";
+import type { ReviewThreadsService } from "../review-threads-service";
 import { resolveReviewSessionBaseCommit } from "../review-worktree-target";
 import {
   type ReviewSoftwareMapBundle,
@@ -54,6 +55,7 @@ export interface ReviewSessionHandlerInput {
   reviewPath: string;
   softwareMapRootPath?: string;
   stateReviewPath?: string;
+  threadsService?: ReviewThreadsService;
   routePath: string;
   token?: string;
   sessionId?: string;
@@ -369,6 +371,10 @@ export async function createReviewSessionHandler(
     response.headers.set("content-type", "text/event-stream; charset=utf-8");
     return response;
   });
+  const unsubscribeThreads = input.threadsService?.subscribe((commit) => {
+    broadcast({ event: "review-threads-committed", commit });
+    input.onReviewThreadsCommit?.(commit);
+  });
   const reviewApi = createReviewApi({
     reviewPath: input.reviewPath,
     reviewDocumentsDir: documentsDir,
@@ -376,6 +382,7 @@ export async function createReviewSessionHandler(
     reviewRootPath,
     toolingRoot: input.toolingRoot,
     stateReviewPath: input.stateReviewPath,
+    threadsService: input.threadsService,
     telemetry: sessionTelemetry,
     onSubmission: async (event) => {
       broadcast({
@@ -451,6 +458,7 @@ export async function createReviewSessionHandler(
     },
     close: async () => {
       await reviewApi.close();
+      unsubscribeThreads?.();
       for (const client of eventClients) client.close();
       eventClients.clear();
     },

--- a/packages/progressive-review/src/threads-cli.test.ts
+++ b/packages/progressive-review/src/threads-cli.test.ts
@@ -158,6 +158,12 @@ async function makeReview(): Promise<{
       author: "Reviewer",
     });
   const api: ReviewCanvasApi = {
+    getDocumentFile: async () => {
+      throw new Error("Not used by thread CLI tests.");
+    },
+    writeDocumentFile: async () => {
+      throw new Error("Not used by thread CLI tests.");
+    },
     getComments: async () => ({ ok: true, snapshot: threads().snapshot() }),
     command: async (_reviewId, command) => {
       const commit = threads().dispatch(command);

--- a/packages/progressive-review/src/threads-cli.test.ts
+++ b/packages/progressive-review/src/threads-cli.test.ts
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { ReviewCanvasApi } from "./review-canvas-api-client";
 import { type StoredReview, createReviewDir } from "./review-home";
 import { requireCompletedAgentResponsesForRepublish } from "./review-publish-thread-gate";
 import { appendReviewComment } from "./review-state-store";
@@ -15,6 +16,7 @@ import {
   closeAllReviewThreadStores,
   reviewThreadDbPath,
 } from "./review-thread-store-backend";
+import { ReviewThreadsService } from "./review-threads-service";
 import {
   runReviewThreadsList,
   runReviewThreadsReply,
@@ -35,7 +37,7 @@ afterEach(async () => {
 
 describe("review threads CLI", () => {
   it("lists, replies to, and resolves comment threads", async () => {
-    const { root, review, document } = await makeReview();
+    const { api, root, review, document } = await makeReview();
 
     appendReviewComment(document, {
       threadId: "thread-1",
@@ -46,7 +48,7 @@ describe("review threads CLI", () => {
     });
     const listed = JSON.parse(
       await captureOutput((stdout) =>
-        runReviewThreadsList({ cwd: root, stdout }),
+        runReviewThreadsList({ api, cwd: root, stdout }),
       ),
     );
     expect(listed).toMatchObject({
@@ -60,6 +62,7 @@ describe("review threads CLI", () => {
       await captureOutput((stdout) =>
         runReviewThreadsReply({
           cwd: root,
+          api,
           threadId: "thread-1",
           body: "Fixed in the latest revision.",
           stdout,
@@ -70,7 +73,12 @@ describe("review threads CLI", () => {
 
     const resolved = JSON.parse(
       await captureOutput((stdout) =>
-        runReviewThreadsResolve({ cwd: root, threadId: "thread-1", stdout }),
+        runReviewThreadsResolve({
+          api,
+          cwd: root,
+          threadId: "thread-1",
+          stdout,
+        }),
       ),
     );
     expect(resolved).toMatchObject({
@@ -80,7 +88,7 @@ describe("review threads CLI", () => {
 
     const after = JSON.parse(
       await captureOutput((stdout) =>
-        runReviewThreadsList({ cwd: root, stdout }),
+        runReviewThreadsList({ api, cwd: root, stdout }),
       ),
     );
     expect(after.comments["thread-1"]).toMatchObject({
@@ -108,10 +116,11 @@ describe("review threads CLI", () => {
   });
 
   it("rejects unknown threads and reviews", async () => {
-    const { root } = await makeReview();
+    const { api, root } = await makeReview();
     await expect(
       runReviewThreadsResolve({
         cwd: root,
+        api,
         threadId: "missing",
         stdout: outputStream(),
       }),
@@ -119,6 +128,7 @@ describe("review threads CLI", () => {
     await expect(
       runReviewThreadsList({
         cwd: root,
+        api,
         reviewUuid: "22222222-2222-4222-8222-222222222222",
         stdout: outputStream(),
       }),
@@ -127,6 +137,7 @@ describe("review threads CLI", () => {
 });
 
 async function makeReview(): Promise<{
+  api: ReviewCanvasApi;
   root: string;
   review: StoredReview;
   document: string;
@@ -141,7 +152,38 @@ async function makeReview(): Promise<{
     baseCommit: await git(root, ["rev-parse", "HEAD"]),
   });
   const document = path.join(review.dir, "review.mdx");
-  return { root, review, document };
+  const threads = () =>
+    new ReviewThreadsService({
+      reviewPath: document,
+      author: "Reviewer",
+    });
+  const api: ReviewCanvasApi = {
+    getComments: async () => ({ ok: true, snapshot: threads().snapshot() }),
+    command: async (_reviewId, command) => {
+      const commit = threads().dispatch(command);
+      if (!commit) return { ok: false, error: "Comment thread not found." };
+      return { ok: true, commit };
+    },
+    reply: async (input) => {
+      const commit = threads().appendAgentMessage({
+        mutationId: input.mutationId,
+        threadId: input.threadId,
+        messageId: input.messageId,
+        author: input.author ?? "Agent",
+        body: input.body,
+        format: "plain",
+      });
+      if (!commit) return { ok: false, error: "Comment thread not found." };
+      return { ok: true, commit };
+    },
+    getDocument: async () => {
+      throw new Error("Not used by thread CLI tests.");
+    },
+    mutateDocument: async () => {
+      throw new Error("Not used by thread CLI tests.");
+    },
+  };
+  return { api, root, review, document };
 }
 
 async function makeGitRepository(): Promise<string> {

--- a/packages/progressive-review/src/threads-cli.ts
+++ b/packages/progressive-review/src/threads-cli.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import path from "node:path";
 import type { Writable } from "node:stream";
 
 import {
@@ -12,18 +11,19 @@ import {
   REVIEW_AGENT_THREAD_TOKEN_ENV,
   REVIEW_AGENT_THREAD_URL_ENV,
 } from "./native-agent/terminal-command";
+import {
+  type ReviewCanvasApi,
+  ReviewCanvasApiClient,
+  ReviewCanvasApiError,
+} from "./review-canvas-api-client";
 import { reviewUuidForManagedCheckout } from "./review-head-checkout";
 import { type StoredReview, findReview, listReviews } from "./review-home";
-import {
-  appendReviewAgentMessage,
-  readReviewComments,
-  updateReviewComment,
-} from "./review-state-store";
 
-// `review threads get` reads its attached Review server. Other commands can
-// still operate after that server closes, so they use review.db.
+// Comment state is owned by Review Desktop. CLI commands resolve the target
+// Review locally, then perform every comment read and mutation over its API.
 
 export interface ReviewThreadsTarget {
+  api?: ReviewCanvasApi;
   cwd: string;
   reviewUuid?: string;
 }
@@ -32,10 +32,13 @@ export async function runReviewThreadsList(
   input: ReviewThreadsTarget & { json?: boolean; stdout: Writable },
 ): Promise<number> {
   const review = await resolveThreadsReview(input.cwd, input.reviewUuid);
-  const document = reviewDocumentPath(review);
+  const response = await reviewCanvasApi(input.api).getComments(
+    review.review.uuid,
+  );
+  if (!response.ok) throw new Error(response.error);
   const payload = {
     review: review.review.uuid,
-    comments: readReviewComments(document),
+    comments: response.snapshot.comments,
   };
   // Indented output is easier for a human to read, but it breaks any reader
   // that takes one event per line. --json picks the line-oriented form.
@@ -121,8 +124,15 @@ export async function runReviewThreadsResolve(
   },
 ): Promise<number> {
   const review = await resolveThreadsReview(input.cwd, input.reviewUuid);
-  const document = reviewDocumentPath(review);
-  if (!updateReviewComment(document, input.threadId, { status: "resolved" })) {
+  const response = await commentThreadRequest(input.threadId, () =>
+    reviewCanvasApi(input.api).command(review.review.uuid, {
+      command: "comment.update",
+      mutationId: randomUUID(),
+      threadId: input.threadId,
+      update: { status: "resolved" },
+    }),
+  );
+  if (!response.ok) {
     throw new Error(`Comment thread not found: ${input.threadId}`);
   }
   input.stdout.write(
@@ -146,23 +156,23 @@ export async function runReviewThreadsReply(
   const body = input.body.trim();
   if (!body) throw new Error("Reply body is required.");
   const review = await resolveThreadsReview(input.cwd, input.reviewUuid);
-  const document = reviewDocumentPath(review);
-  const thread = readReviewComments(document)[input.threadId];
-  if (!thread) {
-    throw new Error(`Comment thread not found: ${input.threadId}`);
-  }
   const messageId = randomUUID();
   // The republish gate requires a completed model response with role "agent"
   // on every current-round thread, so a CLI reply must not read as another
   // reviewer message.
-  appendReviewAgentMessage(document, input.threadId, {
-    id: messageId,
-    by: input.author?.trim() || "Agent",
-    at: new Date().toISOString(),
-    body,
-    role: "agent",
-    format: "plain",
-  });
+  const response = await commentThreadRequest(input.threadId, () =>
+    reviewCanvasApi(input.api).reply({
+      reviewId: review.review.uuid,
+      threadId: input.threadId,
+      mutationId: randomUUID(),
+      messageId,
+      author: input.author?.trim() || "Agent",
+      body,
+    }),
+  );
+  if (!response.ok) {
+    throw new Error(`Comment thread not found: ${input.threadId}`);
+  }
   input.stdout.write(
     `${JSON.stringify({
       event: "replied",
@@ -174,8 +184,22 @@ export async function runReviewThreadsReply(
   return 0;
 }
 
-function reviewDocumentPath(review: StoredReview): string {
-  return path.join(review.dir, "review.mdx");
+function reviewCanvasApi(api?: ReviewCanvasApi): ReviewCanvasApi {
+  return api ?? new ReviewCanvasApiClient();
+}
+
+async function commentThreadRequest<T>(
+  threadId: string,
+  request: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await request();
+  } catch (error) {
+    if (error instanceof ReviewCanvasApiError && error.statusCode === 404) {
+      throw new Error(`Comment thread not found: ${threadId}`);
+    }
+    throw error;
+  }
 }
 
 async function resolveThreadsReview(

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -691,6 +691,25 @@ export type ReviewDocumentSnapshot = z.infer<
   typeof ReviewDocumentSnapshotSchema
 >;
 
+// Rich MDX authoring exposes only its two authored inputs, never arbitrary paths.
+export const ReviewDocumentFileNameSchema = z.enum(["review.mdx", "data.ts"]);
+export type ReviewDocumentFileName = z.infer<
+  typeof ReviewDocumentFileNameSchema
+>;
+export const ReviewDocumentFileSchema = z.strictObject({
+  name: ReviewDocumentFileNameSchema,
+  source: z.string().nullable(),
+  sourceHash: requiredString.nullable(),
+});
+export type ReviewDocumentFile = z.infer<typeof ReviewDocumentFileSchema>;
+export const ReviewDocumentFileWriteSchema = z.strictObject({
+  source: z.string(),
+  expectedSourceHash: requiredString.nullable(),
+});
+export type ReviewDocumentFileWrite = z.infer<
+  typeof ReviewDocumentFileWriteSchema
+>;
+
 const ReviewDocumentNodePatchSchema = z
   .strictObject({
     kind: ReviewDocumentNodeSchema.shape.kind.optional(),
@@ -1338,6 +1357,14 @@ export const ReviewErrorResponseSchema = z.strictObject({
   error: requiredString,
 });
 export type ReviewErrorResponse = z.infer<typeof ReviewErrorResponseSchema>;
+
+export const ReviewDocumentFileResponseSchema = z.discriminatedUnion("ok", [
+  z.strictObject({ ok: z.literal(true), file: ReviewDocumentFileSchema }),
+  ReviewErrorResponseSchema,
+]);
+export type ReviewDocumentFileResponse = z.infer<
+  typeof ReviewDocumentFileResponseSchema
+>;
 
 export const ReviewDocumentSnapshotResponseSchema = z.discriminatedUnion("ok", [
   z.strictObject({

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -664,6 +664,82 @@ export const ReviewThreadsCommandSchema = z.discriminatedUnion("command", [
 ]);
 export type ReviewThreadsCommand = z.infer<typeof ReviewThreadsCommandSchema>;
 
+const reviewNodeIdSchema = z
+  .string({ error: "must be a stable node ID" })
+  .regex(/^[A-Za-z][A-Za-z0-9._-]{0,127}$/, "must be a stable node ID");
+
+export const ReviewDocumentNodeSchema = z.strictObject({
+  id: reviewNodeIdSchema,
+  kind: z.enum(["markdown", "callout", "code"]),
+  content: z.string(),
+  title: z.string().optional(),
+  tone: z.enum(["info", "warning", "success", "danger"]).optional(),
+  language: z.string().optional(),
+});
+export type ReviewDocumentNode = z.infer<typeof ReviewDocumentNodeSchema>;
+
+export const ReviewDocumentSnapshotSchema = z.strictObject({
+  reviewId: z.uuid({ error: "must be a UUID" }),
+  routePath: routePathSchema,
+  mode: z.enum(["compiled", "incremental"]),
+  revision: nonNegativeInteger,
+  sourceHash: requiredString,
+  source: z.string(),
+  nodes: z.array(ReviewDocumentNodeSchema).nullable(),
+});
+export type ReviewDocumentSnapshot = z.infer<
+  typeof ReviewDocumentSnapshotSchema
+>;
+
+const ReviewDocumentNodePatchSchema = z
+  .strictObject({
+    kind: ReviewDocumentNodeSchema.shape.kind.optional(),
+    content: z.string().optional(),
+    title: z.string().nullable().optional(),
+    tone: ReviewDocumentNodeSchema.shape.tone.nullable().optional(),
+    language: z.string().nullable().optional(),
+  })
+  .refine((patch) => Object.keys(patch).length > 0, "must not be empty");
+
+export const ReviewDocumentOperationSchema = z.discriminatedUnion("type", [
+  z.strictObject({
+    type: z.literal("replace"),
+    nodes: z.array(ReviewDocumentNodeSchema),
+  }),
+  z.strictObject({
+    type: z.literal("insert"),
+    index: nonNegativeInteger,
+    node: ReviewDocumentNodeSchema,
+  }),
+  z.strictObject({
+    type: z.literal("update"),
+    nodeId: reviewNodeIdSchema,
+    patch: ReviewDocumentNodePatchSchema,
+  }),
+  z.strictObject({
+    type: z.literal("delete"),
+    nodeId: reviewNodeIdSchema,
+  }),
+  z.strictObject({
+    type: z.literal("move"),
+    nodeId: reviewNodeIdSchema,
+    index: nonNegativeInteger,
+  }),
+]);
+export type ReviewDocumentOperation = z.infer<
+  typeof ReviewDocumentOperationSchema
+>;
+
+export const ReviewDocumentMutationRequestSchema = z.strictObject({
+  mutationId: threadTargetNonEmptyStringSchema,
+  expectedRevision: nonNegativeInteger,
+  expectedSourceHash: requiredString.optional(),
+  operation: ReviewDocumentOperationSchema,
+});
+export type ReviewDocumentMutationRequest = z.infer<
+  typeof ReviewDocumentMutationRequestSchema
+>;
+
 export interface ReviewLocalCommentThread {
   clientStatus: "draft" | "submitting";
   thread: ReviewCommentThreadRecord;
@@ -1263,6 +1339,29 @@ export const ReviewErrorResponseSchema = z.strictObject({
 });
 export type ReviewErrorResponse = z.infer<typeof ReviewErrorResponseSchema>;
 
+export const ReviewDocumentSnapshotResponseSchema = z.discriminatedUnion("ok", [
+  z.strictObject({
+    ok: z.literal(true),
+    snapshot: ReviewDocumentSnapshotSchema,
+  }),
+  ReviewErrorResponseSchema,
+]);
+export type ReviewDocumentSnapshotResponse = z.infer<
+  typeof ReviewDocumentSnapshotResponseSchema
+>;
+
+export const ReviewDocumentMutationResponseSchema = z.discriminatedUnion("ok", [
+  z.strictObject({
+    ok: z.literal(true),
+    mutationId: threadTargetNonEmptyStringSchema,
+    snapshot: ReviewDocumentSnapshotSchema,
+  }),
+  ReviewErrorResponseSchema,
+]);
+export type ReviewDocumentMutationResponse = z.infer<
+  typeof ReviewDocumentMutationResponseSchema
+>;
+
 export const ReviewThreadsSnapshotResponseSchema = z.discriminatedUnion("ok", [
   z.strictObject({
     ok: z.literal(true),
@@ -1538,9 +1637,16 @@ export const ReviewDesktopGlobalEventSchema = z.discriminatedUnion("event", [
   z.strictObject({
     event: z.literal("review-threads-committed"),
     uuid: z.uuid({ error: "must be a UUID" }),
-    sessionId: requiredString,
+    sessionId: requiredString.optional(),
     commit: ReviewThreadsCommitSchema,
     commentCount: nonNegativeInteger,
+  }),
+  z.strictObject({
+    event: z.literal("review-document-changed"),
+    uuid: z.uuid({ error: "must be a UUID" }),
+    routePath: routePathSchema,
+    revision: nonNegativeInteger,
+    mutationId: threadTargetNonEmptyStringSchema,
   }),
   z.strictObject({
     event: z.literal("session-closed"),

--- a/packages/review-protocol/src/index.ts
+++ b/packages/review-protocol/src/index.ts
@@ -21,6 +21,12 @@ import {
   ReviewDesktopVerbResultSchema,
   type ReviewDiffFilesResponse,
   ReviewDiffFilesResponseSchema,
+  type ReviewDocumentMutationRequest,
+  ReviewDocumentMutationRequestSchema,
+  type ReviewDocumentMutationResponse,
+  ReviewDocumentMutationResponseSchema,
+  type ReviewDocumentSnapshotResponse,
+  ReviewDocumentSnapshotResponseSchema,
   type ReviewFileContentRequest,
   ReviewFileContentRequestSchema,
   type ReviewFileContentResponse,
@@ -127,6 +133,24 @@ export function parseReviewDiffFilesResponse(
   value: JsonValue,
 ): ReviewDiffFilesResponse {
   return parseZod(ReviewDiffFilesResponseSchema, value);
+}
+
+export function parseReviewDocumentMutationRequest(
+  value: JsonValue,
+): ReviewDocumentMutationRequest {
+  return parseZod(ReviewDocumentMutationRequestSchema, value);
+}
+
+export function parseReviewDocumentSnapshotResponse(
+  value: JsonValue,
+): ReviewDocumentSnapshotResponse {
+  return parseZod(ReviewDocumentSnapshotResponseSchema, value);
+}
+
+export function parseReviewDocumentMutationResponse(
+  value: JsonValue,
+): ReviewDocumentMutationResponse {
+  return parseZod(ReviewDocumentMutationResponseSchema, value);
 }
 
 export function parseReviewFileContentResponse(


### PR DESCRIPTION
Stacked on #131. Review authoring clients can read and edit documents and comments through the authenticated Desktop API without opening document files or executing SQL.

- Rich MDX: `review_get_document_file` and `review_write_document_file` expose only `review.mdx` and `data.ts`. Source-hash checks protect writes, retries are safe when the requested contents already won, and terminal reviews reject writes. Rich components and imports are preserved; the existing publish operation compiles and presents the completed inputs.
- Incremental documents: stable markdown, callout, and code nodes support replace, insert, update, move, and delete, with revision checks, atomic source writes, mutation receipts, and crash-window recovery. Incremental source cannot bypass node mutations through the file API.
- Comments: one review-owned service supplies snapshots and increasing revisions to global API requests and all open sessions. Session event subscriptions are released on close. This prevents successive MCP updates from each emitting revision 1 and being ignored by the canvas.
- `review mcp` exposes explicit stdio tools, and comment CLI commands use the same API. Authoring instructions require API access for both rich and incremental documents.

Validation: authenticated API tests cover rich source preservation, stale writes, retries, filename restrictions, node-only incremental writes, and increasing comment revisions. Session tests cover shared snapshots, cross-session mutations, and subscription cleanup. In the rebuilt isolated app, authored both rich inputs through MCP, published successfully, and visually verified AnchorLink and native CodePeek rendering. Also verified a second API comment mutation appeared in an already-open canvas. The final stack passed 1,186 progressive-review tests, protocol and desktop tests, TypeScript checks, lint, formatting, and diff checks.
