### PR TITLE
Render incremental review document updates

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
@@ -115,7 +115,7 @@ import { IReviewSessionService } from "../../../services/reviewSessionService.js
 import { ReviewCommentStore } from "../../../services/reviewCommentStore.js";
 import {
 	IReviewSessionModelService,
-	loadReviewSessionDocument,
+	loadReviewSessionCanvasDocument,
 	loadReviewSessionSoftwareMap,
 	type ReviewDesktopSession,
 	type ReviewSessionModel,
@@ -1507,7 +1507,7 @@ export class ReviewCanvasEditorPane extends EditorPane {
 				this.resolveValidationSession(sessionId),
 			);
 			const documentPromise = timed("fetch + load document module", () =>
-				loadReviewSessionDocument(session, (draftSession, moduleUrl) =>
+				loadReviewSessionCanvasDocument(session, (draftSession, moduleUrl) =>
 					loadReviewDocumentModule(
 						draftSession,
 						moduleUrl,

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewDocumentStore.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewDocumentStore.test.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ReviewDocumentSnapshot } from "../common/reviewProtocol.js";
+import { ReviewDocumentStore } from "./reviewDocumentStore.js";
+
+const reviewId = "11111111-1111-4111-8111-111111111111";
+
+test("keeps unchanged node identities and ignores stale snapshots", () => {
+	const overview = {
+		id: "overview",
+		kind: "markdown" as const,
+		content: "Overview",
+	};
+	const store = new ReviewDocumentStore(snapshot(1, [overview]));
+	let changes = 0;
+	const subscription = store.subscribe(() => {
+		changes += 1;
+	});
+
+	store.replace(
+		snapshot(2, [
+			{ id: "intro", kind: "callout", content: "New" },
+			{ ...overview },
+		]),
+	);
+	const current = store.getSnapshot();
+	assert.equal(current.revision, 2);
+	assert.strictEqual(current.nodes?.[1], overview);
+	assert.equal(changes, 1);
+
+	store.replace(snapshot(1, [{ ...overview, content: "stale" }]));
+	assert.strictEqual(store.getSnapshot(), current);
+	assert.equal(changes, 1);
+
+	subscription.dispose();
+	store.dispose();
+});
+
+function snapshot(
+	revision: number,
+	nodes: NonNullable<ReviewDocumentSnapshot["nodes"]>,
+): ReviewDocumentSnapshot {
+	return {
+		reviewId,
+		routePath: "/",
+		mode: "incremental",
+		revision,
+		sourceHash: `hash-${revision}`,
+		source: "",
+		nodes,
+	};
+}

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewDocumentStore.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewDocumentStore.test.ts
@@ -42,6 +42,29 @@ test("keeps unchanged node identities and ignores stale snapshots", () => {
 	store.dispose();
 });
 
+test("publishes ephemeral authoring target changes without changing revisions", () => {
+	const store = new ReviewDocumentStore(
+		snapshot(1, [{ id: "overview", kind: "markdown", content: "Overview" }]),
+	);
+	let changes = 0;
+	store.subscribe(() => {
+		changes += 1;
+	});
+
+	store.setAuthoringTargetNodeId("overview");
+	assert.equal(store.getAuthoringTargetNodeId(), "overview");
+	assert.equal(store.getSnapshot().revision, 1);
+	assert.equal(changes, 1);
+
+	store.setAuthoringTargetNodeId("overview");
+	assert.equal(changes, 1);
+
+	store.setAuthoringTargetNodeId(null);
+	assert.equal(store.getAuthoringTargetNodeId(), null);
+	assert.equal(changes, 2);
+	store.dispose();
+});
+
 function snapshot(
 	revision: number,
 	nodes: NonNullable<ReviewDocumentSnapshot["nodes"]>,

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewDocumentStore.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewDocumentStore.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter } from "../../base/common/event.js";
+import { Disposable } from "../../base/common/lifecycle.js";
+import type {
+	ReviewDocumentNode,
+	ReviewDocumentSnapshot,
+	ReviewDocumentStoreBridge,
+} from "../common/reviewProtocol.js";
+
+/** Host-owned external store consumed by the Review canvas. */
+export class ReviewDocumentStore
+	extends Disposable
+	implements ReviewDocumentStoreBridge
+{
+	private readonly _onDidChange = this._register(new Emitter<void>());
+
+	constructor(private snapshot: ReviewDocumentSnapshot) {
+		super();
+	}
+
+	getSnapshot(): ReviewDocumentSnapshot {
+		return this.snapshot;
+	}
+
+	subscribe(listener: () => void) {
+		return this._onDidChange.event(listener);
+	}
+
+	replace(snapshot: ReviewDocumentSnapshot): void {
+		if (
+			snapshot.routePath !== this.snapshot.routePath ||
+			snapshot.revision <= this.snapshot.revision
+		) {
+			return;
+		}
+		const previousNodes = new Map(
+			(this.snapshot.nodes ?? []).map((node) => [node.id, node]),
+		);
+		this.snapshot = snapshot.nodes
+			? {
+					...snapshot,
+					nodes: snapshot.nodes.map((node) => {
+						const previous = previousNodes.get(node.id);
+						return previous && sameReviewDocumentNode(previous, node)
+							? previous
+							: node;
+					}),
+				}
+			: snapshot;
+		this._onDidChange.fire();
+	}
+}
+
+function sameReviewDocumentNode(
+	left: ReviewDocumentNode,
+	right: ReviewDocumentNode,
+): boolean {
+	return (
+		left.id === right.id &&
+		left.kind === right.kind &&
+		left.content === right.content &&
+		left.title === right.title &&
+		left.tone === right.tone &&
+		left.language === right.language
+	);
+}

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewDocumentStore.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewDocumentStore.ts
@@ -17,6 +17,7 @@ export class ReviewDocumentStore
 	implements ReviewDocumentStoreBridge
 {
 	private readonly _onDidChange = this._register(new Emitter<void>());
+	private authoringTargetNodeId: string | null = null;
 
 	constructor(private snapshot: ReviewDocumentSnapshot) {
 		super();
@@ -24,6 +25,10 @@ export class ReviewDocumentStore
 
 	getSnapshot(): ReviewDocumentSnapshot {
 		return this.snapshot;
+	}
+
+	getAuthoringTargetNodeId(): string | null {
+		return this.authoringTargetNodeId;
 	}
 
 	subscribe(listener: () => void) {
@@ -51,6 +56,14 @@ export class ReviewDocumentStore
 					}),
 				}
 			: snapshot;
+		this._onDidChange.fire();
+	}
+
+	setAuthoringTargetNodeId(nodeId: string | null): void {
+		if (nodeId === this.authoringTargetNodeId) {
+			return;
+		}
+		this.authoringTargetNodeId = nodeId;
 		this._onDidChange.fire();
 	}
 }

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.test.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	loadReviewSessionCanvasDocument,
+	type ReviewDesktopSession,
+} from "./reviewSessionModelService.js";
+
+test("loads a session-scoped incremental snapshot without importing MDX", async () => {
+	let moduleLoads = 0;
+	const content = await loadReviewSessionCanvasDocument(
+		session(),
+		async () => {
+			moduleLoads += 1;
+			return {};
+		},
+		async (url) => {
+			assert.match(url, /__progressive-review\/document$/);
+			return Response.json({
+				ok: true,
+				snapshot: {
+					reviewId: "11111111-1111-4111-8111-111111111111",
+					routePath: "/",
+					mode: "incremental",
+					revision: 2,
+					sourceHash: "hash-2",
+					source: "source",
+					nodes: [
+						{ id: "summary", kind: "markdown", content: "# Summary" },
+					],
+				},
+			});
+		},
+	);
+
+	assert.equal(content.kind, "incremental");
+	assert.equal(moduleLoads, 0);
+	assert.equal(
+		content.kind === "incremental" ? content.store.getSnapshot().revision : -1,
+		2,
+	);
+});
+
+function session(): ReviewDesktopSession {
+	return {
+		serverUrl: "http://127.0.0.1:5570",
+		sessionUrl: "http://127.0.0.1:5570/sessions/test",
+		token: "token",
+		descriptor: { routePath: "/" },
+		review: {},
+		session: { sessionId: "test", storageDir: "/tmp/review", routePath: "/" },
+	} as ReviewDesktopSession;
+}

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.test.ts
@@ -6,10 +6,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { Emitter, Event } from "../../base/common/event.js";
 import {
 	loadReviewSessionCanvasDocument,
 	type ReviewDesktopSession,
+	ReviewSessionModel,
 } from "./reviewSessionModelService.js";
+import type { ReviewDocumentAuthoringTargetChangedEvent } from "./reviewSessionService.js";
 
 test("loads a session-scoped incremental snapshot without importing MDX", async () => {
 	let moduleLoads = 0;
@@ -45,6 +48,70 @@ test("loads a session-scoped incremental snapshot without importing MDX", async 
 		2,
 	);
 });
+
+test("forwards ephemeral authoring targets into the incremental document store", async () => {
+	const targets = new Emitter<ReviewDocumentAuthoringTargetChangedEvent>();
+	const model = new TestReviewSessionModel(targets);
+	const content = await model.resolveDocument(async () => ({}));
+	assert.equal(content.kind, "incremental");
+	if (content.kind !== "incremental") return;
+
+	targets.fire({
+		event: "review-document-authoring-target-changed",
+		uuid: "11111111-1111-4111-8111-111111111111",
+		routePath: "/",
+		targetNodeId: "summary",
+	});
+	assert.equal(content.store.getAuthoringTargetNodeId(), "summary");
+
+	targets.fire({
+		event: "review-document-authoring-target-changed",
+		uuid: "11111111-1111-4111-8111-111111111111",
+		routePath: "/",
+		targetNodeId: null,
+	});
+	assert.equal(content.store.getAuthoringTargetNodeId(), null);
+
+	model.dispose();
+	targets.dispose();
+});
+
+class TestReviewSessionModel extends ReviewSessionModel {
+	constructor(
+		targets: Emitter<ReviewDocumentAuthoringTargetChangedEvent>,
+	) {
+		const current = session();
+		super(
+			"11111111-1111-4111-8111-111111111111",
+			current,
+			async () => current,
+			Event.None,
+			Event.None,
+			Event.None,
+			() => true,
+			Event.None,
+			Event.None,
+			targets.event,
+		);
+	}
+
+	override async request(): Promise<Response> {
+		return Response.json({
+			ok: true,
+			snapshot: {
+				reviewId: "11111111-1111-4111-8111-111111111111",
+				routePath: "/",
+				mode: "incremental",
+				revision: 2,
+				sourceHash: "hash-2",
+				source: "source",
+				nodes: [
+					{ id: "summary", kind: "markdown", content: "# Summary" },
+				],
+			},
+		});
+	}
+}
 
 function session(): ReviewDesktopSession {
 	return {

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.ts
@@ -272,27 +272,36 @@ export class ReviewSessionModel extends Disposable {
 	private async loadDocument(
 		loader: ReviewDocumentModuleLoader,
 	): Promise<ReviewCanvasDocument> {
-		if (!this._session.session.historicalRevision) {
-			const snapshot = await loadReviewDocumentSnapshot(
+		if (this._session.session.historicalRevision) {
+			return loadReviewSessionCanvasDocument(
 				this._session,
-				this.reviewUuid,
+				loader,
 				(url, init) => this.request(url, init),
 			);
-			if (
-				snapshot.mode === "incremental" &&
-				snapshot.routePath === reviewRoutePath(this._session)
-			) {
-				this.incrementalDocumentStore?.dispose();
-				this.incrementalDocumentStore = new ReviewDocumentStore(snapshot);
-				return {
-					kind: "incremental",
-					store: this.incrementalDocumentStore,
-				};
-			}
+		}
+		const snapshot = await loadReviewDocumentSnapshot(
+			this._session,
+			this.reviewUuid,
+			(url, init) => this.request(url, init),
+		);
+		if (
+			snapshot.mode === "incremental" &&
+			snapshot.routePath === reviewRoutePath(this._session)
+		) {
+			this.incrementalDocumentStore?.dispose();
+			this.incrementalDocumentStore = new ReviewDocumentStore(snapshot);
+			return {
+				kind: "incremental",
+				store: this.incrementalDocumentStore,
+			};
 		}
 		return {
 			kind: "compiled",
-			bundle: await loadReviewSessionDocument(this._session, loader),
+			bundle: await loadReviewSessionDocument(
+				this._session,
+				loader,
+				(url, init) => this.request(url, init),
+			),
 		};
 	}
 
@@ -334,6 +343,41 @@ export class ReviewSessionModel extends Disposable {
 		this.incrementalDocumentStore?.dispose();
 		super.dispose();
 	}
+}
+
+export async function loadReviewSessionCanvasDocument(
+	session: ReviewDesktopSession,
+	loader: ReviewDocumentModuleLoader,
+	fetchImpl: (url: string, init: RequestInit) => Promise<Response> = fetch,
+): Promise<ReviewCanvasDocument> {
+	const snapshot = await loadReviewSessionDocumentSnapshot(session, fetchImpl);
+	if (snapshot.mode === "incremental") {
+		return { kind: "incremental", store: new ReviewDocumentStore(snapshot) };
+	}
+	return {
+		kind: "compiled",
+		bundle: await loadReviewSessionDocument(session, loader, fetchImpl),
+	};
+}
+
+async function loadReviewSessionDocumentSnapshot(
+	session: ReviewDesktopSession,
+	fetchImpl: (url: string, init: RequestInit) => Promise<Response> = fetch,
+): Promise<ReviewDocumentSnapshot> {
+	const url = new URL(`${session.sessionUrl}/__progressive-review/document`);
+	const response = await fetchImpl(url.href, {
+		headers: { "x-review-token": session.token },
+		signal: AbortSignal.timeout(30_000),
+	});
+	const payload = parseReviewDocumentSnapshotResponse(await response.json());
+	if (!response.ok || !payload.ok) {
+		throw new Error(
+			payload.ok
+				? `Review document returned ${response.status}.`
+				: payload.error,
+		);
+	}
+	return payload.snapshot;
 }
 
 async function loadReviewDocumentSnapshot(
@@ -388,13 +432,14 @@ export function reviewSessionApiRequest(
 export async function loadReviewSessionDocument(
 	session: ReviewDesktopSession,
 	loader: ReviewDocumentModuleLoader,
+	fetchImpl: (url: string, init: RequestInit) => Promise<Response> = fetch,
 ): Promise<unknown> {
 	const url = new URL(`${session.sessionUrl}/__progressive-review/doc-module`);
 	const routePath = session.session.routePath ?? session.descriptor.routePath;
 	if (routePath && routePath !== "/") {
 		url.searchParams.set("document", routePath);
 	}
-	const response = await fetch(url, {
+	const response = await fetchImpl(url.href, {
 		headers: { "x-review-token": session.token },
 		signal: AbortSignal.timeout(30_000),
 	});

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.ts
@@ -31,6 +31,7 @@ import {
 import {
 	IReviewSessionService,
 	type ReviewDataChangedEvent,
+	type ReviewDocumentAuthoringTargetChangedEvent,
 	type ReviewDocumentChangedEvent,
 	type ReviewSessionConnection,
 	type ReviewSessionClosedEvent,
@@ -96,6 +97,7 @@ export class ReviewSessionModel extends Disposable {
 	private refreshPromise: Promise<void> | undefined;
 	private _comments: ReviewCommentStore;
 	private incrementalDocumentStore: ReviewDocumentStore | undefined;
+	private documentAuthoringTargetNodeId: string | null = null;
 	get comments(): ReviewCommentStoreBridge {
 		return this._comments;
 	}
@@ -109,6 +111,9 @@ export class ReviewSessionModel extends Disposable {
 		private readonly shouldRefresh: ReviewSessionRefreshPredicate = () => true,
 		onDidCommitReviewThreads: Event<ReviewThreadsCommittedEvent> = Event.None,
 		onDidChangeReviewDocument: Event<ReviewDocumentChangedEvent> = Event.None,
+		onDidChangeReviewDocumentAuthoringTarget: Event<
+			ReviewDocumentAuthoringTargetChangedEvent
+		> = Event.None,
 	) {
 		super();
 		this._session = session;
@@ -165,6 +170,22 @@ export class ReviewSessionModel extends Disposable {
 			}),
 		);
 		this._register(
+			onDidChangeReviewDocumentAuthoringTarget((event) => {
+				if (
+					event.uuid !== this.reviewUuid ||
+					event.routePath !== reviewRoutePath(this._session) ||
+					this._state !== "active" ||
+					this._session.session.historicalRevision
+				) {
+					return;
+				}
+				this.documentAuthoringTargetNodeId = event.targetNodeId;
+				this.incrementalDocumentStore?.setAuthoringTargetNodeId(
+					event.targetNodeId,
+				);
+			}),
+		);
+		this._register(
 			onDidCommitReviewThreads((event) => {
 				if (
 					event.uuid !== this.reviewUuid ||
@@ -218,6 +239,8 @@ export class ReviewSessionModel extends Disposable {
 				) {
 					this._comments.dispose();
 					this._comments = this.createCommentStore();
+					this.documentAuthoringTargetNodeId = null;
+					this.incrementalDocumentStore?.setAuthoringTargetNodeId(null);
 				}
 				this.documentRevision = reviewDocumentRevision(session);
 				if (
@@ -290,6 +313,9 @@ export class ReviewSessionModel extends Disposable {
 		) {
 			this.incrementalDocumentStore?.dispose();
 			this.incrementalDocumentStore = new ReviewDocumentStore(snapshot);
+			this.incrementalDocumentStore.setAuthoringTargetNodeId(
+				this.documentAuthoringTargetNodeId,
+			);
 			return {
 				kind: "incremental",
 				store: this.incrementalDocumentStore,
@@ -690,6 +716,7 @@ export class ReviewSessionModelService
 			(current) => this.shouldRefreshModel(current),
 			this.sessionService.onDidCommitReviewThreads ?? Event.None,
 			this.sessionService.onDidChangeReviewDocument ?? Event.None,
+			this.sessionService.onDidChangeReviewDocumentAuthoringTarget ?? Event.None,
 		);
 		this.models.set(key, model);
 		return model;

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.ts
@@ -17,10 +17,13 @@ import {
 } from "../../platform/instantiation/common/instantiation.js";
 import { ReviewModuleCache } from "../common/reviewModuleCache.js";
 import {
+	parseReviewDocumentSnapshotResponse,
 	ReviewDocModuleResponseSchema,
 	ReviewSoftwareMapModuleResponseSchema,
+	type ReviewCanvasDocument,
 	type ReviewCommentStoreBridge,
 	type ReviewDescriptor,
+	type ReviewDocumentSnapshot,
 	type ReviewSessionDescriptor,
 	type ReviewSessionWire,
 	parseReviewSessionResponse,
@@ -28,11 +31,13 @@ import {
 import {
 	IReviewSessionService,
 	type ReviewDataChangedEvent,
+	type ReviewDocumentChangedEvent,
 	type ReviewSessionConnection,
 	type ReviewSessionClosedEvent,
 	type ReviewThreadsCommittedEvent,
 } from "./reviewSessionService.js";
 import { ReviewCommentStore } from "./reviewCommentStore.js";
+import { ReviewDocumentStore } from "./reviewDocumentStore.js";
 
 export interface ReviewDesktopSession {
 	readonly serverUrl: string;
@@ -90,6 +95,7 @@ export class ReviewSessionModel extends Disposable {
 	private readonly modules = new ReviewModuleCache();
 	private refreshPromise: Promise<void> | undefined;
 	private _comments: ReviewCommentStore;
+	private incrementalDocumentStore: ReviewDocumentStore | undefined;
 	get comments(): ReviewCommentStoreBridge {
 		return this._comments;
 	}
@@ -102,6 +108,7 @@ export class ReviewSessionModel extends Disposable {
 		onDidCloseSession: Event<ReviewSessionClosedEvent> = Event.None,
 		private readonly shouldRefresh: ReviewSessionRefreshPredicate = () => true,
 		onDidCommitReviewThreads: Event<ReviewThreadsCommittedEvent> = Event.None,
+		onDidChangeReviewDocument: Event<ReviewDocumentChangedEvent> = Event.None,
 	) {
 		super();
 		this._session = session;
@@ -129,10 +136,40 @@ export class ReviewSessionModel extends Disposable {
 			}),
 		);
 		this._register(
+			onDidChangeReviewDocument((event) => {
+				if (
+					event.uuid !== this.reviewUuid ||
+					event.routePath !== reviewRoutePath(this._session) ||
+					this._state !== "active" ||
+					this._session.session.historicalRevision
+				) {
+					return;
+				}
+				if (!this.incrementalDocumentStore) {
+					this.modules.clear();
+					this._onDidChange.fire();
+					return;
+				}
+				if (
+					event.revision <=
+					this.incrementalDocumentStore.getSnapshot().revision
+				) {
+					return;
+				}
+				void this.refreshIncrementalDocument().catch((error) => {
+					console.error(
+						`[Review Desktop] failed to refresh incremental document ${reviewUuid}`,
+						error,
+					);
+				});
+			}),
+		);
+		this._register(
 			onDidCommitReviewThreads((event) => {
 				if (
 					event.uuid !== this.reviewUuid ||
-					event.sessionId !== this._session.session.sessionId ||
+					(event.sessionId !== undefined &&
+						event.sessionId !== this._session.session.sessionId) ||
 					this._state !== "active"
 				) {
 					return;
@@ -214,7 +251,9 @@ export class ReviewSessionModel extends Disposable {
 		return this.refreshPromise;
 	}
 
-	resolveDocument(loader: ReviewDocumentModuleLoader): Promise<unknown> {
+	resolveDocument(
+		loader: ReviewDocumentModuleLoader,
+	): Promise<ReviewCanvasDocument> {
 		return this.modules.load("document", () => this.loadDocument(loader));
 	}
 
@@ -230,8 +269,49 @@ export class ReviewSessionModel extends Disposable {
 		return fetch(url, init);
 	}
 
-	private loadDocument(loader: ReviewDocumentModuleLoader): Promise<unknown> {
-		return loadReviewSessionDocument(this._session, loader);
+	private async loadDocument(
+		loader: ReviewDocumentModuleLoader,
+	): Promise<ReviewCanvasDocument> {
+		if (!this._session.session.historicalRevision) {
+			const snapshot = await loadReviewDocumentSnapshot(
+				this._session,
+				this.reviewUuid,
+				(url, init) => this.request(url, init),
+			);
+			if (
+				snapshot.mode === "incremental" &&
+				snapshot.routePath === reviewRoutePath(this._session)
+			) {
+				this.incrementalDocumentStore?.dispose();
+				this.incrementalDocumentStore = new ReviewDocumentStore(snapshot);
+				return {
+					kind: "incremental",
+					store: this.incrementalDocumentStore,
+				};
+			}
+		}
+		return {
+			kind: "compiled",
+			bundle: await loadReviewSessionDocument(this._session, loader),
+		};
+	}
+
+	private async refreshIncrementalDocument(): Promise<void> {
+		const store = this.incrementalDocumentStore;
+		if (!store) return;
+		const snapshot = await loadReviewDocumentSnapshot(
+			this._session,
+			this.reviewUuid,
+			(url, init) => this.request(url, init),
+		);
+		if (snapshot.mode !== "incremental") {
+			this.incrementalDocumentStore = undefined;
+			store.dispose();
+			this.modules.clear();
+			this._onDidChange.fire();
+			return;
+		}
+		store.replace(snapshot);
 	}
 
 	private loadSoftwareMap(
@@ -251,8 +331,37 @@ export class ReviewSessionModel extends Disposable {
 
 	override dispose(): void {
 		this._comments.dispose();
+		this.incrementalDocumentStore?.dispose();
 		super.dispose();
 	}
+}
+
+async function loadReviewDocumentSnapshot(
+	session: ReviewDesktopSession,
+	reviewUuid: string,
+	fetchImpl: (url: string, init: RequestInit) => Promise<Response> = fetch,
+): Promise<ReviewDocumentSnapshot> {
+	const url = new URL(
+		`/reviews/${encodeURIComponent(reviewUuid)}/document`,
+		session.serverUrl,
+	);
+	const response = await fetchImpl(url.href, {
+		headers: { "x-review-token": session.token },
+		signal: AbortSignal.timeout(30_000),
+	});
+	const payload = parseReviewDocumentSnapshotResponse(await response.json());
+	if (!response.ok || !payload.ok) {
+		throw new Error(
+			payload.ok
+				? `Review document returned ${response.status}.`
+				: payload.error,
+		);
+	}
+	return payload.snapshot;
+}
+
+function reviewRoutePath(session: ReviewDesktopSession): string {
+	return session.session.routePath ?? session.descriptor.routePath ?? "/";
 }
 
 /**
@@ -535,6 +644,7 @@ export class ReviewSessionModelService
 			this.sessionService.onDidCloseSession,
 			(current) => this.shouldRefreshModel(current),
 			this.sessionService.onDidCommitReviewThreads ?? Event.None,
+			this.sessionService.onDidChangeReviewDocument ?? Event.None,
 		);
 		this.models.set(key, model);
 		return model;

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
@@ -59,6 +59,11 @@ export type ReviewThreadsCommittedEvent = Extract<
 	{ event: "review-threads-committed" }
 >;
 
+export type ReviewDocumentChangedEvent = Extract<
+	ReviewDesktopGlobalEvent,
+	{ event: "review-document-changed" }
+>;
+
 export interface ReviewSessionClosedEvent {
 	readonly session: ReviewSessionDescriptor;
 	readonly review: ReviewDescriptor | undefined;
@@ -83,6 +88,7 @@ export interface IReviewSessionService {
 	readonly _serviceBrand: undefined;
 	readonly onDidChangeLists: Event<void>;
 	readonly onDidChangeReviewData: Event<ReviewDataChangedEvent>;
+	readonly onDidChangeReviewDocument: Event<ReviewDocumentChangedEvent>;
 	readonly onDidCommitReviewThreads: Event<ReviewThreadsCommittedEvent>;
 	readonly onDidCloseSession: Event<ReviewSessionClosedEvent>;
 	readonly onDidRegisterSession: Event<ReviewSessionRegisteredEvent>;
@@ -146,6 +152,11 @@ export class ReviewSessionService
 		new Emitter<ReviewDataChangedEvent>(),
 	);
 	readonly onDidChangeReviewData = this._onDidChangeReviewData.event;
+	private readonly _onDidChangeReviewDocument = this._register(
+		new Emitter<ReviewDocumentChangedEvent>(),
+	);
+	readonly onDidChangeReviewDocument =
+		this._onDidChangeReviewDocument.event;
 	private readonly _onDidCommitReviewThreads = this._register(
 		new Emitter<ReviewThreadsCommittedEvent>(),
 	);
@@ -844,6 +855,10 @@ export class ReviewSessionService
 				if (event.event === "review-threads-committed") {
 					this.patchReview(event.uuid, { commentCount: event.commentCount });
 					this._onDidCommitReviewThreads.fire(event);
+					return;
+				}
+				if (event.event === "review-document-changed") {
+					this._onDidChangeReviewDocument.fire(event);
 					return;
 				}
 				if (event.event === "session-registered") {

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
@@ -64,6 +64,11 @@ export type ReviewDocumentChangedEvent = Extract<
 	{ event: "review-document-changed" }
 >;
 
+export type ReviewDocumentAuthoringTargetChangedEvent = Extract<
+	ReviewDesktopGlobalEvent,
+	{ event: "review-document-authoring-target-changed" }
+>;
+
 export interface ReviewSessionClosedEvent {
 	readonly session: ReviewSessionDescriptor;
 	readonly review: ReviewDescriptor | undefined;
@@ -89,6 +94,9 @@ export interface IReviewSessionService {
 	readonly onDidChangeLists: Event<void>;
 	readonly onDidChangeReviewData: Event<ReviewDataChangedEvent>;
 	readonly onDidChangeReviewDocument: Event<ReviewDocumentChangedEvent>;
+	readonly onDidChangeReviewDocumentAuthoringTarget: Event<
+		ReviewDocumentAuthoringTargetChangedEvent
+	>;
 	readonly onDidCommitReviewThreads: Event<ReviewThreadsCommittedEvent>;
 	readonly onDidCloseSession: Event<ReviewSessionClosedEvent>;
 	readonly onDidRegisterSession: Event<ReviewSessionRegisteredEvent>;
@@ -157,6 +165,11 @@ export class ReviewSessionService
 	);
 	readonly onDidChangeReviewDocument =
 		this._onDidChangeReviewDocument.event;
+	private readonly _onDidChangeReviewDocumentAuthoringTarget = this._register(
+		new Emitter<ReviewDocumentAuthoringTargetChangedEvent>(),
+	);
+	readonly onDidChangeReviewDocumentAuthoringTarget =
+		this._onDidChangeReviewDocumentAuthoringTarget.event;
 	private readonly _onDidCommitReviewThreads = this._register(
 		new Emitter<ReviewThreadsCommittedEvent>(),
 	);
@@ -859,6 +872,10 @@ export class ReviewSessionService
 				}
 				if (event.event === "review-document-changed") {
 					this._onDidChangeReviewDocument.fire(event);
+					return;
+				}
+				if (event.event === "review-document-authoring-target-changed") {
+					this._onDidChangeReviewDocumentAuthoringTarget.fire(event);
 					return;
 				}
 				if (event.event === "session-registered") {

--- a/apps/review-desktop/scripts/review-presented-telemetry-contract.test.mjs
+++ b/apps/review-desktop/scripts/review-presented-telemetry-contract.test.mjs
@@ -19,7 +19,7 @@ test("presented telemetry follows a successful visible canvas ready signal", asy
 
   assert.match(
     desktopEntry,
-    /Promise\.all\(\[documentBundle, softwareMapBundle\]\)/,
+    /Promise\.all\(\[documentContent, softwareMapBundle\]\)/,
   );
   assert.match(
     desktopEntry,

--- a/packages/progressive-review/app/src/desktop-entry.tsx
+++ b/packages/progressive-review/app/src/desktop-entry.tsx
@@ -13,6 +13,7 @@ import {
   createReviewSession,
   useReviewSession,
 } from "./host/review-session";
+import { createIncrementalReviewDocumentEntry } from "./incremental-review-document";
 import { ReviewCanvasLoading } from "./review-canvas-loading";
 import { reviewDefinitionDiagnostics } from "./review-definition-runtime";
 import type { ReadyReviewDocumentEntry } from "./review-documents-runtime";
@@ -36,7 +37,7 @@ interface ReviewDocumentBundle {
 }
 
 function DesktopReviewApp({
-  documentBundle,
+  documentContent,
   softwareMapBundle,
   softwareMapEnabled,
   range,
@@ -45,7 +46,10 @@ function DesktopReviewApp({
   tutorial,
   findHost,
 }: {
-  documentBundle: Promise<unknown>;
+  documentContent: Extract<
+    ReviewCanvasContent,
+    { kind: "session" }
+  >["document"];
   softwareMapBundle: Promise<unknown | null>;
   softwareMapEnabled: boolean;
   range: Extract<ReviewCanvasContent, { kind: "session" }>["range"];
@@ -76,14 +80,19 @@ function DesktopReviewApp({
     setSoftwareMap(null);
     setSoftwareMapLoaded(false);
     setError(null);
-    void Promise.all([documentBundle, softwareMapBundle]).then(
+    void Promise.all([documentContent, softwareMapBundle]).then(
       ([documentValue, softwareMapValue]) => {
         if (cancelled) return;
-        // SAFETY: the desktop host resolves the session content's `document`
-        // promise with the loaded review-document module, whose exports are
-        // the ReviewDocumentBundle (`activeReviewDocument`).
-        const bundle = documentValue as ReviewDocumentBundle;
-        setDocument(bundle.activeReviewDocument);
+        if (documentValue.kind === "incremental") {
+          setDocument(
+            createIncrementalReviewDocumentEntry(documentValue.store),
+          );
+        } else {
+          // SAFETY: the desktop host resolves compiled content with the loaded
+          // review-document module, whose exports are ReviewDocumentBundle.
+          const bundle = documentValue.bundle as ReviewDocumentBundle;
+          setDocument(bundle.activeReviewDocument);
+        }
         // SAFETY: the host resolves `softwareMap` with the published software
         // map module, or null when no map was published for the review.
         setSoftwareMap(softwareMapValue as PublishedSoftwareMap | null);
@@ -109,7 +118,7 @@ function DesktopReviewApp({
     return () => {
       cancelled = true;
     };
-  }, [documentBundle, softwareMapBundle]);
+  }, [documentContent, softwareMapBundle]);
 
   useEffect(() => {
     if (document && softwareMapLoaded && !error) session.signalReady();
@@ -166,7 +175,7 @@ function ReviewCanvas({
     return (
       <DesktopReviewApp
         key={content.bridge.config.sessionId}
-        documentBundle={content.document}
+        documentContent={content.document}
         softwareMapBundle={content.softwareMap}
         softwareMapEnabled={content.softwareMapEnabled}
         range={content.range}

--- a/packages/progressive-review/app/src/incremental-review-document.test.tsx
+++ b/packages/progressive-review/app/src/incremental-review-document.test.tsx
@@ -12,11 +12,16 @@ import { IncrementalReviewDocument } from "./incremental-review-document";
 
 class TestDocumentStore implements ReviewDocumentStoreBridge {
   private readonly listeners = new Set<() => void>();
+  private authoringTargetNodeId: string | null = null;
 
   constructor(private snapshot: ReviewDocumentSnapshot) {}
 
   getSnapshot(): ReviewDocumentSnapshot {
     return this.snapshot;
+  }
+
+  getAuthoringTargetNodeId(): string | null {
+    return this.authoringTargetNodeId;
   }
 
   subscribe(listener: () => void) {
@@ -26,6 +31,11 @@ class TestDocumentStore implements ReviewDocumentStoreBridge {
 
   replace(snapshot: ReviewDocumentSnapshot): void {
     this.snapshot = snapshot;
+    for (const listener of this.listeners) listener();
+  }
+
+  select(nodeId: string | null): void {
+    this.authoringTargetNodeId = nodeId;
     for (const listener of this.listeners) listener();
   }
 }
@@ -84,9 +94,53 @@ describe("incremental review document", () => {
     expect(details?.textContent).toContain("Updated details");
     expect(
       container
+        .querySelector('[data-review-node-id="intro"]')
+        ?.classList.contains("review-incremental-node--entering"),
+    ).toBe(true);
+    expect(
+      overview?.classList.contains("review-incremental-node--entering"),
+    ).toBe(false);
+    expect(
+      container
         .querySelector(".review-incremental-document")
         ?.getAttribute("data-review-document-revision"),
     ).toBe("2");
+  });
+
+  it("shows Paper-style activity only on the selected authoring node", () => {
+    const store = new TestDocumentStore(
+      snapshot(1, [
+        { id: "overview", kind: "markdown", content: "# Overview" },
+        { id: "details", kind: "markdown", content: "Details" },
+      ]),
+    );
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    roots.push(root);
+    act(() => root.render(<IncrementalReviewDocument store={store} />));
+
+    act(() => store.select("details"));
+
+    expect(
+      container
+        .querySelector('[data-review-node-id="details"]')
+        ?.getAttribute("data-review-authoring-target"),
+    ).toBe("true");
+    expect(
+      container.querySelectorAll(
+        '[data-review-node-id="details"] .review-incremental-node__authoring-sparkles i',
+      ),
+    ).toHaveLength(28);
+    expect(
+      container
+        .querySelector('[data-review-node-id="overview"]')
+        ?.hasAttribute("data-review-authoring-target"),
+    ).toBe(false);
+
+    act(() => store.select(null));
+    expect(
+      container.querySelector("[data-review-authoring-target]"),
+    ).toBeNull();
   });
 
   it("renders callout and code node kinds without evaluating document source", () => {

--- a/packages/progressive-review/app/src/incremental-review-document.test.tsx
+++ b/packages/progressive-review/app/src/incremental-review-document.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+import type {
+  ReviewDocumentSnapshot,
+  ReviewDocumentStoreBridge,
+} from "@dev.fast/review-protocol";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { IncrementalReviewDocument } from "./incremental-review-document";
+
+class TestDocumentStore implements ReviewDocumentStoreBridge {
+  private readonly listeners = new Set<() => void>();
+
+  constructor(private snapshot: ReviewDocumentSnapshot) {}
+
+  getSnapshot(): ReviewDocumentSnapshot {
+    return this.snapshot;
+  }
+
+  subscribe(listener: () => void) {
+    this.listeners.add(listener);
+    return { dispose: () => this.listeners.delete(listener) };
+  }
+
+  replace(snapshot: ReviewDocumentSnapshot): void {
+    this.snapshot = snapshot;
+    for (const listener of this.listeners) listener();
+  }
+}
+
+const roots: Array<ReturnType<typeof createRoot>> = [];
+
+afterEach(() => {
+  act(() => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.innerHTML = "";
+});
+
+describe("incremental review document", () => {
+  it("preserves unchanged keyed DOM while applying document snapshots", () => {
+    const firstNode = {
+      id: "overview",
+      kind: "markdown" as const,
+      content: "# Overview",
+    };
+    const store = new TestDocumentStore(
+      snapshot(1, [
+        firstNode,
+        { id: "details", kind: "markdown", content: "Initial details" },
+      ]),
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    act(() => root.render(<IncrementalReviewDocument store={store} />));
+
+    const overview = container.querySelector(
+      '[data-review-node-id="overview"]',
+    );
+    const details = container.querySelector('[data-review-node-id="details"]');
+    expect(overview).not.toBeNull();
+    expect(details?.textContent).toContain("Initial details");
+
+    act(() => {
+      store.replace(
+        snapshot(2, [
+          { id: "intro", kind: "callout", title: "Note", content: "Inserted" },
+          firstNode,
+          { id: "details", kind: "markdown", content: "Updated details" },
+        ]),
+      );
+    });
+
+    expect(container.querySelector('[data-review-node-id="overview"]')).toBe(
+      overview,
+    );
+    expect(container.querySelector('[data-review-node-id="details"]')).toBe(
+      details,
+    );
+    expect(details?.textContent).toContain("Updated details");
+    expect(
+      container
+        .querySelector(".review-incremental-document")
+        ?.getAttribute("data-review-document-revision"),
+    ).toBe("2");
+  });
+
+  it("renders callout and code node kinds without evaluating document source", () => {
+    const store = new TestDocumentStore(
+      snapshot(1, [
+        {
+          id: "warning",
+          kind: "callout",
+          tone: "warning",
+          title: "Heads up",
+          content: "**Check** the migration.",
+        },
+        {
+          id: "example",
+          kind: "code",
+          language: "ts",
+          content: "const ready = true;",
+        },
+      ]),
+    );
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    roots.push(root);
+    act(() => root.render(<IncrementalReviewDocument store={store} />));
+
+    expect(container.querySelector("strong")?.textContent).toBe("Heads up");
+    expect(container.innerHTML).toContain("<strong>Check</strong>");
+    expect(
+      container.querySelector("[data-language='ts']")?.textContent,
+    ).toContain("const ready = true;");
+  });
+});
+
+function snapshot(
+  revision: number,
+  nodes: NonNullable<ReviewDocumentSnapshot["nodes"]>,
+): ReviewDocumentSnapshot {
+  return {
+    reviewId: "123e4567-e89b-42d3-a456-426614174000",
+    routePath: "/",
+    mode: "incremental",
+    revision,
+    sourceHash: `hash-${revision}`,
+    source: "",
+    nodes,
+  };
+}

--- a/packages/progressive-review/app/src/incremental-review-document.tsx
+++ b/packages/progressive-review/app/src/incremental-review-document.tsx
@@ -1,0 +1,121 @@
+import type {
+  ReviewDocumentNode,
+  ReviewDocumentSnapshot,
+  ReviewDocumentStoreBridge,
+} from "@dev.fast/review-protocol";
+import {
+  type ReactElement,
+  memo,
+  useCallback,
+  useSyncExternalStore,
+} from "react";
+
+import { AgentMarkdown } from "./agent-markdown";
+import { RenderedCodeBlock } from "./code-block";
+import type {
+  ReadyReviewDocumentEntry,
+  ReviewDocumentComponent,
+} from "./review-documents-runtime";
+
+/**
+ * Adapts the host-owned document store to the existing document runtime. The
+ * component identity is stable for the lifetime of the store, so document
+ * updates do not reset panels, scroll position, or view-local React state.
+ */
+export function createIncrementalReviewDocumentEntry(
+  store: ReviewDocumentStoreBridge,
+): ReadyReviewDocumentEntry {
+  const initial = store.getSnapshot();
+  const Component: ReviewDocumentComponent = function IncrementalDocument() {
+    return <IncrementalReviewDocument store={store} />;
+  };
+  return {
+    slug: "incremental-review",
+    routePath: initial.routePath,
+    filePath: `incremental:${initial.reviewId}:${initial.routePath}`,
+    title: incrementalDocumentTitle(initial),
+    documentSoftwareModels: [],
+    anchors: new Map(),
+    anchorContents: new Map(),
+    Component,
+    isDefault: initial.routePath === "/",
+  };
+}
+
+export function IncrementalReviewDocument({
+  store,
+}: {
+  store: ReviewDocumentStoreBridge;
+}): ReactElement {
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      const subscription = store.subscribe(listener);
+      return () => subscription.dispose();
+    },
+    [store],
+  );
+  const snapshot = useSyncExternalStore(
+    subscribe,
+    () => store.getSnapshot(),
+    () => store.getSnapshot(),
+  );
+  if (snapshot.mode !== "incremental" || !snapshot.nodes) {
+    throw new Error("The incremental renderer received a compiled document.");
+  }
+  return (
+    <div
+      className="review-incremental-document"
+      data-review-document-revision={snapshot.revision}
+    >
+      {snapshot.nodes.map((node) => (
+        <IncrementalReviewNode key={node.id} node={node} />
+      ))}
+    </div>
+  );
+}
+
+const IncrementalReviewNode = memo(function IncrementalReviewNode({
+  node,
+}: {
+  node: ReviewDocumentNode;
+}): ReactElement {
+  return (
+    <section
+      className={`review-incremental-node review-incremental-node--${node.kind}`}
+      data-review-node-id={node.id}
+    >
+      {node.kind === "code" ? (
+        <RenderedCodeBlock
+          className="markdown-code-block"
+          code={node.content}
+          language={node.language}
+        />
+      ) : (
+        <>
+          {node.kind === "callout" && node.title ? (
+            <strong className="review-incremental-callout-title">
+              {node.title}
+            </strong>
+          ) : null}
+          <AgentMarkdown
+            className={
+              node.kind === "callout"
+                ? `review-incremental-callout review-incremental-callout--${node.tone ?? "info"}`
+                : "review-incremental-markdown"
+            }
+            source={node.content}
+          />
+        </>
+      )}
+    </section>
+  );
+});
+
+function incrementalDocumentTitle(snapshot: ReviewDocumentSnapshot): string {
+  for (const node of snapshot.nodes ?? []) {
+    if (node.title?.trim()) return node.title.trim();
+    const heading = /^#\s+(.+)$/m.exec(node.content);
+    if (heading?.[1]) return heading[1].trim();
+  }
+  return "Review";
+}

--- a/packages/progressive-review/app/src/incremental-review-document.tsx
+++ b/packages/progressive-review/app/src/incremental-review-document.tsx
@@ -4,9 +4,12 @@ import type {
   ReviewDocumentStoreBridge,
 } from "@dev.fast/review-protocol";
 import {
+  type CSSProperties,
   type ReactElement,
   memo,
   useCallback,
+  useEffect,
+  useRef,
   useSyncExternalStore,
 } from "react";
 
@@ -59,6 +62,22 @@ export function IncrementalReviewDocument({
     () => store.getSnapshot(),
     () => store.getSnapshot(),
   );
+  const authoringTargetNodeId = useSyncExternalStore(
+    subscribe,
+    () => store.getAuthoringTargetNodeId(),
+    () => store.getAuthoringTargetNodeId(),
+  );
+  const previousNodeIds = useRef<ReadonlySet<string> | null>(null);
+  const enteringNodeIds = new Set(
+    previousNodeIds.current
+      ? (snapshot.nodes ?? [])
+          .filter((node) => !previousNodeIds.current?.has(node.id))
+          .map((node) => node.id)
+      : [],
+  );
+  useEffect(() => {
+    previousNodeIds.current = new Set(snapshot.nodes?.map((node) => node.id));
+  }, [snapshot.nodes, snapshot.revision]);
   if (snapshot.mode !== "incremental" || !snapshot.nodes) {
     throw new Error("The incremental renderer received a compiled document.");
   }
@@ -68,7 +87,12 @@ export function IncrementalReviewDocument({
       data-review-document-revision={snapshot.revision}
     >
       {snapshot.nodes.map((node) => (
-        <IncrementalReviewNode key={node.id} node={node} />
+        <IncrementalReviewNode
+          key={node.id}
+          node={node}
+          isAuthoring={authoringTargetNodeId === node.id}
+          isEntering={enteringNodeIds.has(node.id)}
+        />
       ))}
     </div>
   );
@@ -76,14 +100,28 @@ export function IncrementalReviewDocument({
 
 const IncrementalReviewNode = memo(function IncrementalReviewNode({
   node,
+  isAuthoring,
+  isEntering,
 }: {
   node: ReviewDocumentNode;
+  isAuthoring: boolean;
+  isEntering: boolean;
 }): ReactElement {
+  const className = [
+    "review-incremental-node",
+    `review-incremental-node--${node.kind}`,
+    isAuthoring ? "review-incremental-node--authoring-active" : undefined,
+    isEntering ? "review-incremental-node--entering" : undefined,
+  ]
+    .filter(Boolean)
+    .join(" ");
   return (
     <section
-      className={`review-incremental-node review-incremental-node--${node.kind}`}
+      className={className}
       data-review-node-id={node.id}
+      {...(isAuthoring ? { "data-review-authoring-target": "true" } : {})}
     >
+      {isAuthoring ? <AuthoringSparkles /> : null}
       {node.kind === "code" ? (
         <RenderedCodeBlock
           className="markdown-code-block"
@@ -110,6 +148,30 @@ const IncrementalReviewNode = memo(function IncrementalReviewNode({
     </section>
   );
 });
+
+const AUTHORING_SPARKLE_COUNT = 28;
+
+function AuthoringSparkles(): ReactElement {
+  return (
+    <span
+      className="review-incremental-node__authoring-sparkles"
+      aria-hidden="true"
+    >
+      {Array.from({ length: AUTHORING_SPARKLE_COUNT }, (_, index) => (
+        <i
+          key={index}
+          style={
+            // SAFETY: React accepts custom CSS properties at runtime; the
+            // standard CSSProperties type does not model their names.
+            {
+              "--review-sparkle-index": index,
+            } as CSSProperties
+          }
+        />
+      ))}
+    </span>
+  );
+}
 
 function incrementalDocumentTitle(snapshot: ReviewDocumentSnapshot): string {
   for (const node of snapshot.nodes ?? []) {

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -10463,3 +10463,31 @@ button.review-stack-row:disabled .review-stack-relation {
 .review-trace-peek-open-full:hover {
   background: var(--accent-wash);
 }
+/* Incremental documents keep one keyed surface per API node. Updating one
+ * node therefore leaves sibling DOM (and text-thread targets) undisturbed. */
+.review-incremental-node {
+  display: flow-root;
+}
+
+.review-incremental-node--callout {
+  border-inline-start: 3px solid var(--vscode-textBlockQuote-border);
+  margin-block: 1rem;
+  padding: 0.65rem 0.9rem;
+}
+
+.review-incremental-callout-title {
+  display: block;
+  margin-block-end: 0.35rem;
+}
+
+.review-incremental-callout--warning {
+  border-inline-start-color: var(--vscode-editorWarning-foreground);
+}
+
+.review-incremental-callout--danger {
+  border-inline-start-color: var(--vscode-editorError-foreground);
+}
+
+.review-incremental-callout--success {
+  border-inline-start-color: var(--vscode-testing-iconPassed);
+}

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -10501,17 +10501,17 @@ button.review-stack-row:disabled .review-stack-relation {
 .review-incremental-node__authoring-sparkles {
   position: absolute;
   z-index: 2;
-  top: -29px;
-  left: 10px;
+  top: 4px;
+  left: -59px;
   display: grid;
-  grid-template-columns: repeat(14, 7px);
-  grid-template-rows: repeat(2, 7px);
+  grid-template-columns: repeat(4, 7px);
+  grid-template-rows: repeat(7, 7px);
   gap: 4px 5px;
-  width: 163px;
-  height: 18px;
+  width: 43px;
+  height: 73px;
   pointer-events: none;
   mask-image: linear-gradient(
-    90deg,
+    180deg,
     transparent,
     #000 9%,
     #000 91%,

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -10469,6 +10469,109 @@ button.review-stack-row:disabled .review-stack-relation {
   display: flow-root;
 }
 
+.review-incremental-node--entering {
+  animation: review-incremental-node-enter 220ms cubic-bezier(0.2, 0.8, 0.2, 1)
+    both;
+}
+
+@keyframes review-incremental-node-enter {
+  from {
+    opacity: 0;
+    transform: translateY(7px) scale(0.995);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.review-incremental-node--authoring-active {
+  position: relative;
+  isolation: isolate;
+  border-radius: 8px;
+  outline: 1px solid color-mix(in srgb, var(--accent) 86%, transparent);
+  outline-offset: 6px;
+  box-shadow:
+    0 0 0 6px color-mix(in srgb, var(--accent-wash) 72%, transparent),
+    0 8px 28px color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+/* Paper-style agent activity belongs to exactly one stable API node. */
+.review-incremental-node__authoring-sparkles {
+  position: absolute;
+  z-index: 2;
+  top: -29px;
+  left: 10px;
+  display: grid;
+  grid-template-columns: repeat(14, 7px);
+  grid-template-rows: repeat(2, 7px);
+  gap: 4px 5px;
+  width: 163px;
+  height: 18px;
+  pointer-events: none;
+  mask-image: linear-gradient(
+    90deg,
+    transparent,
+    #000 9%,
+    #000 91%,
+    transparent
+  );
+}
+
+.review-incremental-node__authoring-sparkles i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 5px color-mix(in srgb, var(--accent) 22%, transparent);
+  animation: review-authoring-sparkle 1.55s ease-in-out infinite;
+  animation-delay: calc(var(--review-sparkle-index) * -113ms);
+}
+
+.review-incremental-node__authoring-sparkles i:nth-child(3n) {
+  animation-duration: 1.9s;
+}
+
+.review-incremental-node__authoring-sparkles i:nth-child(4n + 1) {
+  animation-duration: 1.2s;
+}
+
+.review-incremental-node__authoring-sparkles i:nth-child(6n + 2),
+.review-incremental-node__authoring-sparkles i:nth-child(11n + 5) {
+  visibility: hidden;
+}
+
+@keyframes review-authoring-sparkle {
+  0%,
+  100% {
+    opacity: 0.18;
+    transform: scale(0.72);
+  }
+
+  38% {
+    opacity: 0.96;
+    transform: scale(1);
+  }
+
+  64% {
+    opacity: 0.42;
+    transform: scale(0.86);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .review-incremental-node--entering,
+  .review-incremental-node__authoring-sparkles i {
+    animation: none;
+    transform: none;
+  }
+
+  .review-incremental-node__authoring-sparkles i {
+    opacity: 0.62;
+  }
+}
+
 .review-incremental-node--callout {
   border-inline-start: 3px solid var(--vscode-textBlockQuote-border);
   margin-block: 1rem;

--- a/packages/progressive-review/src/incremental-review-document.ts
+++ b/packages/progressive-review/src/incremental-review-document.ts
@@ -120,28 +120,12 @@ export async function readReviewDocumentSnapshot(
 ): Promise<ReviewDocumentSnapshot> {
   const routePath = "/";
   const documentPath = path.join(review.dir, "review.mdx");
-  const source = await readFile(documentPath, "utf8");
-  const sourceHash = hashSource(source);
-  const parsed = parseIncrementalReviewDocument(source);
-  const snapshot: ReviewDocumentSnapshot = parsed
-    ? {
-        reviewId: review.review.uuid,
-        routePath,
-        mode: "incremental",
-        revision: parsed.revision,
-        sourceHash,
-        source,
-        nodes: parsed.nodes,
-      }
-    : {
-        reviewId: review.review.uuid,
-        routePath,
-        mode: "compiled",
-        revision: 0,
-        sourceHash,
-        source,
-        nodes: null,
-      };
+  const snapshot = await readReviewDocumentFileSnapshot({
+    reviewId: review.review.uuid,
+    routePath,
+    documentPath,
+  });
+  const sourceHash = snapshot.sourceHash;
   const stored = readReviewDocumentState(review.dir, routePath);
   if (
     !stored ||
@@ -157,6 +141,36 @@ export async function readReviewDocumentSnapshot(
     });
   }
   return snapshot;
+}
+
+export async function readReviewDocumentFileSnapshot(input: {
+  reviewId: string;
+  routePath: string;
+  documentPath: string;
+}): Promise<ReviewDocumentSnapshot> {
+  const { reviewId, routePath, documentPath } = input;
+  const source = await readFile(documentPath, "utf8");
+  const sourceHash = hashSource(source);
+  const parsed = parseIncrementalReviewDocument(source);
+  return parsed
+    ? {
+        reviewId,
+        routePath,
+        mode: "incremental",
+        revision: parsed.revision,
+        sourceHash,
+        source,
+        nodes: parsed.nodes,
+      }
+    : {
+        reviewId,
+        routePath,
+        mode: "compiled",
+        revision: 0,
+        sourceHash,
+        source,
+        nodes: null,
+      };
 }
 
 export async function mutateReviewDocument(

--- a/packages/progressive-review/src/review-canvas-api-client.ts
+++ b/packages/progressive-review/src/review-canvas-api-client.ts
@@ -9,6 +9,8 @@ import {
   type ReviewDocumentMutationRequest,
   type ReviewDocumentMutationResponse,
   ReviewDocumentMutationResponseSchema,
+  type ReviewDocumentNodeResponse,
+  ReviewDocumentNodeResponseSchema,
   type ReviewDocumentSnapshotResponse,
   ReviewDocumentSnapshotResponseSchema,
   type ReviewThreadsCommand,
@@ -34,6 +36,10 @@ export interface ReviewCanvasApi {
     request: ReviewDocumentFileWrite,
   ): Promise<ReviewDocumentFileResponse>;
   getDocument(reviewId: string): Promise<ReviewDocumentSnapshotResponse>;
+  getDocumentNode(
+    reviewId: string,
+    nodeId: string,
+  ): Promise<ReviewDocumentNodeResponse>;
   mutateDocument(
     reviewId: string,
     request: ReviewDocumentMutationRequest,
@@ -92,6 +98,17 @@ export class ReviewCanvasApiClient implements ReviewCanvasApi {
   async getDocument(reviewId: string): Promise<ReviewDocumentSnapshotResponse> {
     return ReviewDocumentSnapshotResponseSchema.parse(
       await this.request(`/reviews/${encodeURIComponent(reviewId)}/document`),
+    );
+  }
+
+  async getDocumentNode(
+    reviewId: string,
+    nodeId: string,
+  ): Promise<ReviewDocumentNodeResponse> {
+    return ReviewDocumentNodeResponseSchema.parse(
+      await this.request(
+        `/reviews/${encodeURIComponent(reviewId)}/document/nodes/${encodeURIComponent(nodeId)}`,
+      ),
     );
   }
 

--- a/packages/progressive-review/src/review-mcp.test.ts
+++ b/packages/progressive-review/src/review-mcp.test.ts
@@ -75,10 +75,38 @@ describe("Review MCP server", () => {
       result: {
         tools: expect.arrayContaining([
           expect.objectContaining({ name: "review_get_document" }),
+          expect.objectContaining({ name: "review_get_node" }),
           expect.objectContaining({ name: "review_insert_node" }),
           expect.objectContaining({ name: "review_reply_comment" }),
         ]),
       },
+    });
+  });
+
+  it("reads and selects a node before authoring it", async () => {
+    const api = fakeApi();
+    const getNode = vi.mocked(api.getDocumentNode);
+    const output = await exchange(api, [
+      {
+        jsonrpc: "2.0",
+        id: "node-1",
+        method: "tools/call",
+        params: {
+          name: "review_get_node",
+          arguments: {
+            reviewId: "11111111-1111-4111-8111-111111111111",
+            nodeId: "next",
+          },
+        },
+      },
+    ]);
+
+    expect(getNode).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "next",
+    );
+    expect(output[0]).toMatchObject({
+      result: { structuredContent: { ok: true, node: { id: "next" } } },
     });
   });
 
@@ -164,6 +192,15 @@ function fakeApi(): ReviewCanvasApi {
     ok: true,
     snapshot,
   }));
+  const getDocumentNode = vi.fn<ReviewCanvasApi["getDocumentNode"]>(
+    async (reviewId, nodeId) => ({
+      ok: true,
+      reviewId,
+      routePath: "/",
+      revision: snapshot.revision,
+      node: snapshot.nodes.find((node) => node.id === nodeId)!,
+    }),
+  );
   const mutateDocument = vi.fn<ReviewCanvasApi["mutateDocument"]>(
     async (_reviewId, request) => ({
       ok: true,
@@ -213,6 +250,7 @@ function fakeApi(): ReviewCanvasApi {
       }),
     ),
     getDocument,
+    getDocumentNode,
     mutateDocument,
     getComments,
     command,

--- a/packages/progressive-review/src/review-mcp.ts
+++ b/packages/progressive-review/src/review-mcp.ts
@@ -147,6 +147,11 @@ async function callReviewTool(
   if (name === "review_get_document") {
     return requireOk(await api.getDocument(reviewId));
   }
+  if (name === "review_get_node") {
+    return requireOk(
+      await api.getDocumentNode(reviewId, requireString(args, "nodeId")),
+    );
+  }
   if (name === "review_list_comments") {
     return requireOk(await api.getComments(reviewId));
   }
@@ -336,8 +341,19 @@ const REVIEW_MCP_TOOLS: JsonValue[] = [
     required: ["reviewId"],
   }),
   tool(
+    "review_get_node",
+    "Read and visibly select one stable node before authoring it.",
+    {
+      properties: {
+        reviewId: BASE_PROPERTIES.reviewId,
+        nodeId: { type: "string" },
+      },
+      required: ["reviewId", "nodeId"],
+    },
+  ),
+  tool(
     "review_replace_document",
-    "Replace or initialize stable Review nodes.",
+    "Replace or initialize stable Review nodes. Select an existing lead node with review_get_node first when replacing a visible document.",
     {
       properties: {
         ...MUTATION_PROPERTIES,
@@ -346,34 +362,50 @@ const REVIEW_MCP_TOOLS: JsonValue[] = [
       required: ["reviewId", "expectedRevision", "nodes"],
     },
   ),
-  tool("review_insert_node", "Insert one stable node at an index.", {
-    properties: {
-      ...MUTATION_PROPERTIES,
-      index: { type: "integer", minimum: 0 },
-      node: nodeSchema(),
+  tool(
+    "review_insert_node",
+    "Insert one stable node at an index. Select the neighboring node with review_get_node first when one exists.",
+    {
+      properties: {
+        ...MUTATION_PROPERTIES,
+        index: { type: "integer", minimum: 0 },
+        node: nodeSchema(),
+      },
+      required: ["reviewId", "expectedRevision", "index", "node"],
     },
-    required: ["reviewId", "expectedRevision", "index", "node"],
-  }),
-  tool("review_update_node", "Update one node without replacing the canvas.", {
-    properties: {
-      ...MUTATION_PROPERTIES,
-      nodeId: { type: "string" },
-      patch: { type: "object" },
+  ),
+  tool(
+    "review_update_node",
+    "Update one node without replacing the canvas. Call review_get_node for this node first.",
+    {
+      properties: {
+        ...MUTATION_PROPERTIES,
+        nodeId: { type: "string" },
+        patch: { type: "object" },
+      },
+      required: ["reviewId", "expectedRevision", "nodeId", "patch"],
     },
-    required: ["reviewId", "expectedRevision", "nodeId", "patch"],
-  }),
-  tool("review_delete_node", "Delete one node by stable ID.", {
-    properties: { ...MUTATION_PROPERTIES, nodeId: { type: "string" } },
-    required: ["reviewId", "expectedRevision", "nodeId"],
-  }),
-  tool("review_move_node", "Move one node to a new index.", {
-    properties: {
-      ...MUTATION_PROPERTIES,
-      nodeId: { type: "string" },
-      index: { type: "integer", minimum: 0 },
+  ),
+  tool(
+    "review_delete_node",
+    "Delete one node by stable ID. Call review_get_node for this node first.",
+    {
+      properties: { ...MUTATION_PROPERTIES, nodeId: { type: "string" } },
+      required: ["reviewId", "expectedRevision", "nodeId"],
     },
-    required: ["reviewId", "expectedRevision", "nodeId", "index"],
-  }),
+  ),
+  tool(
+    "review_move_node",
+    "Move one node to a new index. Call review_get_node for this node first.",
+    {
+      properties: {
+        ...MUTATION_PROPERTIES,
+        nodeId: { type: "string" },
+        index: { type: "integer", minimum: 0 },
+      },
+      required: ["reviewId", "expectedRevision", "nodeId", "index"],
+    },
+  ),
   tool("review_list_comments", "Read Review comment threads.", {
     properties: { reviewId: BASE_PROPERTIES.reviewId },
     required: ["reviewId"],

--- a/packages/progressive-review/src/review-publication-preparation.test.ts
+++ b/packages/progressive-review/src/review-publication-preparation.test.ts
@@ -1,0 +1,53 @@
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { serializeIncrementalReviewDocument } from "./incremental-review-document";
+import { REVIEW_DOCUMENT_BUNDLE_DIR } from "./review-bundle";
+import type { StoredReview } from "./review-home";
+import { prepareReviewDocumentBundle } from "./review-publication-preparation";
+
+let reviewDir: string | undefined;
+
+afterEach(async () => {
+  if (reviewDir) await rm(reviewDir, { recursive: true, force: true });
+  reviewDir = undefined;
+});
+
+describe("incremental Review publication", () => {
+  it("validates the node envelope without compiling its markdown as MDX", async () => {
+    reviewDir = await mkdtemp(
+      path.join(tmpdir(), "review-publish-incremental-"),
+    );
+    await writeFile(
+      path.join(reviewDir, "review.mdx"),
+      serializeIncrementalReviewDocument(1, [
+        {
+          id: "untrusted",
+          kind: "markdown",
+          content: "# Safe\n\n<ComponentThatMustNotExecute />",
+        },
+      ]),
+      "utf8",
+    );
+    const staleBundle = path.join(reviewDir, REVIEW_DOCUMENT_BUNDLE_DIR);
+    await mkdir(staleBundle, { recursive: true });
+    await writeFile(path.join(staleBundle, "review-document.js"), "stale");
+
+    await expect(
+      prepareReviewDocumentBundle({ review: storedReview(reviewDir) }),
+    ).resolves.toEqual({ warnings: [] });
+    await expect(access(staleBundle)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+function storedReview(dir: string): StoredReview {
+  return {
+    dir,
+    review: {
+      uuid: "86df96ed-65ef-46de-9348-c94811e3bb46",
+    },
+  } as StoredReview;
+}

--- a/packages/progressive-review/src/review-publication-preparation.ts
+++ b/packages/progressive-review/src/review-publication-preparation.ts
@@ -1,8 +1,13 @@
+import { readFile, rm } from "node:fs/promises";
 import path from "node:path";
 
 import { patchChangedLines } from "./call-stack-diff";
 import type { ReviewDocumentDiagnostic } from "./compiler/review-document-compiler";
-import { writeReviewDocumentBundle } from "./review-bundle";
+import { parseIncrementalReviewDocument } from "./incremental-review-document";
+import {
+  REVIEW_DOCUMENT_BUNDLE_DIR,
+  writeReviewDocumentBundle,
+} from "./review-bundle";
 import {
   type ReviewDiffFilesResult,
   resolveReviewDiffFiles,
@@ -55,9 +60,22 @@ export async function prepareReviewDocumentBundle(input: {
   review: StoredReview;
 }): Promise<{ warnings: string[] }> {
   const warnings: string[] = [];
+  const reviewPath = path.join(input.review.dir, "review.mdx");
+  const source = await readFile(reviewPath, "utf8");
+  if (parseIncrementalReviewDocument(source)) {
+    // Incremental node content is untrusted runtime markdown. Do not feed it
+    // through the executable MDX compiler; the canvas renders its validated
+    // node projection. Remove any bundle left by a prior compiled revision so
+    // the sealed candidate cannot accidentally serve stale executable code.
+    await rm(path.join(input.review.dir, REVIEW_DOCUMENT_BUNDLE_DIR), {
+      recursive: true,
+      force: true,
+    });
+    return { warnings };
+  }
   const compiled = await span("publish: compile document bundle", () =>
     compileReviewDocumentBundle({
-      reviewPath: path.join(input.review.dir, "review.mdx"),
+      reviewPath,
       reviewDocumentsDir: path.join(input.review.dir, ".review-documents"),
       reviewRootPath: input.review.dir,
       routePath: "/",

--- a/packages/progressive-review/src/server/desktop-server-review-api.test.ts
+++ b/packages/progressive-review/src/server/desktop-server-review-api.test.ts
@@ -117,6 +117,16 @@ describe("Review Desktop document and comment API", () => {
           expectedSourceHash: replaced.ok ? replaced.snapshot.sourceHash : null,
         }),
       ).rejects.toMatchObject({ statusCode: 409 });
+      await expect(
+        client.getDocumentNode(reviewId, "intro"),
+      ).resolves.toMatchObject({
+        ok: true,
+        revision: 1,
+        node: { id: "intro", content: "# Hello" },
+      });
+      await expect(
+        client.getDocumentNode(reviewId, "missing"),
+      ).rejects.toMatchObject({ statusCode: 404 });
 
       await expect(
         client.mutateDocument(reviewId, {

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -317,6 +317,7 @@ export function createGlobalReviewServer(
   const sessions = new Map<string, ActiveReviewSession>();
   const reviewLocks = new Map<string, Promise<void>>();
   const reviewThreads = new Map<string, ReviewThreadsService>();
+  const documentAuthoringTargets = new Map<string, string>();
   const globalClients = new Set<ReviewDesktopEventClient>();
   const tutorial = createTutorialService({
     packageRoot: input.packageRoot,
@@ -472,6 +473,34 @@ export function createGlobalReviewServer(
       snapshot: await readReviewDocumentSnapshot(review),
     });
   });
+  app.get("/reviews/:uuid/document/nodes/:nodeId", async (context) => {
+    const uuid = context.req.param("uuid");
+    const review = await requireStoredReview(uuid);
+    const snapshot = await readReviewDocumentSnapshot(review);
+    const nodeId = context.req.param("nodeId");
+    const node = snapshot.nodes?.find((candidate) => candidate.id === nodeId);
+    if (!node) {
+      throw new ReviewServerError(
+        `Review document node not found: ${nodeId}`,
+        404,
+        "review_document_node_not_found",
+      );
+    }
+    documentAuthoringTargets.set(uuid, nodeId);
+    broadcastGlobal({
+      event: "review-document-authoring-target-changed",
+      uuid,
+      routePath: snapshot.routePath,
+      targetNodeId: nodeId,
+    });
+    return globalJson(200, {
+      ok: true,
+      reviewId: uuid,
+      routePath: snapshot.routePath,
+      revision: snapshot.revision,
+      node,
+    });
+  });
   app.post("/reviews/:uuid/document/mutations", async (context) => {
     const uuid = context.req.param("uuid");
     const review = await requireStoredReview(uuid);
@@ -498,6 +527,14 @@ export function createGlobalReviewServer(
       revision: response.snapshot.revision,
       mutationId: request.mutationId,
     });
+    if (documentAuthoringTargets.delete(uuid)) {
+      broadcastGlobal({
+        event: "review-document-authoring-target-changed",
+        uuid,
+        routePath: response.snapshot.routePath,
+        targetNodeId: null,
+      });
+    }
     return globalJson(200, response);
   });
   app.get("/reviews/:uuid/document/files/:name", async (context) => {

--- a/packages/progressive-review/src/server/session-handler.test.ts
+++ b/packages/progressive-review/src/server/session-handler.test.ts
@@ -9,6 +9,7 @@ import type {
 } from "@dev.fast/review-protocol";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { serializeIncrementalReviewDocument } from "../incremental-review-document";
 import type { PostHogCaptureInput } from "../posthog-capture-client";
 import {
   ProgressiveReviewTelemetry,
@@ -265,6 +266,58 @@ describe("createReviewSessionHandler", () => {
 
       expect(response.status).toBe(200);
       expect(await response.json()).toMatchObject({ ok: true });
+    } finally {
+      await handler.close();
+    }
+  });
+
+  it("serves an incremental snapshot from the session revision", async () => {
+    rootPath = await mkdtemp(path.join(tmpdir(), "review-session-handler-"));
+    const reviewPath = path.join(rootPath, "review.mdx");
+    const sessionUrl = "http://127.0.0.1:5570/sessions/test-session";
+    const token = "session-secret";
+    const reviewUuid = "86df96ed-65ef-46de-9348-c94811e3bb46";
+    await writeFile(
+      reviewPath,
+      serializeIncrementalReviewDocument(3, [
+        { id: "summary", kind: "markdown", content: "# Safe snapshot" },
+      ]),
+      "utf8",
+    );
+    const handler = await createReviewSessionHandler({
+      ...unusedAgentServices,
+      rootPath,
+      toolingRoot: rootPath,
+      reviewPath,
+      reviewUuid,
+      routePath: "/",
+      token,
+      session: {
+        rootPath,
+        baseRef: "HEAD",
+        appUrl: sessionUrl,
+        reviewPath,
+        startedAt: Date.now(),
+      },
+    });
+
+    try {
+      const response = await handler.handle(
+        new Request(new URL("/__progressive-review/document", sessionUrl), {
+          headers: { "x-review-token": token },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        snapshot: {
+          reviewId: reviewUuid,
+          mode: "incremental",
+          revision: 3,
+          nodes: [{ id: "summary", content: "# Safe snapshot" }],
+        },
+      });
     } finally {
       await handler.close();
     }

--- a/packages/progressive-review/src/server/session-handler.ts
+++ b/packages/progressive-review/src/server/session-handler.ts
@@ -16,6 +16,7 @@ import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 
 import type { ReviewAgentHarness, SessionRef } from "../authoring-session";
+import { readReviewDocumentFileSnapshot } from "../incremental-review-document";
 import type { AgentServer } from "../native-agent/native-session";
 import { readReviewDocumentBundle } from "../review-bundle";
 import type { ReviewThreadsService } from "../review-threads-service";
@@ -261,6 +262,25 @@ export async function createReviewSessionHandler(
     }
     return jsonResponse(
       { ok: true, versions: await input.listDocumentVersions() },
+      200,
+    );
+  });
+  app.get(`${API_PREFIX}/document`, async () => {
+    if (!input.reviewUuid) {
+      return jsonResponse(
+        { ok: false, error: "The Review document is unavailable." },
+        404,
+      );
+    }
+    return jsonResponse(
+      {
+        ok: true,
+        snapshot: await readReviewDocumentFileSnapshot({
+          reviewId: input.reviewUuid,
+          routePath: input.routePath,
+          documentPath: input.reviewPath,
+        }),
+      },
       200,
     );
   });

--- a/packages/progressive-review/src/threads-cli.test.ts
+++ b/packages/progressive-review/src/threads-cli.test.ts
@@ -185,6 +185,9 @@ async function makeReview(): Promise<{
     getDocument: async () => {
       throw new Error("Not used by thread CLI tests.");
     },
+    getDocumentNode: async () => {
+      throw new Error("Not used by thread CLI tests.");
+    },
     mutateDocument: async () => {
       throw new Error("Not used by thread CLI tests.");
     },

--- a/packages/review-protocol/src/contracts.test.ts
+++ b/packages/review-protocol/src/contracts.test.ts
@@ -217,6 +217,16 @@ const contracts: Array<[string, ZodType, JsonObject]> = [
     },
   ],
   [
+    "desktop document authoring target event",
+    ReviewDesktopGlobalEventSchema,
+    {
+      event: "review-document-authoring-target-changed",
+      uuid: reviewRecord.uuid,
+      routePath: "/",
+      targetNodeId: "summary",
+    },
+  ],
+  [
     "desktop review deleted event",
     ReviewDesktopGlobalEventSchema,
     {

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1064,6 +1064,20 @@ export interface ReviewCanvasSettingsContent {
   install?: ReviewCanvasInstallContent;
 }
 
+/**
+ * A host-owned, read-only projection of the current incremental document.
+ * The canvas subscribes to this bridge instead of performing network or
+ * filesystem I/O itself.
+ */
+export interface ReviewDocumentStoreBridge {
+  getSnapshot(): ReviewDocumentSnapshot;
+  subscribe(listener: () => void): ReviewDisposable;
+}
+
+export type ReviewCanvasDocument =
+  | { kind: "compiled"; bundle: unknown }
+  | { kind: "incremental"; store: ReviewDocumentStoreBridge };
+
 export type ReviewCanvasContent =
   | { kind: "loading" }
   | {
@@ -1127,7 +1141,7 @@ export type ReviewCanvasContent =
   | {
       kind: "session";
       bridge: ReviewCanvasBridge;
-      document: Promise<unknown>;
+      document: Promise<ReviewCanvasDocument>;
       softwareMap: Promise<unknown | null>;
       softwareMapEnabled: boolean;
       reviewErrors: readonly ReviewListError[];

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -678,6 +678,13 @@ export const ReviewDocumentNodeSchema = z.strictObject({
 });
 export type ReviewDocumentNode = z.infer<typeof ReviewDocumentNodeSchema>;
 
+export const ReviewDocumentAuthoringTargetSchema = z.strictObject({
+  targetNodeId: reviewNodeIdSchema,
+});
+export type ReviewDocumentAuthoringTarget = z.infer<
+  typeof ReviewDocumentAuthoringTargetSchema
+>;
+
 export const ReviewDocumentSnapshotSchema = z.strictObject({
   reviewId: z.uuid({ error: "must be a UUID" }),
   routePath: routePathSchema,
@@ -1071,6 +1078,7 @@ export interface ReviewCanvasSettingsContent {
  */
 export interface ReviewDocumentStoreBridge {
   getSnapshot(): ReviewDocumentSnapshot;
+  getAuthoringTargetNodeId(): string | null;
   subscribe(listener: () => void): ReviewDisposable;
 }
 
@@ -1391,6 +1399,20 @@ export type ReviewDocumentSnapshotResponse = z.infer<
   typeof ReviewDocumentSnapshotResponseSchema
 >;
 
+export const ReviewDocumentNodeResponseSchema = z.discriminatedUnion("ok", [
+  z.strictObject({
+    ok: z.literal(true),
+    reviewId: z.uuid({ error: "must be a UUID" }),
+    routePath: routePathSchema,
+    revision: nonNegativeInteger,
+    node: ReviewDocumentNodeSchema,
+  }),
+  ReviewErrorResponseSchema,
+]);
+export type ReviewDocumentNodeResponse = z.infer<
+  typeof ReviewDocumentNodeResponseSchema
+>;
+
 export const ReviewDocumentMutationResponseSchema = z.discriminatedUnion("ok", [
   z.strictObject({
     ok: z.literal(true),
@@ -1688,6 +1710,12 @@ export const ReviewDesktopGlobalEventSchema = z.discriminatedUnion("event", [
     routePath: routePathSchema,
     revision: nonNegativeInteger,
     mutationId: threadTargetNonEmptyStringSchema,
+  }),
+  z.strictObject({
+    event: z.literal("review-document-authoring-target-changed"),
+    uuid: z.uuid({ error: "must be a UUID" }),
+    routePath: routePathSchema,
+    targetNodeId: reviewNodeIdSchema.nullable(),
   }),
   z.strictObject({
     event: z.literal("session-closed"),


### PR DESCRIPTION
Stacked on #132 and #131. The canvas consumes authenticated incremental document snapshots and reconciles newer revisions while preserving unchanged node identities and local view state. Rich MDX keeps its compiled rendering path; sealed and historical incremental documents load through the session API.

The renderer safely displays markdown, callout, and code nodes without evaluating runtime MDX. Inserted nodes ease into place, and `review_get_node` selects a node with animated activity in the left gutter and an outline. Successful mutations clear activity. Reduced-motion preferences disable motion.

Publication recognizes incremental documents, skips executable MDX compilation, and removes stale compiled bundles. Global comment events apply across sessions using the shared revision stream from #132.

Validation: progressive-review 162 files / 1,186 tests, review-protocol 4 files / 99 tests, desktop scripts and 90 desktop TypeScript tests; TypeScript, lint, formatting, and diff checks passed. Computer-use verification in the rebuilt isolated app confirmed successive API comment updates without reopening the canvas and rich MDX authored entirely through MCP rendering AnchorLink and native CodePeek after publication. Previous computer-use verification covered live node mutations, selection activity, gutter placement, insertion transitions, and incremental republishing.
