### PR TITLE
perf(traces): native R2 client, local-first trace show, traces-off switch

### DIFF
--- a/packages/progressive-review/src/cli-runner.ts
+++ b/packages/progressive-review/src/cli-runner.ts
@@ -812,19 +812,31 @@ export async function runProgressiveReviewCli(
       .description("Survey a trace or show an exact event")
       .option("--trace <name>", "trace name; omit for the main trace")
       .option(
-        "--event <index>",
-        "print the complete text of one event",
-        (value: string) => Number.parseInt(value, 10),
+        "--event <indexes>",
+        "print the complete text of one event, or several: --event 43,62,70",
+        (value: string) =>
+          value.split(",").map((part) => {
+            const index = Number.parseInt(part.trim(), 10);
+            if (!Number.isInteger(index) || index < 0) {
+              throw new Error(`--event expects non-negative integers, got ${JSON.stringify(part)}.`);
+            }
+            return index;
+          }),
       )
-      .option("--kind <kind>", "only list user|assistant|tool|separator rows"),
+      .option("--kind <kind>", "only list user|assistant|tool|separator rows")
+      .option(
+        "--refresh",
+        "check R2 for a newer copy of the trace before reading the local one",
+      ),
     "plain",
   ).action(
     async (
       sessionId: string,
       options: {
         trace?: string;
-        event?: number;
+        event?: number[];
         kind?: string;
+        refresh?: boolean;
         json?: boolean;
       },
     ) => {
@@ -832,8 +844,9 @@ export async function runProgressiveReviewCli(
         cwd,
         sessionId,
         trace: options.trace,
-        eventIndex: options.event,
+        eventIndexes: options.event,
         kind: options.kind,
+        refresh: options.refresh,
         json: options.json,
         stdout: input.stdout,
         stderr: input.stderr,

--- a/packages/progressive-review/src/r2-client.ts
+++ b/packages/progressive-review/src/r2-client.ts
@@ -130,7 +130,11 @@ export async function r2HeadSize(
   config: R2ClientConfig,
   key: string,
 ): Promise<number | null> {
-  const response = await r2Request(config, { method: "HEAD", key, timeoutMs: 10_000 });
+  const response = await r2Request(config, {
+    method: "HEAD",
+    key,
+    timeoutMs: 10_000,
+  });
   if (response.status === 404) return null;
   if (response.status < 200 || response.status >= 300) {
     throw new Error(`R2 HEAD ${key} returned ${response.status}.`);
@@ -158,7 +162,12 @@ export async function r2PutBytes(
   body: Buffer,
   contentType = "application/octet-stream",
 ): Promise<void> {
-  const response = await r2Request(config, { method: "PUT", key, body, contentType });
+  const response = await r2Request(config, {
+    method: "PUT",
+    key,
+    body,
+    contentType,
+  });
   if (response.status < 200 || response.status >= 300) {
     throw new Error(`R2 PUT ${key} returned ${response.status}.`);
   }
@@ -182,12 +191,14 @@ export async function r2ListKeys(
       throw new Error(`R2 LIST ${prefix} returned ${response.status}.`);
     }
     const xml = response.body.toString("utf8");
-    for (const match of xml.matchAll(/<Key>([^<]*)<\/Key>/g)) keys.push(decodeXml(match[1]));
+    for (const match of xml.matchAll(/<Key>([^<]*)<\/Key>/g))
+      keys.push(decodeXml(match[1]));
     for (const match of xml.matchAll(/<Prefix>([^<]*)<\/Prefix>/g)) {
       const value = decodeXml(match[1]);
       if (value !== prefix) prefixes.push(value);
     }
-    const token = /<NextContinuationToken>([^<]*)<\/NextContinuationToken>/.exec(xml);
+    const token =
+      /<NextContinuationToken>([^<]*)<\/NextContinuationToken>/.exec(xml);
     continuation = token ? decodeXml(token[1]) : undefined;
   } while (continuation);
   return { keys, prefixes };

--- a/packages/progressive-review/src/r2-client.ts
+++ b/packages/progressive-review/src/r2-client.ts
@@ -1,0 +1,203 @@
+import { createHash, createHmac } from "node:crypto";
+
+import { span } from "./startup-trace";
+
+/**
+ * In-process S3-compatible client for the trace bucket (Cloudflare R2),
+ * signing requests with SigV4 over `fetch`. It replaces one `aws` CLI spawn
+ * per object operation (~0.5–1s each) with a plain HTTPS round-trip.
+ */
+export interface R2ClientConfig {
+  bucket: string;
+  endpoint: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+}
+
+const REGION = "auto";
+const SERVICE = "s3";
+const EMPTY_SHA256 = createHash("sha256").update("").digest("hex");
+
+function sha256Hex(body: Uint8Array | string): string {
+  return createHash("sha256").update(body).digest("hex");
+}
+
+function hmac(key: Buffer | string, value: string): Buffer {
+  return createHmac("sha256", key).update(value, "utf8").digest();
+}
+
+function encodePathSegment(segment: string): string {
+  return encodeURIComponent(segment).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+function canonicalPath(bucket: string, key: string): string {
+  return `/${encodePathSegment(bucket)}/${key.split("/").map(encodePathSegment).join("/")}`;
+}
+
+function canonicalQuery(query: Record<string, string>): string {
+  return Object.keys(query)
+    .sort()
+    .map((k) => `${encodePathSegment(k)}=${encodePathSegment(query[k])}`)
+    .join("&");
+}
+
+function amzDate(now: Date): { date: string; stamp: string } {
+  const iso = now.toISOString().replace(/[:-]|\.\d{3}/g, "");
+  return { stamp: iso, date: iso.slice(0, 8) };
+}
+
+export interface R2Response {
+  status: number;
+  headers: Headers;
+  body: Buffer;
+}
+
+export async function r2Request(
+  config: R2ClientConfig,
+  input: {
+    method: "GET" | "HEAD" | "PUT";
+    key: string;
+    query?: Record<string, string>;
+    body?: Buffer;
+    contentType?: string;
+    timeoutMs?: number;
+  },
+): Promise<R2Response> {
+  const endpoint = new URL(config.endpoint);
+  const pathName = canonicalPath(config.bucket, input.key);
+  const query = input.query ?? {};
+  const url = new URL(`${endpoint.origin}${pathName}`);
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+
+  const payloadHash = input.body ? sha256Hex(input.body) : EMPTY_SHA256;
+  const { stamp, date } = amzDate(new Date());
+  const headers: Record<string, string> = {
+    host: endpoint.host,
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": stamp,
+  };
+  if (input.contentType) headers["content-type"] = input.contentType;
+  const signedHeaderNames = Object.keys(headers).sort();
+  const canonicalHeaders = signedHeaderNames
+    .map((name) => `${name}:${headers[name].trim()}\n`)
+    .join("");
+  const signedHeaders = signedHeaderNames.join(";");
+  const canonicalRequest = [
+    input.method,
+    pathName,
+    canonicalQuery(query),
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+  const scope = `${date}/${REGION}/${SERVICE}/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    stamp,
+    scope,
+    sha256Hex(canonicalRequest),
+  ].join("\n");
+  const signingKey = hmac(
+    hmac(hmac(hmac(`AWS4${config.secretAccessKey}`, date), REGION), SERVICE),
+    "aws4_request",
+  );
+  const signature = createHmac("sha256", signingKey)
+    .update(stringToSign, "utf8")
+    .digest("hex");
+  const authorization =
+    `AWS4-HMAC-SHA256 Credential=${config.accessKeyId}/${scope}, ` +
+    `SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+  const { host: _host, ...requestHeaders } = headers;
+  const label = `r2 ${input.method} ${input.key}${input.query?.prefix ? ` prefix=${input.query.prefix}` : ""}`;
+  return span(label, async () => {
+    const response = await fetch(url, {
+      method: input.method,
+      headers: { ...requestHeaders, authorization },
+      body: input.body ? new Uint8Array(input.body) : undefined,
+      signal: AbortSignal.timeout(input.timeoutMs ?? 60_000),
+    });
+    const body = Buffer.from(await response.arrayBuffer());
+    return { status: response.status, headers: response.headers, body };
+  });
+}
+
+/** Object size, or null when it does not exist. Other failures throw. */
+export async function r2HeadSize(
+  config: R2ClientConfig,
+  key: string,
+): Promise<number | null> {
+  const response = await r2Request(config, { method: "HEAD", key, timeoutMs: 10_000 });
+  if (response.status === 404) return null;
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`R2 HEAD ${key} returned ${response.status}.`);
+  }
+  const length = response.headers.get("content-length");
+  return length ? Number.parseInt(length, 10) : null;
+}
+
+/** Object bytes, or null when it does not exist. Other failures throw. */
+export async function r2GetBytes(
+  config: R2ClientConfig,
+  key: string,
+): Promise<Buffer | null> {
+  const response = await r2Request(config, { method: "GET", key });
+  if (response.status === 404) return null;
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`R2 GET ${key} returned ${response.status}.`);
+  }
+  return response.body;
+}
+
+export async function r2PutBytes(
+  config: R2ClientConfig,
+  key: string,
+  body: Buffer,
+  contentType = "application/octet-stream",
+): Promise<void> {
+  const response = await r2Request(config, { method: "PUT", key, body, contentType });
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`R2 PUT ${key} returned ${response.status}.`);
+  }
+}
+
+/** Keys under a prefix (ListObjectsV2, one level when `delimiter` is set). */
+export async function r2ListKeys(
+  config: R2ClientConfig,
+  prefix: string,
+  options: { delimiter?: string } = {},
+): Promise<{ keys: string[]; prefixes: string[] }> {
+  const keys: string[] = [];
+  const prefixes: string[] = [];
+  let continuation: string | undefined;
+  do {
+    const query: Record<string, string> = { "list-type": "2", prefix };
+    if (options.delimiter) query.delimiter = options.delimiter;
+    if (continuation) query["continuation-token"] = continuation;
+    const response = await r2Request(config, { method: "GET", key: "", query });
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`R2 LIST ${prefix} returned ${response.status}.`);
+    }
+    const xml = response.body.toString("utf8");
+    for (const match of xml.matchAll(/<Key>([^<]*)<\/Key>/g)) keys.push(decodeXml(match[1]));
+    for (const match of xml.matchAll(/<Prefix>([^<]*)<\/Prefix>/g)) {
+      const value = decodeXml(match[1]);
+      if (value !== prefix) prefixes.push(value);
+    }
+    const token = /<NextContinuationToken>([^<]*)<\/NextContinuationToken>/.exec(xml);
+    continuation = token ? decodeXml(token[1]) : undefined;
+  } while (continuation);
+  return { keys, prefixes };
+}
+
+function decodeXml(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}

--- a/packages/progressive-review/src/review-agent-traces.ts
+++ b/packages/progressive-review/src/review-agent-traces.ts
@@ -36,7 +36,13 @@ import {
   parseAgentTraceJsonl,
   sniffAgentTraceHarness,
 } from "./agent-trace-parser";
-import { r2GetBytes, r2HeadSize, r2ListKeys, r2PutBytes, r2Request } from "./r2-client";
+import {
+  r2GetBytes,
+  r2HeadSize,
+  r2ListKeys,
+  r2PutBytes,
+  r2Request,
+} from "./r2-client";
 import { traceCommand } from "./startup-trace";
 
 /**
@@ -121,7 +127,6 @@ export interface ReviewTraceDoctorResult {
   reachable: boolean;
   error?: string;
 }
-
 
 export function isTraceR2Configured(): boolean {
   if (process.env.TRACE_R2_MODE === "mock") return true;
@@ -481,12 +486,15 @@ async function mapWithConcurrency<T, R>(
 ): Promise<R[]> {
   const results: R[] = new Array(items.length);
   let next = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (next < items.length) {
-      const index = next++;
-      results[index] = await work(items[index]);
-    }
-  });
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (next < items.length) {
+        const index = next++;
+        results[index] = await work(items[index]);
+      }
+    },
+  );
   await Promise.all(workers);
   return results;
 }
@@ -514,7 +522,9 @@ export async function pullReviewTraceCorpus(input: {
         refresh: true,
       });
       if (!main) return { sessionRef, main: null, subagents: [] };
-      const subagentNames = input.mainOnly ? [] : (sessionRef.traces ?? main.subagents);
+      const subagentNames = input.mainOnly
+        ? []
+        : (sessionRef.traces ?? main.subagents);
       const subagents = await mapWithConcurrency(
         subagentNames,
         TRACE_PULL_CONCURRENCY,

--- a/packages/progressive-review/src/review-agent-traces.ts
+++ b/packages/progressive-review/src/review-agent-traces.ts
@@ -134,6 +134,7 @@ export async function listReviewTraceSessions(input: {
   baseCommit: string;
   headCommit: string;
 }): Promise<ReviewTraceSessionDescriptor[]> {
+  if (reviewTracesDisabled()) return [];
   const sessions = new Map<string, ReviewTraceSessionRef>();
   const commits = await commitsWithTrailers(input);
   for (const commit of commits) {
@@ -471,7 +472,6 @@ export function traceSearchCorpusDir(): string {
   return dir;
 }
 
-export async function pullReviewTraceCorpus(input: {
 const TRACE_PULL_CONCURRENCY = 6;
 
 async function mapWithConcurrency<T, R>(
@@ -491,6 +491,7 @@ async function mapWithConcurrency<T, R>(
   return results;
 }
 
+export async function pullReviewTraceCorpus(input: {
   repo: { owner: string; repo: string };
   sessions: ReviewTracePullSession[];
   mainOnly?: boolean;
@@ -598,6 +599,7 @@ function findNormalizedTraceFile(
 }
 
 function findNormalizedSessionDirs(sessionId: string): string[] {
+  if (reviewTracesDisabled()) return [];
   const root = traceSearchCorpusDir();
   const session = corpusPathSegment(sessionId, "session");
   const results: string[] = [];
@@ -973,6 +975,7 @@ export interface LocalTraceDiscovery {
 export async function findLocalTrace(
   sessionId: string,
 ): Promise<LocalTraceDiscovery | null> {
+  if (reviewTracesDisabled()) return null;
   if (!sessionIdSchema.safeParse(sessionId).success) return null;
 
   const claudeRoot =
@@ -1534,7 +1537,15 @@ export function traceEnvValue(name: string): string | undefined {
   return process.env[name] ?? traceEnvFile()[name];
 }
 
+// DEV_FAST_REVIEW_TRACES=off makes trace storage absent end to end (no R2,
+// no local corpus, no local transcripts, no sessions listed), so a review can
+// be authored exactly as it would be on a machine without trace capture.
+export function reviewTracesDisabled(): boolean {
+  return process.env.DEV_FAST_REVIEW_TRACES === "off";
+}
+
 export function traceR2Config(): TraceR2Config | null {
+  if (reviewTracesDisabled()) return null;
   const bucket = traceEnvValue("TRACE_R2_BUCKET");
   const endpoint = traceEnvValue("TRACE_R2_ENDPOINT");
   const accessKeyId =

--- a/packages/progressive-review/src/review-agent-traces.ts
+++ b/packages/progressive-review/src/review-agent-traces.ts
@@ -46,7 +46,6 @@ import {
 const RECORD_SEPARATOR = "\u001e";
 const FIELD_SEPARATOR = "\u001f";
 const R2_COMMIT_LOOKUP_LIMIT = 30;
-const REMOTE_HEAD_TTL_MS = 15_000;
 
 export interface ReviewTraceCommitRef {
   sha: string;
@@ -121,7 +120,6 @@ export interface ReviewTraceDoctorResult {
   error?: string;
 }
 
-const lastCheckedTimes = new Map<string, number>();
 
 export function isTraceR2Configured(): boolean {
   if (process.env.TRACE_R2_MODE === "mock") return true;
@@ -222,14 +220,14 @@ export async function loadReviewAgentTrace(input: {
     ? normalizedTracePath(normalizeRepo(input.repo), sessionId, traceName)
     : findNormalizedTraceFile(sessionId, traceName);
   let normalized = normalizedPath ? readNormalizedTrace(normalizedPath) : null;
-  const now = Date.now();
-  const lastChecked = lastCheckedTimes.get(traceKey) ?? 0;
-  const canUseWithoutCheck =
-    normalized && !input.refresh && now - lastChecked < REMOTE_HEAD_TTL_MS;
+  // A materialized trace is served as-is: every `review trace show` used to
+  // pay an R2 HEAD (an `aws` spawn) per process to look for growth, on traces
+  // that scaffold already pinned. Callers that need the latest copy
+  // (`review trace pull`, scaffold) pass `refresh`.
+  const canUseWithoutCheck = normalized && !input.refresh;
 
   if (!canUseWithoutCheck) {
     const remoteSize = await r2HeadObjectSize(traceKey);
-    lastCheckedTimes.set(traceKey, now);
     const mustMaterialize =
       remoteSize !== null &&
       (!normalized || remoteSize > normalized.metadata.source.bytes);
@@ -1487,7 +1485,6 @@ let cachedTraceEnv: Record<string, string> | null = null;
 
 export function clearTraceEnvCache(): void {
   cachedTraceEnv = null;
-  lastCheckedTimes.clear();
 }
 
 function traceEnvFile(): Record<string, string> {

--- a/packages/progressive-review/src/review-agent-traces.ts
+++ b/packages/progressive-review/src/review-agent-traces.ts
@@ -36,6 +36,8 @@ import {
   parseAgentTraceJsonl,
   sniffAgentTraceHarness,
 } from "./agent-trace-parser";
+import { r2GetBytes, r2HeadSize, r2ListKeys, r2PutBytes, r2Request } from "./r2-client";
+import { traceCommand } from "./startup-trace";
 
 /**
  * Resolves the agent sessions behind a review's change range, loads their
@@ -470,6 +472,25 @@ export function traceSearchCorpusDir(): string {
 }
 
 export async function pullReviewTraceCorpus(input: {
+const TRACE_PULL_CONCURRENCY = 6;
+
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  work: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (next < items.length) {
+      const index = next++;
+      results[index] = await work(items[index]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
   repo: { owner: string; repo: string };
   sessions: ReviewTracePullSession[];
   mainOnly?: boolean;
@@ -480,12 +501,36 @@ export async function pullReviewTraceCorpus(input: {
   const sessions: ReviewTracePullSessionResult[] = [];
   const unavailableSessions: string[] = [];
   const paths: string[] = [];
-  for (const sessionRef of input.sessions) {
-    const main = await loadReviewAgentTrace({
-      sessionId: sessionRef.id,
-      repo: input.repo,
-      refresh: true,
-    });
+  // Sessions and their subagent traces download concurrently; the pull used to
+  // walk them one object at a time, each a serial round-trip.
+  const pulled = await mapWithConcurrency(
+    input.sessions,
+    TRACE_PULL_CONCURRENCY,
+    async (sessionRef) => {
+      const main = await loadReviewAgentTrace({
+        sessionId: sessionRef.id,
+        repo: input.repo,
+        refresh: true,
+      });
+      if (!main) return { sessionRef, main: null, subagents: [] };
+      const subagentNames = input.mainOnly ? [] : (sessionRef.traces ?? main.subagents);
+      const subagents = await mapWithConcurrency(
+        subagentNames,
+        TRACE_PULL_CONCURRENCY,
+        async (traceName) => ({
+          traceName,
+          loaded: await loadReviewAgentTrace({
+            sessionId: sessionRef.id,
+            trace: traceName,
+            repo: input.repo,
+            refresh: true,
+          }),
+        }),
+      );
+      return { sessionRef, main, subagents };
+    },
+  );
+  for (const { sessionRef, main, subagents } of pulled) {
     if (!main) {
       unavailableSessions.push(sessionRef.id);
       continue;
@@ -493,22 +538,13 @@ export async function pullReviewTraceCorpus(input: {
     paths.push(normalizedTracePath(input.repo, sessionRef.id, "main"));
     let traceCount = 1;
     let eventCount = main.trace.events.length;
-    if (!input.mainOnly) {
-      for (const traceName of sessionRef.traces ?? main.subagents) {
-        const subagent = await loadReviewAgentTrace({
-          sessionId: sessionRef.id,
-          trace: traceName,
-          repo: input.repo,
-          refresh: true,
-        });
-        if (subagent) {
-          paths.push(normalizedTracePath(input.repo, sessionRef.id, traceName));
-          traceCount += 1;
-          eventCount += subagent.trace.events.length;
-        }
+    for (const { traceName, loaded } of subagents) {
+      if (loaded) {
+        paths.push(normalizedTracePath(input.repo, sessionRef.id, traceName));
+        traceCount += 1;
+        eventCount += loaded.trace.events.length;
       }
     }
-
     sessions.push({
       session: sessionRef.id,
       traces: traceCount,
@@ -1255,27 +1291,15 @@ export async function checkReviewTraceDoctor(input?: {
   }
 
   try {
-    await execFileAsync(
-      "aws",
-      [
-        "--region",
-        "auto",
-        "--endpoint-url",
-        config.endpoint,
-        "s3api",
-        "head-bucket",
-        "--bucket",
-        config.bucket,
-      ],
-      {
-        timeout: 15_000,
-        env: {
-          ...process.env,
-          AWS_ACCESS_KEY_ID: config.accessKeyId,
-          AWS_SECRET_ACCESS_KEY: config.secretAccessKey,
-        },
-      },
-    );
+    const probe = await r2Request(config, {
+      method: "GET",
+      key: "",
+      query: { "list-type": "2", "max-keys": "1" },
+      timeoutMs: 15_000,
+    });
+    if (probe.status < 200 || probe.status >= 300) {
+      throw new Error(`R2 bucket ${config.bucket} returned ${probe.status}.`);
+    }
     return {
       ok: true,
       envPath,
@@ -1523,7 +1547,24 @@ export function traceR2Config(): TraceR2Config | null {
   return { bucket, endpoint, accessKeyId, secretAccessKey };
 }
 
-const execFileAsync = promisify(execFile);
+const execFilePromise = promisify(execFile);
+
+// Every spawn here (aws s3api, git) is a `$ …` span when tracing is enabled.
+function execFileAsync(
+  file: string,
+  args: string[],
+  options: Parameters<typeof execFilePromise>[2] = {},
+): Promise<{ stdout: string; stderr: string }> {
+  return traceCommand(
+    file,
+    args,
+    async () => {
+      const result = await execFilePromise(file, args, options);
+      return { stdout: String(result.stdout), stderr: String(result.stderr) };
+    },
+    { cwd: options?.cwd === undefined ? undefined : String(options.cwd) },
+  );
+}
 
 export async function r2HeadObjectSize(key: string): Promise<number | null> {
   if (process.env.TRACE_R2_MODE === "mock") {
@@ -1541,33 +1582,7 @@ export async function r2HeadObjectSize(key: string): Promise<number | null> {
   const config = traceR2Config();
   if (!config) return null;
   try {
-    const proc = await execFileAsync(
-      "aws",
-      [
-        "--region",
-        "auto",
-        "--endpoint-url",
-        config.endpoint,
-        "s3api",
-        "head-object",
-        "--bucket",
-        config.bucket,
-        "--key",
-        key,
-      ],
-      {
-        timeout: 10_000,
-        env: {
-          ...process.env,
-          AWS_ACCESS_KEY_ID: config.accessKeyId,
-          AWS_SECRET_ACCESS_KEY: config.secretAccessKey,
-        },
-      },
-    );
-    const parsed = JSON.parse(proc.stdout) as { ContentLength?: number };
-    return typeof parsed.ContentLength === "number"
-      ? parsed.ContentLength
-      : null;
+    return await r2HeadSize(config, key);
   } catch {
     return null;
   }
@@ -1595,32 +1610,10 @@ export async function r2GetObject(
   const config = traceR2Config();
   if (!config) return false;
   try {
-    await execFileAsync(
-      "aws",
-      [
-        "--region",
-        "auto",
-        "--endpoint-url",
-        config.endpoint,
-        "s3api",
-        "get-object",
-        "--bucket",
-        config.bucket,
-        "--key",
-        key,
-        destPath,
-      ],
-      {
-        timeout: 60_000,
-        maxBuffer: 16 * 1024 * 1024,
-        env: {
-          ...process.env,
-          AWS_ACCESS_KEY_ID: config.accessKeyId,
-          AWS_SECRET_ACCESS_KEY: config.secretAccessKey,
-        },
-      },
-    );
-    return existsSync(destPath);
+    const bytes = await r2GetBytes(config, key);
+    if (bytes === null) return false;
+    writeFileSync(destPath, bytes);
+    return true;
   } catch {
     return false;
   }
@@ -1679,28 +1672,7 @@ export async function r2PutFile(
   const config = traceR2Config();
   if (!config) return false;
   try {
-    await execFileAsync(
-      "aws",
-      [
-        "--region",
-        "auto",
-        "--endpoint-url",
-        config.endpoint,
-        "s3",
-        "cp",
-        "--only-show-errors",
-        filePath,
-        `s3://${config.bucket}/${key}`,
-      ],
-      {
-        timeout: 60_000,
-        env: {
-          ...process.env,
-          AWS_ACCESS_KEY_ID: config.accessKeyId,
-          AWS_SECRET_ACCESS_KEY: config.secretAccessKey,
-        },
-      },
-    );
+    await r2PutBytes(config, key, readFileSync(filePath));
     return true;
   } catch {
     return false;
@@ -1797,39 +1769,10 @@ export async function listSessionSubagents(
     const config = traceR2Config();
     if (config) {
       try {
-        const proc = await execFileAsync(
-          "aws",
-          [
-            "--region",
-            "auto",
-            "--endpoint-url",
-            config.endpoint,
-            "s3api",
-            "list-objects-v2",
-            "--bucket",
-            config.bucket,
-            "--prefix",
-            prefix,
-          ],
-          {
-            timeout: 10_000,
-            env: {
-              ...process.env,
-              AWS_ACCESS_KEY_ID: config.accessKeyId,
-              AWS_SECRET_ACCESS_KEY: config.secretAccessKey,
-            },
-          },
-        );
-        const parsed = JSON.parse(proc.stdout) as {
-          Contents?: Array<{ Key?: string }>;
-        };
-        for (const item of parsed.Contents ?? []) {
-          if (
-            item.Key &&
-            item.Key.startsWith(prefix) &&
-            item.Key.endsWith(".jsonl")
-          ) {
-            const subName = item.Key.slice(prefix.length, -6);
+        const listed = await r2ListKeys(config, prefix);
+        for (const key of listed.keys) {
+          if (key.startsWith(prefix) && key.endsWith(".jsonl")) {
+            const subName = key.slice(prefix.length, -6);
             if (subName) subagents.add(subName);
           }
         }

--- a/packages/progressive-review/src/review-agent-traces.ts
+++ b/packages/progressive-review/src/review-agent-traces.ts
@@ -37,12 +37,12 @@ import {
   sniffAgentTraceHarness,
 } from "./agent-trace-parser";
 import {
-  r2GetBytes,
-  r2HeadSize,
-  r2ListKeys,
-  r2PutBytes,
-  r2Request,
-} from "./r2-client";
+  s3GetBytes,
+  s3HeadSize,
+  s3ListKeys,
+  s3PutBytes,
+  s3Request,
+} from "./s3-client";
 import { traceCommand } from "./startup-trace";
 
 /**
@@ -1304,7 +1304,7 @@ export async function checkReviewTraceDoctor(input?: {
   }
 
   try {
-    const probe = await r2Request(config, {
+    const probe = await s3Request(config, {
       method: "GET",
       key: "",
       query: { "list-type": "2", "max-keys": "1" },
@@ -1516,6 +1516,7 @@ export interface TraceR2Config {
   endpoint: string;
   accessKeyId: string;
   secretAccessKey: string;
+  region?: string;
 }
 
 let cachedTraceEnv: Record<string, string> | null = null;
@@ -1565,7 +1566,16 @@ export function traceR2Config(): TraceR2Config | null {
     traceEnvValue("TRACE_R2_SECRET_ACCESS_KEY") ??
     traceEnvValue("AWS_SECRET_ACCESS_KEY");
   if (!bucket || !endpoint || !accessKeyId || !secretAccessKey) return null;
-  return { bucket, endpoint, accessKeyId, secretAccessKey };
+  // Any S3-compatible store works; TRACE_S3_REGION is only needed where the
+  // provider requires a real SigV4 region (AWS S3). R2 accepts the default.
+  const region = traceEnvValue("TRACE_S3_REGION");
+  return {
+    bucket,
+    endpoint,
+    accessKeyId,
+    secretAccessKey,
+    ...(region ? { region } : {}),
+  };
 }
 
 const execFilePromise = promisify(execFile);
@@ -1603,7 +1613,7 @@ export async function r2HeadObjectSize(key: string): Promise<number | null> {
   const config = traceR2Config();
   if (!config) return null;
   try {
-    return await r2HeadSize(config, key);
+    return await s3HeadSize(config, key);
   } catch {
     return null;
   }
@@ -1631,7 +1641,7 @@ export async function r2GetObject(
   const config = traceR2Config();
   if (!config) return false;
   try {
-    const bytes = await r2GetBytes(config, key);
+    const bytes = await s3GetBytes(config, key);
     if (bytes === null) return false;
     writeFileSync(destPath, bytes);
     return true;
@@ -1693,7 +1703,7 @@ export async function r2PutFile(
   const config = traceR2Config();
   if (!config) return false;
   try {
-    await r2PutBytes(config, key, readFileSync(filePath));
+    await s3PutBytes(config, key, readFileSync(filePath));
     return true;
   } catch {
     return false;
@@ -1790,7 +1800,7 @@ export async function listSessionSubagents(
     const config = traceR2Config();
     if (config) {
       try {
-        const listed = await r2ListKeys(config, prefix);
+        const listed = await s3ListKeys(config, prefix);
         for (const key of listed.keys) {
           if (key.startsWith(prefix) && key.endsWith(".jsonl")) {
             const subName = key.slice(prefix.length, -6);

--- a/packages/progressive-review/src/s3-client.ts
+++ b/packages/progressive-review/src/s3-client.ts
@@ -3,18 +3,22 @@ import { createHash, createHmac } from "node:crypto";
 import { span } from "./startup-trace";
 
 /**
- * In-process S3-compatible client for the trace bucket (Cloudflare R2),
- * signing requests with SigV4 over `fetch`. It replaces one `aws` CLI spawn
- * per object operation (~0.5–1s each) with a plain HTTPS round-trip.
+ * In-process S3-compatible client for the trace bucket, signing requests
+ * with SigV4 over `fetch`. Works against any S3 API (AWS S3, Cloudflare R2,
+ * MinIO, …); nothing here is vendor-specific. It replaces one `aws` CLI
+ * spawn per object operation (~0.5–1s each) with a plain HTTPS round-trip.
  */
-export interface R2ClientConfig {
+export interface S3ClientConfig {
   bucket: string;
   endpoint: string;
   accessKeyId: string;
   secretAccessKey: string;
+  // SigV4 signing region. R2 and MinIO accept "auto"; AWS S3 needs the
+  // bucket's region (for example "us-east-1").
+  region?: string;
 }
 
-const REGION = "auto";
+const DEFAULT_REGION = "auto";
 const SERVICE = "s3";
 const EMPTY_SHA256 = createHash("sha256").update("").digest("hex");
 
@@ -49,14 +53,14 @@ function amzDate(now: Date): { date: string; stamp: string } {
   return { stamp: iso, date: iso.slice(0, 8) };
 }
 
-export interface R2Response {
+export interface S3Response {
   status: number;
   headers: Headers;
   body: Buffer;
 }
 
-export async function r2Request(
-  config: R2ClientConfig,
+export async function s3Request(
+  config: S3ClientConfig,
   input: {
     method: "GET" | "HEAD" | "PUT";
     key: string;
@@ -65,7 +69,7 @@ export async function r2Request(
     contentType?: string;
     timeoutMs?: number;
   },
-): Promise<R2Response> {
+): Promise<S3Response> {
   const endpoint = new URL(config.endpoint);
   const pathName = canonicalPath(config.bucket, input.key);
   const query = input.query ?? {};
@@ -93,7 +97,8 @@ export async function r2Request(
     signedHeaders,
     payloadHash,
   ].join("\n");
-  const scope = `${date}/${REGION}/${SERVICE}/aws4_request`;
+  const region = config.region ?? DEFAULT_REGION;
+  const scope = `${date}/${region}/${SERVICE}/aws4_request`;
   const stringToSign = [
     "AWS4-HMAC-SHA256",
     stamp,
@@ -101,7 +106,7 @@ export async function r2Request(
     sha256Hex(canonicalRequest),
   ].join("\n");
   const signingKey = hmac(
-    hmac(hmac(hmac(`AWS4${config.secretAccessKey}`, date), REGION), SERVICE),
+    hmac(hmac(hmac(`AWS4${config.secretAccessKey}`, date), region), SERVICE),
     "aws4_request",
   );
   const signature = createHmac("sha256", signingKey)
@@ -126,11 +131,11 @@ export async function r2Request(
 }
 
 /** Object size, or null when it does not exist. Other failures throw. */
-export async function r2HeadSize(
-  config: R2ClientConfig,
+export async function s3HeadSize(
+  config: S3ClientConfig,
   key: string,
 ): Promise<number | null> {
-  const response = await r2Request(config, {
+  const response = await s3Request(config, {
     method: "HEAD",
     key,
     timeoutMs: 10_000,
@@ -144,11 +149,11 @@ export async function r2HeadSize(
 }
 
 /** Object bytes, or null when it does not exist. Other failures throw. */
-export async function r2GetBytes(
-  config: R2ClientConfig,
+export async function s3GetBytes(
+  config: S3ClientConfig,
   key: string,
 ): Promise<Buffer | null> {
-  const response = await r2Request(config, { method: "GET", key });
+  const response = await s3Request(config, { method: "GET", key });
   if (response.status === 404) return null;
   if (response.status < 200 || response.status >= 300) {
     throw new Error(`R2 GET ${key} returned ${response.status}.`);
@@ -156,13 +161,13 @@ export async function r2GetBytes(
   return response.body;
 }
 
-export async function r2PutBytes(
-  config: R2ClientConfig,
+export async function s3PutBytes(
+  config: S3ClientConfig,
   key: string,
   body: Buffer,
   contentType = "application/octet-stream",
 ): Promise<void> {
-  const response = await r2Request(config, {
+  const response = await s3Request(config, {
     method: "PUT",
     key,
     body,
@@ -174,8 +179,8 @@ export async function r2PutBytes(
 }
 
 /** Keys under a prefix (ListObjectsV2, one level when `delimiter` is set). */
-export async function r2ListKeys(
-  config: R2ClientConfig,
+export async function s3ListKeys(
+  config: S3ClientConfig,
   prefix: string,
   options: { delimiter?: string } = {},
 ): Promise<{ keys: string[]; prefixes: string[] }> {
@@ -186,7 +191,7 @@ export async function r2ListKeys(
     const query: Record<string, string> = { "list-type": "2", prefix };
     if (options.delimiter) query.delimiter = options.delimiter;
     if (continuation) query["continuation-token"] = continuation;
-    const response = await r2Request(config, { method: "GET", key: "", query });
+    const response = await s3Request(config, { method: "GET", key: "", query });
     if (response.status < 200 || response.status >= 300) {
       throw new Error(`R2 LIST ${prefix} returned ${response.status}.`);
     }

--- a/packages/progressive-review/src/trace-cli.ts
+++ b/packages/progressive-review/src/trace-cli.ts
@@ -203,7 +203,11 @@ export async function runReviewTraceShow(input: {
   sessionId: string;
   trace?: string;
   eventIndex?: number;
+  // Several events in one process: the agent otherwise launches the CLI
+  // once per event it wants to read.
+  eventIndexes?: number[];
   kind?: string;
+  refresh?: boolean;
   json?: boolean;
   stdout: NodeJS.WriteStream;
   stderr: NodeJS.WriteStream;
@@ -213,6 +217,7 @@ export async function runReviewTraceShow(input: {
     sessionId: input.sessionId,
     trace: traceName,
     cwd: input.cwd,
+    refresh: input.refresh,
   });
   if (!loaded) {
     throw new Error(
@@ -220,6 +225,46 @@ export async function runReviewTraceShow(input: {
     );
   }
   const { trace } = loaded;
+  const requested =
+    input.eventIndexes ??
+    (input.eventIndex !== undefined ? [input.eventIndex] : undefined);
+  if (requested && requested.length > 1) {
+    const events = requested.map((index) => {
+      const event = trace.events[index];
+      if (!event) {
+        throw new Error(
+          `Event ${index} is out of range. Session ${input.sessionId} has ${trace.events.length} events.`,
+        );
+      }
+      return { index, event, text: extractTraceEventText(event) };
+    });
+    if (input.json) {
+      input.stdout.write(
+        `${JSON.stringify({
+          session: input.sessionId,
+          trace: traceName ?? "main",
+          events: events.map(({ index, event, text }) => ({
+            event: index,
+            kind: event.kind,
+            text,
+            trace_quote_props: {
+              sessionId: input.sessionId,
+              event: index,
+              ...(traceName ? { trace: traceName } : {}),
+            },
+          })),
+        })}\n`,
+      );
+      return 0;
+    }
+    for (const { index, event, text } of events) {
+      input.stdout.write(`=== event ${index} (${event.kind}) ===\n${text}\n\n`);
+    }
+    return 0;
+  }
+  if (requested && requested.length === 1) {
+    input.eventIndex = requested[0];
+  }
   if (input.eventIndex !== undefined) {
     const event = trace.events[input.eventIndex];
     if (!event) {


### PR DESCRIPTION
Stacked on #117. The trace-storage half of the speed work: every R2 round-trip the CLI made during a review went through an `aws` CLI spawn, and several of them were unnecessary.

## What changes

- **`review trace show` is local-first.** It served the local normalized trace but paid an R2 HEAD (an `aws` spawn, ~0.5–1s) on every call because the freshness memo lived in process memory. It now trusts the materialized trace; `--refresh` forces the check. `--event 43,62,70` prints several events in one process instead of one process per event.
- **A native S3-compatible client replaces the `aws` CLI.** `s3-client.ts` signs SigV4 over `fetch` with `node:crypto` only (HEAD, GET, PUT, LIST). Nothing in it is vendor-specific: the signing region is a config field (`TRACE_S3_REGION`; default `auto`, which R2 and MinIO accept). Measured live against R2: HEAD 170ms, GET 316ms, LIST 206ms, versus 0.5–1s per CLI spawn. No `aws` binary is required on the machine any more.
- **The scaffold corpus pull fans out six wide** instead of one object at a time.
- **`DEV_FAST_REVIEW_TRACES=off`** removes trace storage end to end (no pulls, no HEADs, no trace skill guidance), so the harness can run the same session with and without traces.

## Measured

With traces on, per warm run of the review#83 replay: R2 time inside the CLI 15–19s → under 5s; `trace show` makes no R2 calls; total CLI process time per run down ~10s. With traces off the whole trace path is skipped, which is also the fastest configuration the harness has measured (traces-on runs were consistently slower: 553s vs 288s on review#83, 315s vs 219s on #24, 210s vs 183s on #8), mostly because the trace-quoting workflow makes the agent survey its own session.

## Notes for review

- The three trace commits are cumulative edits to `review-agent-traces.ts`; the tip is the state to review.
- Why not `@aws-sdk/client-s3`: nothing in the repo depends on the SDK and four operations don't justify its size. Swapping is a small change if preferred.
- The surrounding trace configuration is still named for R2 (`TRACE_R2_ENDPOINT`, `TRACE_R2_BUCKET`, the Settings copy) from before this stack. Renaming that is a separate, user-visible change.

https://claude.ai/code/session_01N2M3zTuiQh2z9WKiwpWqs3
