### PR TITLE
perf(publish): resolve code peeks at publish and embed them in the bundle

### DIFF
--- a/packages/progressive-review/app/src/review-definition-runtime.test.ts
+++ b/packages/progressive-review/app/src/review-definition-runtime.test.ts
@@ -151,3 +151,66 @@ it("creates a browser definition session without materialized software maps", as
 
   await expect(session.ready()).resolves.toBeUndefined();
 });
+
+it("resolves peeks from the bundle's embedded resolutions without a request", async () => {
+  const sourceId = "source-range:src/example.ts:3-4";
+  const resolution = {
+    snapshot: {
+      roots: [{ kind: "source", sourceId }],
+      resolved: {
+        [sourceId]: {
+          source: {
+            id: sourceId,
+            name: "example.ts L3-L4",
+            kind: "source-range",
+            file: "src/example.ts",
+            line: 3,
+            endLine: 4,
+          },
+          lines: [
+            [{ t: "const a = 1;", k: "t" }],
+            [{ t: "const b = 2;", k: "t" }],
+          ],
+        },
+      },
+    },
+  };
+  vi.stubGlobal("__reviewEmbeddedCodePeeks", {
+    "/": { "head|src/example.ts|3|4": resolution },
+  });
+  const fetchMock = vi.fn<typeof fetch>();
+  vi.stubGlobal("fetch", fetchMock);
+
+  const session = createBrowserReviewDefinitionSession({
+    routePath: "/",
+    softwareMap: null,
+    baseSoftwareMap: null,
+  });
+  session.begin();
+  const anchors = session.defineAnchors({
+    example: {
+      title: "Example",
+      peek: { file: "src/example.ts", fromLine: 3, toLine: 4 },
+    },
+  });
+  await expect(session.ready()).resolves.toBeUndefined();
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(anchors.example.peek?.resolution).toEqual(resolution);
+});
+
+it("fails a peek the published bundle does not carry", async () => {
+  vi.stubGlobal("__reviewEmbeddedCodePeeks", { "/": {} });
+  const session = createBrowserReviewDefinitionSession({
+    routePath: "/",
+    softwareMap: null,
+    baseSoftwareMap: null,
+  });
+  session.begin();
+  session.defineAnchors({
+    example: {
+      title: "Example",
+      peek: { file: "src/example.ts", fromLine: 3, toLine: 4 },
+    },
+  });
+  await expect(session.ready()).rejects.toThrow(/not in the published bundle/);
+});

--- a/packages/progressive-review/app/src/review-definition-runtime.ts
+++ b/packages/progressive-review/app/src/review-definition-runtime.ts
@@ -5,6 +5,7 @@ import {
   calls,
   createReviewDefinitionSession,
 } from "../../src/authoring";
+import { codePeekResolutionKey } from "../../src/code-peek-diff";
 
 export { calls };
 import { reviewFetch } from "./host/review-client";
@@ -47,6 +48,10 @@ export function createBrowserReviewDefinitionSession(input: {
   // produced before the origin-agnostic change keep working.
   const requestOrigin = input.requestOrigin ?? reviewRequestContext?.origin;
   const requestToken = input.requestToken ?? reviewRequestContext?.token;
+  // A published bundle carries every peek publish resolved; mounting it needs
+  // no request. Bundles from before that change carry nothing and still
+  // resolve against the running server.
+  const embedded = embeddedCodePeeks(input.routePath);
   return createReviewDefinitionSession({
     softwareMap: input.softwareMap,
     baseSoftwareMap: input.baseSoftwareMap,
@@ -54,14 +59,45 @@ export function createBrowserReviewDefinitionSession(input: {
     resolveCodePeek:
       input.resolveCodePeeks === false
         ? undefined
-        : (props) =>
-            resolveCodePeek(
-              input.routePath,
-              props,
-              requestOrigin,
-              requestToken,
-            ),
+        : embedded
+          ? (props) => resolveEmbeddedCodePeek(embedded, props)
+          : (props) =>
+              resolveCodePeek(
+                input.routePath,
+                props,
+                requestOrigin,
+                requestToken,
+              ),
   });
+}
+
+type EmbeddedCodePeeks = Record<string, CodePeekResolution>;
+
+declare global {
+  // Written by publish as a prelude of the bundle it just evaluated (see
+  // embedCodePeeks in doc-bundler): routePath -> peek key -> resolution.
+  // eslint-disable-next-line no-var
+  var __reviewEmbeddedCodePeeks:
+    | Record<string, EmbeddedCodePeeks | undefined>
+    | undefined;
+}
+
+function embeddedCodePeeks(routePath: string): EmbeddedCodePeeks | null {
+  return globalThis.__reviewEmbeddedCodePeeks?.[routePath] ?? null;
+}
+
+async function resolveEmbeddedCodePeek(
+  embedded: EmbeddedCodePeeks,
+  props: CodePeekProps,
+): Promise<CodePeekResolution> {
+  const key = codePeekResolutionKey(props);
+  const resolution = embedded[key];
+  if (!resolution) {
+    throw new Error(
+      `Code peek ${key} is not in the published bundle; republish the review.`,
+    );
+  }
+  return resolution;
 }
 
 async function resolveCodePeek(

--- a/packages/progressive-review/src/code-peek-diff.ts
+++ b/packages/progressive-review/src/code-peek-diff.ts
@@ -1,0 +1,71 @@
+import type { CodePeekDiffPayload } from "./authoring";
+import {
+  codePeekRootSourceRanges,
+  sliceReviewDiffFileToCodePeekRanges,
+} from "./codepeek-symbol-diff";
+import type { ReviewDiffFile } from "./review-diff-files";
+import type { SourceSnapshot } from "./source-code-types";
+
+/**
+ * The diff summary a code peek carries: the pinned range's slice of the
+ * review's diff, one entry per file the peek touches. Shared by the desktop
+ * server (per request) and publish (once, embedded into the bundle).
+ */
+export function codePeekDiffFromFiles(input: {
+  snapshot: SourceSnapshot;
+  files: readonly ReviewDiffFile[];
+  baseRef?: string;
+  headRef?: string;
+  graph: "head" | "base";
+  includePatch: boolean;
+}): CodePeekDiffPayload | undefined {
+  if (!input.baseRef) return undefined;
+  const ranges = codePeekRootSourceRanges(input.snapshot);
+  const paths = new Set(
+    ranges.map((range) => range.file).filter((file) => file.trim().length > 0),
+  );
+  if (paths.size === 0) return undefined;
+  const files = input.files
+    .filter(
+      (file) =>
+        paths.has(file.path) ||
+        (file.previousPath !== undefined && paths.has(file.previousPath)),
+    )
+    .map((file) =>
+      sliceReviewDiffFileToCodePeekRanges({
+        file,
+        ranges,
+        orientation: input.graph,
+        contextLines: 0,
+      }),
+    )
+    .filter((file): file is ReviewDiffFile => file !== null);
+  if (files.length === 0) return undefined;
+  return {
+    baseRef: input.baseRef,
+    headRef: input.headRef,
+    orientation: input.graph,
+    files: files.map((file) => {
+      const entry: CodePeekDiffPayload["files"][number] = {
+        path: file.path,
+        previousPath: file.previousPath,
+        status: file.status,
+        additions: file.additions,
+        deletions: file.deletions,
+      };
+      if (input.includePatch) entry.patch = file.patch ?? "";
+      return entry;
+    }),
+  };
+}
+
+/** Stable key for a peek's resolution, shared by publish (writer) and the
+    browser runtime (reader). */
+export function codePeekResolutionKey(props: {
+  graph?: "head" | "base";
+  file: string;
+  fromLine: number;
+  toLine: number;
+}): string {
+  return `${props.graph ?? "head"}|${props.file}|${props.fromLine}|${props.toLine}`;
+}

--- a/packages/progressive-review/src/review-publication-preparation.ts
+++ b/packages/progressive-review/src/review-publication-preparation.ts
@@ -13,7 +13,10 @@ import {
   type ReviewSourceTarget,
   resolveReviewSourceTarget,
 } from "./review-worktree-target";
-import { compileReviewDocumentBundle } from "./server/doc-bundler";
+import {
+  compileReviewDocumentBundle,
+  embedCodePeeks,
+} from "./server/doc-bundler";
 import {
   type ReviewSoftwareMapBundle,
   bundleReviewSoftwareMap,
@@ -102,6 +105,11 @@ export async function prepareReviewDocumentBundle(input: {
           base: source.preparedBase
             ? { sourceRootPath: source.preparedBase.sourceRootPath }
             : undefined,
+          diff: {
+            baseRef: source.baseRef,
+            headRef: source.headRef,
+            files: async () => (await diffFiles()).files,
+          },
         };
       },
       // A "-" frame must anchor lines the change deletes and a "+" frame
@@ -123,8 +131,11 @@ export async function prepareReviewDocumentBundle(input: {
       ...new Set([...warnings, ...evaluation.warnings]),
     ]);
   }
+  // The desktop mounts the bundle without a request per peek: every
+  // resolution evaluate just produced ships inside the bundle.
+  const published = embedCodePeeks(bundle, evaluation.codePeeks);
   await span("publish: write document bundle", () =>
-    writeReviewDocumentBundle(input.review.dir, bundle),
+    writeReviewDocumentBundle(input.review.dir, published),
   );
   return { warnings: [...new Set([...warnings, ...evaluation.warnings])] };
 }

--- a/packages/progressive-review/src/review-publish-evaluate.ts
+++ b/packages/progressive-review/src/review-publish-evaluate.ts
@@ -21,8 +21,10 @@ import {
   callStackEvidenceErrors,
   diffCallStacks,
 } from "./call-stack-diff";
+import { codePeekDiffFromFiles, codePeekResolutionKey } from "./code-peek-diff";
 import { errorMessage } from "./error-message";
 import { loadReviewAgentTrace } from "./review-agent-traces";
+import type { ReviewDiffFile } from "./review-diff-files";
 import {
   type PublishAuditTraceQuote,
   auditReviewDocumentComponent,
@@ -70,9 +72,18 @@ export interface ReviewPublishSourceTarget {
   sourceRootPath: string;
 }
 
+export interface ReviewPublishDiffSource {
+  baseRef?: string;
+  headRef?: string;
+  // The review's full diff between the pinned commits, resolved once by the
+  // caller; each peek carries its own slice of it.
+  files: () => Promise<readonly ReviewDiffFile[]>;
+}
+
 export interface ReviewPublishEvidenceTargets {
   head: ReviewPublishSourceTarget;
   base?: ReviewPublishSourceTarget;
+  diff?: ReviewPublishDiffSource;
 }
 
 export interface ReviewPublishRangePeek extends CodePeekProps {
@@ -84,6 +95,10 @@ export interface ReviewPublishEvaluationResult {
   // never ran.
   peekCount: number;
   rangePeeks: ReviewPublishRangePeek[];
+  // Every peek's resolution (snapshot + diff slice), keyed by
+  // codePeekResolutionKey, ready to embed into the published bundle so the
+  // desktop mounts the document without a request per peek.
+  codePeeks: Record<string, CodePeekResolution>;
   errors: string[];
   warnings: string[];
 }
@@ -102,6 +117,7 @@ export async function evaluateReviewDocumentBundleForPublish(input: {
 }): Promise<ReviewPublishEvaluationResult> {
   const failures: string[] = [];
   const rangePeeks: ReviewPublishRangePeek[] = [];
+  const codePeeks: Record<string, CodePeekResolution> = {};
   const callStackProps: CallStackDiffProps[] = [];
   const traceQuotes: PublishAuditTraceQuote[] = [];
   let peekCount = 0;
@@ -162,8 +178,23 @@ export async function evaluateReviewDocumentBundleForPublish(input: {
           toLine: props.toLine,
         },
       });
+      const graph = props.graph ?? "head";
+      const diff = targets.diff
+        ? codePeekDiffFromFiles({
+            snapshot,
+            files: await targets.diff.files(),
+            baseRef: targets.diff.baseRef,
+            headRef: targets.diff.headRef,
+            graph,
+            includePatch: false,
+          })
+        : undefined;
+      const resolution: CodePeekResolution = diff
+        ? { snapshot, diff }
+        : { snapshot };
+      codePeeks[codePeekResolutionKey(props)] = resolution;
       peekSpan.end();
-      return { snapshot };
+      return resolution;
     } catch (error) {
       peekSpan.fail();
       const message = `Code peek range ${props.file}:${props.fromLine}-${props.toLine}: ${errorMessage(error)}`;
@@ -361,6 +392,7 @@ export async function evaluateReviewDocumentBundleForPublish(input: {
   return {
     peekCount,
     rangePeeks,
+    codePeeks,
     errors,
     warnings: [...new Set(warnings)],
   };

--- a/packages/progressive-review/src/server/doc-bundler.ts
+++ b/packages/progressive-review/src/server/doc-bundler.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { type BuildFailure, type Plugin, build } from "esbuild";
 
+import type { CodePeekResolution } from "../authoring";
 import {
   type ReviewDocumentDiagnostic,
   compileReviewDocument,
@@ -72,6 +73,30 @@ export async function compileReviewDocumentBundle(
       routePath: result.document.routePath,
       sourcePath: result.document.filePath,
     },
+  };
+}
+
+export const EMBEDDED_CODE_PEEKS_GLOBAL = "__reviewEmbeddedCodePeeks";
+
+/** Prepend the publish-time code peek resolutions to the bundle. The browser
+    runtime reads them at session creation instead of requesting each peek. */
+export function embedCodePeeks(
+  bundle: ReviewDocumentBundle,
+  codePeeks: Record<string, CodePeekResolution>,
+): ReviewDocumentBundle {
+  const prelude =
+    `globalThis.${EMBEDDED_CODE_PEEKS_GLOBAL} = Object.assign(` +
+    `globalThis.${EMBEDDED_CODE_PEEKS_GLOBAL} ?? {}, ` +
+    `${JSON.stringify({ [bundle.routePath]: codePeeks })});\n`;
+  const code = prelude + bundle.code;
+  return {
+    ...bundle,
+    code,
+    contentHash: crypto
+      .createHash("sha256")
+      .update(code)
+      .digest("hex")
+      .slice(0, 20),
   };
 }
 


### PR DESCRIPTION
Stacked on #117 (depends only on #157 for the span helpers; it does not need the timer or docs changes below it).

## Problem

The published bundle ends in `await __reviewDefinitionsReady()`, which in the browser waits on one `POST /code-peek/resolve` per peek, 8 concurrent, each re-resolving the pinned worktrees and running `git diff`. On `main`, warm review#83 with 20 anchors: `mount: import document` 5.5s of a 7.7s mount, on every publish and every later open.

## Change

Publish's evaluate step already resolves every peek against the pinned worktrees. It now also computes each peek's diff slice (`codePeekDiffFromFiles`, the same logic the server route uses), collects the resolutions keyed by `graph|file|fromLine|toLine`, and the bundler prepends them to the bundle as `globalThis.__reviewEmbeddedCodePeeks[routePath]`. The browser runtime reads that map instead of fetching; a missing key throws (the bundle is immutable, so a miss is a publish bug); bundles from before this change carry no map and keep the fetch path.

Measured on `main`, same session, back to back with #117 applied:

| step | before | after |
|---|---|---|
| `mount: import document` | 5.55s | 3ms |
| `validate canvas mount` | 5.6s | 0.11s |
| `POST /publish-ready` | 8.36s | 0.67s |
| publish loop (CLI wall-clock) | 10.8s | 2.5s |

## Design choices worth arguing

- Transport: a JS prelude that assigns a global, rather than a sidecar JSON asset the runtime fetches once. The prelude keeps the bundle self-contained (one file, one hash); a sidecar would keep the bundle text stable across peek-only changes.
- Key: `graph|file|fromLine|toLine`, shared via `codePeekResolutionKey`, so the writer and reader cannot drift.
- Failure mode: a missing key is a hard error rather than a fetch fallback, so a stale bundle is loud instead of slow.
- The evaluate result grows a `codePeeks` field; `ReviewPublishEvidenceTargets` grows an optional `diff` source so evaluate can slice the review diff without a second `git diff`.

https://claude.ai/code/session_01N2M3zTuiQh2z9WKiwpWqs3
