### PR TITLE
docs(dev-review): ast-grep code search guidance for source ranges

### DIFF
--- a/packages/progressive-review/skills/dev-review/references/document-authoring.md
+++ b/packages/progressive-review/skills/dev-review/references/document-authoring.md
@@ -66,7 +66,7 @@ Scaffold creates one pinned checkout per pinned commit and prints both paths in 
 
 1. **Load the change into your context window**:
    - *IMPORTANT*: THIS STEP IS OPTIONAL; SKIP to #2 IF THIS IS THE SAME SESSION THAT AUTHORED THE CHANGE
-   - Typically involves batched commands; utilize code mode + parallel subagents to minimize the number of tool calls.
+   - Typically involves batched commands; utilize code mode + parallel subagents to minimize the number of tool calls. If it's available, use ast-grep as per the code search section below.
    - infer if "this is the same session that authored the change" via the user's messages.
 2. **Decide on the evidence that you want to show**
 3. **For locations where you can't remember specific line numbers, search for code locations to match your chosen examples/anchors.**
@@ -74,6 +74,32 @@ Scaffold creates one pinned checkout per pinned commit and prints both paths in 
 Default to `AnchorLink` or `CodePeek` for source evidence (prefer `AnchorLink`, with `CodePeek` superior for examples which are best demonstrated via inline code, e.g. an API change).
 
 A path outside the pinned checkout blocks document publication.
+
+### Code Search
+   - Utilize batching to minimize tool calls / code-mode + parallelism (e.g. via subagents) to speed things up.
+   - *IMPORTANT*: when at all possible, use `ast-grep` (on PATH) vs. vanilla grep, reading files (e.g. via sed/cat), or counting line ranges. 'sed, grep, cat' are slow and ill-fitted to this use-case (finding starting/closing brackets of code snippets).
+      - Match declarations by **node kind + name** with `ast-grep scan`, not by a code pattern (`ast-grep run -p`): a pattern must parse as a complete program, and a bare method or signature does not, so method patterns return nothing.
+      - One call resolves every anchor on a checkout. List all the names in the regex; run it once for head and once for base:
+      ```sh
+      ast-grep scan --json=compact --inline-rules '
+      id: anchors
+      language: TypeScript
+      rule:
+        any: [{kind: function_declaration}, {kind: method_definition}, {kind: class_declaration},
+              {kind: interface_declaration}, {kind: type_alias_declaration}, {kind: variable_declarator}]
+        has: {field: name, regex: ^(nameA|nameB|nameC)$}
+      ' <checkout>/<dir> \
+        | jq -r '.[] | "\(.file) \(.range.start.line+1)-\(.range.end.line+1)\n\(.text)\n"'
+      ```
+      - The output is `file fromLine-toLine` followed by the full source of the match, already 1-based (`range.*.line` is 0-based; the `+1` is in the jq). That text is the code you will describe or peek at; do not re-read it with `sed`/`cat`.
+      - Private members match by their `#name` (`regex: ^#mirror$`).
+      - If a declaration shape is not matching, ask ast-grep which kind carries its `name:` field and use that kind:
+      ```sh
+      ast-grep run -l <lang> -p '<one complete, valid declaration of that shape>' --debug-query=ast
+      ```
+        e.g. `const f = (x: X): Y => { … }` shows `lexical_declaration > variable_declarator > name: identifier`, so the kind is `variable_declarator`. This is also how to get kinds for other languages.
+      - For a range inside a declaration (one call, one statement), add `inside: {kind: <declaration kind>, has: {field: name, regex: ^outer$}}` to the rule and match the inner node.
+      - The range from ast-grep is authorative & there's no need to second-guess it with 'sed' or 'cat' calls.
 
 Remember that a review has two pinned checkouts (base checkout, or `baseCommit`, and head checkout, or `sourceCommit`). Depending on the anchor/code ref you may need to be specific about one side or the other.
 

--- a/scripts/review-latency/PLAN.md
+++ b/scripts/review-latency/PLAN.md
@@ -246,3 +246,19 @@ Per-run detail (after):
 - Fork worktrees share the repo's stash stack. A "perf WIP (stashed by agent-server refactor)" entry, created by the review#83 session itself, cost one warm run 20s of "important finding" detours. Dropped; keep the stash stack empty during experiments.
 - The `review` shim broke whenever the agent's shell cwd was inside the fork worktree's `packages/progressive-review`: tsx reads tsconfig from the cwd, and the worktree's `paths` remapped `@dev.fast/local-vcs` onto the worktree's older source (no `setLocalVcsCommandObserver`). The agent then routed around the shim with the worktree's own `cli.ts`, silently changing the CLI under test (16:21 and 17:50 runs). Fixed: the shim pins `--tsconfig` to the instrumented checkout, and the runner aborts on any CLI load failure (`review-shim-stderr.log`).
 - Rule placement matters more than wording: the typecheck/test reflex fires at call ~4, before any `references/*.md` is opened. Rules about what not to do before authoring belong in SKILL.md (loaded at invocation); `document-authoring.md` is only in context once the agent is about to write.
+
+## code-search skill + effort experiments (2026-09-04, review-83-fork, traces off, warm)
+
+All runs same night, same prefix, `code-search` skill installed (except the 00:57 baseline).
+
+| variant | totals (s) | thinking tokens | thinking s | doc (KB / anchors / diagrams) |
+|---|---|---|---|---|
+| opus @ high, before code-search | 252 | 8.1k | 89 | 10.5 / 20 / 2 |
+| opus @ high, with code-search | 319, 325, 336, 367 | 12.3k–15.9k | 145–193 | 11–13 / 18–22 / 1–2 |
+| opus @ medium | 347, 412, 351 | 14.3k–16.5k | 172–199 | 11.5–13.9 / 21–26 / 1–2 |
+| opus @ low | 270, 263, 309 | 9.0k–12.4k | 107–150 | 10.6–13.5 / 15–26 / 1–2 |
+
+- code-search skill: every run loaded it unprompted, used `#name` and `inside:` rules, ran zero sed/cat after the scan, ran no tests. The scan→Write window did not shrink (95–120s either way): removing tool calls moved the thinking, it did not remove it. Wall-clock unchanged (median 330 vs 312).
+- Pre-scan reads (3–4 `cat` calls of the files the session wrote) survive every wording tried; stop editing text for that.
+- `--effort medium` produced the same thinking-token volume as high. `--effort low` cut thinking tokens ~30% and wall-clock ~60s (median 270 vs 330) with document shape unchanged. Effort is the first knob that moved time without moving shape. Next: low on the cold and traces-on variants, and on review-84/#24 to check it generalizes.
+- Harness: runs now wrapped in `caffeinate -i -s` (machine slept mid-run once); shim pins `--tsconfig`; aborts on CLI load failure.

--- a/scripts/review-latency/review_latency/runner.py
+++ b/scripts/review-latency/review_latency/runner.py
@@ -170,7 +170,24 @@ def write_review_shim(bin_dir: Path, calls_log: Path) -> Path:
         "exit $code\n"
     )
     shim.chmod(shim.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    # ast-grep rides along on the same PATH when the machine has it, so the
+    # skill's code-search guidance can be exercised; without it the run still
+    # proceeds and the agent falls back to grep/sed.
+    binary = ast_grep_binary()
+    for name in ("ast-grep", "sg"):
+        link = bin_dir / name
+        if link.is_symlink() or link.exists():
+            link.unlink()
+        if binary is not None:
+            link.symlink_to(binary)
     return shim
+
+
+def ast_grep_binary() -> Path | None:
+    """The ast-grep on PATH (`brew install ast-grep`), or None. It is not a
+    workspace dependency: pnpm refuses its postinstall in CI."""
+    found = shutil.which("ast-grep") or shutil.which("sg")
+    return Path(found) if found else None
 
 
 def write_zdotdir(zdotdir: Path, bin_dir: Path) -> Path:


### PR DESCRIPTION
Stacked on #117. Only the ast-grep part of the dev-review skill text, so it can be judged separately from the guidance that did move the clock.

## What it says

In `references/document-authoring.md`, under Source ranges: resolve every anchor's `fromLine`/`toLine` with one `ast-grep scan` per checkout, matching declarations by node kind + name; the output carries the match text, so no follow-up read; `#name` for private members; `--debug-query=ast` to find the node kind for any shape or language; `inside:` for a range within a declaration.

## What it did in measurement

Warm review#83 replay, traces off, four runs with this text versus the runs before it:

- Every run used it unprompted: one scan on head, one on base, all anchors resolved first time, including private methods and inner ranges.
- Post-scan `sed`/`cat` re-reads went from 3–7 per run to 0. Turns went from 24 to 15–18.
- Wall-clock did not move: 319–367s with it, 252–343s before. The time freed from tool calls went to thinking between calls.

So this is a robustness change for anchors (exact ranges, first time, one call), not a speed change. A fresh-eyes read also flagged that the text assumes `ast-grep` is on PATH and gives no fallback when it is not; that is worth fixing here before merge.

## Not included

The "faster code search" Settings toggle that installed ast-grep via Homebrew, and the vendored ast-grep rule reference, are parked on the local tag `sm/code-search-feature`.

https://claude.ai/code/session_01N2M3zTuiQh2z9WKiwpWqs3
