### PR TITLE
Make the desktop server own Review lifecycle and storage

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
@@ -846,6 +846,10 @@ export class ReviewSessionService
 			response.body,
 			async (value) => {
 				const event = parseReviewDesktopGlobalEvent(value);
+				if (event.event === "review-metadata-changed") {
+					await this.refreshLists();
+					return;
+				}
 				if (event.event === "review-data-changed") {
 					this._onDidChangeReviewData.fire(event);
 					return;

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -39,6 +39,40 @@ review app pick --review <uuid>
 
 Most people let the installed Review skill drive this workflow.
 
+Review Desktop must be running for Review lifecycle, document, and comment
+operations. The CLI is an API client; it does not fall back to editing Review
+storage when the desktop is unavailable.
+
+### MCP authoring
+
+Configure an MCP client to run `review mcp` over stdio. This bridge discovers
+the running desktop and forwards requests to its authenticated local API.
+It does not start another database or own a separate Review lifecycle.
+
+Use `review_create` to scaffold a Review, `review_get` to read its metadata,
+and `review_update_metadata` to set its title. Metadata updates include the
+previous title as `expectedTitle`, preventing silent concurrent overwrites.
+An explicit title survives subsequent document publication.
+
+Use `review_get_document_file` to read `review.mdx` or `data.ts`, then
+`review_write_document_file` with the returned `sourceHash` as
+`expectedSourceHash`. A missing file has a null hash. Conflicts require a new
+read and reconciliation; an identical retry succeeds. `review_publish`
+validates and presents the result. Do not read or edit Review source directly
+on disk. Source repository inspection and software-map scratch files remain
+separate from Review document storage.
+
+`review_list_comments`, `review_comment_command`, and `review_reply_comment`
+use the same comment service as the canvas. Replies are stored as agent
+messages, not reviewer messages. The existing `review threads` commands use
+this API too.
+
+Without MCP, `review document get review.mdx --review <uuid>` returns the same
+source and hash as JSON. Pipe replacement source into
+`review document write review.mdx --review <uuid> --expected-hash <hash>`.
+Both commands also accept `data.ts`. Writes read source from stdin, not from
+the Review directory.
+
 ## Machine-readable output
 
 Commands that expose `--json` accept it after the complete command path:

--- a/docs/how-review-works.md
+++ b/docs/how-review-works.md
@@ -11,7 +11,7 @@ system views, and a structured feedback loop around that document.
 ```mermaid
 flowchart LR
   A[Branch, change, or PR] --> B[Agent authors a Review]
-  B --> C[CLI validates and publishes]
+  B --> C[Desktop API validates and publishes]
   C --> D[Reviewer reads in Review Desktop]
   D --> E{Decision}
   E -->|Request changes| B
@@ -45,10 +45,11 @@ checkout does not silently change the code being reviewed. Run
 
 `review publish` validates the Review document, checks its software-map
 relationship, and resolves every source range against the pinned checkout. The
-CLI seals a revision only after these checks pass. Review Desktop then mounts
+desktop server seals a revision only after these checks pass. Review Desktop then mounts
 the candidate before making it visible.
 
-Authoring remains `review.mdx` and `data.ts`. The CLI parses the document,
+Authoring remains `review.mdx` and `data.ts`, accessed through API calls rather
+than direct client filesystem access. The desktop server parses the document,
 checks authored TypeScript, and loads helpers in a disposable Node worker. It
 constructs and audits schema-checked JSON directly; it does not compile an MDX
 component or bundle authored modules. The installed runtime does not need
@@ -139,13 +140,15 @@ Authored Reviews are stored under:
 ${DEV_REVIEW_HOME:-~/.dev}/reviews/<uuid>/
 ```
 
-The directory contains the document, supporting TypeScript, pinned state,
-thread database, sealed revisions, and disposable build output. Review owns the
-infrastructure files; agents author `review.mdx` and `data.ts`, and use the CLI
-for publication and threads.
+The directory contains document source, supporting TypeScript, sealed revisions,
+and disposable build output. One `${DEV_REVIEW_HOME:-~/.dev}/review.db` holds
+metadata and comment state for all Reviews, scoped by Review UUID. Legacy
+per-Review databases are imported without deleting the original recovery files.
+The desktop owns this storage. Agents author `review.mdx` and `data.ts` through
+the document API and use API-backed CLI/MCP operations for publication and threads.
 
-`review.json` uses store schema 5 and records the independent document and map
-presentation pointers. Candidate JSON bundles live under `.bundle/`; private
+`review.json` remains a schema-5 compatibility mirror of metadata, including the
+independent document and map presentation pointers. Candidate JSON bundles live under `.bundle/`; private
 Git commits seal revisions and `.build/<revision>/` holds disposable
 materializations. Immutable old history or a failed migration may still contain
 legacy JavaScript. The local server can evaluate the exact sealed current

--- a/packages/progressive-review/skills/dev-review/SKILL.md
+++ b/packages/progressive-review/skills/dev-review/SKILL.md
@@ -59,7 +59,7 @@ Pass resolved commit ids to `--base` and `--head`. Parent suffixes like `<rev>^`
 
 If scaffold warns that `devfast.prepare` is not configured, set up that command according to [Prepared worktrees](references/prepared-worktrees.md).
 
-Read the scaffold JSON event and `<review-dir>/review.json`. Together they carry these values; record them:
+Read the scaffold JSON event; `review_get` through MCP provides additional metadata when needed. Record these values from the API responses:
 
 - Review UUID and directory
 - source worktree
@@ -107,6 +107,16 @@ Continue document work while the worker runs. Do not author the map in the main-
 If no sub-agent facility exists, publish the document. Report that the map is not published. Do not silently author it in the main-agent context.
 
 ### 4. Author the document
+
+Read and update Review source through the desktop API, never directly on disk.
+With MCP (`review mcp`), use `review_get_document_file` and
+`review_write_document_file` for `review.mdx` and `data.ts`. Pass the last read
+`sourceHash` as `expectedSourceHash`; on a conflict, read again and reconcile.
+Without MCP, `review document get <name> --review <uuid>` returns source and
+hash as JSON; pipe the replacement source into
+`review document write <name> --review <uuid> --expected-hash <hash>`.
+Use `null` only when the read reports an absent file. Repository source files
+and software-map scratch files are outside this document-storage boundary.
 
 Read [Document authoring](references/document-authoring.md) before you edit `review.mdx` or `data.ts`.
 

--- a/packages/progressive-review/src/cli-runner.ts
+++ b/packages/progressive-review/src/cli-runner.ts
@@ -48,14 +48,18 @@ import {
   runReviewAppLaunch,
 } from "./review-app-launcher";
 import { runReviewCodexWait } from "./review-codex-wait";
-import {
-  type StoredReview,
-  listReviews,
-  sealReviewCandidate,
-} from "./review-home";
+import type { StoredReview } from "./review-home";
 import { runReviewInfo } from "./review-info";
 import { runReviewInternalTest } from "./review-internal-test";
+import {
+  listReviewsClient as listReviews,
+  requestReviewLifecycle,
+  scaffoldReviewClient as runReviewScaffold,
+  checkpointReviewClient as sealReviewCandidate,
+} from "./review-lifecycle-client";
+import { ReviewDocumentFileNameSchema } from "./review-lifecycle-contracts";
 import { emitReviewEvent, serializeReviewError } from "./review-logger";
+import { runReviewMcp } from "./review-mcp";
 import { prepareReviewPinnedCheckout } from "./review-prepare";
 import { runReviewPublish } from "./review-publish";
 import { runReviewRebind } from "./review-rebind";
@@ -65,7 +69,6 @@ import {
   readReopenMarker,
 } from "./review-reopen-marker";
 import { runReviewRepair } from "./review-repair";
-import { runReviewScaffold } from "./review-scaffold";
 import { runReviewWait, validateReviewWait } from "./review-wait";
 import { installReviewCommand, pathShimPath } from "./server/cli-install";
 import { reviewDesktopDiscoveryPath } from "./server/desktop-paths";
@@ -268,6 +271,59 @@ export async function runProgressiveReviewCli(
   // over locals, so a default would clobber a subcommand's own true.
   program.addOption(new Option("--json").hideHelp());
   program.exitOverride();
+  const document = program
+    .command("document")
+    .description("Read or write Review source through the desktop API");
+  document
+    .command("get <name>")
+    .requiredOption("--review <uuid>")
+    .action(async (name: string, options: { review: string }) => {
+      const result = await requestReviewLifecycle("/lifecycle/document/read", {
+        reviewUuid: options.review,
+        name: ReviewDocumentFileNameSchema.parse(name),
+      });
+      input.stdout.write(`${JSON.stringify(result)}\n`);
+      state.exitCode = 0;
+    });
+  document
+    .command("write <name>")
+    .requiredOption("--review <uuid>")
+    .requiredOption(
+      "--expected-hash <hash>",
+      "Hash from get, or null for an absent file",
+    )
+    .action(
+      async (
+        name: string,
+        options: { review: string; expectedHash: string },
+      ) => {
+        const stream = input.stdin ?? process.stdin;
+        stream.setEncoding("utf8");
+        let source = "";
+        for await (const chunk of stream) source += chunk;
+        const result = await requestReviewLifecycle(
+          "/lifecycle/document/write",
+          {
+            reviewUuid: options.review,
+            name: ReviewDocumentFileNameSchema.parse(name),
+            source,
+            expectedSourceHash:
+              options.expectedHash === "null" ? null : options.expectedHash,
+          },
+        );
+        input.stdout.write(`${JSON.stringify(result)}\n`);
+        state.exitCode = 0;
+      },
+    );
+  program
+    .command("mcp")
+    .description("Connect an MCP client to Review Desktop over stdio")
+    .action(async () => {
+      state.exitCode = await runReviewMcp({
+        stdin: input.stdin ?? process.stdin,
+        stdout: input.stdout,
+      });
+    });
 
   configureJsonOutput(
     program.command("version").description("Print Review package version"),
@@ -1347,8 +1403,7 @@ function progressiveReviewTopLevelHelp(): string {
   return [
     "",
     "Use `review info` to discover Review documents for this checkout, or `review scaffold` to create one.",
-    "Edit the returned review.mdx and data.ts files, then use `review present` (alias of `review publish`). It validates in the CLI before contacting Review Desktop.",
-    "The CLI validates before publishing; Review Desktop promotes the revision before mounting it.",
+    "Author review.mdx and data.ts through the document API (`review mcp`), then use `review present` (alias of `review publish`). Review Desktop validates, seals, and presents the document.",
     "Use `review app launch` to start Review Desktop. Use `review app pick --review <uuid>` after publication.",
     "Use `--view <review|commits|diff|map|trace>` with `review publish` or `review app pick` to choose the opened tab.",
     "",

--- a/packages/progressive-review/src/cli-runner.ts
+++ b/packages/progressive-review/src/cli-runner.ts
@@ -188,20 +188,25 @@ export async function runProgressiveReviewCli(
 ): Promise<number> {
   const env = input.env ?? process.env;
   const cwd = input.cwd ?? env.INIT_CWD ?? process.cwd();
+
   const cliVersion =
     input.cliVersion ?? readProgressiveReviewPackageVersion(import.meta.url);
+
   const runtime = progressiveReviewCliRuntime(input.runtime);
   const telemetry = input.telemetry ?? ProgressiveReviewTelemetry.fromEnv(env);
+
   const state: CliRunState = {
     exitCode: 0,
     parseSurface: "review",
     parserErrorOutput: "",
     json: jsonRequestedInArgv(input.argv),
   };
+
   let telemetryProperties: Record<
     string,
     boolean | number | string | null | undefined
   > = {};
+
   let activeTelemetry:
     | {
         command: ProgressiveReviewCommandPath;
@@ -224,6 +229,7 @@ export async function runProgressiveReviewCli(
       },
     });
     command.showHelpAfterError();
+
     return command;
   };
 
@@ -239,6 +245,7 @@ export async function runProgressiveReviewCli(
     configureOutput(command, surface).addOption(
       new Option("--json", "print machine-readable JSON events on stdout"),
     );
+
   const viewOption = () =>
     new Option("--view <view>", "view to show after opening").choices([
       "review",
@@ -266,14 +273,17 @@ export async function runProgressiveReviewCli(
     .version(cliVersion)
     .description("Create, publish, and open dev.fast Reviews.")
     .addHelpText("after", progressiveReviewTopLevelHelp());
+
   // Tolerate the leading form (`review --json scaffold`) as well as the usual
   // trailing one. Never give this a .default(): optsWithGlobals merges globals
   // over locals, so a default would clobber a subcommand's own true.
   program.addOption(new Option("--json").hideHelp());
   program.exitOverride();
+
   const document = program
     .command("document")
     .description("Read or write Review source through the desktop API");
+
   document
     .command("get <name>")
     .requiredOption("--review <uuid>")
@@ -282,6 +292,7 @@ export async function runProgressiveReviewCli(
         reviewUuid: options.review,
         name: ReviewDocumentFileNameSchema.parse(name),
       });
+
       input.stdout.write(`${JSON.stringify(result)}\n`);
       state.exitCode = 0;
     });
@@ -300,7 +311,9 @@ export async function runProgressiveReviewCli(
         const stream = input.stdin ?? process.stdin;
         stream.setEncoding("utf8");
         let source = "";
+
         for await (const chunk of stream) source += chunk;
+
         const result = await requestReviewLifecycle(
           "/lifecycle/document/write",
           {
@@ -311,6 +324,7 @@ export async function runProgressiveReviewCli(
               options.expectedHash === "null" ? null : options.expectedHash,
           },
         );
+
         input.stdout.write(`${JSON.stringify(result)}\n`);
         state.exitCode = 0;
       },
@@ -363,6 +377,7 @@ export async function runProgressiveReviewCli(
       input.stdout.write(`Review Desktop is showing "${event.title}".\n`);
     }
   };
+
   const pickReview = async (options: {
     review?: string;
     view?: ReviewView;
@@ -379,20 +394,26 @@ export async function runProgressiveReviewCli(
       // not be stdout: the picker's ANSI frames would corrupt the event line.
       stdout: humanStream({ ...input, json: options.json }),
     });
+
     if (!event) {
       state.exitCode = 1;
+
       return;
     }
+
     writeAppEvent(event, options.json);
     state.exitCode = 0;
   };
+
   const launchApp = async (options: { json?: boolean }) => {
     const event = await runtime.runReviewAppLaunch();
     writeAppEvent(event, options.json);
     state.exitCode = 0;
   };
+
   const bindActiveReview = async (reviewUuid: string): Promise<void> => {
     const active = activeTelemetry;
+
     if (!active || active.finished || active.reviewUuid) return;
     active.reviewUuid = reviewUuid;
     setTraceAttribute("reviewUuid", reviewUuid);
@@ -404,6 +425,7 @@ export async function runProgressiveReviewCli(
       }),
     );
   };
+
   const app = configureJsonOutput(
     program
       .command("app")
@@ -414,9 +436,11 @@ export async function runProgressiveReviewCli(
   ).action(
     async (options: { review?: string; view?: ReviewView; json?: boolean }) => {
       if (options.review) return pickReview(options);
+
       return launchApp(options);
     },
   );
+
   configureJsonOutput(
     app.command("launch").description("Start or activate Review Desktop"),
     "plain",
@@ -516,10 +540,12 @@ export async function runProgressiveReviewCli(
   ).action(async (options: ReviewWaitOptions) => {
     if (options.codex) {
       const threadId = requireCodexThreadId(env);
+
       const review = await runtime.validateReviewWait({
         cwd,
         reviewUuid: options.review,
       });
+
       const registration = await runtime.startCodexWaitProcess({
         cliEntryPath: process.argv[1]!,
         cwd,
@@ -528,6 +554,7 @@ export async function runProgressiveReviewCli(
         threadId,
         timeout: String(options.timeout),
       });
+
       input.stdout.write(
         `${JSON.stringify({
           event: "codex-wait",
@@ -539,8 +566,10 @@ export async function runProgressiveReviewCli(
         })}\n`,
       );
       state.exitCode = 0;
+
       return;
     }
+
     state.exitCode = await runtime.runReviewWait({
       cwd,
       reviewUuid: options.review,
@@ -581,14 +610,17 @@ export async function runProgressiveReviewCli(
       .requiredOption("--commit <commit>")
       .action(async (checkoutPath: string, options: { commit: string }) => {
         const resolvedPath = path.resolve(checkoutPath);
+
         const commands = await devfastPrepareCommands(resolvedPath).catch(
           (): string[] => [],
         );
+
         const result = await runtime.prepareReviewPinnedCheckout({
           checkoutPath: resolvedPath,
           commit: options.commit,
           commands,
         });
+
         state.exitCode = result.prepared ? 0 : 1;
       }),
     "plain",
@@ -608,6 +640,7 @@ export async function runProgressiveReviewCli(
         all: options.all,
         reviewUuid: options.review,
       });
+
       input.stdout.write(`${JSON.stringify(event)}\n`);
       state.exitCode = 0;
     });
@@ -652,6 +685,7 @@ export async function runProgressiveReviewCli(
         newReview: options.new,
         onReviewBound: bindActiveReview,
       });
+
       input.stdout.write(`${JSON.stringify(event)}\n`);
       state.exitCode = 0;
     });
@@ -701,6 +735,7 @@ export async function runProgressiveReviewCli(
       .addHelpText("after", progressiveReviewInstallHelp()),
     "plain",
   );
+
   install.action(
     async (
       targets: string[],
@@ -717,9 +752,11 @@ export async function runProgressiveReviewCli(
     ) => {
       const selectedTargets = installTargets(targets);
       const installShim = options.shim !== false;
+
       const cliSource = installShim
         ? await resolveInstallCliSource(env)
         : undefined;
+
       const installInput: RunInstallInput = {
         targets: selectedTargets,
         env,
@@ -728,7 +765,9 @@ export async function runProgressiveReviewCli(
         stdout: input.stdout,
         stderr: input.stderr,
       };
+
       if (installShim) installInput.reviewCommand = pathShimPath();
+
       // Trace capture is experimental and opt-in: only a request that names
       // R2 credentials configures it. --without-traces stays accepted so
       // existing scripts keep working.
@@ -743,7 +782,9 @@ export async function runProgressiveReviewCli(
           },
         };
       }
+
       state.exitCode = await runtime.runInstall(installInput);
+
       if (state.exitCode !== 0 || !installShim) return;
 
       const human = humanStream({
@@ -751,16 +792,20 @@ export async function runProgressiveReviewCli(
         stdout: input.stdout,
         stderr: input.stderr,
       });
+
       if (!cliSource) {
         human.write(
           "Review did not install the review command because no built CLI was found. The skills were installed.\n",
         );
+
         return;
       }
+
       const installed = await runtime.installReviewCommand({
         ...cliSource,
         env,
       });
+
       human.write(installed.output);
     },
   );
@@ -769,6 +814,7 @@ export async function runProgressiveReviewCli(
     program.command("migrate").description("Migrate legacy Review data"),
     "plain",
   );
+
   configureJsonOutput(
     migrate
       .command("apply")
@@ -794,6 +840,7 @@ export async function runProgressiveReviewCli(
       .description("Read and update review comment threads"),
     "plain",
   );
+
   configureJsonOutput(
     threads
       .command("get <thread-id>")
@@ -868,23 +915,28 @@ export async function runProgressiveReviewCli(
     "plain",
   ).action(async () => {
     const payload = await readStopHookPayload(input);
+
     for (const review of await touchedStopHookReviews(
       payload,
       runtime.listReviews,
     )) {
       await runtime.sealReviewCandidate(review.dir, "Review turn checkpoint");
     }
+
     const decisionCwd = payload.cwd ?? cwd;
     const marker = await readReopenMarker(decisionCwd);
     const decision = decideStopHook(marker);
+
     if (decision.markNudged && marker) {
       await markReopenNudged(decisionCwd, marker);
     }
+
     if (decision.block) {
       input.stdout.write(
         `${JSON.stringify({ decision: "block", reason: decision.reason })}\n`,
       );
     }
+
     state.exitCode = 0;
   });
 
@@ -893,6 +945,7 @@ export async function runProgressiveReviewCli(
     program.command("trace").description("Manage agent traces"),
     "plain",
   );
+
   configureOutput(
     trace
       .command("status")
@@ -956,6 +1009,7 @@ export async function runProgressiveReviewCli(
       if (options.review && options.commit) {
         throw new Error("Use either --review or --commit, not both.");
       }
+
       state.exitCode = await runtime.runReviewTraceList({
         cwd,
         reviewUuid: options.review,
@@ -1025,9 +1079,11 @@ export async function runProgressiveReviewCli(
         options.commit,
         options.session,
       ].filter(Boolean);
+
       if (selectors.length > 1) {
         throw new Error("Use only one of --review, --commit, or --session.");
       }
+
       state.exitCode = await runtime.runReviewTracePull({
         cwd,
         repo: options.repo,
@@ -1151,6 +1207,7 @@ export async function runProgressiveReviewCli(
       .addHelpText("after", progressiveReviewMapHelp()),
     "map",
   );
+
   map.action((mapArgs: string[]) => executeMap(mapArgs));
 
   program.hook("preAction", async (_command, actionCommand) => {
@@ -1159,7 +1216,9 @@ export async function runProgressiveReviewCli(
     if (actionCommand.optsWithGlobals().json === true) {
       state.json = true;
     }
+
     const command = telemetryCommandPath(actionCommand, input.argv);
+
     if (!command) return;
     const commandRunId = telemetry.createCommandRunId();
     setTraceAttribute("command", command);
@@ -1187,6 +1246,7 @@ export async function runProgressiveReviewCli(
 
   try {
     await program.parseAsync(input.argv, { from: "user" });
+
     return state.exitCode;
   } catch (error) {
     if (error instanceof CommanderError) {
@@ -1198,9 +1258,12 @@ export async function runProgressiveReviewCli(
             : "help",
           0,
         );
+
         return 0;
       }
+
       const surface = state.parseSurface;
+
       // stdout carries the parseable failure whenever the caller asked for
       // JSON; stderr keeps the commander message and the help that
       // showHelpAfterError() produced, because a human may be reading too.
@@ -1213,11 +1276,13 @@ export async function runProgressiveReviewCli(
           },
         });
       }
+
       if (surface !== "review") {
         input.stderr.write(
           state.parserErrorOutput || ensureTrailingNewline(error.message),
         );
       }
+
       await finishActiveTelemetry(
         telemetry,
         activeTelemetry,
@@ -1225,9 +1290,11 @@ export async function runProgressiveReviewCli(
         error,
         telemetryProperties,
       );
+
       if (!activeTelemetry) {
         await captureOneOffCommand(telemetry, "invalid", 1, error);
       }
+
       return 1;
     }
 
@@ -1239,6 +1306,7 @@ export async function runProgressiveReviewCli(
     } else {
       input.stderr.write(ensureTrailingNewline(formatCliError(error)));
     }
+
     await finishActiveTelemetry(
       telemetry,
       activeTelemetry,
@@ -1246,6 +1314,7 @@ export async function runProgressiveReviewCli(
       error,
       telemetryProperties,
     );
+
     return 1;
   } finally {
     await attemptTelemetry(() => telemetry.shutdown(1_000));
@@ -1254,9 +1323,11 @@ export async function runProgressiveReviewCli(
 
 function parseTimeoutSeconds(value: string): number {
   const timeout = Number(value);
+
   if (!Number.isFinite(timeout) || timeout <= 0) {
     throw new Error("Timeout must be a positive number of seconds.");
   }
+
   return timeout;
 }
 
@@ -1264,13 +1335,16 @@ function installTargets(targets: readonly string[]): InstallTarget[] {
   if (targets.length === 0 || targets.includes("all")) {
     return [...ALL_INSTALL_TARGETS];
   }
-  return [
-    ...new Set(
-      targets
-        .map((target) => (target === "claude-code" ? "claude" : target))
-        .filter(isInstallTarget),
-    ),
-  ];
+
+  const uniqueTargets = new Set<InstallTarget>();
+
+  for (const target of targets) {
+    const normalizedTarget = target === "claude-code" ? "claude" : target;
+
+    if (isInstallTarget(normalizedTarget)) uniqueTargets.add(normalizedTarget);
+  }
+
+  return [...uniqueTargets];
 }
 
 interface StopHookPayload {
@@ -1282,20 +1356,28 @@ async function readStopHookPayload(
   input: ProgressiveReviewCliInput,
 ): Promise<StopHookPayload> {
   const stdin = input.stdin ?? process.stdin;
+
   if (stdin.isTTY) return {};
+
   try {
     const chunks: Buffer[] = [];
+
     for await (const chunk of stdin) {
       chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
     }
+
     const raw = Buffer.concat(chunks).toString("utf8").trim();
+
     if (!raw) return {};
     const parsed = jsonObject(parseJsonText(raw));
     const payload: StopHookPayload = {};
     const cwd = jsonString(parsed?.cwd);
+
     if (cwd !== undefined) payload.cwd = cwd;
     const transcriptPath = jsonString(parsed?.transcript_path);
+
     if (transcriptPath !== undefined) payload.transcriptPath = transcriptPath;
+
     return payload;
   } catch {
     return {};
@@ -1311,20 +1393,27 @@ async function touchedStopHookReviews(
 ): Promise<StoredReview[]> {
   const listed = await scan();
   const cwd = input.cwd ? path.resolve(input.cwd) : undefined;
+
   const transcript = input.transcriptPath
     ? await readFile(input.transcriptPath, "utf8")
     : "";
+
   const touched = (reviewDir: string) => {
     const dir = path.resolve(reviewDir);
+
     const cwdInside =
       cwd === dir || (cwd?.startsWith(`${dir}${path.sep}`) ?? false);
+
     return cwdInside || transcript.includes(dir);
   };
+
   const errors = listed.errors.filter((error) => touched(error.reviewDir));
+
   if (errors.length > 0)
     throw new Error(
       `Could not checkpoint reviews:\n${errors.map((error) => `${error.reviewDir}: ${error.message}`).join("\n")}`,
     );
+
   return listed.reviews.filter((review) => touched(review.dir));
 }
 
@@ -1382,11 +1471,14 @@ async function resolveInstallCliSource(
     const discovery = await readReviewDesktopDiscovery(
       reviewDesktopDiscoveryPath(env),
     );
+
     if (discovery?.cliPath && (await isFile(discovery.cliPath))) {
       const source: InstallCliSource = { cliPath: discovery.cliPath };
+
       if (discovery.cliRuntimePath) {
         source.cliRuntimePath = discovery.cliRuntimePath;
       }
+
       return source;
     }
   } catch {
@@ -1394,6 +1486,7 @@ async function resolveInstallCliSource(
   }
 
   const packageCliPath = path.join(defaultPackageRoot(), "dist", "cli.js");
+
   return (await isFile(packageCliPath))
     ? { cliPath: packageCliPath }
     : undefined;
@@ -1493,6 +1586,7 @@ function mapCommandProperties(
   const metadata = parsed.ok
     ? mapTelemetryMetadata(parsed.command, parsed.force, parsed.diffRefs)
     : mapTelemetryMetadata("check", false, {});
+
   return {
     command: "map",
     subcommand: normalizeMapTelemetrySubcommand(mapArgs),
@@ -1512,6 +1606,7 @@ function mapTelemetryMetadata(
     command === "init" || command === "update" || command === "check"
       ? command
       : "check";
+
   return {
     mode,
     has_base_ref: Boolean(diffRefs.baseRef),
@@ -1543,9 +1638,11 @@ function normalizeMapTelemetrySubcommand(
   const args = inputArgs[0] === "--" ? inputArgs.slice(1) : inputArgs;
   const rawCommand = args[0] ?? "check";
   const command = rawCommand === "present" ? "publish" : rawCommand;
+
   if (isMapHelpCommand(command)) {
     return "help";
   }
+
   if (
     command === "open" ||
     command === "check" ||
@@ -1562,6 +1659,7 @@ function normalizeMapTelemetrySubcommand(
   ) {
     return command;
   }
+
   return "unknown";
 }
 
@@ -1641,10 +1739,12 @@ function telemetryCommandPath(
 ): ProgressiveReviewCommandPath | undefined {
   const name = command.name();
   const parent = command.parent?.name();
+
   if (parent === "map" || name === "map") {
     const subcommand = normalizeMapTelemetrySubcommand(
       name === "map" ? argv.slice(argv.indexOf("map") + 1) : [name],
     );
+
     return subcommand === "open" ||
       subcommand === "check" ||
       subcommand === "publish" ||
@@ -1654,16 +1754,21 @@ function telemetryCommandPath(
       ? `map.${subcommand}`
       : "invalid";
   }
+
   if (parent === "migrate" && name === "apply") return "migrate.apply";
+
   if (parent === "app" && (name === "launch" || name === "pick")) {
     return `app.${name}`;
   }
+
   if (parent === "threads") {
     if (name === "list" || name === "resolve" || name === "reply") {
       return `threads.${name}`;
     }
+
     return "invalid";
   }
+
   if (
     name === "version" ||
     name === "rebind" ||
@@ -1675,6 +1780,7 @@ function telemetryCommandPath(
   ) {
     return name;
   }
+
   if (name === "app") {
     return argv.some(
       (argument) => argument === "--review" || argument.startsWith("--review="),
@@ -1682,6 +1788,7 @@ function telemetryCommandPath(
       ? "app.pick"
       : "app.launch";
   }
+
   return undefined;
 }
 
@@ -1697,19 +1804,24 @@ function errorClassification(
   if (cause instanceof CommanderError || command === "invalid") {
     return { errorName: "usage_error", errorCategory: "user_input" };
   }
+
   const name = cause instanceof Error ? cause.name.toLowerCase() : "";
+
   if (name.includes("notfound")) {
     return { errorName: "review_not_found", errorCategory: "local_state" };
   }
+
   if (command.startsWith("app.")) {
     return {
       errorName: "desktop_connection_error",
       errorCategory: "dependency",
     };
   }
+
   if (command === "scaffold") {
     return { errorName: "index_error", errorCategory: "dependency" };
   }
+
   if (
     command === "publish" ||
     command === "wait" ||
@@ -1719,12 +1831,15 @@ function errorClassification(
   ) {
     return { errorName: "review_state_error", errorCategory: "local_state" };
   }
+
   if (command.startsWith("map.") || command.startsWith("cache.")) {
     return { errorName: "repository_error", errorCategory: "local_state" };
   }
+
   if (cause) {
     return { errorName: "unexpected_error", errorCategory: "internal" };
   }
+
   return { errorName: "process_error", errorCategory: "dependency" };
 }
 
@@ -1744,6 +1859,7 @@ function formatCliError(cause: unknown): string {
   if (cause instanceof Error) {
     return cause.stack || `${cause.name}: ${cause.message}`;
   }
+
   return String(cause);
 }
 

--- a/packages/progressive-review/src/map-cli.test.ts
+++ b/packages/progressive-review/src/map-cli.test.ts
@@ -680,6 +680,7 @@ describe("review map check", () => {
     const rootPath = await realpath(rawRootPath);
     const previousReviewHome = process.env.DEV_REVIEW_HOME;
     process.env.DEV_REVIEW_HOME = path.join(rootPath, ".dev-home");
+    const server = await startLifecycleTestServer();
     try {
       execGit(rootPath, ["init"]);
       execGit(rootPath, ["config", "user.email", "review@example.com"]);
@@ -738,6 +739,7 @@ describe("review map check", () => {
         "map-worker",
       ]);
     } finally {
+      await server.close();
       if (previousReviewHome === undefined) {
         delete process.env.DEV_REVIEW_HOME;
       } else {
@@ -1377,3 +1379,4 @@ function execGitOutput(cwd: string, args: string[]): string {
     stdio: ["ignore", "pipe", "ignore"],
   }).trim();
 }
+import { startLifecycleTestServer } from "./review-lifecycle-test-utils";

--- a/packages/progressive-review/src/map-cli.test.ts
+++ b/packages/progressive-review/src/map-cli.test.ts
@@ -169,12 +169,14 @@ describe("removed commands point at their replacements", () => {
     "review map %s points at check's flush-on-green",
     async (command) => {
       const stderr: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: [command],
         cwd: "/repo",
         stdout: writable([]),
         stderr: writable(stderr),
       });
+
       expect(exitCode).toBe(1);
       expect(stderr.join("")).toContain(`review map ${command} was removed`);
       expect(stderr.join("")).toContain("flushes the scratch");
@@ -183,12 +185,14 @@ describe("removed commands point at their replacements", () => {
 
   it("review map scaffold points at open", async () => {
     const stderr: string[] = [];
+
     const exitCode = await runSoftwareMapCli({
       args: ["scaffold"],
       cwd: "/repo",
       stdout: writable([]),
       stderr: writable(stderr),
     });
+
     expect(exitCode).toBe(1);
     expect(stderr.join("")).toContain("review map scaffold was removed");
     expect(stderr.join("")).toContain("review map open <rev>");
@@ -198,12 +202,14 @@ describe("removed commands point at their replacements", () => {
     "rejects review map %s with guidance",
     async (command) => {
       const stderr: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: [command],
         cwd: "/repo",
         stdout: writable([]),
         stderr: writable(stderr),
       });
+
       expect(exitCode).toBe(1);
       expect(stderr.join("")).toContain(`review map ${command} was removed`);
       expect(stderr.join("")).toContain("review map open");
@@ -215,12 +221,14 @@ describe("removed commands point at their replacements", () => {
 describe("unknown flag handling", () => {
   it("exits 1 and names the flag (a --froce typo must not proceed)", async () => {
     const stderr: string[] = [];
+
     const exitCode = await runSoftwareMapCli({
       args: ["open", "HEAD", "--froce"],
       cwd: "/repo",
       stdout: writable([]),
       stderr: writable(stderr),
     });
+
     expect(exitCode).toBe(1);
     expect(stderr.join("")).toContain("Unknown flag: --froce");
   });
@@ -270,20 +278,25 @@ describe("review map open", () => {
   it("hydrates a stub scratch and reports provenance", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-open-");
+
     try {
       const commit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
       const stdout: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: ["open", "HEAD"],
         cwd: rootPath,
         stdout: writable(stdout),
         stderr: writable([]),
       });
+
       expect(exitCode).toBe(0);
+
       const scratchPath = scratchSoftwareMapPath({
         repoRootPath: rootPath,
         commit,
       })!;
+
       expect(stdout.join("")).toContain(`scratch: ${scratchPath}`);
       expect(stdout.join("")).toContain(
         "no note found on HEAD or any ancestor; scratch is a schema stub — author a full map",
@@ -298,6 +311,7 @@ describe("review map open", () => {
   it("hydrates from an existing note and protects dirty scratches", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-open-note-");
+
     try {
       const commit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
       await writeNote({
@@ -316,10 +330,12 @@ describe("review map open", () => {
       expect(openStdout.join("")).toContain(
         `hydrated from the note on ${commit.slice(0, 12)} (this commit); the map is current — verify and check to confirm`,
       );
+
       const scratchPath = scratchSoftwareMapPath({
         repoRootPath: rootPath,
         commit,
       })!;
+
       expect(await readFile(scratchPath, "utf8")).toBe(
         authoredMapSource("Note map"),
       );
@@ -327,12 +343,14 @@ describe("review map open", () => {
       // Dirty the scratch; open must leave it alone and say so.
       await writeFile(scratchPath, authoredMapSource("Edited"), "utf8");
       const stdout: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: ["open", "HEAD"],
         cwd: rootPath,
         stdout: writable(stdout),
         stderr: writable([]),
       });
+
       expect(exitCode).toBe(0);
       expect(stdout.join("")).toContain("unflushed edits");
       expect(await readFile(scratchPath, "utf8")).toBe(
@@ -367,6 +385,7 @@ describe("review map open", () => {
     expect(stderr.join("")).toContain("Usage: review map open <rev>");
 
     const dir = await mkdtemp(path.join(os.tmpdir(), "review-map-open-nogit-"));
+
     try {
       const nogitStderr: string[] = [];
       expect(
@@ -388,6 +407,7 @@ describe("review map check", () => {
   it("preflights the Git identity required to write the map note", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-check-identity-");
+
     try {
       const commit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
       await runSoftwareMapCli({
@@ -396,10 +416,12 @@ describe("review map check", () => {
         stdout: writable([]),
         stderr: writable([]),
       });
+
       const scratchPath = scratchSoftwareMapPath({
         repoRootPath: rootPath,
         commit,
       })!;
+
       await writeFile(
         scratchPath,
         [
@@ -418,6 +440,7 @@ describe("review map check", () => {
       execGit(rootPath, ["config", "user.email", ""]);
 
       const stderr: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: ["check", "HEAD"],
         cwd: rootPath,
@@ -438,6 +461,7 @@ describe("review map check", () => {
   it("validates the scratch and flushes it to the note on success", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-check-");
+
     try {
       const commit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
       await runSoftwareMapCli({
@@ -446,10 +470,12 @@ describe("review map check", () => {
         stdout: writable([]),
         stderr: writable([]),
       });
+
       const scratchPath = scratchSoftwareMapPath({
         repoRootPath: rootPath,
         commit,
       })!;
+
       const authored = [
         `import { defineSoftwareMap } from "${CANONICAL_SOFTWARE_MAP_MODEL_IMPORT}";`,
         "",
@@ -460,10 +486,12 @@ describe("review map check", () => {
         "});",
         "",
       ].join("\n");
+
       await writeFile(scratchPath, authored, "utf8");
 
       const stdout: string[] = [];
       const stderr: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: ["check", "HEAD"],
         cwd: rootPath,
@@ -489,6 +517,7 @@ describe("review map check", () => {
   it("blocks an element-free stub model at check (no note is flushed)", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-check-stub-");
+
     try {
       const commit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
       // open with no notes anywhere writes the schema stub verbatim.
@@ -501,6 +530,7 @@ describe("review map check", () => {
 
       const stdout: string[] = [];
       const stderr: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: ["check", "HEAD"],
         cwd: rootPath,
@@ -523,6 +553,7 @@ describe("review map check", () => {
   it("keeps concurrent checks of different commits isolated (per-invocation check modules)", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-check-concurrent-");
+
     try {
       const commitA = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
       execGitOutput(rootPath, [
@@ -532,6 +563,7 @@ describe("review map check", () => {
         "second commit",
       ]);
       const commitB = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
+
       const authored = (label: string) =>
         [
           `import { defineSoftwareMap } from "${CANONICAL_SOFTWARE_MAP_MODEL_IMPORT}";`,
@@ -543,6 +575,7 @@ describe("review map check", () => {
           "});",
           "",
         ].join("\n");
+
       for (const [commit, rev] of [
         [commitA, commitA],
         [commitB, "HEAD"],
@@ -553,10 +586,12 @@ describe("review map check", () => {
           stdout: writable([]),
           stderr: writable([]),
         });
+
         const scratchPath = scratchSoftwareMapPath({
           repoRootPath: rootPath,
           commit,
         })!;
+
         await writeFile(scratchPath, authored(`Map for ${commit}`), "utf8");
       }
 
@@ -572,6 +607,7 @@ describe("review map check", () => {
           }),
         ),
       );
+
       expect(exitA).toBe(0);
       expect(exitB).toBe(0);
       expect(
@@ -588,19 +624,23 @@ describe("review map check", () => {
           commit: commitB,
         }),
       ).toBe(authored(`Map for ${commitB}`));
+
       // The per-invocation check dirs were cleaned up after import.
       const gitDir = execGitOutput(rootPath, [
         "rev-parse",
         "--path-format=absolute",
         "--git-common-dir",
       ]);
+
       const checkRoot = path.join(gitDir, "dev-fast", "check");
       let leftovers: string[] = [];
+
       try {
         leftovers = await readdir(checkRoot);
       } catch {
         // The whole check root being gone is fine too.
       }
+
       expect(leftovers).toEqual([]);
     } finally {
       await rm(rootPath, { recursive: true, force: true });
@@ -610,6 +650,7 @@ describe("review map check", () => {
   it("writes nothing when the scratch is invalid", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-check-bad-");
+
     try {
       const commit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
       await runSoftwareMapCli({
@@ -618,10 +659,12 @@ describe("review map check", () => {
         stdout: writable([]),
         stderr: writable([]),
       });
+
       const scratchPath = scratchSoftwareMapPath({
         repoRootPath: rootPath,
         commit,
       })!;
+
       await writeFile(
         scratchPath,
         [
@@ -634,6 +677,7 @@ describe("review map check", () => {
       );
 
       const stderr: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: ["check", "HEAD"],
         cwd: rootPath,
@@ -656,14 +700,17 @@ describe("review map check", () => {
   it("asks for a revision when no scratch or review session locates one", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-check-norev-");
+
     try {
       const stderr: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: ["check", "HEAD"],
         cwd: rootPath,
         stdout: writable([]),
         stderr: writable(stderr),
       });
+
       expect(exitCode).toBe(1);
       expect(stderr.join("")).toContain("No scratch exists");
       expect(stderr.join("")).toContain("review map open");
@@ -674,13 +721,16 @@ describe("review map check", () => {
 
   it("resolves the current review's head when no rev is given", async () => {
     if (!commandExists("git")) return;
+
     const rawRootPath = await mkdtemp(
       path.join(os.tmpdir(), "review-map-check-session-"),
     );
+
     const rootPath = await realpath(rawRootPath);
     const previousReviewHome = process.env.DEV_REVIEW_HOME;
     process.env.DEV_REVIEW_HOME = path.join(rootPath, ".dev-home");
     const server = await startLifecycleTestServer();
+
     try {
       execGit(rootPath, ["init"]);
       execGit(rootPath, ["config", "user.email", "review@example.com"]);
@@ -704,10 +754,12 @@ describe("review map check", () => {
         stdout: writable([]),
         stderr: writable([]),
       });
+
       const scratchPath = scratchSoftwareMapPath({
         repoRootPath: rootPath,
         commit,
       })!;
+
       await writeFile(
         scratchPath,
         authoredMapSource("Active session map"),
@@ -716,6 +768,7 @@ describe("review map check", () => {
 
       const stdout: string[] = [];
       const stderr: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: ["check", "--review", review.review.uuid],
         cwd: rootPath,
@@ -732,19 +785,23 @@ describe("review map check", () => {
       expect(
         await readNote({ rootPath, ref: SOFTWARE_MAP_NOTES_REF, commit }),
       ).toContain("Active session map");
+
       const record = JSON.parse(
         await readFile(path.join(review.dir, "review.json"), "utf8"),
       );
+
       expect(record.agentSessions["codex:map-worker-1"].roles).toEqual([
         "map-worker",
       ]);
     } finally {
       await server.close();
+
       if (previousReviewHome === undefined) {
         delete process.env.DEV_REVIEW_HOME;
       } else {
         process.env.DEV_REVIEW_HOME = previousReviewHome;
       }
+
       await rm(rawRootPath, { recursive: true, force: true });
     }
   });
@@ -754,6 +811,7 @@ describe("coverage validates against the target commit's tree", () => {
   it("passes for a historical commit whose tree still has the file, fails for the commit that deleted it", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-check-tree-");
+
     try {
       // Commit A adds legacy.ts; the next commit deletes it; the working
       // copy sits at the later commit.
@@ -782,19 +840,23 @@ describe("coverage validates against the target commit's tree", () => {
         stdout: writable([]),
         stderr: writable([]),
       });
+
       const scratchA = scratchSoftwareMapPath({
         repoRootPath: rootPath,
         commit: commitA,
       })!;
+
       await writeFile(scratchA, claimingMap, "utf8");
       const passStdout: string[] = [];
       const passStderr: string[] = [];
+
       const passExit = await runSoftwareMapCli({
         args: ["check", commitA],
         cwd: rootPath,
         stdout: writable(passStdout),
         stderr: writable(passStderr),
       });
+
       expect(passStderr.join("")).toBe("");
       expect(passExit).toBe(0);
       expect(passStdout.join("")).toContain(
@@ -816,18 +878,22 @@ describe("coverage validates against the target commit's tree", () => {
         stdout: writable([]),
         stderr: writable([]),
       });
+
       const scratchB = scratchSoftwareMapPath({
         repoRootPath: rootPath,
         commit: commitB,
       })!;
+
       await writeFile(scratchB, claimingMap, "utf8");
       const failStderr: string[] = [];
+
       const failExit = await runSoftwareMapCli({
         args: ["check", commitB],
         cwd: rootPath,
         stdout: writable([]),
         stderr: writable(failStderr),
       });
+
       expect(failExit).toBe(1);
       expect(failStderr.join("")).toContain(
         `claims file "legacy.ts" missing from tree of ${commitB.slice(0, 12)}`,
@@ -847,6 +913,7 @@ describe("coverage validates against the target commit's tree", () => {
   it("matches glob coverage against a historical tree", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-check-tree-glob-");
+
     try {
       await mkdir(path.join(rootPath, "src", "old"), { recursive: true });
       await writeFile(
@@ -929,6 +996,7 @@ describe("coverage validates against the target commit's tree", () => {
   it("ignores on-disk files the target tree does not contain (uniform tree frame)", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-check-tree-uniform-");
+
     try {
       const commit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
       // The file exists on disk (uncommitted) but not in HEAD's tree: the
@@ -980,6 +1048,7 @@ describe("ancestor seeding (the quiet-diff fast path)", () => {
   it("open seeds head from base's note and prints the diff work order", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-seed-");
+
     try {
       const baseCommit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
       await writeFile(path.join(rootPath, "next.txt"), "next\n", "utf8");
@@ -995,22 +1064,26 @@ describe("ancestor seeding (the quiet-diff fast path)", () => {
       });
       const stdout: string[] = [];
       const stderr: string[] = [];
+
       const openExit = await runSoftwareMapCli({
         args: ["open", "HEAD"],
         cwd: rootPath,
         stdout: writable(stdout),
         stderr: writable(stderr),
       });
+
       expect(stderr.join("")).toBe("");
       expect(openExit).toBe(0);
       expect(stdout.join("")).toContain(
         `hydrated from the note on ${baseCommit.slice(0, 12)}, 1 commits behind HEAD; review the diff ${baseCommit.slice(0, 12)}..HEAD and update the map to match`,
       );
+
       // The scratch seeds byte-equal from the ancestor note.
       const scratchPath = scratchSoftwareMapPath({
         repoRootPath: rootPath,
         commit: headCommit,
       })!;
+
       expect(await readFile(scratchPath, "utf8")).toBe(
         authoredMapSource("Base map"),
       );
@@ -1018,12 +1091,14 @@ describe("ancestor seeding (the quiet-diff fast path)", () => {
       // Quiet diff: check with no edits flushes head's own note.
       const checkStdout: string[] = [];
       const checkStderr: string[] = [];
+
       const checkExit = await runSoftwareMapCli({
         args: ["check", "HEAD"],
         cwd: rootPath,
         stdout: writable(checkStdout),
         stderr: writable(checkStderr),
       });
+
       expect(checkStderr.join("")).toBe("");
       expect(checkExit).toBe(0);
       expect(checkStdout.join("")).toContain(
@@ -1046,6 +1121,7 @@ describe("review map prune", () => {
   it("drops notes on unreachable commits and keeps reachable ones", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-prune-");
+
     try {
       const keptCommit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
       execGit(rootPath, ["checkout", "-q", "-b", "doomed"]);
@@ -1067,6 +1143,7 @@ describe("review map prune", () => {
       }
 
       const stdout: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: ["prune"],
         cwd: rootPath,
@@ -1087,6 +1164,7 @@ describe("review map prune", () => {
   it("deletes a scratch whose canonicalized content equals its commit's note", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-prune-scratch-");
+
     try {
       const commit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
       const content = authoredMapSource("Flushed map");
@@ -1096,10 +1174,12 @@ describe("review map prune", () => {
         commit,
         content,
       });
+
       const scratchPath = scratchSoftwareMapPath({
         repoRootPath: rootPath,
         commit,
       });
+
       if (!scratchPath) throw new Error("expected a scratch path");
       await mkdir(path.dirname(scratchPath), { recursive: true });
       // The scratch spells the model import relatively; only the canonicalized
@@ -1115,6 +1195,7 @@ describe("review map prune", () => {
       );
 
       const stdout: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: ["prune"],
         cwd: rootPath,
@@ -1141,6 +1222,7 @@ describe("review map prune", () => {
   it("keeps a dirty scratch (content differs from the note)", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-prune-dirty-");
+
     try {
       const commit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
       await writeNote({
@@ -1149,16 +1231,19 @@ describe("review map prune", () => {
         commit,
         content: authoredMapSource("Flushed version"),
       });
+
       const scratchPath = scratchSoftwareMapPath({
         repoRootPath: rootPath,
         commit,
       });
+
       if (!scratchPath) throw new Error("expected a scratch path");
       await mkdir(path.dirname(scratchPath), { recursive: true });
       const dirtyContent = authoredMapSource("Unflushed edits");
       await writeFile(scratchPath, dirtyContent, "utf8");
 
       const stdout: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: ["prune"],
         cwd: rootPath,
@@ -1177,18 +1262,22 @@ describe("review map prune", () => {
   it("keeps a scratch whose commit has no note", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-prune-no-note-");
+
     try {
       const commit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
+
       const scratchPath = scratchSoftwareMapPath({
         repoRootPath: rootPath,
         commit,
       });
+
       if (!scratchPath) throw new Error("expected a scratch path");
       await mkdir(path.dirname(scratchPath), { recursive: true });
       const unflushedContent = authoredMapSource("Never flushed");
       await writeFile(scratchPath, unflushedContent, "utf8");
 
       const stdout: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: ["prune"],
         cwd: rootPath,
@@ -1210,6 +1299,7 @@ describe("review map push / fetch", () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-push-remote-");
     const bareDir = await mkdtemp(path.join(os.tmpdir(), "review-map-fork-"));
+
     try {
       execGit(bareDir, ["init", "--bare"]);
       execGit(rootPath, ["remote", "add", "fork", bareDir]);
@@ -1247,9 +1337,11 @@ describe("review map push / fetch", () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-push-");
     const bareDir = await mkdtemp(path.join(os.tmpdir(), "review-map-origin-"));
+
     const cloneParent = await mkdtemp(
       path.join(os.tmpdir(), "review-map-clone-"),
     );
+
     try {
       execGit(bareDir, ["init", "--bare"]);
       execGit(rootPath, ["remote", "add", "origin", bareDir]);
@@ -1263,30 +1355,36 @@ describe("review map push / fetch", () => {
       });
 
       const pushStdout: string[] = [];
+
       const pushExit = await runSoftwareMapCli({
         args: ["push"],
         cwd: rootPath,
         stdout: writable(pushStdout),
         stderr: writable([]),
       });
+
       expect(pushExit).toBe(0);
       expect(pushStdout.join("")).toContain(SOFTWARE_MAP_NOTES_REF);
 
       execGit(cloneParent, ["clone", "-q", bareDir, "clone"]);
       const clonePath = path.join(cloneParent, "clone");
       const fetchStdout: string[] = [];
+
       const fetchExit = await runSoftwareMapCli({
         args: ["fetch"],
         cwd: clonePath,
         stdout: writable(fetchStdout),
         stderr: writable([]),
       });
+
       expect(fetchExit).toBe(0);
+
       const remoteNote = await readNote({
         rootPath: clonePath,
         ref: remoteNotesRef(SOFTWARE_MAP_NOTES_REF),
         commit,
       });
+
       expect(remoteNote).toContain("Shared map");
     } finally {
       await rm(rootPath, { recursive: true, force: true });
@@ -1298,6 +1396,7 @@ describe("review map push / fetch", () => {
   it("push fails soft against an unreachable origin", async () => {
     if (!commandExists("git")) return;
     const rootPath = await gitFixture("review-map-push-bad-");
+
     try {
       const commit = execGitOutput(rootPath, ["rev-parse", "HEAD"]);
       await writeNote({
@@ -1313,12 +1412,14 @@ describe("review map push / fetch", () => {
         path.join(os.tmpdir(), "missing-origin.git"),
       ]);
       const stderr: string[] = [];
+
       const exitCode = await runSoftwareMapCli({
         args: ["push"],
         cwd: rootPath,
         stdout: writable([]),
         stderr: writable(stderr),
       });
+
       expect(exitCode).toBe(1);
       expect(stderr.join("")).toContain("software map push failed");
     } finally {
@@ -1351,6 +1452,7 @@ async function gitFixture(prefix: string): Promise<string> {
   await writeFile(path.join(rootPath, "README.md"), "base\n", "utf8");
   execGit(rootPath, ["add", "README.md"]);
   execGit(rootPath, ["commit", "-m", "base"]);
+
   return rootPath;
 }
 
@@ -1359,6 +1461,7 @@ function commandExists(command: string): boolean {
     execFileSync(command, ["--version"], {
       stdio: ["ignore", "ignore", "ignore"],
     });
+
     return true;
   } catch {
     return false;
@@ -1379,4 +1482,5 @@ function execGitOutput(cwd: string, args: string[]): string {
     stdio: ["ignore", "pipe", "ignore"],
   }).trim();
 }
+
 import { startLifecycleTestServer } from "./review-lifecycle-test-utils";

--- a/packages/progressive-review/src/map-cli.ts
+++ b/packages/progressive-review/src/map-cli.ts
@@ -80,14 +80,17 @@ export async function runSoftwareMapCli(
   // A parse failure happens before options resolve, so read the flag from raw
   // argv the same way the top-level CLI does.
   const json = parsed.ok ? parsed.json : jsonRequestedInArgv(input.args);
+
   const output: CliJsonOutput = {
     json,
     stdout: input.stdout,
     stderr: input.stderr,
   };
+
   if (!parsed.ok) {
     const exitCode = failWithJsonError(output, "map", parsed.error);
     input.stderr.write(softwareMapCliHelp());
+
     return exitCode;
   }
 
@@ -95,10 +98,13 @@ export async function runSoftwareMapCli(
 
   if (command === "--help" || command === "-h" || command === "help") {
     input.stdout.write(softwareMapCliHelp());
+
     return 0;
   }
+
   if (input.args.includes("--help") || input.args.includes("-h")) {
     input.stdout.write(softwareMapCliHelp());
+
     return 0;
   }
 
@@ -184,7 +190,9 @@ export async function runSoftwareMapCli(
     "map",
     `Unknown map command: ${command}`,
   );
+
   input.stderr.write(softwareMapCliHelp());
+
   return exitCode;
 }
 
@@ -236,6 +244,7 @@ export function parseSoftwareMapCliArgs(
   const rawCommand = args[0] ?? "check";
   // `present` is an alias of `publish`.
   const command = rawCommand === "present" ? "publish" : rawCommand;
+
   if (command === "--help" || command === "-h" || command === "help") {
     return {
       ok: true,
@@ -248,12 +257,14 @@ export function parseSoftwareMapCliArgs(
   }
 
   const commandModel = softwareMapCommandModel(command);
+
   try {
     commandModel.parse(args.slice(1), { from: "user" });
   } catch (error) {
     if (!(error instanceof CommanderError)) {
       throw error;
     }
+
     if (error.exitCode === 0) {
       return {
         ok: true,
@@ -264,6 +275,7 @@ export function parseSoftwareMapCliArgs(
         json: args.includes("--json"),
       };
     }
+
     return { ok: false, error: softwareMapCommanderError(error, command) };
   }
 
@@ -276,6 +288,7 @@ export function parseSoftwareMapCliArgs(
     remote?: string;
     json?: boolean;
   }>();
+
   const missingRemovedOption = (
     [
       ["base", options.base],
@@ -283,12 +296,14 @@ export function parseSoftwareMapCliArgs(
       ["pr", options.pr],
     ] as const
   ).find(([, value]) => value === "");
+
   if (missingRemovedOption) {
     return {
       ok: false,
       error: `Expected a value after --${missingRemovedOption[0]}.`,
     };
   }
+
   if (options.remote !== undefined && !options.remote.trim()) {
     return { ok: false, error: "Expected a value after --remote." };
   }
@@ -332,14 +347,17 @@ function softwareMapCommandModel(commandName: string): Command {
   if (commandName === "open") {
     return command.addArgument(new Argument("<rev>"));
   }
+
   if (commandName === "check") {
     return command
       .addArgument(new Argument("[rev]"))
       .addOption(new Option("--review <uuid>"));
   }
+
   if (commandName === "publish") {
     return command.addOption(new Option("--review <uuid>"));
   }
+
   if (
     commandName === "prune" ||
     commandName === "push" ||
@@ -349,6 +367,7 @@ function softwareMapCommandModel(commandName: string): Command {
       ? command.addOption(new Option("--remote <name>"))
       : command;
   }
+
   return command.addArgument(new Argument("[args...]"));
 }
 
@@ -359,14 +378,17 @@ function softwareMapCommanderError(
   if (/option '--remote <name>' argument missing/.test(error.message)) {
     return "Expected a value after --remote.";
   }
+
   const missingRemovedOption = error.message.match(
     /option '(--(?:base|head|pr))(?: <[^>]+>)?' argument missing/,
   )?.[1];
+
   if (missingRemovedOption) {
     return `Expected a value after ${missingRemovedOption}.`;
   }
 
   const unknownOption = error.message.match(/unknown option '([^']+)'/)?.[1];
+
   if (unknownOption) {
     // Unknown flags are a hard error: `--froce` silently proceeding as a
     // typo-ignoring success would discard the user's stated intent.
@@ -398,6 +420,7 @@ async function openSoftwareMapScratch(
   },
 ) {
   const human = humanStream(input);
+
   if (!input.rev) {
     return failWithJsonError(
       input,
@@ -405,6 +428,7 @@ async function openSoftwareMapScratch(
       "Usage: review map open <rev> [--force]",
     );
   }
+
   if (!gitCommonDirSync(input.rootPath)) {
     return failWithJsonError(
       input,
@@ -412,12 +436,14 @@ async function openSoftwareMapScratch(
       `${input.rootPath} is not inside a git repository; software maps are stored as git notes and need one.`,
     );
   }
+
   try {
     const hydrated = await hydrateScratch({
       repoRootPath: input.rootPath,
       rev: input.rev,
       force: input.force,
     });
+
     if (hydrated.dirty) {
       human.write(`scratch: ${hydrated.path}\n`);
       human.write(
@@ -429,11 +455,14 @@ async function openSoftwareMapScratch(
         commit: hydrated.commit,
         dirty: true,
       });
+
       return 0;
     }
+
     human.write(`scratch: ${hydrated.path}\n`);
     human.write(`commit: ${hydrated.commit}\n`);
     human.write(`${openProvenanceLine(hydrated, input.rev)}\n`);
+
     const opened: MapOpenEvent = {
       event: "map-open",
       scratch: hydrated.path,
@@ -441,13 +470,17 @@ async function openSoftwareMapScratch(
       dirty: false,
       hydratedFrom: hydrated.hydratedFrom,
     };
+
     if (hydrated.seedCommit) opened.seedCommit = hydrated.seedCommit;
+
     if (hydrated.hydratedFrom === "ancestor-note") {
       opened.distance = hydrated.distance;
       // The diff the map agent must apply before it checks.
       opened.diffRange = `${hydrated.seedCommit}..${input.rev}`;
     }
+
     emitJsonEvent(input, opened);
+
     return 0;
   } catch (error) {
     return failWithJsonError(
@@ -465,6 +498,7 @@ function openProvenanceLine(
   rev: string,
 ): string {
   const short = (sha: string) => sha.slice(0, 12);
+
   switch (hydrated.hydratedFrom) {
     case "note":
     case "remote-note":
@@ -489,12 +523,15 @@ async function checkSoftwareMapScratch(
 ) {
   const human = humanStream(input);
   const target = await resolveCheckTarget(input);
+
   if (!target.ok) {
     return failWithJsonError(input, "map-check", target.error);
   }
+
   const { repoRootPath, commit } = target;
 
   const mapPath = scratchSoftwareMapPath({ repoRootPath, commit });
+
   if (!mapPath) {
     return failWithJsonError(
       input,
@@ -502,7 +539,9 @@ async function checkSoftwareMapScratch(
       `${repoRootPath} is not inside a git repository; software maps are stored as git notes and need one.`,
     );
   }
+
   const rawMapSource = readFileOrNull(mapPath);
+
   if (rawMapSource === null) {
     return failWithJsonError(
       input,
@@ -510,9 +549,11 @@ async function checkSoftwareMapScratch(
       `No scratch exists for ${commit}. Run review map open ${input.rev ?? commit.slice(0, 12)} first.`,
     );
   }
+
   const authorIdentity = await git(repoRootPath, ["var", "GIT_AUTHOR_IDENT"], {
     allowFailure: true,
   });
+
   if (!authorIdentity.ok) {
     return failWithJsonError(
       input,
@@ -523,6 +564,7 @@ async function checkSoftwareMapScratch(
       ].join("\n"),
     );
   }
+
   // The shared check core validates the canonicalized form — the exact bytes
   // the flush publishes — so check-validated bytes and flushed bytes stay the
   // same bytes. `review publish` runs this same function as its map gate.
@@ -532,9 +574,12 @@ async function checkSoftwareMapScratch(
     source: rawMapSource,
     sourceName: mapPath,
   });
+
   const mapSource = check.canonicalSource;
+
   if (!check.model || check.errors.length > 0) {
     input.stderr.write("software map: error\n");
+
     for (const error of check.errors) input.stderr.write(`- ${error}\n`);
     emitJsonEvent(input, {
       event: "error",
@@ -543,14 +588,17 @@ async function checkSoftwareMapScratch(
       file: mapPath,
       diagnostics: check.errors,
     });
+
     return 1;
   }
+
   const model = check.model;
 
   const warnings = [
     ...collectSoftwareMapConnectivityWarnings(mapSource),
     ...collectSoftwareMapOwnershipWarnings(model),
   ];
+
   const counts = countSoftwareMapElements(model.elements);
 
   // The scratch is valid: flush it. Every green check publishes — and it
@@ -567,6 +615,7 @@ async function checkSoftwareMapScratch(
   }
 
   const agent = resolveAuthoringSessionRef(input.env ?? process.env);
+
   if (agent && input.reviewUuid) {
     const worktreeRoot = await resolveReviewRoot(input.rootPath);
     const review = await resolvePublishReview(worktreeRoot, input.reviewUuid);
@@ -594,6 +643,7 @@ async function checkSoftwareMapScratch(
 
   if (warnings.length > 0) {
     human.write("software map warnings:\n");
+
     for (const warning of warnings) human.write(`- ${warning}\n`);
   }
 
@@ -626,20 +676,24 @@ async function resolveCheckTarget(input: {
     const resolved = await resolveRevision(input.rootPath, input.rev).catch(
       () => null,
     );
+
     if (!resolved?.commit) {
       return { ok: false, error: `Unable to resolve revision: ${input.rev}` };
     }
+
     return { ok: true, repoRootPath: input.rootPath, commit: resolved.commit };
   }
 
   const worktreeRoot = await resolveReviewRoot(input.rootPath);
   const review = await resolvePublishReview(worktreeRoot, input.reviewUuid);
   const repoRootPath = resolveReviewRepoRootFromStore(review.dir);
+
   const head = review.review.sourceCommit
     ? await resolveRevision(repoRootPath, review.review.sourceCommit).catch(
         () => null,
       )
     : await currentHead(repoRootPath).catch(() => null);
+
   if (!head?.commit) {
     return {
       ok: false,
@@ -647,6 +701,7 @@ async function resolveCheckTarget(input: {
         "Unable to resolve the active review's head commit. Pass one: review map check <rev>.",
     };
   }
+
   return { ok: true, repoRootPath, commit: head.commit };
 }
 
@@ -655,6 +710,7 @@ async function pruneSoftwareMapNotes(
 ) {
   const human = humanStream(input);
   const gitDir = gitCommonDirSync(input.rootPath);
+
   if (!gitDir) {
     return failWithJsonError(
       input,
@@ -662,10 +718,12 @@ async function pruneSoftwareMapNotes(
       `${input.rootPath} is not inside a git repository; software maps are stored as git notes and need one.`,
     );
   }
+
   const pruned = await pruneNotes({
     rootPath: input.rootPath,
     ref: SOFTWARE_MAP_NOTES_REF,
   });
+
   human.write(
     pruned.removed.length === 0
       ? `${SOFTWARE_MAP_NOTES_REF}: nothing to prune\n`
@@ -673,11 +731,13 @@ async function pruneSoftwareMapNotes(
           .map((commit) => commit.slice(0, 12))
           .join(", ")})\n`,
   );
+
   const swept = await sweepFlushedScratches({
     rootPath: input.rootPath,
     gitDir,
     stdout: human,
   });
+
   emitJsonEvent(input, {
     event: "map-prune",
     note: SOFTWARE_MAP_NOTES_REF,
@@ -685,6 +745,7 @@ async function pruneSoftwareMapNotes(
     scratchDeleted: swept.deleted,
     scratchKept: swept.kept,
   });
+
   return 0;
 }
 
@@ -701,17 +762,21 @@ async function sweepFlushedScratches(input: {
 }): Promise<{ deleted: number; kept: number }> {
   const scratchRoot = path.join(devFastGitDir(input.gitDir), "scratch");
   let commits: string[] = [];
+
   try {
     commits = readdirSync(scratchRoot);
   } catch {
     // No scratch directory yet: nothing to sweep.
   }
+
   let deleted = 0;
   let kept = 0;
+
   for (const commit of commits) {
     // Scratch dirs are named by their target commit; skip anything else.
     if (!/^[0-9a-f]{40,64}$/i.test(commit)) continue;
     const scratchDir = path.join(scratchRoot, commit);
+
     if (
       await scratchIsFullyFlushed({
         rootPath: input.rootPath,
@@ -728,7 +793,9 @@ async function sweepFlushedScratches(input: {
       kept += 1;
     }
   }
+
   input.stdout.write(`scratch: ${deleted} deleted, ${kept} kept\n`);
+
   return { deleted, kept };
 }
 
@@ -740,13 +807,17 @@ async function scratchIsFullyFlushed(input: {
   const mapSource = readFileOrNull(
     path.join(input.scratchDir, SOFTWARE_MAP_FILE_NAME),
   );
+
   if (mapSource === null) return false;
+
   const mapNote = await readNote({
     rootPath: input.rootPath,
     ref: SOFTWARE_MAP_NOTES_REF,
     commit: input.commit,
   });
+
   if (mapNote === null) return false;
+
   return canonicalizeModelImport(mapSource) === mapNote;
 }
 
@@ -755,11 +826,13 @@ async function pushSoftwareMapNotes(
 ) {
   const human = humanStream(input);
   const remote = await notesRemote(input.rootPath, input.remote);
+
   const result = await pushNotes({
     rootPath: input.rootPath,
     remote,
     refs: [SOFTWARE_MAP_NOTES_REF],
   });
+
   if (!result.ok) {
     return failWithJsonError(
       input,
@@ -767,12 +840,14 @@ async function pushSoftwareMapNotes(
       `software map push failed for ${remote}: ${result.error ?? "unknown error"}. If another remote is writable, retry with --remote <name>.`,
     );
   }
+
   human.write(
     result.pushed.length === 0
       ? "no software-map notes to push.\n"
       : `pushed ${result.pushed.join(", ")} to ${remote}. Teammates receive them on their next fetch (review install configures the refspec).\n`,
   );
   emitJsonEvent(input, { event: "map-push", remote, pushed: result.pushed });
+
   return 0;
 }
 
@@ -782,6 +857,7 @@ async function fetchSoftwareMapNotes(
   const human = humanStream(input);
   const remote = await notesRemote(input.rootPath, input.remote);
   const result = await fetchNotes({ rootPath: input.rootPath, remote });
+
   if (!result.ok) {
     return failWithJsonError(
       input,
@@ -789,6 +865,7 @@ async function fetchSoftwareMapNotes(
       `software map fetch failed for ${remote}: ${result.error ?? "unknown error"}`,
     );
   }
+
   human.write(
     result.skipped
       ? "software-map note fetch skipped (devFast.fetchNotes=false).\n"
@@ -799,6 +876,7 @@ async function fetchSoftwareMapNotes(
     remote,
     skipped: result.skipped ?? false,
   });
+
   return 0;
 }
 
@@ -829,9 +907,11 @@ function countSoftwareMapElements(
 
 function collectSoftwareMapOwnershipWarnings(model: NormalizedSoftwareModel) {
   const warnings: string[] = [];
+
   const componentCount = model.elements.filter(
     (element) => element.type === "component",
   ).length;
+
   const uncoveredComponents = model.elements
     .filter((element) => element.type === "component" && !element.coverage)
     .map((element) => element.path);
@@ -841,11 +921,13 @@ function collectSoftwareMapOwnershipWarnings(model: NormalizedSoftwareModel) {
       `SoftwareMap ownership: ${uncoveredComponents.length}/${componentCount} component(s) have no coverage claim: ${previewList(uncoveredComponents)}.`,
     );
   }
+
   return warnings;
 }
 
 function previewList(values: readonly string[]) {
   const preview = values.slice(0, 8).join(", ");
   const suffix = values.length > 8 ? `, and ${values.length - 8} more` : "";
+
   return `${preview}${suffix}`;
 }

--- a/packages/progressive-review/src/map-cli.ts
+++ b/packages/progressive-review/src/map-cli.ts
@@ -26,7 +26,10 @@ import {
   humanStream,
   jsonRequestedInArgv,
 } from "./cli-output";
-import { touchReviewAgentSession } from "./review-home";
+import {
+  resolveReviewClient as resolvePublishReview,
+  touchReviewAgentSessionClient as touchReviewAgentSession,
+} from "./review-lifecycle-client";
 import { runReviewMapPublish } from "./review-map-publish";
 import {
   SOFTWARE_MAP_FILE_NAME,
@@ -35,7 +38,6 @@ import {
 } from "./review-storage";
 import { resolveReviewRepoRootFromStore } from "./review-worktree-target";
 import { resolveReviewRoot } from "./runtime";
-import { resolvePublishReview } from "./server/publish-preparation";
 import {
   type HydrateScratchResult,
   canonicalizeModelImport,

--- a/packages/progressive-review/src/migrate.ts
+++ b/packages/progressive-review/src/migrate.ts
@@ -35,6 +35,7 @@ import {
   parseAnyStoredReviewRecord,
   parseStoredReviewRecord,
 } from "./review-home";
+import { putReviewRecord } from "./review-state-db";
 import { devReviewHome } from "./review-storage";
 import { reviewVcs } from "./review-vcs";
 import { writePrivateJsonAtomic } from "./server/desktop-paths";
@@ -397,6 +398,15 @@ export async function migrateJjReviewRepositories(input: {
         recordSource,
         force: input.force,
       });
+      putReviewRecord(
+        reviewDir,
+        parseStoredReviewRecord(
+          JSON.parse(
+            await readFile(path.join(reviewDir, "review.json"), "utf8"),
+          ),
+        ),
+        input.reviewHome,
+      );
       input.log?.(`Converted jj Review repository ${reviewDir} to plain Git.`);
       result.migrated += 1;
     } catch (error) {

--- a/packages/progressive-review/src/migrate.ts
+++ b/packages/progressive-review/src/migrate.ts
@@ -43,8 +43,10 @@ import { auditStoredReviewDocuments } from "./stored-review-document-audit";
 import { migrateStoredReviewData } from "./stored-review-migration";
 
 const PACKAGE_NAME = "@dev.fast/review";
+
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 const LEGACY_SKILL_NAMES = [
   "review",
   "review-map",
@@ -52,11 +54,13 @@ const LEGACY_SKILL_NAMES = [
   "progressive-review",
   "pr-review",
 ] as const;
+
 const CURRENT_SKILL_NAMES = [
   "dev-review",
   "dev-review-map",
   "trace-archaeology",
 ] as const;
+
 const execFilePromise = promisify(execFile);
 
 export type ReviewPackageManager = "npm" | "pnpm" | "yarn" | "bun";
@@ -105,6 +109,7 @@ export async function runReviewMigration(input: {
   const homeDir = input.homeDir ?? os.homedir();
   const reviewHome = devReviewHome(env, homeDir);
   const packageRoot = input.packageRoot ?? defaultPackageRoot();
+
   const runtime: RunReviewMigrationRuntime = {
     migrateStoredReviewData,
     migrateJjReviewRepositories,
@@ -117,6 +122,7 @@ export async function runReviewMigration(input: {
   };
 
   const blockers: string[] = [];
+
   const stored = await runMigrationPhase(
     "Old Review cleanup",
     {
@@ -137,6 +143,7 @@ export async function runReviewMigration(input: {
       }),
     blockers,
   );
+
   const jj = await runMigrationPhase(
     "jj repository migration",
     { checked: 0, migrated: 0, blockers: [] },
@@ -149,6 +156,7 @@ export async function runReviewMigration(input: {
       }),
     blockers,
   );
+
   const managedCheckouts = await runMigrationPhase(
     "Review-managed checkout migration",
     { checked: 0, created: 0, legacyRemoved: 0, blockers: [] },
@@ -160,6 +168,7 @@ export async function runReviewMigration(input: {
       }),
     blockers,
   );
+
   const audit = await runMigrationPhase(
     "Review document audit",
     { documents: 0, issues: [] },
@@ -171,12 +180,14 @@ export async function runReviewMigration(input: {
       }),
     blockers,
   );
+
   const catalog = await runMigrationPhase(
     "obsolete Desktop catalog cleanup",
     { checked: 0, removed: 0, blockers: [] },
     () => runtime.removeLegacyDesktopCatalog({ reviewHome }),
     blockers,
   );
+
   const skills = await runMigrationPhase(
     "legacy skill cleanup",
     { checked: 0, removed: 0, blockers: [] },
@@ -187,6 +198,7 @@ export async function runReviewMigration(input: {
       }),
     blockers,
   );
+
   const globalCli = await runMigrationPhase(
     "legacy global CLI cleanup",
     { checked: 0, removed: 0, blockers: [] },
@@ -209,18 +221,22 @@ export async function runReviewMigration(input: {
     ...skills.blockers,
     ...globalCli.blockers,
   );
+
   if (audit.issues.length > 0) {
     const affectedDocuments = new Set(
       audit.issues.map((issue) => issue.filePath),
     ).size;
+
     blockers.push(
       `${count(audit.issues.length, "authoring issue")} across ${count(affectedDocuments, "Review document")} needs an agent.`,
     );
+
     for (const issue of audit.issues) {
       human.write(
         `${issue.filePath}:${issue.line} ${issue.code}: ${issue.message}\n`,
       );
     }
+
     human.write(
       "Correct these Review documents and rerun `review migrate apply`.\n",
     );
@@ -243,9 +259,11 @@ export async function runReviewMigration(input: {
       `${count(blockers.length, "blocker")}.`,
     ].join(" ") + "\n",
   );
+
   for (const blocker of blockers) {
     input.stderr.write(`Review migration blocker: ${blocker}\n`);
   }
+
   emitJsonEvent(input, {
     event: "migrated",
     documents: stored.documents,
@@ -267,6 +285,7 @@ export async function runReviewMigration(input: {
     })),
     blockers,
   });
+
   return blockers.length === 0 ? 0 : 1;
 }
 
@@ -276,26 +295,34 @@ export async function migrateReviewManagedCheckouts(input: {
   log?: (message: string) => void;
 }): Promise<ManagedCheckoutMigrationResult> {
   const reviewsRoot = path.join(input.reviewHome, "reviews");
+
   const result: ManagedCheckoutMigrationResult = {
     checked: 0,
     created: 0,
     legacyRemoved: 0,
     blockers: [],
   };
+
   const sourceRoots = new Set<string>();
+
   for (const entry of await readDirectory(reviewsRoot)) {
     if (!entry.isDirectory() || !UUID_PATTERN.test(entry.name)) continue;
+
     if (input.skipReviewUuids?.includes(entry.name)) continue;
     const reviewDir = path.join(reviewsRoot, entry.name);
     result.checked += 1;
+
     try {
       const review = parseStoredReviewRecord(
         JSON.parse(await readFile(path.join(reviewDir, "review.json"), "utf8")),
       );
+
       if (review.uuid !== entry.name) {
         throw new Error("review.json UUID does not match its directory");
       }
+
       sourceRoots.add(review.worktreePath);
+
       const pins = [
         review.sourceCommit
           ? { role: "head" as const, commit: review.sourceCommit }
@@ -304,6 +331,7 @@ export async function migrateReviewManagedCheckouts(input: {
           ? { role: "base" as const, commit: review.baseCommit }
           : null,
       ].filter((pin): pin is NonNullable<typeof pin> => Boolean(pin));
+
       for (const pin of pins) {
         const checkout = await ensureReviewPinnedCheckout({
           rootPath: review.worktreePath,
@@ -311,18 +339,22 @@ export async function migrateReviewManagedCheckouts(input: {
           reviewUuid: review.uuid,
           role: pin.role,
         });
+
         if (!checkout) {
           throw new Error(
             `cannot create ${pin.role} checkout at ${pin.commit}`,
           );
         }
+
         result.created += 1;
       }
+
       input.log?.(`Created managed checkouts for Review ${review.uuid}.`);
     } catch (error) {
       result.blockers.push(`${reviewDir}: ${errorMessage(error)}`);
     }
   }
+
   for (const sourceRoot of sourceRoots) {
     try {
       result.legacyRemoved += await removeLegacyReviewCheckouts({
@@ -335,6 +367,7 @@ export async function migrateReviewManagedCheckouts(input: {
       );
     }
   }
+
   return result;
 }
 
@@ -348,6 +381,7 @@ async function runMigrationPhase<T>(
     return await phase();
   } catch (error) {
     blockers.push(`${label} failed: ${errorMessage(error)}`);
+
     return fallback;
   }
 }
@@ -359,27 +393,34 @@ export async function migrateJjReviewRepositories(input: {
   log?: (message: string) => void;
 }): Promise<JjMigrationResult> {
   const reviewsRoot = path.join(input.reviewHome, "reviews");
+
   const result: JjMigrationResult = {
     checked: 0,
     migrated: 0,
     blockers: [],
   };
+
   for (const entry of await readDirectory(reviewsRoot)) {
     if (!entry.isDirectory() || !UUID_PATTERN.test(entry.name)) continue;
     const reviewDir = path.join(reviewsRoot, entry.name);
+
     if (!(await pathExists(path.join(reviewDir, ".jj")))) continue;
+
     if (input.skipReviewUuids?.includes(entry.name)) continue;
     result.checked += 1;
     let recordSource: string;
+
     try {
       recordSource = await readFile(
         path.join(reviewDir, "review.json"),
         "utf8",
       );
       const parsed = parseAnyStoredReviewRecord(JSON.parse(recordSource));
+
       if (parsed.uuid !== entry.name) {
         throw new Error("review.json UUID does not match its directory");
       }
+
       // The current implementation already reads the colocated Git objects.
       // Rebuilding from the worktree would erase immutable publication history.
       if (
@@ -392,6 +433,7 @@ export async function migrateJjReviewRepositories(input: {
         );
         continue;
       }
+
       await resetJjReviewRepository({
         reviewDir,
         review: parsed,
@@ -413,6 +455,7 @@ export async function migrateJjReviewRepositories(input: {
       result.blockers.push(`${reviewDir}: ${errorMessage(error)}`);
     }
   }
+
   return result;
 }
 
@@ -426,16 +469,19 @@ async function resetJjReviewRepository(input: {
   const jjDir = path.join(input.reviewDir, ".jj");
   const backupDir = `${input.reviewDir}.review-migrate-git-backup`;
   const backupExists = await pathExists(backupDir);
+
   if (backupExists && !input.force) {
     throw new Error(
       `an interrupted Git backup exists at ${backupDir}; rerun with --force`,
     );
   }
+
   if (backupExists) {
     await rm(backupDir, { recursive: true, force: true });
   }
 
   let movedGit = false;
+
   try {
     await rename(gitDir, backupDir);
     movedGit = true;
@@ -445,6 +491,7 @@ async function resetJjReviewRepository(input: {
     ) {
       throw error;
     }
+
     if (!input.force) {
       throw new Error("the colocated .git directory is missing");
     }
@@ -460,16 +507,20 @@ async function resetJjReviewRepository(input: {
     const excludeDir = path.join(gitDir, "info");
     await mkdir(excludeDir, { recursive: true });
     await writeFile(path.join(excludeDir, "exclude"), ".jj/\n", "utf8");
+
     const revision = await reviewVcs.seal(
       input.reviewDir,
       "Migrate Review history to plain Git",
     );
+
     await reviewVcs.resolve(input.reviewDir, revision);
+
     const stored = parseStoredReviewRecord(
       JSON.parse(
         await readFile(path.join(input.reviewDir, "review.json"), "utf8"),
       ),
     );
+
     if (
       stored.uuid !== input.review.uuid ||
       stored.presentedDocumentRevision !== null ||
@@ -477,12 +528,15 @@ async function resetJjReviewRepository(input: {
     ) {
       throw new Error("the migrated review.json did not verify");
     }
+
     await rm(jjDir, { recursive: true, force: false });
   } catch (error) {
     await rm(gitDir, { recursive: true, force: true });
+
     if (movedGit && (await pathExists(backupDir))) {
       await rename(backupDir, gitDir);
     }
+
     await writeFile(
       path.join(input.reviewDir, "review.json"),
       input.recordSource,
@@ -490,6 +544,7 @@ async function resetJjReviewRepository(input: {
     );
     throw error;
   }
+
   if (movedGit) {
     await rm(backupDir, { recursive: true, force: false });
   }
@@ -500,21 +555,27 @@ export async function removeLegacyDesktopCatalog(input: {
 }): Promise<CleanupResult> {
   const directory = path.join(input.reviewHome, "review-desktop", "reviews");
   const result: CleanupResult = { checked: 0, removed: 0, blockers: [] };
+
   for (const entry of await readDirectory(directory)) {
     if (!entry.isFile() || path.extname(entry.name) !== ".json") continue;
     const filePath = path.join(directory, entry.name);
     result.checked += 1;
     const key = entry.name.slice(0, -5);
+
     if (!/^[a-f0-9]{32}$/.test(key)) {
       result.blockers.push(`${filePath} has an unknown catalog file name.`);
       continue;
     }
+
     let record: JsonObject;
+
     try {
       const value = parseJsonText(await readFile(filePath, "utf8"));
+
       if (!isJsonObject(value)) {
         throw new Error("catalog entry must contain an object");
       }
+
       record = value;
     } catch (error) {
       result.blockers.push(
@@ -522,15 +583,18 @@ export async function removeLegacyDesktopCatalog(input: {
       );
       continue;
     }
+
     if (!isLegacyDesktopCatalogRecord(record, key)) {
       result.blockers.push(
         `${filePath} is not a recognized Review catalog entry.`,
       );
       continue;
     }
+
     await rm(filePath, { force: false });
     result.removed += 1;
   }
+
   return result;
 }
 
@@ -539,7 +603,9 @@ function isLegacyDesktopCatalogRecord(
   reviewKey: string,
 ): boolean {
   const repository = record.repository;
+
   if (!isJsonObject(repository)) return false;
+
   const requiredStrings = [
     record.rootPath,
     record.reviewPath,
@@ -549,6 +615,7 @@ function isLegacyDesktopCatalogRecord(
     repository.repositoryPath,
     repository.worktreeRoot,
   ];
+
   return (
     record.reviewKey === reviewKey &&
     requiredStrings
@@ -583,28 +650,37 @@ export async function removeLegacyReviewSkills(input: {
     path.join(input.homeDir, ".agents", "skills"),
     path.join(input.homeDir, ".cursor", "skills"),
   ];
+
   const result: CleanupResult = { checked: 0, removed: 0, blockers: [] };
+
   for (const root of roots) {
     for (const name of LEGACY_SKILL_NAMES) {
       const skillDir = path.join(root, name);
+
       if (!(await pathExists(skillDir))) continue;
       result.checked += 1;
+
       if (!(await isOwnedLegacySkill(skillDir, name))) {
         result.blockers.push(
           `${skillDir} is not a positively identified Review-owned skill.`,
         );
         continue;
       }
+
       await rm(skillDir, { recursive: true, force: false });
       result.removed += 1;
     }
+
     for (const name of CURRENT_SKILL_NAMES) {
       const skillDir = path.join(root, name);
+
       if (!(await pathExists(skillDir))) continue;
       const installed = await readSkillSource(skillDir);
+
       const bundled = await readSkillSource(
         path.join(input.packageRoot, "skills", name),
       );
+
       if (
         installed === undefined ||
         bundled === undefined ||
@@ -616,6 +692,7 @@ export async function removeLegacyReviewSkills(input: {
       }
     }
   }
+
   return result;
 }
 
@@ -625,10 +702,12 @@ async function isOwnedLegacySkill(
 ): Promise<boolean> {
   try {
     const metadata = await lstat(skillDir);
+
     if (!metadata.isDirectory() || metadata.isSymbolicLink()) return false;
     const source = await readFile(path.join(skillDir, "SKILL.md"), "utf8");
     const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(source)?.[1];
     const name = frontmatter?.match(/^name:\s*["']?([^"'\n]+)["']?\s*$/m)?.[1];
+
     return (
       name === expectedName &&
       /@dev\.fast\/review|dev\.fast Review|progressive Review/i.test(source)
@@ -641,7 +720,9 @@ async function isOwnedLegacySkill(
 async function readSkillSource(skillDir: string): Promise<string | undefined> {
   try {
     const metadata = await lstat(skillDir);
+
     if (!metadata.isDirectory() || metadata.isSymbolicLink()) return undefined;
+
     return await readFile(path.join(skillDir, "SKILL.md"), "utf8");
   } catch {
     return undefined;
@@ -673,6 +754,7 @@ export async function removeLegacyGlobalReviewInstalls(input: {
 }): Promise<CleanupResult> {
   const result: CleanupResult = { checked: 0, removed: 0, blockers: [] };
   const currentPackageRoot = await canonicalPath(input.packageRoot);
+
   const runCommand =
     input.runCommand ??
     (async (command, args) => {
@@ -680,8 +762,10 @@ export async function removeLegacyGlobalReviewInstalls(input: {
         encoding: "utf8",
         env: input.env,
       });
+
       return { stdout: executed.stdout, stderr: executed.stderr };
     });
+
   const runProcess = input.runProcess ?? spawnProcess;
   const seen = new Set<string>();
 
@@ -691,16 +775,21 @@ export async function removeLegacyGlobalReviewInstalls(input: {
       homeDir: input.homeDir,
       runCommand,
     });
+
     for (const root of roots) {
       const packageRoot = path.join(root, PACKAGE_NAME);
       const packagePath = path.join(packageRoot, "package.json");
+
       if (!(await pathExists(packagePath))) continue;
       const canonicalRoot = await canonicalPath(packageRoot);
+
       if (seen.has(canonicalRoot)) continue;
       seen.add(canonicalRoot);
       result.checked += 1;
+
       try {
         const metadata = parseJsonText(await readFile(packagePath, "utf8"));
+
         if (!isJsonObject(metadata) || metadata.name !== PACKAGE_NAME) {
           result.blockers.push(
             `${packageRoot} is not a positively identified ${PACKAGE_NAME} installation.`,
@@ -725,6 +814,7 @@ export async function removeLegacyGlobalReviewInstalls(input: {
       }
 
       const uninstall = packageManagerUninstall(manager);
+
       const exitCode = await runProcess({
         command: manager,
         args: uninstall,
@@ -732,6 +822,7 @@ export async function removeLegacyGlobalReviewInstalls(input: {
         stdout: input.stdout,
         stderr: input.stderr,
       });
+
       if (exitCode === 0) {
         result.removed += 1;
       } else {
@@ -741,6 +832,7 @@ export async function removeLegacyGlobalReviewInstalls(input: {
       }
     }
   }
+
   return result;
 }
 
@@ -754,17 +846,22 @@ async function globalPackageRoots(input: {
       const root = (
         await input.runCommand(input.manager, ["root", "--global"])
       ).stdout.trim();
+
       return root ? [root] : [];
     }
+
     if (input.manager === "yarn") {
       const root = (
         await input.runCommand("yarn", ["global", "dir"])
       ).stdout.trim();
+
       return root ? [root, path.join(root, "node_modules")] : [];
     }
+
     const bin = (
       await input.runCommand("bun", ["pm", "bin", "--global"])
     ).stdout.trim();
+
     return uniquePaths([
       path.join(input.homeDir, ".bun", "install", "global", "node_modules"),
       ...(bin
@@ -778,8 +875,11 @@ async function globalPackageRoots(input: {
 
 function packageManagerUninstall(manager: ReviewPackageManager): string[] {
   if (manager === "npm") return ["uninstall", "--global", PACKAGE_NAME];
+
   if (manager === "pnpm") return ["remove", "--global", PACKAGE_NAME];
+
   if (manager === "yarn") return ["global", "remove", PACKAGE_NAME];
+
   return ["remove", "--global", PACKAGE_NAME];
 }
 
@@ -795,12 +895,15 @@ function spawnProcess(input: {
       env: input.env,
       stdio: ["inherit", input.stdout, input.stderr],
     });
+
     child.once("error", reject);
     child.once("close", (code, signal) => {
       if (signal) {
         reject(new Error(`${input.command} terminated by signal ${signal}`));
+
         return;
       }
+
       resolve(code ?? 1);
     });
   });
@@ -809,11 +912,13 @@ function spawnProcess(input: {
 async function pathExists(targetPath: string): Promise<boolean> {
   try {
     await access(targetPath);
+
     return true;
   } catch (error) {
     if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return false;
     }
+
     throw error;
   }
 }

--- a/packages/progressive-review/src/review-app.ts
+++ b/packages/progressive-review/src/review-app.ts
@@ -58,16 +58,20 @@ export async function runReviewAppPick(
     fetch: globalThis.fetch,
     ...overrides,
   };
+
   await runtime.launch();
   const reviewRoot = await runtime.resolveReviewRoot(input.cwd);
   const review = await selectAppReview(input, reviewRoot, runtime);
+
   if (!review) return null;
   const discovery = await runtime.readReviewDesktopDiscovery();
+
   if (!discovery) {
     throw new Error(
       "Review Desktop is not ready. Run `review app launch` and retry `review app pick`.",
     );
   }
+
   const response = await runtime.fetch(
     `${discovery.url}/reviews/${encodeURIComponent(review.review.uuid)}/open`,
     {
@@ -79,10 +83,13 @@ export async function runReviewAppPick(
       body: JSON.stringify(input.view ? { view: input.view } : {}),
     },
   );
+
   const payload: JsonValue = await response.json();
+
   if (!response.ok) {
     throw new Error(reviewAppResponseError(payload, response.status));
   }
+
   return {
     event: "app",
     action: "pick",
@@ -103,14 +110,19 @@ async function selectAppReview(
       worktreePath: reviewRoot,
       includeTerminal: true,
     });
+
     if (!selected) throw new Error(`Review not found: ${input.reviewUuid}`);
+
     return requirePublishedReview(selected);
   }
+
   const listed = await runtime.listReviews({ worktreePath: reviewRoot });
+
   if (listed.errors.length > 0)
     throw new Error(
       `Could not read reviews:\n${listed.errors.map((error) => error.message).join("\n")}`,
     );
+
   return pickAppReview(
     await actionableReviewsForCheckout(listed.reviews, reviewRoot),
     input,
@@ -124,6 +136,7 @@ function requirePublishedReview(selected: StoredReview): StoredReview {
       `Review ${selected.review.uuid} is not published. Run \`review publish --review ${selected.review.uuid}\` first.`,
     );
   }
+
   return selected;
 }
 
@@ -137,12 +150,15 @@ async function pickAppReview(
       "review app pick needs a terminal without --review. Pass --review <uuid> or run it in a terminal.",
     );
   }
+
   const openable = reviews.filter(
     (review) => review.review.presentedDocumentRevision !== null,
   );
+
   if (openable.length === 0) {
     throw new Error("No published review to show. Run `review publish` first.");
   }
+
   const items: ReviewPickerItem[] = [...openable]
     .sort((left, right) =>
       (right.review.lastPublishedAt ?? "").localeCompare(
@@ -155,13 +171,17 @@ async function pickAppReview(
       status: review.review.status,
       lastPublishedAt: review.review.lastPublishedAt,
     }));
+
   const picked = await runtime.pickReview(items, {
     stdin: input.stdin,
     stdout: input.stdout,
   });
+
   if (!picked) return null;
   const selected = reviews.find((review) => review.review.uuid === picked.uuid);
+
   if (!selected) throw new Error(`Review not found: ${picked.uuid}`);
+
   return requirePublishedReview(selected);
 }
 

--- a/packages/progressive-review/src/review-app.ts
+++ b/packages/progressive-review/src/review-app.ts
@@ -11,11 +11,11 @@ import { readReviewDesktopDiscovery } from "./desktop-discovery";
 import { runReviewAppLaunch } from "./review-app-launcher";
 import { type ReviewPickerItem, pickReview } from "./review-app-picker";
 import { actionableReviewsForCheckout } from "./review-change-scope";
+import type { StoredReview } from "./review-home";
 import {
-  type StoredReview,
-  findScopedReview,
-  listReviews,
-} from "./review-home";
+  findScopedReviewClient as findScopedReview,
+  listReviewsClient as listReviews,
+} from "./review-lifecycle-client";
 import { resolveReviewRoot } from "./runtime";
 
 interface ReviewAppRuntime {

--- a/packages/progressive-review/src/review-attention.ts
+++ b/packages/progressive-review/src/review-attention.ts
@@ -30,6 +30,7 @@ export async function writeReviewRecord(
     const current = parseStoredReviewRecord(readReviewRecord(stored.dir));
     const review: StoredReviewRecord = { ...current, ...patch };
     await persistStoredReviewRecord(stored.dir, review);
+
     return { ...stored, review };
   });
 }
@@ -43,6 +44,7 @@ export async function markReviewViewed(
   now = new Date(),
 ): Promise<StoredReview> {
   if (stored.review.viewedAt) return stored;
+
   return writeReviewRecord(stored, { viewedAt: now.toISOString() });
 }
 
@@ -51,6 +53,7 @@ export async function dismissReview(
   now = new Date(),
 ): Promise<StoredReview> {
   if (stored.review.dismissedAt) return stored;
+
   return writeReviewRecord(stored, { dismissedAt: now.toISOString() });
 }
 
@@ -59,6 +62,7 @@ export async function restoreReview(
   stored: StoredReview,
 ): Promise<StoredReview> {
   if (!stored.review.dismissedAt) return stored;
+
   return writeReviewRecord(stored, { dismissedAt: null });
 }
 
@@ -71,6 +75,7 @@ export async function resetReviewAttention(
   stored: StoredReview,
 ): Promise<StoredReview> {
   if (!stored.review.viewedAt && !stored.review.dismissedAt) return stored;
+
   return writeReviewRecord(stored, { viewedAt: null, dismissedAt: null });
 }
 
@@ -81,7 +86,9 @@ export function reviewReapsAt(
 ): string | null {
   if (!review.dismissedAt || retentionDays === null) return null;
   const dismissed = Date.parse(review.dismissedAt);
+
   if (!Number.isFinite(dismissed)) return null;
+
   return new Date(dismissed + retentionDays * DAY_MS).toISOString();
 }
 
@@ -91,6 +98,7 @@ export function isReviewReapable(
   now = new Date(),
 ): boolean {
   const reapsAt = reviewReapsAt(review, retentionDays);
+
   return reapsAt !== null && Date.parse(reapsAt) <= now.getTime();
 }
 
@@ -104,6 +112,7 @@ export function selectReapableReviews(
   now = new Date(),
 ): StoredReview[] {
   if (retentionDays === null) return [];
+
   return reviews.filter((stored) =>
     isReviewReapable(stored.review, retentionDays, now),
   );

--- a/packages/progressive-review/src/review-attention.ts
+++ b/packages/progressive-review/src/review-attention.ts
@@ -1,15 +1,13 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
-
 import type { ReviewRecord } from "@dev.fast/review-protocol";
 
 import {
   type StoredReview,
   type StoredReviewRecord,
   parseStoredReviewRecord,
+  persistStoredReviewRecord,
 } from "./review-home";
 import { withReviewMutationLock } from "./review-mutation-lock";
-import { writePrivateJsonAtomic } from "./server/desktop-paths";
+import { readReviewRecord } from "./review-state-db";
 
 /**
  * The reader-facing lifecycle: new -> viewed -> dismissed. It is a separate
@@ -29,11 +27,9 @@ export async function writeReviewRecord(
   patch: Partial<StoredReviewRecord>,
 ): Promise<StoredReview> {
   return withReviewMutationLock(stored.dir, async () => {
-    const current = parseStoredReviewRecord(
-      JSON.parse(await readFile(path.join(stored.dir, "review.json"), "utf8")),
-    );
+    const current = parseStoredReviewRecord(readReviewRecord(stored.dir));
     const review: StoredReviewRecord = { ...current, ...patch };
-    await writePrivateJsonAtomic(path.join(stored.dir, "review.json"), review);
+    await persistStoredReviewRecord(stored.dir, review);
     return { ...stored, review };
   });
 }

--- a/packages/progressive-review/src/review-busy.test.ts
+++ b/packages/progressive-review/src/review-busy.test.ts
@@ -13,8 +13,10 @@ import {
   withReviewMutationLock,
 } from "./review-mutation-lock";
 import { runReviewPublish } from "./review-publish";
+import { deleteReviewState } from "./review-state-db";
 import { closeAllReviewThreadStores } from "./review-thread-store-backend";
 import { createGlobalReviewServer } from "./server/desktop-server";
+import { GlobalReviewDesktopVerbRelay } from "./server/global-verb-relay";
 import { createReviewSessionHandler } from "./server/session-handler";
 
 const roots: string[] = [];
@@ -55,17 +57,24 @@ it("reports loader, open, and CLI contention as busy and allows migration after 
   const recordPath = path.join(review.dir, "review.json");
   const recordBytes = JSON.stringify({ ...review.review, schemaVersion: 4 });
   await writeFile(recordPath, recordBytes);
+  deleteReviewState(review.dir);
   const packageRoot = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     "..",
   );
+  const relay = new GlobalReviewDesktopVerbRelay();
+  relay.attach({
+    signal: new AbortController().signal,
+    write: () => {},
+    close: () => {},
+  });
   const server = createGlobalReviewServer({
     appPid: process.pid,
     packageRoot,
     toolingRoot: packageRoot,
     token: "busy-token",
     port: 0,
-    discoveryPath: path.join(home, "desktop.json"),
+    relay,
   });
   const entered = Promise.withResolvers<void>();
   const release = Promise.withResolvers<void>();

--- a/packages/progressive-review/src/review-busy.test.ts
+++ b/packages/progressive-review/src/review-busy.test.ts
@@ -20,6 +20,7 @@ import { GlobalReviewDesktopVerbRelay } from "./server/global-verb-relay";
 import { createReviewSessionHandler } from "./server/session-handler";
 
 const roots: string[] = [];
+
 afterEach(async () => {
   vi.unstubAllEnvs();
   closeAllReviewThreadStores();
@@ -38,8 +39,10 @@ it("reports loader, open, and CLI contention as busy and allows migration after 
   );
   const root = path.join(home, "source");
   await mkdir(root);
+
   const git = (args: string[]) =>
     execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+
   git(["init", "-q", "-b", "main"]);
   git(["config", "user.email", "review@example.test"]);
   git(["config", "user.name", "Review Test"]);
@@ -47,6 +50,7 @@ it("reports loader, open, and CLI contention as busy and allows migration after 
   git(["add", "."]);
   git(["commit", "-qm", "source"]);
   const sourceCommit = git(["rev-parse", "HEAD"]);
+
   const review = await createReviewDir({
     worktreePath: root,
     baseRef: "main",
@@ -54,20 +58,24 @@ it("reports loader, open, and CLI contention as busy and allows migration after 
     sourceCommit,
     sourceIdentity: { kind: "git-branch", name: "main" },
   });
+
   const recordPath = path.join(review.dir, "review.json");
   const recordBytes = JSON.stringify({ ...review.review, schemaVersion: 4 });
   await writeFile(recordPath, recordBytes);
   deleteReviewState(review.dir);
+
   const packageRoot = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     "..",
   );
+
   const relay = new GlobalReviewDesktopVerbRelay();
   relay.attach({
     signal: new AbortController().signal,
     write: () => {},
     close: () => {},
   });
+
   const server = createGlobalReviewServer({
     appPid: process.pid,
     packageRoot,
@@ -76,20 +84,25 @@ it("reports loader, open, and CLI contention as busy and allows migration after 
     port: 0,
     relay,
   });
+
   const entered = Promise.withResolvers<void>();
   const release = Promise.withResolvers<void>();
+
   const holding = withReviewMutationLock(review.dir, async () => {
     entered.resolve();
     await release.promise;
   });
+
   await entered.promise;
   const stdout = new PassThrough();
   let output = "";
   stdout.on("data", (chunk) => {
     output += String(chunk);
   });
+
   try {
     await server.listen();
+
     const [loaded, response, exitCode, ...readyResponses] = await Promise.all([
       readStoredReview(review.dir),
       fetch(`${server.url}/reviews/${review.review.uuid}/open`, {
@@ -129,6 +142,7 @@ it("reports loader, open, and CLI contention as busy and allows migration after 
         }),
       ),
     ]);
+
     expect(loaded).toMatchObject({
       error: {
         code: "REVIEW_BUSY",
@@ -143,6 +157,7 @@ it("reports loader, open, and CLI contention as busy and allows migration after 
       code: "review_busy",
       retryable: true,
     });
+
     for (const readyResponse of readyResponses) {
       expect(readyResponse.status).toBe(409);
       expect(await readyResponse.json()).toMatchObject({
@@ -151,6 +166,7 @@ it("reports loader, open, and CLI contention as busy and allows migration after 
         retryable: true,
       });
     }
+
     expect(exitCode).toBe(1);
     expect(output).toContain("Retry after its current operation completes");
     expect(output).not.toContain("review repair");
@@ -160,6 +176,7 @@ it("reports loader, open, and CLI contention as busy and allows migration after 
     await holding;
     await server.close();
   }
+
   expect(await readStoredReview(review.dir)).toMatchObject({
     review: { schemaVersion: 5 },
   });
@@ -172,6 +189,7 @@ it.each(["thread-commands", "revisions"])(
     roots.push(root);
     const reviewPath = path.join(root, "review.mdx");
     await writeFile(reviewPath, "# Review\n");
+
     const handler = await createReviewSessionHandler({
       rootPath: root,
       reviewPath,
@@ -198,6 +216,7 @@ it.each(["thread-commands", "revisions"])(
         throw new ReviewBusyError(root);
       },
     });
+
     try {
       const response = await handler.handle(
         new Request(`http://127.0.0.1:5570/__progressive-review/${route}`, {
@@ -208,6 +227,7 @@ it.each(["thread-commands", "revisions"])(
           },
         }),
       );
+
       expect(response.status).toBe(409);
       expect(await response.json()).toMatchObject({
         ok: false,

--- a/packages/progressive-review/src/review-document-files.ts
+++ b/packages/progressive-review/src/review-document-files.ts
@@ -1,0 +1,58 @@
+import { createHash } from "node:crypto";
+import { lstat, readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { writeFileAtomicAsync } from "./atomic-write";
+import type { StoredReview } from "./review-home";
+import type { ReviewDocumentFileName } from "./review-lifecycle-contracts";
+import { ReviewServerError } from "./server/http-json";
+
+export async function readReviewDocumentFile(
+  review: StoredReview,
+  name: ReviewDocumentFileName,
+) {
+  const filePath = path.join(review.dir, name);
+  try {
+    if (!(await lstat(filePath)).isFile()) {
+      throw new ReviewServerError(
+        "Document source must be a regular file, not a symlink.",
+        409,
+      );
+    }
+    const source = await readFile(filePath, "utf8");
+    return {
+      name,
+      source,
+      sourceHash: createHash("sha256").update(source).digest("hex"),
+    };
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return { name, source: null, sourceHash: null };
+    }
+    throw error;
+  }
+}
+
+/** The caller holds the Review mutation lock across comparison and replacement. */
+export async function writeReviewDocumentFile(
+  review: StoredReview,
+  input: {
+    name: ReviewDocumentFileName;
+    source: string;
+    expectedSourceHash: string | null;
+  },
+) {
+  const current = await readReviewDocumentFile(review, input.name);
+  if (current.source === input.source) return current;
+  if (current.sourceHash !== input.expectedSourceHash) {
+    throw new ReviewServerError(
+      "Document source changed. Read it again before retrying.",
+      409,
+    );
+  }
+  await writeFileAtomicAsync(path.join(review.dir, input.name), input.source, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  return readReviewDocumentFile(review, input.name);
+}

--- a/packages/progressive-review/src/review-document-files.ts
+++ b/packages/progressive-review/src/review-document-files.ts
@@ -12,6 +12,7 @@ export async function readReviewDocumentFile(
   name: ReviewDocumentFileName,
 ) {
   const filePath = path.join(review.dir, name);
+
   try {
     if (!(await lstat(filePath)).isFile()) {
       throw new ReviewServerError(
@@ -19,7 +20,9 @@ export async function readReviewDocumentFile(
         409,
       );
     }
+
     const source = await readFile(filePath, "utf8");
+
     return {
       name,
       source,
@@ -29,6 +32,7 @@ export async function readReviewDocumentFile(
     if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return { name, source: null, sourceHash: null };
     }
+
     throw error;
   }
 }
@@ -43,16 +47,20 @@ export async function writeReviewDocumentFile(
   },
 ) {
   const current = await readReviewDocumentFile(review, input.name);
+
   if (current.source === input.source) return current;
+
   if (current.sourceHash !== input.expectedSourceHash) {
     throw new ReviewServerError(
       "Document source changed. Read it again before retrying.",
       409,
     );
   }
+
   await writeFileAtomicAsync(path.join(review.dir, input.name), input.source, {
     encoding: "utf8",
     mode: 0o600,
   });
+
   return readReviewDocumentFile(review, input.name);
 }

--- a/packages/progressive-review/src/review-home.test.ts
+++ b/packages/progressive-review/src/review-home.test.ts
@@ -34,6 +34,7 @@ import {
   updateReviewPins,
 } from "./review-home";
 import { withReviewMutationLock } from "./review-mutation-lock";
+import { deleteReviewState } from "./review-state-db";
 import { appendReviewComment, readReviewComments } from "./review-state-store";
 import {
   cleanupTempDirs,
@@ -260,7 +261,7 @@ describe("review home", () => {
     await expect(
       readFile(path.join(created.dir, "package.json"), "utf8"),
     ).resolves.toContain('"test": "node review-test.mjs"');
-    expect(existsSync(path.join(created.dir, "review.db"))).toBe(true);
+    expect(existsSync(path.join(created.dir, "review.db"))).toBe(false);
     expect(existsSync(path.join(created.dir, "comments.json"))).toBe(false);
     expect(existsSync(path.join(created.dir, "questions.json"))).toBe(false);
     await expect(
@@ -1005,6 +1006,7 @@ async function legacyRecord(
   schemaVersion: 2 | 3 | 4,
   revision: string,
 ) {
+  deleteReviewState(created.dir);
   const {
     sourceSession,
     presentedDocumentRevision: _document,

--- a/packages/progressive-review/src/review-home.test.ts
+++ b/packages/progressive-review/src/review-home.test.ts
@@ -828,6 +828,7 @@ describe("legacy records on read", () => {
         uuid: "11111111-1111-4111-8111-111111111111",
       }),
     ]) {
+      deleteReviewState(created.dir);
       await writeFile(recordPath, value);
       await expect(
         findReviewForRepair(created.review.uuid),

--- a/packages/progressive-review/src/review-home.test.ts
+++ b/packages/progressive-review/src/review-home.test.ts
@@ -73,6 +73,7 @@ describe("review home", () => {
       createdAt: "2024-01-01T00:00:00.000Z",
       lastPublishedAt: null,
     };
+
     expect(
       parseAnyStoredReviewRecord({
         ...base,
@@ -160,6 +161,7 @@ describe("review home", () => {
     const root = await gitRepository();
     await reviewHome();
     const commit = await git(root, ["rev-parse", "HEAD"]);
+
     const created = await createReviewDir({
       worktreePath: root,
       baseRef: "main",
@@ -192,6 +194,7 @@ describe("review home", () => {
     const root = await gitRepository();
     await reviewHome();
     const commit = await git(root, ["rev-parse", "HEAD"]);
+
     const created = await createReviewDir({
       worktreePath: root,
       baseRef: "main",
@@ -200,18 +203,21 @@ describe("review home", () => {
       sourceIdentity: { kind: "git-branch", name: "main" },
       sourceSession: "codex:creator",
     });
+
     const first = await touchReviewAgentSession(
       created,
       "codex:creator",
       "publisher",
       "2026-08-12T10:00:00.000Z",
     );
+
     const second = await touchReviewAgentSession(
       first,
       "codex:creator",
       "publisher",
       "2026-08-12T11:00:00.000Z",
     );
+
     expect(second.review.sourceSession).toBe("codex:creator");
     expect(second.review.agentSessions?.["codex:creator"]).toMatchObject({
       roles: ["author", "publisher"],
@@ -278,9 +284,11 @@ describe("review home", () => {
       baseRef: "main",
       baseCommit: await git(root, ["rev-parse", "HEAD"]),
     });
+
     const record = JSON.parse(
       await readFile(path.join(created.dir, "review.json"), "utf8"),
     );
+
     await writeFile(
       path.join(created.dir, "review.json"),
       JSON.stringify({
@@ -352,6 +360,7 @@ describe("review home", () => {
     await git(root, ["add", "."]);
     await git(root, ["commit", "-m", "add feature"]);
     const sourceCommit = await git(root, ["rev-parse", "HEAD"]);
+
     const created = await createReviewDir({
       worktreePath: root,
       baseRef: baseCommit,
@@ -361,6 +370,7 @@ describe("review home", () => {
       pullRequestNumber: 673,
       pullRequestUrl: "https://github.com/Fix-Fast/dev/pull/673",
     });
+
     appendReviewComment(path.join(created.dir, "review.mdx"), {
       threadId: "thread-1",
       messageId: "message-1",
@@ -368,6 +378,7 @@ describe("review home", () => {
       body: "Review this.",
       author: "reviewer",
     });
+
     const documentUpdatedAt = (
       await stat(path.join(created.dir, "review.mdx"))
     ).mtime.toISOString();
@@ -397,12 +408,14 @@ describe("review home", () => {
     const root = await gitRepository();
     await reviewHome();
     const baseCommit = await git(root, ["rev-parse", "HEAD"]);
+
     const created = await createReviewDir({
       worktreePath: root,
       baseRef: baseCommit,
       baseCommit,
       sourceCommit: baseCommit,
     });
+
     await rm(reviewThreadDbPath(path.join(created.dir, "review.mdx")));
     await expect(
       reviewDescriptor(created, { threads: "read-only" }),
@@ -480,6 +493,7 @@ describe("review home", () => {
     await git(root, ["add", "."]);
     await git(root, ["commit", "-m", "add example"]);
     const originalCommit = await git(root, ["rev-parse", "HEAD"]);
+
     const created = await createReviewDir({
       worktreePath: root,
       baseRef: "main",
@@ -487,7 +501,9 @@ describe("review home", () => {
       sourceCommit: originalCommit,
       sourceIdentity: { kind: "git-branch", name: "main" },
     });
+
     const reviewPath = path.join(created.dir, "review.mdx");
+
     const originalPosition = createGitLabTextDiffPosition({
       base_sha: originalCommit,
       start_sha: originalCommit,
@@ -497,11 +513,13 @@ describe("review home", () => {
       start: { old_line: null, new_line: 8 },
       end: { old_line: null, new_line: 9 },
     });
+
     const originalTarget = {
       kind: "code" as const,
       original_position: originalPosition,
       position: originalPosition,
     };
+
     appendReviewComment(reviewPath, {
       threadId: "thread-1",
       messageId: "message-1",
@@ -518,6 +536,7 @@ describe("review home", () => {
     await git(root, ["add", "."]);
     await git(root, ["commit", "-m", "insert lines"]);
     const movedCommit = await git(root, ["rev-parse", "HEAD"]);
+
     const movedReview = await updateReviewPins(created, {
       baseRef: "main",
       baseCommit: originalCommit,
@@ -525,7 +544,9 @@ describe("review home", () => {
       sourceIdentity: { kind: "git-branch", name: "main" },
       sourceSession: created.review.sourceSession,
     });
+
     const moved = readReviewComments(reviewPath)["thread-1"]!;
+
     if (moved.target.kind !== "code") throw new Error("Expected code target.");
     expect(moved.target.original_position).toEqual(originalPosition);
     expect(moved.target.position).toMatchObject({
@@ -544,6 +565,7 @@ describe("review home", () => {
     await git(root, ["add", "."]);
     await git(root, ["commit", "-m", "change selected line"]);
     const changedCommit = await git(root, ["rev-parse", "HEAD"]);
+
     const outdatedReview = await updateReviewPins(movedReview, {
       baseRef: "main",
       baseCommit: originalCommit,
@@ -551,10 +573,13 @@ describe("review home", () => {
       sourceIdentity: { kind: "git-branch", name: "main" },
       sourceSession: movedReview.review.sourceSession,
     });
+
     const outdated = readReviewComments(reviewPath)["thread-1"]!;
+
     if (outdated.target.kind !== "code") {
       throw new Error("Expected code target.");
     }
+
     expect(outdated.target.position).toEqual(moved.target.position);
     expect(outdated.target.change_position).toMatchObject({
       head_sha: changedCommit,
@@ -576,9 +601,11 @@ describe("review home", () => {
       sourceSession: outdatedReview.review.sourceSession,
     });
     const stillOutdated = readReviewComments(reviewPath)["thread-1"]!;
+
     if (stillOutdated.target.kind !== "code") {
       throw new Error("Expected code target.");
     }
+
     expect(stillOutdated.target.position).toEqual(moved.target.position);
     expect(stillOutdated.target.change_position).toMatchObject({
       head_sha: restoredCommit,
@@ -589,15 +616,18 @@ describe("review home", () => {
   it("ignores active and stale locks and unrelated directories during discovery", async () => {
     const root = await gitRepository();
     await reviewHome();
+
     const created = await createReviewDir({
       worktreePath: root,
       baseRef: "main",
       baseCommit: await git(root, ["rev-parse", "HEAD"]),
     });
+
     const staleReviewDir = path.join(
       reviewsHomeDir(),
       "11111111-1111-4111-8111-111111111111",
     );
+
     const staleLock = `${staleReviewDir}.mutation-lock`;
     const unrelated = path.join(reviewsHomeDir(), "notes");
     await mkdir(staleLock);
@@ -717,12 +747,14 @@ describe("review home", () => {
     await reviewHome();
 
     const sourceCommit = await git(root, ["rev-parse", "HEAD"]);
+
     const review = await createReviewDir({
       worktreePath: root,
       baseRef: "main",
       baseCommit: sourceCommit,
       sourceCommit,
     });
+
     await createReviewDir({
       worktreePath: otherRoot,
       baseRef: "main",
@@ -748,6 +780,7 @@ describe("review home", () => {
     await reviewHome();
 
     const sourceCommit = await git(root, ["rev-parse", "HEAD"]);
+
     const review = await createReviewDir({
       visibility: "system",
       worktreePath: root,
@@ -796,6 +829,7 @@ async function git(root: string, args: string[]): Promise<string> {
   const { stdout } = await execFilePromise("git", ["-C", root, ...args], {
     encoding: "utf8",
   });
+
   return stdout.trim();
 }
 
@@ -803,11 +837,13 @@ describe("legacy records on read", () => {
   it("reads repair metadata without migration and preserves lookup validation", async () => {
     const root = await gitRepository();
     await reviewHome();
+
     const created = await createReviewDir({
       worktreePath: root,
       baseRef: "main",
       baseCommit: await git(root, ["rev-parse", "HEAD"]),
     });
+
     const recordPath = path.join(created.dir, "review.json");
     const record = await legacyRecord(created, 4, "a".repeat(40));
     const bytes = JSON.stringify(record);
@@ -819,6 +855,7 @@ describe("legacy records on read", () => {
     });
     expect(loaded).not.toHaveProperty("recovery");
     expect(await readFile(recordPath, "utf8")).toBe(bytes);
+
     for (const value of [
       "{broken",
       JSON.stringify({ ...record, baseCommit: 42 }),
@@ -835,6 +872,7 @@ describe("legacy records on read", () => {
       ).rejects.toBeInstanceOf(ReviewHomeScanError);
       expect(await readFile(recordPath, "utf8")).toBe(value);
     }
+
     await expect(findReviewForRepair("not-a-uuid")).rejects.toThrow(
       "Review UUID is invalid",
     );
@@ -847,18 +885,22 @@ describe("legacy records on read", () => {
     async (schemaVersion) => {
       const root = await gitRepository();
       await reviewHome();
+
       const created = await createReviewDir({
         worktreePath: root,
         baseRef: "main",
         baseCommit: await git(root, ["rev-parse", "HEAD"]),
       });
+
       const recordPath = path.join(created.dir, "review.json");
       await sealReviewCandidate(created.dir, "Initial document");
+
       const record = await legacyRecord(
         created,
         schemaVersion === 6 ? 4 : schemaVersion,
         "a".repeat(40),
       );
+
       const bytes = JSON.stringify(
         schemaVersion === 6
           ? { ...created.review, schemaVersion }
@@ -869,6 +911,7 @@ describe("legacy records on read", () => {
               agentSession: "codex",
             },
       );
+
       await writeFile(recordPath, bytes);
       const refs = await git(created.dir, ["rev-parse", "HEAD"]);
       const listed = await listReviews();
@@ -887,16 +930,20 @@ describe("legacy records on read", () => {
     async (schemaVersion) => {
       const root = await gitRepository();
       const home = await reviewHome();
+
       const created = await createReviewDir({
         worktreePath: root,
         baseRef: "main",
         baseCommit: await git(root, ["rev-parse", "HEAD"]),
       });
+
       await writeLegacyDocument(created.dir);
+
       const revision = await sealReviewCandidate(
         created.dir,
         "Legacy document",
       );
+
       const recordPath = path.join(created.dir, "review.json");
       await writeFile(
         recordPath,
@@ -938,11 +985,13 @@ describe("legacy records on read", () => {
   it("migrates once when two readers race", async () => {
     const root = await gitRepository();
     await reviewHome();
+
     const created = await createReviewDir({
       worktreePath: root,
       baseRef: "main",
       baseCommit: await git(root, ["rev-parse", "HEAD"]),
     });
+
     await writeLegacyDocument(created.dir);
     const revision = await sealReviewCandidate(created.dir, "Legacy document");
     await writeFile(
@@ -964,11 +1013,13 @@ describe("legacy records on read", () => {
   it("reports repair without touching a review whose sealed document is broken", async () => {
     const root = await gitRepository();
     await reviewHome();
+
     const created = await createReviewDir({
       worktreePath: root,
       baseRef: "main",
       baseCommit: await git(root, ["rev-parse", "HEAD"]),
     });
+
     await writeLegacyDocument(created.dir, {
       code: 'import { jsx } from "review-doc-runtime"; throw new Error("broken sealed document");',
     });
@@ -1008,12 +1059,14 @@ async function legacyRecord(
   revision: string,
 ) {
   deleteReviewState(created.dir);
+
   const {
     sourceSession,
     presentedDocumentRevision: _document,
     presentedSoftwareMapRevision: _map,
     ...common
   } = created.review;
+
   return {
     ...common,
     schemaVersion,

--- a/packages/progressive-review/src/review-home.ts
+++ b/packages/progressive-review/src/review-home.ts
@@ -479,9 +479,9 @@ export async function findReviewForRepair(
   const dir = path.join(reviewsHomeDir(devHome), uuid);
   let value: JsonValue;
   try {
-    value = parseJsonText(
-      await readFile(path.join(dir, "review.json"), "utf8"),
-    );
+    const canonical = readReviewRecord(dir);
+    if (canonical === null) return null;
+    value = canonical;
   } catch (error) {
     if (isMissingFileError(error)) return null;
     const detail: ReviewHomeErrorDetail = {
@@ -703,9 +703,7 @@ async function readReviewForList(
   if (!filter.worktreePath && !filter.repoKey) return readStoredReview(dir);
   let record: JsonObject | undefined;
   try {
-    record = jsonObject(
-      parseJsonText(await readFile(path.join(dir, "review.json"), "utf8")),
-    );
+    record = jsonObject(readReviewRecord(dir));
   } catch {
     return unreadableReview(dir, filter);
   }
@@ -729,7 +727,7 @@ async function readReviewForList(
     : null;
 }
 
-/** Every scope test in one place, so the cheap JSON pre-pass and the final
+/** Every scope test in one place, so the canonical record pre-pass and the final
  * pass answer the same question about the same fields. */
 function reviewMatchesFilter(
   record: {

--- a/packages/progressive-review/src/review-home.ts
+++ b/packages/progressive-review/src/review-home.ts
@@ -49,6 +49,11 @@ import {
   assertReviewUnchanged,
   withReviewMutationLock,
 } from "./review-mutation-lock";
+import {
+  deleteReviewState,
+  putReviewRecord,
+  readReviewRecord,
+} from "./review-state-db";
 import { readReviewComments } from "./review-state-store";
 import { devReviewHome } from "./review-storage";
 import {
@@ -171,7 +176,8 @@ export async function createReviewDir(
   if (!UUID_PATTERN.test(uuid)) {
     throw new Error(`Review UUID is invalid: ${uuid}`);
   }
-  const dir = path.join(reviewsHomeDir(binding.reviewsHomePath), uuid);
+  const reviewHome = binding.reviewsHomePath ?? devReviewHome();
+  const dir = path.join(reviewsHomeDir(reviewHome), uuid);
   const worktreePath = path.resolve(binding.worktreePath);
   const repository = await resolveReviewRepositoryIdentity(worktreePath);
   const createdAt = new Date().toISOString();
@@ -223,9 +229,10 @@ export async function createReviewDir(
       writeFile(path.join(dir, "review-test.mjs"), reviewTestShim, "utf8"),
       writeFile(path.join(dir, ".gitignore"), reviewGitignore, "utf8"),
     ]);
-    createReviewThreadDb(dir);
-    await writePrivateJsonAtomic(path.join(dir, "review.json"), review);
+    createReviewThreadDb(dir, reviewHome);
+    await persistStoredReviewRecord(dir, review, reviewHome);
   } catch (error) {
+    deleteReviewState(dir, reviewHome);
     await rm(dir, { recursive: true, force: true });
     throw error;
   }
@@ -250,15 +257,12 @@ export async function touchReviewAgentSession(
   if (!parseAuthoringSessionKey(sessionKey)) {
     throw new Error(`Review agent session key is invalid: ${sessionKey}`);
   }
-  const recordPath = path.join(review.dir, "review.json");
   const outcome = await withReviewMutationLock(review.dir, () =>
     withFileLock(
       path.join(review.dir, ".agent-sessions.lock"),
       AGENT_SESSION_LOCK_OPTIONS,
       async () => {
-        const current = parseStoredReviewRecord(
-          JSON.parse(await readFile(recordPath, "utf8")),
-        );
+        const current = parseStoredReviewRecord(readReviewRecord(review.dir));
         const prior = current.agentSessions?.[sessionKey];
         const roles = prior?.roles.includes(role)
           ? prior.roles
@@ -274,7 +278,7 @@ export async function touchReviewAgentSession(
             },
           },
         };
-        await writePrivateJsonAtomic(recordPath, updated);
+        await persistStoredReviewRecord(review.dir, updated);
         return { dir: review.dir, review: updated };
       },
     ),
@@ -296,15 +300,12 @@ export async function bindReviewAuthorSession(
   now = new Date().toISOString(),
 ): Promise<StoredReview> {
   const sessionKey = authoringSessionKey(session);
-  const recordPath = path.join(review.dir, "review.json");
   const outcome = await withReviewMutationLock(review.dir, () =>
     withFileLock(
       path.join(review.dir, ".agent-sessions.lock"),
       AGENT_SESSION_LOCK_OPTIONS,
       async () => {
-        const current = parseStoredReviewRecord(
-          JSON.parse(await readFile(recordPath, "utf8")),
-        );
+        const current = parseStoredReviewRecord(readReviewRecord(review.dir));
         const freshHarness = parseFreshSourceSessionHarness(
           current.sourceSession,
         );
@@ -338,7 +339,7 @@ export async function bindReviewAuthorSession(
             },
           },
         };
-        await writePrivateJsonAtomic(recordPath, updated);
+        await persistStoredReviewRecord(review.dir, updated);
         return { dir: review.dir, review: updated };
       },
     ),
@@ -441,10 +442,7 @@ async function updateReviewPinsLocked(
       sourceCommit: refreshed.review.sourceCommit,
     },
   });
-  await writePrivateJsonAtomic(
-    path.join(refreshed.dir, "review.json"),
-    refreshed.review,
-  );
+  await persistStoredReviewRecord(refreshed.dir, refreshed.review);
   threadStore.writeCommentState(comments, remappedDrafts);
   return refreshed;
 }
@@ -814,9 +812,9 @@ export async function materializeReviewRevision(
 export async function readStoredReview(
   dir: string,
 ): Promise<StoredReview | { error: ReviewHomeError }> {
-  const reviewPath = path.join(dir, "review.json");
   try {
-    let value = parseJsonText(await readFile(reviewPath, "utf8"));
+    await access(dir);
+    let value = readReviewRecord(dir);
     let parsed = safeParseStoredReviewRecord(value);
     if (!parsed.success && isLegacyStoredReviewRecord(value, dir)) {
       try {
@@ -836,7 +834,7 @@ export async function readStoredReview(
           }),
         };
       }
-      value = parseJsonText(await readFile(reviewPath, "utf8"));
+      value = readReviewRecord(dir);
       parsed = safeParseStoredReviewRecord(value);
     }
     if (!parsed.success) {
@@ -859,6 +857,15 @@ export async function readStoredReview(
     if (code) detail.code = code;
     return { error: reviewHomeError(dir, undefined, detail) };
   }
+}
+
+export async function persistStoredReviewRecord(
+  dir: string,
+  review: StoredReviewRecord,
+  reviewHome?: string,
+): Promise<void> {
+  putReviewRecord(dir, review, reviewHome);
+  await writePrivateJsonAtomic(path.join(dir, "review.json"), review);
 }
 
 function isLegacyStoredReviewRecord(value: JsonValue, dir: string): boolean {

--- a/packages/progressive-review/src/review-home.ts
+++ b/packages/progressive-review/src/review-home.ts
@@ -89,16 +89,19 @@ export interface CreateReviewDirBinding {
 export const DISABLED_REVIEW_SOURCE_SESSION = "disabled:review";
 
 export const StoredReviewRecordSchema = ReviewRecordSchema;
+
 export type StoredReviewRecord = ReviewRecord;
 
 const legacyStoredSourceSessionFields = {
   sourceSession: z.string().min(1).optional(),
   agentSession: z.string().min(1).optional(),
 };
+
 const legacyStoredReviewRecordFields = StoredReviewRecordSchema.omit({
   schemaVersion: true,
   sourceSession: true,
 });
+
 const LegacyStoredReviewRecordSchema = z
   .union([
     StoredReviewRecordSchema.extend({ schemaVersion: z.literal(4) }),
@@ -173,18 +176,22 @@ export async function createReviewDir(
   binding: CreateReviewDirBinding,
 ): Promise<StoredReview> {
   const uuid = binding.uuid ?? createReviewUuid();
+
   if (!UUID_PATTERN.test(uuid)) {
     throw new Error(`Review UUID is invalid: ${uuid}`);
   }
+
   const reviewHome = binding.reviewsHomePath ?? devReviewHome();
   const dir = path.join(reviewsHomeDir(reviewHome), uuid);
   const worktreePath = path.resolve(binding.worktreePath);
   const repository = await resolveReviewRepositoryIdentity(worktreePath);
   const createdAt = new Date().toISOString();
   const sourceSession = binding.sourceSession ?? DISABLED_REVIEW_SOURCE_SESSION;
+
   const attributedAgentSession = parseAuthoringSessionKey(sourceSession)
     ? sourceSession
     : null;
+
   const review: StoredReviewRecord = {
     schemaVersion: REVIEW_SCHEMA_VERSION,
     uuid,
@@ -204,7 +211,9 @@ export async function createReviewDir(
     createdAt,
     lastPublishedAt: null,
   };
+
   if (binding.visibility) review.visibility = binding.visibility;
+
   if (attributedAgentSession) {
     review.agentSessions = {
       [attributedAgentSession]: {
@@ -216,6 +225,7 @@ export async function createReviewDir(
   }
 
   await mkdirReviewDir(dir);
+
   try {
     await reviewVcs.init(dir);
     await Promise.all([
@@ -257,6 +267,7 @@ export async function touchReviewAgentSession(
   if (!parseAuthoringSessionKey(sessionKey)) {
     throw new Error(`Review agent session key is invalid: ${sessionKey}`);
   }
+
   const outcome = await withReviewMutationLock(review.dir, () =>
     withFileLock(
       path.join(review.dir, ".agent-sessions.lock"),
@@ -264,9 +275,11 @@ export async function touchReviewAgentSession(
       async () => {
         const current = parseStoredReviewRecord(readReviewRecord(review.dir));
         const prior = current.agentSessions?.[sessionKey];
+
         const roles = prior?.roles.includes(role)
           ? prior.roles
           : [...(prior?.roles ?? []), role];
+
         const updated: StoredReviewRecord = {
           ...current,
           agentSessions: {
@@ -278,16 +291,20 @@ export async function touchReviewAgentSession(
             },
           },
         };
+
         await persistStoredReviewRecord(review.dir, updated);
+
         return { dir: review.dir, review: updated };
       },
     ),
   );
+
   if (!outcome.acquired) {
     throw new Error(
       `Timed out while updating agent sessions for Review ${review.review.uuid}.`,
     );
   }
+
   return outcome.result;
 }
 
@@ -300,21 +317,26 @@ export async function bindReviewAuthorSession(
   now = new Date().toISOString(),
 ): Promise<StoredReview> {
   const sessionKey = authoringSessionKey(session);
+
   const outcome = await withReviewMutationLock(review.dir, () =>
     withFileLock(
       path.join(review.dir, ".agent-sessions.lock"),
       AGENT_SESSION_LOCK_OPTIONS,
       async () => {
         const current = parseStoredReviewRecord(readReviewRecord(review.dir));
+
         const freshHarness = parseFreshSourceSessionHarness(
           current.sourceSession,
         );
+
         const boundSession = parseAuthoringSessionKey(current.sourceSession);
+
         if (freshHarness && freshHarness !== session.harness) {
           throw new Error(
             `Review fresh-session harness ${freshHarness} does not match ${session.harness}.`,
           );
         }
+
         if (
           !freshHarness &&
           (!boundSession || authoringSessionKey(boundSession) !== sessionKey)
@@ -323,10 +345,13 @@ export async function bindReviewAuthorSession(
             "Review is already bound to another authoring session.",
           );
         }
+
         const prior = current.agentSessions?.[sessionKey];
+
         const roles = prior?.roles.includes("author")
           ? prior.roles
           : [...(prior?.roles ?? []), "author" as const];
+
         const updated: StoredReviewRecord = {
           ...current,
           sourceSession: sessionKey,
@@ -339,16 +364,20 @@ export async function bindReviewAuthorSession(
             },
           },
         };
+
         await persistStoredReviewRecord(review.dir, updated);
+
         return { dir: review.dir, review: updated };
       },
     ),
   );
+
   if (!outcome.acquired) {
     throw new Error(
       `Timed out while binding the author session for Review ${review.review.uuid}.`,
     );
   }
+
   return outcome.result;
 }
 
@@ -365,6 +394,7 @@ export async function updateReviewPins(
 ): Promise<StoredReview> {
   return withReviewMutationLock(review.dir, async () => {
     await assertReviewUnchanged(review.dir, review.review);
+
     return updateReviewPinsLocked(
       {
         ...review,
@@ -399,7 +429,9 @@ async function updateReviewPinsLocked(
   ) {
     return review;
   }
+
   const now = new Date().toISOString();
+
   const sourceAttribution = parseAuthoringSessionKey(pins.sourceSession)
     ? {
         agentSessions: {
@@ -414,14 +446,18 @@ async function updateReviewPinsLocked(
         },
       }
     : {};
+
   const refreshed: StoredReview = {
     ...review,
     review: { ...review.review, ...pins, ...sourceAttribution },
   };
+
   const threadStore = reviewThreadStoreBackend(
     path.join(refreshed.dir, "review.mdx"),
   );
+
   const drafts = threadStore.readCommentDrafts();
+
   const comments = await remapReviewCodeThreads({
     rootPath: refreshed.review.worktreePath,
     comments: threadStore.readComments(),
@@ -434,6 +470,7 @@ async function updateReviewPinsLocked(
       sourceCommit: refreshed.review.sourceCommit,
     },
   });
+
   const remappedDrafts = await remapReviewCodeDrafts({
     rootPath: refreshed.review.worktreePath,
     drafts,
@@ -442,8 +479,10 @@ async function updateReviewPinsLocked(
       sourceCommit: refreshed.review.sourceCommit,
     },
   });
+
   await persistStoredReviewRecord(refreshed.dir, refreshed.review);
   threadStore.writeCommentState(comments, remappedDrafts);
+
   return refreshed;
 }
 
@@ -456,10 +495,13 @@ export async function reviewTitleFromDocument(
   documentPath: string,
 ): Promise<string | undefined> {
   const document = await readFile(documentPath, "utf8");
+
   for (const line of document.split(/\r?\n/)) {
     const heading = /^#\s+(.+?)\s*#*\s*$/.exec(line);
+
     if (heading) return heading[1].trim() || undefined;
   }
+
   return undefined;
 }
 
@@ -478,23 +520,30 @@ export async function findReviewForRepair(
     throw new Error(`Review UUID is invalid: ${uuid}`);
   const dir = path.join(reviewsHomeDir(devHome), uuid);
   let value: JsonValue;
+
   try {
     const canonical = readReviewRecord(dir);
+
     if (canonical === null) return null;
     value = canonical;
   } catch (error) {
     if (isMissingFileError(error)) return null;
+
     const detail: ReviewHomeErrorDetail = {
       message: `Could not read review.json: ${errorMessage(error)}`,
     };
+
     const code =
       error instanceof Error && "code" in error
         ? z.string().safeParse(error.code)
         : null;
+
     if (code?.success) detail.code = code.data;
     throw new ReviewHomeScanError([reviewHomeError(dir, undefined, detail)]);
   }
+
   let review: StoredReviewRecord;
+
   try {
     review = parseAnyStoredReviewRecord(value);
   } catch (error) {
@@ -505,12 +554,14 @@ export async function findReviewForRepair(
       }),
     ]);
   }
+
   if (review.uuid !== uuid)
     throw new ReviewHomeScanError([
       reviewHomeError(dir, review, {
         message: "review.json UUID does not match its directory.",
       }),
     ]);
+
   return { dir, review };
 }
 
@@ -535,18 +586,23 @@ export async function findScopedReview(
   const found = await (
     scope.includeLegacySchema ? findReviewForRepair : findReview
   )(uuid, scope.devHome);
+
   if (!found) return null;
+
   const [storedRoot, requestedRoot] = await Promise.all(
     [found.review.worktreePath, scope.worktreePath].map((root) =>
       realpath(root).catch(() => path.resolve(root)),
     ),
   );
+
   if (storedRoot !== requestedRoot) return null;
+
   if (
     !scope.includeTerminal &&
     (found.review.status === "accepted" || found.review.status === "rejected")
   )
     return null;
+
   return found;
 }
 
@@ -557,13 +613,16 @@ async function findReviewRecord(
   if (!UUID_PATTERN.test(uuid)) {
     throw new Error(`Review UUID is invalid: ${uuid}`);
   }
+
   const loaded = await readStoredReview(
     path.join(reviewsHomeDir(devHome), uuid),
   );
+
   if ("error" in loaded) {
     if (loaded.error.code === "ENOENT") return null;
     throw new ReviewHomeScanError([loaded.error]);
   }
+
   if (loaded.review.uuid !== uuid) {
     throw new ReviewHomeScanError([
       reviewHomeError(loaded.dir, loaded.review, {
@@ -571,6 +630,7 @@ async function findReviewRecord(
       }),
     ]);
   }
+
   return loaded;
 }
 
@@ -587,18 +647,22 @@ export async function reviewDescriptor(
     options.retentionDays === undefined
       ? DEFAULT_DISMISSED_RETENTION_DAYS
       : options.retentionDays;
+
   const documentPath = path.join(stored.dir, "review.mdx");
+
   const [reviewDirExists, worktreeExists, documentStats] = await Promise.all([
     pathExists(stored.dir),
     pathExists(stored.review.worktreePath),
     statIfExists(documentPath),
   ]);
+
   const documentExists = documentStats !== null;
   const available = reviewDirExists && worktreeExists && documentExists;
   /* Same diff target as the review document (resolveRequestDiffTarget):
      the pinned baseCommit..sourceCommit from review.json. An empty diff
      reports null so the views omit the numbers, as the document does. */
   const headCommit = stored.review.sourceCommit ?? stored.review.baseCommit;
+
   const [diffStats, commits] = await Promise.all([
     worktreeExists && stored.review.sourceCommit
       ? resolveReviewDiffFiles({
@@ -620,6 +684,7 @@ export async function reviewDescriptor(
         }).catch(() => [])
       : [],
   ]);
+
   /* A read-only count that cannot be taken is a real failure, not zero comments:
      the caller decides whether to drop the descriptor. `countReviewComments` keeps
      its own documented zero for the live path. */
@@ -629,6 +694,7 @@ export async function reviewDescriptor(
       : documentExists
         ? countReviewComments(documentPath)
         : 0;
+
   return {
     uuid: stored.review.uuid,
     title: stored.review.title,
@@ -666,6 +732,7 @@ export async function listReviews(
   filter: ListReviewsFilter = {},
 ): Promise<ListReviewsResult> {
   let loaded: Array<StoredReview | { error: ReviewHomeError } | null>;
+
   try {
     const entries = await readdir(reviewsHomeDir(), { withFileTypes: true });
     loaded = await Promise.all(
@@ -679,20 +746,27 @@ export async function listReviews(
     if (isMissingFileError(error)) {
       return { reviews: [], errors: [] };
     }
+
     throw error;
   }
+
   const result: ListReviewsResult = { reviews: [], errors: [] };
+
   for (const entry of loaded) {
     if (!entry) continue;
+
     if ("error" in entry) {
       result.errors.push(entry.error);
       continue;
     }
+
     if (!reviewMatchesFilter(entry.review, filter)) continue;
     const migrationError = reviewThreadMigrationError(entry);
+
     if (migrationError) result.errors.push(migrationError);
     result.reviews.push(entry);
   }
+
   return result;
 }
 
@@ -702,15 +776,18 @@ async function readReviewForList(
 ): Promise<StoredReview | { error: ReviewHomeError } | null> {
   if (!filter.worktreePath && !filter.repoKey) return readStoredReview(dir);
   let record: JsonObject | undefined;
+
   try {
     record = jsonObject(readReviewRecord(dir));
   } catch {
     return unreadableReview(dir, filter);
   }
+
   const scope = {
     worktreePath: jsonString(record?.worktreePath),
     repoKey: jsonString(record?.repoKey),
   };
+
   // A record that cannot answer the scope question is not out of scope; the
   // strict read decides whether it becomes a list error.
   if (
@@ -718,6 +795,7 @@ async function readReviewForList(
     (filter.repoKey && !scope.repoKey)
   )
     return unreadableReview(dir, filter);
+
   return reviewMatchesFilter(scope, {
     worktreePath: filter.worktreePath,
     repoKey: filter.repoKey,
@@ -739,14 +817,18 @@ function reviewMatchesFilter(
   filter: ListReviewsFilter,
 ): boolean {
   if (!filter.includeSystem && record.visibility === "system") return false;
+
   if (
     filter.worktreePath &&
     (!record.worktreePath ||
       path.resolve(record.worktreePath) !== path.resolve(filter.worktreePath))
   )
     return false;
+
   if (filter.repoKey && record.repoKey !== filter.repoKey) return false;
+
   if (filter.status && record.status !== filter.status) return false;
+
   return true;
 }
 
@@ -762,9 +844,11 @@ function reviewThreadMigrationError(
 ): ReviewHomeError | null {
   try {
     checkReviewThreadDbVersion(path.join(stored.dir, "review.mdx"));
+
     return null;
   } catch (error) {
     if (!(error instanceof ReviewThreadDbVersionError)) return null;
+
     return reviewHomeError(stored.dir, stored.review, {
       code: "MIGRATION_REQUIRED",
       message: error.message,
@@ -778,22 +862,26 @@ export async function computeSync(
 ): Promise<boolean> {
   if (!review.sourceCommit) return false;
   const head = await currentHead(worktreePath);
+
   if (!head) {
     throw new Error(
       `Could not resolve the current source head at ${worktreePath}.`,
     );
   }
+
   return head.commit === review.sourceCommit;
 }
 
 async function mkdirReviewDir(dir: string): Promise<void> {
   await mkdir(path.dirname(dir), { recursive: true, mode: 0o700 });
+
   try {
     await mkdir(dir, { recursive: false, mode: 0o700 });
   } catch (error) {
     if (error instanceof Error && "code" in error && error.code === "EEXIST") {
       throw new Error(`Review directory already exists: ${dir}`);
     }
+
     throw error;
   }
 }
@@ -814,6 +902,7 @@ export async function readStoredReview(
     await access(dir);
     let value = readReviewRecord(dir);
     let parsed = safeParseStoredReviewRecord(value);
+
     if (!parsed.success && isLegacyStoredReviewRecord(value, dir)) {
       try {
         await migrateLegacyStoredReview(dir);
@@ -825,6 +914,7 @@ export async function readStoredReview(
               message: error.message,
             }),
           };
+
         return {
           error: reviewHomeError(dir, jsonObject(value), {
             code: "REPAIR_REQUIRED",
@@ -832,9 +922,11 @@ export async function readStoredReview(
           }),
         };
       }
+
       value = readReviewRecord(dir);
       parsed = safeParseStoredReviewRecord(value);
     }
+
     if (!parsed.success) {
       return {
         error: reviewHomeError(dir, jsonObject(value), {
@@ -843,16 +935,20 @@ export async function readStoredReview(
         }),
       };
     }
+
     return { dir, review: parsed.data };
   } catch (error) {
     const detail: ReviewHomeErrorDetail = {
       message: `Could not read review.json: ${error instanceof Error ? error.message : String(error)}`,
     };
+
     // SAFETY: the try block only throws fs ErrnoExceptions and JSON
     // SyntaxErrors; `code` is the errno name on the former and absent on the
     // latter.
     const code = (error as NodeJS.ErrnoException).code;
+
     if (code) detail.code = code;
+
     return { error: reviewHomeError(dir, undefined, detail) };
   }
 }
@@ -874,6 +970,7 @@ function isLegacyStoredReviewRecord(value: JsonValue, dir: string): boolean {
       value.schemaVersion !== 4)
   )
     return false;
+
   try {
     return parseAnyStoredReviewRecord(value).uuid === path.basename(dir);
   } catch {
@@ -886,13 +983,16 @@ async function migrateLegacyStoredReview(dir: string): Promise<void> {
     const current = parseJsonText(
       await readFile(path.join(dir, "review.json"), "utf8"),
     );
+
     if (!isLegacyStoredReviewRecord(current, dir)) return;
     const { migrateStoredReview } = await import("./stored-review-migration");
     const uuid = path.basename(dir);
+
     const outcome = await migrateStoredReview({
       reviewDir: dir,
       log: (message) => console.warn(`Review ${uuid}: ${message}`),
     });
+
     if (outcome.threadDbError)
       console.warn(
         `Review ${uuid}: thread database upgrade failed: ${outcome.threadDbError}`,
@@ -913,11 +1013,13 @@ function reviewHomeError(
 ): ReviewHomeError {
   const directoryUuid = path.basename(reviewDir);
   const storedUuid = jsonString(record?.uuid) ?? null;
+
   const reviewUuid = UUID_PATTERN.test(storedUuid ?? "")
     ? storedUuid
     : UUID_PATTERN.test(directoryUuid)
       ? directoryUuid
       : null;
+
   const result: ReviewHomeError = {
     reviewDir,
     reviewUuid,
@@ -926,7 +1028,9 @@ function reviewHomeError(
     lastPublishedAt: jsonString(record?.lastPublishedAt) ?? null,
     message: error.message,
   };
+
   if (error.code) result.code = error.code;
+
   return result;
 }
 
@@ -959,33 +1063,39 @@ export function parseAnyStoredReviewRecord(
 ): StoredReviewRecord {
   if (!isJsonObject(value)) return parseStoredReviewRecord(value);
   const record = stripLegacySoftwareMap(value);
+
   if (record.schemaVersion === REVIEW_SCHEMA_VERSION)
     return parseStoredReviewRecord(record);
   const legacyRecord = LegacyStoredReviewRecordSchema.parse(record);
+
   if (legacyRecord.schemaVersion === 4) {
     return StoredReviewRecordSchema.parse({
       ...legacyRecord,
       schemaVersion: REVIEW_SCHEMA_VERSION,
     });
   }
+
   if (legacyRecord.schemaVersion === 3) {
     const {
       agentSession,
       schemaVersion: _schemaVersion,
       ...current
     } = legacyRecord;
+
     return StoredReviewRecordSchema.parse({
       ...current,
       schemaVersion: REVIEW_SCHEMA_VERSION,
       sourceSession: current.sourceSession ?? agentSession,
     });
   }
+
   const {
     agentSession,
     presentedRevision,
     schemaVersion: _schemaVersion,
     ...current
   } = legacyRecord;
+
   return StoredReviewRecordSchema.parse({
     ...current,
     schemaVersion: REVIEW_SCHEMA_VERSION,
@@ -1004,12 +1114,14 @@ function stripLegacySoftwareMap(value: JsonValue): JsonValue;
 function stripLegacySoftwareMap(value: JsonValue): JsonValue {
   if (!isJsonObject(value)) return value;
   const { softwareMap: _legacySoftwareMap, ...record } = value;
+
   return record;
 }
 
 async function pathExists(targetPath: string): Promise<boolean> {
   try {
     await access(targetPath);
+
     return true;
   } catch (error) {
     if (isMissingFileError(error)) return false;

--- a/packages/progressive-review/src/review-info.test.ts
+++ b/packages/progressive-review/src/review-info.test.ts
@@ -6,8 +6,7 @@ import { promisify } from "node:util";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createReviewDir } from "./review-home";
-import { runReviewRebind as rebindReview } from "./review-rebind";
+import { createReviewDir, persistStoredReviewRecord } from "./review-home";
 import {
   type RunReviewScaffoldInput,
   runReviewScaffold as scaffoldReview,
@@ -24,6 +23,7 @@ import {
 import { closeAllReviewThreadStores } from "./review-thread-store-backend";
 import { prepareReviewPublish } from "./server/publish-preparation";
 import { resolveReviewInfo } from "./server/review-info";
+import { rebindReview } from "./server/review-lifecycle";
 
 const execFilePromise = promisify(execFile);
 
@@ -45,7 +45,9 @@ function runReviewScaffold(input: RunReviewScaffoldInput) {
   return scaffoldReview({ ...input, createSourceAgentSession });
 }
 
-function runReviewRebind(input: Parameters<typeof rebindReview>[0]) {
+function runReviewRebind(
+  input: Parameters<typeof rebindReview>[0] & { stdout: Writable },
+) {
   return rebindReview({ ...input, createSourceAgentSession });
 }
 
@@ -328,10 +330,10 @@ describe("review info", () => {
     expect(different.reviews[0]?.uuid).not.toBe(initial.reviews[0]?.uuid);
     const recordPath = path.join(different.reviews[0]!.dir, "review.json");
     const record = JSON.parse(await readFile(recordPath, "utf8"));
-    await writeFile(
-      recordPath,
-      `${JSON.stringify({ ...record, status: "accepted" }, null, 2)}\n`,
-    );
+    await persistStoredReviewRecord(different.reviews[0]!.dir, {
+      ...record,
+      status: "accepted",
+    });
     const afterTerminal = await runReviewScaffold({ cwd: root });
     expect(afterTerminal.reviews[0]?.uuid).not.toBe(different.reviews[0]?.uuid);
     const rejectedPath = path.join(
@@ -339,10 +341,10 @@ describe("review info", () => {
       "review.json",
     );
     const rejected = JSON.parse(await readFile(rejectedPath, "utf8"));
-    await writeFile(
-      rejectedPath,
-      `${JSON.stringify({ ...rejected, status: "rejected" }, null, 2)}\n`,
-    );
+    await persistStoredReviewRecord(afterTerminal.reviews[0]!.dir, {
+      ...rejected,
+      status: "rejected",
+    });
     await expect(runReviewScaffold({ cwd: root })).resolves.toMatchObject({
       reviews: [{ status: "draft" }],
     });
@@ -932,7 +934,7 @@ describe("review info", () => {
     const reviewJsonPath = path.join(created.reviews[0]!.dir, "review.json");
     const review = JSON.parse(await readFile(reviewJsonPath, "utf8"));
     review.status = "rejected";
-    await writeFile(reviewJsonPath, `${JSON.stringify(review, null, 2)}\n`);
+    await persistStoredReviewRecord(created.reviews[0]!.dir, review);
 
     await expect(resolveReviewInfo({ cwd: root })).resolves.toMatchObject({
       reviews: [],

--- a/packages/progressive-review/src/review-info.test.ts
+++ b/packages/progressive-review/src/review-info.test.ts
@@ -98,6 +98,7 @@ describe("review info", () => {
     const reviewJson = JSON.parse(
       await readFile(path.join(created.reviews[0]!.dir, "review.json"), "utf8"),
     );
+
     expect(reviewJson.sourceSession).toBe("codex:thread-1-fork");
     expect(reviewJson.baseRef).toEqual(expect.any(String));
     expect(created.reviews[0]?.change).toBe(reviewJson.sourceIdentity?.name);
@@ -105,6 +106,7 @@ describe("review info", () => {
       git(root, ["rev-parse", reviewSourceHeadRef(created.reviews[0]!.uuid)]),
     ).resolves.toBe(reviewJson.sourceCommit);
     const document = path.join(created.reviews[0]!.dir, "review.mdx");
+
     for (const threadId of ["open-thread", "resolved-thread"]) {
       appendReviewComment(document, {
         threadId,
@@ -114,6 +116,7 @@ describe("review info", () => {
         author: "Reviewer",
       });
     }
+
     updateReviewComment(document, "resolved-thread", { status: "resolved" });
 
     const reused = await resolveReviewInfo({ cwd: root });
@@ -174,12 +177,14 @@ describe("review info", () => {
       );
 
       const progress: string[] = [];
+
       const created = await runReviewScaffold({
         cwd: root,
         baseRef: "main",
         headRef: "feature",
         progress: (message) => progress.push(message),
       });
+
       const expectedPath = path.join(
         traceSearchDir,
         "acme",
@@ -230,6 +235,7 @@ describe("review info", () => {
       baseRef: "main",
       headRef: "feature",
     });
+
     expect(created.reviews[0]).toMatchObject({
       inSync: false,
       matchesCheckout: false,
@@ -260,6 +266,7 @@ describe("review info", () => {
     const home = await reviewHome();
 
     const createdBindings: string[] = [];
+
     const created = await runReviewScaffold({
       cwd: root,
       onReviewBound: async (uuid) => {
@@ -267,6 +274,7 @@ describe("review info", () => {
         createdBindings.push(uuid);
       },
     });
+
     expect(createdBindings).toEqual([created.reviews[0]!.uuid]);
 
     const updateBindings: string[] = [];
@@ -289,11 +297,13 @@ describe("review info", () => {
     const home = await reviewHome();
 
     const initial = await runReviewScaffold({ cwd: root });
+
     const refsBefore = await git(root, [
       "for-each-ref",
       "--format=%(refname)",
       "refs/dev-fast/reviews",
     ]);
+
     const directoriesBefore = await readdir(path.join(home, "reviews"));
     await expect(runReviewScaffold({ cwd: root })).rejects.toThrow(
       new RegExp(`${initial.reviews[0]!.uuid}.*--update.*--review.*--new`),
@@ -312,10 +322,12 @@ describe("review info", () => {
 
     expect(next.reviews).toHaveLength(1);
     expect(next.reviews[0]?.uuid).not.toBe(initial.reviews[0]?.uuid);
+
     const duplicateError = await runReviewScaffold({ cwd: root }).then(
       () => "",
       (cause: unknown) => String(cause),
     );
+
     expect(duplicateError).toContain(initial.reviews[0]!.uuid);
     expect(duplicateError).toContain(next.reviews[0]!.uuid);
     expect(duplicateError).toContain("--new");
@@ -336,10 +348,12 @@ describe("review info", () => {
     });
     const afterTerminal = await runReviewScaffold({ cwd: root });
     expect(afterTerminal.reviews[0]?.uuid).not.toBe(different.reviews[0]?.uuid);
+
     const rejectedPath = path.join(
       afterTerminal.reviews[0]!.dir,
       "review.json",
     );
+
     const rejected = JSON.parse(await readFile(rejectedPath, "utf8"));
     await persistStoredReviewRecord(afterTerminal.reviews[0]!.dir, {
       ...rejected,
@@ -369,6 +383,7 @@ describe("review info", () => {
       baseRef: "main",
       headRef: "feature",
     });
+
     const reviewJson = JSON.parse(
       await readFile(path.join(created.reviews[0]!.dir, "review.json"), "utf8"),
     );
@@ -392,6 +407,7 @@ describe("review info", () => {
       baseRef: "main",
       headRef: "feature",
     });
+
     const uuid = created.reviews[0]!.uuid;
 
     await writeFile(path.join(root, "README.md"), "# Feature 2\n", "utf8");
@@ -409,11 +425,14 @@ describe("review info", () => {
       update: true,
       env: { CLAUDE_CODE_SESSION_ID: "update-1" },
     });
+
     expect(updated.reviews).toHaveLength(1);
     expect(updated.reviews[0]?.uuid).toBe(uuid);
+
     const reviewJson = JSON.parse(
       await readFile(path.join(updated.reviews[0]!.dir, "review.json"), "utf8"),
     );
+
     expect(reviewJson.sourceCommit).toBe(movedHead);
     expect(reviewJson.baseCommit).toBe(forkPoint);
     expect(reviewJson.baseRef).toBe("main");
@@ -424,9 +443,11 @@ describe("review info", () => {
       update: true,
       baseRef: movedMain,
     });
+
     const rebasedJson = JSON.parse(
       await readFile(path.join(rebased.reviews[0]!.dir, "review.json"), "utf8"),
     );
+
     expect(rebasedJson.baseRef).toBe(movedMain);
     expect(rebasedJson.baseCommit).toBe(forkPoint);
   });
@@ -436,11 +457,13 @@ describe("review info", () => {
     await reviewHome();
 
     await git(root, ["checkout", "-b", "feature"]);
+
     const created = await runReviewScaffold({
       cwd: root,
       baseRef: "main",
       headRef: "feature",
     });
+
     const reviewDir = created.reviews[0]!.dir;
     await writeFile(
       path.join(reviewDir, "data.ts"),
@@ -498,10 +521,13 @@ describe("review info", () => {
       baseRef: "main",
       headRef: "feat-a",
     });
+
     const uuid = created.reviews[0]!.uuid;
+
     const createdJson = JSON.parse(
       await readFile(path.join(created.reviews[0]!.dir, "review.json"), "utf8"),
     );
+
     expect(createdJson.sourceCommit).toBe(featATip);
     expect(createdJson.sourceCommit).not.toBe(featBTip);
     expect(createdJson.baseCommit).toBe(forkPoint);
@@ -520,9 +546,11 @@ describe("review info", () => {
       update: true,
       reviewUuid: uuid,
     });
+
     const updatedJson = JSON.parse(
       await readFile(path.join(updated.reviews[0]!.dir, "review.json"), "utf8"),
     );
+
     expect(updatedJson.sourceCommit).toBe(movedFeatATip);
     expect(updatedJson.sourceCommit).not.toBe(featBTip);
     expect(updatedJson.baseCommit).toBe(forkPoint);
@@ -537,16 +565,20 @@ describe("review info", () => {
     await writeFile(path.join(root, "README.md"), "base\n", "utf8");
     await jj(root, ["commit", "-m", "trunk"]);
     await jj(root, ["bookmark", "create", "main", "-r", "@-"]);
+
     const forkPoint = (
       await jj(root, ["log", "--no-graph", "-r", "@-", "-T", "commit_id"])
     ).trim();
+
     await writeFile(path.join(root, "README.md"), "stacked\n", "utf8");
     await jj(root, ["commit", "-m", "stacked change"]);
+
     const parentChange = (
       await jj(root, ["log", "--no-graph", "-r", "@-", "-T", "commit_id"])
     ).trim();
 
     const created = await runReviewScaffold({ cwd: root });
+
     const reviewJson = JSON.parse(
       await readFile(path.join(created.reviews[0]!.dir, "review.json"), "utf8"),
     );
@@ -572,6 +604,7 @@ describe("review info", () => {
 
     const head = await git(root, ["rev-parse", "HEAD"]);
     const canonicalRoot = await git(root, ["rev-parse", "--show-toplevel"]);
+
     const review = await createReviewDir({
       worktreePath: canonicalRoot,
       baseRef: head,
@@ -596,11 +629,13 @@ describe("review info", () => {
     await git(root, ["checkout", "-b", "feature"]);
     await writeFile(path.join(root, "README.md"), "# Feature\n", "utf8");
     await git(root, ["commit", "-am", "feature"]);
+
     const created = await runReviewScaffold({
       cwd: root,
       baseRef: "main",
       headRef: "feature",
     });
+
     const uuid = created.reviews[0]!.uuid;
 
     // The branch gains a commit; the checkout stays behind on the old tip.
@@ -613,9 +648,11 @@ describe("review info", () => {
     const updated = await runReviewScaffold({ cwd: root, update: true });
     expect(updated.reviews).toHaveLength(1);
     expect(updated.reviews[0]?.uuid).toBe(uuid);
+
     const reviewJson = JSON.parse(
       await readFile(path.join(updated.reviews[0]!.dir, "review.json"), "utf8"),
     );
+
     expect(reviewJson.sourceCommit).toBe(movedTip);
   });
 
@@ -649,11 +686,13 @@ describe("review info", () => {
       await git(root, ["checkout", "-b", "feature"]);
       await writeFile(path.join(root, "README.md"), "# Feature\n", "utf8");
       await git(root, ["commit", "-am", "feature"]);
+
       const created = await runReviewScaffold({
         cwd: root,
         baseRef: "main",
         headRef: "feature",
       });
+
       await git(root, ["checkout", "main"]);
       await git(root, ["checkout", "-b", "other"]);
       await writeFile(path.join(root, "other.txt"), "other\n", "utf8");
@@ -662,6 +701,7 @@ describe("review info", () => {
       const otherTip = await git(root, ["rev-parse", "HEAD"]);
       const recordPath = path.join(created.reviews[0]!.dir, "review.json");
       const original = JSON.parse(await readFile(recordPath, "utf8"));
+
       if (concurrentChange) {
         createSourceAgentSession.mockImplementationOnce(async ({ agent }) => {
           await writeFile(
@@ -671,12 +711,14 @@ describe("review info", () => {
               sourceIdentity: { kind: "git-branch", name: "competing" },
             }),
           );
+
           return {
             harness: agent.harness,
             sessionId: `${agent.sessionId}-fork`,
           };
         });
       }
+
       const rebinding = runReviewRebind({
         cwd: root,
         change: "other",
@@ -684,21 +726,25 @@ describe("review info", () => {
         env: { CODEX_THREAD_ID: "rebind-1" },
         stdout: nullStream(),
       });
+
       const outcome = await rebinding.then(
         () => "rebound",
         (error) => String(error),
       );
+
       expect(outcome).toMatch(
         concurrentChange
           ? /Review changed while preparing publication/
           : /^rebound$/,
       );
+
       const reviewJson = JSON.parse(
         await readFile(
           path.join(created.reviews[0]!.dir, "review.json"),
           "utf8",
         ),
       );
+
       expect(reviewJson.sourceIdentity).toEqual({
         kind: "git-branch",
         name: concurrentChange ? "competing" : "other",
@@ -721,13 +767,16 @@ describe("review info", () => {
     await git(root, ["commit", "-am", "feature"]);
     const featureTip = await git(root, ["rev-parse", "feature"]);
     const mainTip = await git(root, ["rev-parse", "main"]);
+
     const created = await runReviewScaffold({
       cwd: root,
       baseRef: "main",
       headRef: "feature",
     });
+
     const uuid = created.reviews[0]!.uuid;
     const reviewDir = created.reviews[0]!.dir;
+
     const before = JSON.parse(
       await readFile(path.join(reviewDir, "review.json"), "utf8"),
     );
@@ -748,6 +797,7 @@ describe("review info", () => {
     const after = JSON.parse(
       await readFile(path.join(reviewDir, "review.json"), "utf8"),
     );
+
     expect(after.sourceIdentity).toEqual({
       kind: "git-branch",
       name: "feature",
@@ -761,6 +811,7 @@ describe("review info", () => {
       cwd: after.worktreePath,
       reviewUuid: uuid,
     });
+
     expect(prepared.sourceCommit).toBe(featureTip);
     expect(prepared.sourceBranch).toBe("feature");
     expect(prepared).not.toHaveProperty("warnings");
@@ -775,13 +826,16 @@ describe("review info", () => {
     await git(root, ["commit", "-am", "feature"]);
     const featureTip = await git(root, ["rev-parse", "feature"]);
     const mainTip = await git(root, ["rev-parse", "main"]);
+
     const created = await runReviewScaffold({
       cwd: root,
       baseRef: "main",
       headRef: "feature",
     });
+
     const uuid = created.reviews[0]!.uuid;
     const reviewDir = created.reviews[0]!.dir;
+
     const before = JSON.parse(
       await readFile(path.join(reviewDir, "review.json"), "utf8"),
     );
@@ -809,6 +863,7 @@ describe("review info", () => {
     const after = JSON.parse(
       await readFile(path.join(reviewDir, "review.json"), "utf8"),
     );
+
     expect(after.sourceIdentity).toEqual({
       kind: "git-branch",
       name: "feature",
@@ -872,10 +927,13 @@ describe("review info", () => {
       baseRef: baseCommit,
       headRef: featureCommit,
     });
+
     expect(created.warnings).toBeUndefined();
+
     const reviewJson = JSON.parse(
       await readFile(path.join(created.reviews[0]!.dir, "review.json"), "utf8"),
     );
+
     expect(reviewJson.sourceCommit).toBe(featureCommit);
   });
 
@@ -891,6 +949,7 @@ describe("review info", () => {
     await writeFile(path.join(root, "README.md"), "# Git-only head\n", "utf8");
     await git(root, ["add", "README.md"]);
     const tree = await git(root, ["write-tree"]);
+
     const { stdout } = await execFilePromise(
       "git",
       [
@@ -905,6 +964,7 @@ describe("review info", () => {
       ],
       { encoding: "utf8" },
     );
+
     const headCommit = stdout.trim();
 
     await expect(
@@ -916,9 +976,11 @@ describe("review info", () => {
       baseRef: baseCommit,
       headRef: headCommit,
     });
+
     const reviewJson = JSON.parse(
       await readFile(path.join(created.reviews[0]!.dir, "review.json"), "utf8"),
     );
+
     expect(reviewJson.sourceCommit).toBe(headCommit);
     expect(reviewJson.sourceIdentity).toEqual({
       kind: "git-commit",
@@ -959,6 +1021,7 @@ async function git(root: string, args: string[]): Promise<string> {
   const { stdout } = await execFilePromise("git", ["-C", root, ...args], {
     encoding: "utf8",
   });
+
   return stdout.trim();
 }
 
@@ -975,12 +1038,14 @@ async function jj(root: string, args: string[]): Promise<string> {
     cwd: root,
     encoding: "utf8",
   });
+
   return stdout;
 }
 
 async function commandAvailable(command: string): Promise<boolean> {
   try {
     await execFilePromise(command, ["--version"]);
+
     return true;
   } catch {
     return false;

--- a/packages/progressive-review/src/review-info.ts
+++ b/packages/progressive-review/src/review-info.ts
@@ -54,6 +54,7 @@ export async function runReviewInfo(
   const discovery = await span("info: desktop health", () =>
     requireHealthyReviewDesktop("review info"),
   );
+
   const response = await span("info: POST /info", () =>
     fetch(`${discovery.url}/info`, {
       method: "POST",
@@ -64,18 +65,23 @@ export async function runReviewInfo(
       body: JSON.stringify(input),
     }),
   );
+
   const payload: JsonValue = await response.json();
+
   if (!response.ok) {
     throw new Error(reviewInfoResponseError(payload, response.status));
   }
+
   return parseReviewInfoEvent(payload);
 }
 
 function parseReviewInfoEvent(value: JsonValue): ReviewInfoEvent {
   const parsed = ReviewInfoEventSchema.safeParse(value);
+
   if (!parsed.success) {
     throw new Error("Review Desktop returned an invalid info response.");
   }
+
   return parsed.data;
 }
 

--- a/packages/progressive-review/src/review-info.ts
+++ b/packages/progressive-review/src/review-info.ts
@@ -31,7 +31,7 @@ export interface ReviewInfoEvent {
   }>;
 }
 
-const ReviewInfoEventSchema: z.ZodType<ReviewInfoEvent> = z.object({
+export const ReviewInfoEventSchema = z.object({
   event: z.literal("info"),
   warnings: z.array(z.string()).optional(),
   reviews: z.array(

--- a/packages/progressive-review/src/review-lifecycle-client.ts
+++ b/packages/progressive-review/src/review-lifecycle-client.ts
@@ -41,13 +41,17 @@ export async function resolveThreadsReviewClient(
     }),
   );
 }
+
 export async function readThreadsClient(reviewUuid: string) {
   const result = ReviewThreadsSnapshotResponseSchema.parse(
     await requestReviewLifecycle("/lifecycle/threads/snapshot", { reviewUuid }),
   );
+
   if (!result.ok) throw new Error(result.error);
+
   return result.snapshot;
 }
+
 export async function commandThreadsClient(
   reviewUuid: string,
   command: ReviewThreadsCommand,
@@ -58,9 +62,12 @@ export async function commandThreadsClient(
       command,
     }),
   );
+
   if (!result.ok) throw new Error(result.error);
+
   return result.commit;
 }
+
 export async function replyThreadClient(input: {
   reviewUuid: string;
   mutationId: string;
@@ -73,7 +80,9 @@ export async function replyThreadClient(input: {
   const result = ReviewThreadsCommandResponseSchema.parse(
     await requestReviewLifecycle("/lifecycle/threads/reply", input),
   );
+
   if (!result.ok) throw new Error(result.error);
+
   return result.commit;
 }
 
@@ -81,6 +90,7 @@ export const listReviewsClient: typeof listReviews = async (filter = {}) =>
   ReviewListResponseSchema.parse(
     await requestReviewLifecycle("/lifecycle/list", filter),
   );
+
 export const resolveReviewClient: typeof resolvePublishReview = async (
   cwd,
   reviewUuid,
@@ -93,6 +103,7 @@ export const resolveReviewClient: typeof resolvePublishReview = async (
       ...options,
     }),
   );
+
 export const findScopedReviewClient: typeof findScopedReview = async (
   reviewUuid,
   scope,
@@ -105,6 +116,7 @@ export const findScopedReviewClient: typeof findScopedReview = async (
       includeLegacySchema: scope.includeLegacySchema,
     }),
   );
+
 export const checkpointReviewClient: typeof sealReviewCandidate = async (
   reviewDir,
   message,
@@ -115,6 +127,7 @@ export const checkpointReviewClient: typeof sealReviewCandidate = async (
       message,
     }),
   );
+
 export const touchReviewAgentSessionClient: typeof touchReviewAgentSession =
   async (stored, session, role) =>
     ReviewStoredResponseSchema.parse(
@@ -124,6 +137,7 @@ export const touchReviewAgentSessionClient: typeof touchReviewAgentSession =
         role,
       }),
     );
+
 export async function openThreadCountClient(
   reviewDir: string,
 ): Promise<number> {
@@ -137,6 +151,7 @@ export async function openThreadCountClient(
       }),
     );
 }
+
 export async function scaffoldReviewClient(
   input: RunReviewScaffoldInput,
 ): Promise<ReviewScaffoldEvent> {
@@ -153,7 +168,9 @@ export async function scaffoldReviewClient(
       agent: resolveAuthoringSessionRef(input.env ?? process.env),
     }),
   );
+
   for (const review of result.reviews) await input.onReviewBound?.(review.uuid);
+
   return result;
 }
 
@@ -163,6 +180,7 @@ export async function requestReviewLifecycle<Input>(
   body?: Input,
 ): Promise<JsonValue> {
   const desktop = await requireHealthyReviewDesktop("Review lifecycle");
+
   const response = await fetch(`${desktop.url}${pathname}`, {
     method: body === undefined ? "GET" : "POST",
     headers: {
@@ -171,11 +189,14 @@ export async function requestReviewLifecycle<Input>(
     },
     body: JSON.stringify(body),
   });
+
   const result = parseJsonText(await response.text());
+
   if (!response.ok)
     throw new Error(
       jsonString(jsonObject(result)?.error) ??
         `Review Desktop returned ${response.status}.`,
     );
+
   return result;
 }

--- a/packages/progressive-review/src/review-lifecycle-client.ts
+++ b/packages/progressive-review/src/review-lifecycle-client.ts
@@ -1,0 +1,181 @@
+import path from "node:path";
+
+import {
+  type JsonValue,
+  type ReviewThreadsCommand,
+  ReviewThreadsCommandResponseSchema,
+  ReviewThreadsSnapshotResponseSchema,
+  jsonObject,
+  jsonString,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+import { z } from "zod";
+
+import { resolveAuthoringSessionRef } from "./authoring-session";
+import { requireHealthyReviewDesktop } from "./desktop-discovery";
+import type {
+  findScopedReview,
+  listReviews,
+  sealReviewCandidate,
+  touchReviewAgentSession,
+} from "./review-home";
+import {
+  ReviewListResponseSchema,
+  ReviewScaffoldResponseSchema,
+  ReviewStoredResponseSchema,
+} from "./review-lifecycle-contracts";
+import type {
+  ReviewScaffoldEvent,
+  RunReviewScaffoldInput,
+} from "./review-scaffold";
+import type { resolvePublishReview } from "./server/publish-preparation";
+
+export async function resolveThreadsReviewClient(
+  cwd: string,
+  reviewUuid?: string,
+) {
+  return ReviewStoredResponseSchema.parse(
+    await requestReviewLifecycle("/lifecycle/threads/resolve-target", {
+      cwd,
+      reviewUuid,
+    }),
+  );
+}
+export async function readThreadsClient(reviewUuid: string) {
+  const result = ReviewThreadsSnapshotResponseSchema.parse(
+    await requestReviewLifecycle("/lifecycle/threads/snapshot", { reviewUuid }),
+  );
+  if (!result.ok) throw new Error(result.error);
+  return result.snapshot;
+}
+export async function commandThreadsClient(
+  reviewUuid: string,
+  command: ReviewThreadsCommand,
+) {
+  const result = ReviewThreadsCommandResponseSchema.parse(
+    await requestReviewLifecycle("/lifecycle/threads/command", {
+      reviewUuid,
+      command,
+    }),
+  );
+  if (!result.ok) throw new Error(result.error);
+  return result.commit;
+}
+export async function replyThreadClient(input: {
+  reviewUuid: string;
+  mutationId: string;
+  threadId: string;
+  messageId: string;
+  author: string;
+  body: string;
+  format: "plain" | "markdown";
+}) {
+  const result = ReviewThreadsCommandResponseSchema.parse(
+    await requestReviewLifecycle("/lifecycle/threads/reply", input),
+  );
+  if (!result.ok) throw new Error(result.error);
+  return result.commit;
+}
+
+export const listReviewsClient: typeof listReviews = async (filter = {}) =>
+  ReviewListResponseSchema.parse(
+    await requestReviewLifecycle("/lifecycle/list", filter),
+  );
+export const resolveReviewClient: typeof resolvePublishReview = async (
+  cwd,
+  reviewUuid,
+  options = {},
+) =>
+  ReviewStoredResponseSchema.parse(
+    await requestReviewLifecycle("/lifecycle/resolve", {
+      cwd,
+      reviewUuid,
+      ...options,
+    }),
+  );
+export const findScopedReviewClient: typeof findScopedReview = async (
+  reviewUuid,
+  scope,
+) =>
+  ReviewStoredResponseSchema.nullable().parse(
+    await requestReviewLifecycle("/lifecycle/find", {
+      reviewUuid,
+      worktreePath: scope.worktreePath,
+      includeTerminal: scope.includeTerminal,
+      includeLegacySchema: scope.includeLegacySchema,
+    }),
+  );
+export const checkpointReviewClient: typeof sealReviewCandidate = async (
+  reviewDir,
+  message,
+) =>
+  z.string().parse(
+    await requestReviewLifecycle("/lifecycle/checkpoint", {
+      reviewUuid: path.basename(reviewDir),
+      message,
+    }),
+  );
+export const touchReviewAgentSessionClient: typeof touchReviewAgentSession =
+  async (stored, session, role) =>
+    ReviewStoredResponseSchema.parse(
+      await requestReviewLifecycle("/lifecycle/agent-session", {
+        reviewUuid: stored.review.uuid,
+        session,
+        role,
+      }),
+    );
+export async function openThreadCountClient(
+  reviewDir: string,
+): Promise<number> {
+  return z
+    .number()
+    .int()
+    .nonnegative()
+    .parse(
+      await requestReviewLifecycle("/lifecycle/open-thread-count", {
+        reviewUuid: path.basename(reviewDir),
+      }),
+    );
+}
+export async function scaffoldReviewClient(
+  input: RunReviewScaffoldInput,
+): Promise<ReviewScaffoldEvent> {
+  const result = ReviewScaffoldResponseSchema.parse(
+    await requestReviewLifecycle("/lifecycle/scaffold", {
+      cwd: input.cwd,
+      reviewUuid: input.reviewUuid,
+      baseRef: input.baseRef,
+      headRef: input.headRef,
+      pullRequest: input.pullRequest,
+      update: input.update,
+      newReview: input.newReview,
+      background: input.background,
+      agent: resolveAuthoringSessionRef(input.env ?? process.env),
+    }),
+  );
+  for (const review of result.reviews) await input.onReviewBound?.(review.uuid);
+  return result;
+}
+
+/** Only discovery and HTTP live in the client; all Review storage is server-owned. */
+export async function requestReviewLifecycle<Input>(
+  pathname: string,
+  body?: Input,
+): Promise<JsonValue> {
+  const desktop = await requireHealthyReviewDesktop("Review lifecycle");
+  const response = await fetch(`${desktop.url}${pathname}`, {
+    method: body === undefined ? "GET" : "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-review-token": desktop.token,
+    },
+    body: JSON.stringify(body),
+  });
+  const result = parseJsonText(await response.text());
+  if (!response.ok)
+    throw new Error(
+      jsonString(jsonObject(result)?.error) ??
+        `Review Desktop returned ${response.status}.`,
+    );
+  return result;
+}

--- a/packages/progressive-review/src/review-lifecycle-contracts.ts
+++ b/packages/progressive-review/src/review-lifecycle-contracts.ts
@@ -1,0 +1,217 @@
+import {
+  ReviewRecordSchema,
+  ReviewStatusSchema,
+  reviewViewSchema,
+} from "@dev.fast/review-protocol";
+import { z } from "zod";
+
+import { ReviewInfoEventSchema } from "./review-info";
+export const ReviewRepairReadyResponseSchema = z.strictObject({
+  ok: z.literal(true),
+  status: ReviewStatusSchema,
+  oldDocumentRevision: z.string().min(1).nullable(),
+  oldMapRevision: z.string().min(1).nullable(),
+  newDocumentRevision: z.string().regex(/^[0-9a-f]{40}$/),
+  newMapRevision: z
+    .string()
+    .regex(/^[0-9a-f]{40}$/)
+    .nullable(),
+  sessionId: z.string().min(1),
+  url: z.string().min(1),
+});
+
+export const ReviewRepairResultSchema = ReviewRepairReadyResponseSchema.extend({
+  reviewUuid: z.uuid(),
+  noop: z.boolean(),
+  warnings: z.array(z.string()),
+  sessionId: z.string().optional(),
+  url: z.string().optional(),
+  sourceFallback: z
+    .strictObject({ document: z.boolean(), map: z.boolean() })
+    .optional(),
+});
+
+const agent = z.strictObject({
+  harness: z.enum(["codex", "claude-code", "opencode", "pi"]),
+  sessionId: z.string().trim().min(1),
+});
+
+export const ReviewLifecycleTargetSchema = z.strictObject({
+  cwd: z.string().min(1),
+  reviewUuid: z.uuid().optional(),
+});
+
+export const ReviewResolveRequestSchema = ReviewLifecycleTargetSchema.extend({
+  includeTerminal: z.boolean().optional(),
+});
+export const ReviewListRequestSchema = z.strictObject({
+  worktreePath: z.string().optional(),
+  repoKey: z.string().optional(),
+  status: ReviewRecordSchema.shape.status.optional(),
+  includeSystem: z.boolean().optional(),
+});
+
+export const ReviewScaffoldRequestSchema = ReviewLifecycleTargetSchema.extend({
+  baseRef: z.string().optional(),
+  headRef: z.string().optional(),
+  pullRequest: z.string().optional(),
+  update: z.boolean().optional(),
+  newReview: z.boolean().optional(),
+  background: z.boolean().optional(),
+  agent: agent.optional(),
+})
+  .refine((request) => !(request.headRef && request.pullRequest), {
+    message: "Choose headRef or pullRequest, not both.",
+  })
+  .refine(
+    (request) =>
+      !request.update ||
+      !(request.newReview || request.headRef || request.pullRequest),
+    {
+      message:
+        "Repinning cannot also create a new Review or choose a different source; use rebind.",
+    },
+  )
+  .refine((request) => !request.reviewUuid || request.update === true, {
+    message: "reviewUuid requires update=true when scaffolding.",
+  });
+
+export const ReviewPublishRequestSchema = ReviewLifecycleTargetSchema.extend({
+  view: reviewViewSchema.optional(),
+  agent: agent.optional(),
+});
+
+export const ReviewRebindRequestSchema = ReviewLifecycleTargetSchema.extend({
+  change: z.string().trim().min(1),
+  agent: agent.optional(),
+});
+
+export const ReviewPublicationEventSchema = z.discriminatedUnion("event", [
+  z.strictObject({ event: z.literal("review-bound"), reviewUuid: z.uuid() }),
+  z.strictObject({
+    event: z.literal("stage"),
+    name: z.enum(["validate", "revision", "mount", "load"]),
+    status: z.enum(["running", "complete"]),
+    revision: z.string().optional(),
+    sessionId: z.string().optional(),
+    skipped: z.boolean().optional(),
+  }),
+  z.strictObject({
+    event: z.enum(["warning", "error"]),
+    stage: z.string(),
+    diagnostics: z.array(z.string()),
+  }),
+  z.strictObject({
+    event: z.literal("diagnostics"),
+    diagnostics: z.array(
+      z.object({
+        source: z.enum(["mdx", "typescript", "review", "evidence"]),
+        severity: z.enum(["error", "warning"]),
+        code: z.string(),
+        message: z.string(),
+        filePath: z.string(),
+        line: z.number().optional(),
+        column: z.number().optional(),
+      }),
+    ),
+  }),
+  z.strictObject({
+    event: z.literal("document-published"),
+    revision: z.string(),
+    sessionId: z.string(),
+    softwareMapRevision: z.string().nullable(),
+  }),
+  z.strictObject({
+    event: z.literal("map-published"),
+    revision: z.string(),
+    documentRevision: z.string(),
+    unchanged: z.boolean(),
+  }),
+]);
+export type ReviewPublicationEvent = z.infer<
+  typeof ReviewPublicationEventSchema
+>;
+export const ReviewPublicationResultSchema = z.strictObject({
+  ok: z.boolean(),
+  events: z.array(ReviewPublicationEventSchema),
+});
+
+export const ReviewRebindResultSchema = z.strictObject({
+  event: z.literal("rebound"),
+  uuid: z.uuid(),
+  change: z.string(),
+  warnings: z.array(z.string()).optional(),
+});
+
+export const ReviewStoredResponseSchema = z.strictObject({
+  dir: z.string(),
+  review: ReviewRecordSchema,
+});
+export const ReviewListResponseSchema = z.strictObject({
+  reviews: z.array(ReviewStoredResponseSchema),
+  errors: z.array(
+    z.object({
+      reviewDir: z.string(),
+      reviewUuid: z.string().nullable(),
+      title: z.string(),
+      worktreePath: z.string(),
+      lastPublishedAt: z.string().nullable(),
+      message: z.string(),
+      code: z.string().optional(),
+    }),
+  ),
+});
+
+export const ReviewMetadataUpdateSchema = z.strictObject({
+  title: z.string().trim().min(1),
+  expectedTitle: z.string(),
+});
+
+export const ReviewDocumentFileNameSchema = z.enum(["review.mdx", "data.ts"]);
+export type ReviewDocumentFileName = z.infer<
+  typeof ReviewDocumentFileNameSchema
+>;
+export const ReviewDocumentFileResponseSchema = z.strictObject({
+  name: ReviewDocumentFileNameSchema,
+  source: z.string().nullable(),
+  sourceHash: z.string().nullable(),
+});
+export const ReviewDocumentFileWriteSchema = z.strictObject({
+  name: ReviewDocumentFileNameSchema,
+  source: z.string(),
+  expectedSourceHash: z.string().nullable(),
+});
+
+export const ReviewScaffoldResponseSchema = ReviewInfoEventSchema.extend({
+  pins: z
+    .object({ baseCommit: z.string(), sourceCommit: z.string() })
+    .optional(),
+  checkouts: z
+    .object({ head: z.string().nullable(), base: z.string().nullable() })
+    .optional(),
+  traces: z.object({
+    sessions: z.array(
+      z.object({
+        id: z.string(),
+        harness: z.enum(["codex", "claude-code", "opencode", "pi", "unknown"]),
+        available: z.boolean(),
+        traces: z.array(z.string()),
+        commits: z.array(z.object({ sha: z.string(), subject: z.string() })),
+      }),
+    ),
+    corpusRoot: z.string().nullable(),
+    repository: z.string().nullable(),
+    materializedSessions: z.array(
+      z.object({
+        session: z.string(),
+        traces: z.number(),
+        events: z.number(),
+        files: z.number(),
+      }),
+    ),
+    unavailableSessions: z.array(z.string()),
+    events: z.number(),
+    files: z.number(),
+    paths: z.array(z.string()),
+  }),
+});

--- a/packages/progressive-review/src/review-lifecycle-contracts.ts
+++ b/packages/progressive-review/src/review-lifecycle-contracts.ts
@@ -6,6 +6,7 @@ import {
 import { z } from "zod";
 
 import { ReviewInfoEventSchema } from "./review-info";
+
 export const ReviewRepairReadyResponseSchema = z.strictObject({
   ok: z.literal(true),
   status: ReviewStatusSchema,
@@ -44,6 +45,7 @@ export const ReviewLifecycleTargetSchema = z.strictObject({
 export const ReviewResolveRequestSchema = ReviewLifecycleTargetSchema.extend({
   includeTerminal: z.boolean().optional(),
 });
+
 export const ReviewListRequestSchema = z.strictObject({
   worktreePath: z.string().optional(),
   repoKey: z.string().optional(),
@@ -128,9 +130,11 @@ export const ReviewPublicationEventSchema = z.discriminatedUnion("event", [
     unchanged: z.boolean(),
   }),
 ]);
+
 export type ReviewPublicationEvent = z.infer<
   typeof ReviewPublicationEventSchema
 >;
+
 export const ReviewPublicationResultSchema = z.strictObject({
   ok: z.boolean(),
   events: z.array(ReviewPublicationEventSchema),
@@ -147,6 +151,7 @@ export const ReviewStoredResponseSchema = z.strictObject({
   dir: z.string(),
   review: ReviewRecordSchema,
 });
+
 export const ReviewListResponseSchema = z.strictObject({
   reviews: z.array(ReviewStoredResponseSchema),
   errors: z.array(
@@ -168,14 +173,17 @@ export const ReviewMetadataUpdateSchema = z.strictObject({
 });
 
 export const ReviewDocumentFileNameSchema = z.enum(["review.mdx", "data.ts"]);
+
 export type ReviewDocumentFileName = z.infer<
   typeof ReviewDocumentFileNameSchema
 >;
+
 export const ReviewDocumentFileResponseSchema = z.strictObject({
   name: ReviewDocumentFileNameSchema,
   source: z.string().nullable(),
   sourceHash: z.string().nullable(),
 });
+
 export const ReviewDocumentFileWriteSchema = z.strictObject({
   name: ReviewDocumentFileNameSchema,
   source: z.string(),

--- a/packages/progressive-review/src/review-lifecycle-test-utils.ts
+++ b/packages/progressive-review/src/review-lifecycle-test-utils.ts
@@ -10,12 +10,14 @@ export async function startLifecycleTestServer() {
     path.dirname(fileURLToPath(import.meta.url)),
     "..",
   );
+
   const relay = new GlobalReviewDesktopVerbRelay();
   relay.attach({
     signal: new AbortController().signal,
     write: () => {},
     close: () => {},
   });
+
   const server = createGlobalReviewServer({
     appPid: process.pid,
     packageRoot,
@@ -23,6 +25,8 @@ export async function startLifecycleTestServer() {
     port: 0,
     relay,
   });
+
   await server.listen();
+
   return server;
 }

--- a/packages/progressive-review/src/review-lifecycle-test-utils.ts
+++ b/packages/progressive-review/src/review-lifecycle-test-utils.ts
@@ -1,0 +1,28 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createGlobalReviewServer } from "./server/desktop-server";
+import { GlobalReviewDesktopVerbRelay } from "./server/global-verb-relay";
+
+/** Real HTTP/storage boundary with an attached desktop control channel. */
+export async function startLifecycleTestServer() {
+  const packageRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+  );
+  const relay = new GlobalReviewDesktopVerbRelay();
+  relay.attach({
+    signal: new AbortController().signal,
+    write: () => {},
+    close: () => {},
+  });
+  const server = createGlobalReviewServer({
+    appPid: process.pid,
+    packageRoot,
+    toolingRoot: packageRoot,
+    port: 0,
+    relay,
+  });
+  await server.listen();
+  return server;
+}

--- a/packages/progressive-review/src/review-lifecycle.test.ts
+++ b/packages/progressive-review/src/review-lifecycle.test.ts
@@ -23,6 +23,7 @@ import {
 import { closeAllReviewThreadStores } from "./review-thread-store-backend";
 
 let server: Awaited<ReturnType<typeof startLifecycleTestServer>> | undefined;
+
 afterEach(async () => {
   await server?.close();
   server = undefined;
@@ -33,21 +34,26 @@ afterEach(async () => {
 async function fixture() {
   await reviewHome();
   const worktreePath = await gitRepository();
+
   const review = await createReviewDir({
     worktreePath,
     baseRef: "main",
     baseCommit: "a".repeat(40),
   });
+
   server = await startLifecycleTestServer();
+
   return review;
 }
 
 it("serializes source edits, rejects stale writes and symlinks, and preserves accepted content", async () => {
   const review = await fixture();
   const target = { reviewUuid: review.review.uuid, name: "review.mdx" };
+
   const initial = ReviewDocumentFileResponseSchema.parse(
     await requestReviewLifecycle("/lifecycle/document/read", target),
   );
+
   const writes = await Promise.allSettled(
     ["# One\n", "# Two\n"].map((source) =>
       requestReviewLifecycle("/lifecycle/document/write", {
@@ -57,15 +63,18 @@ it("serializes source edits, rejects stale writes and symlinks, and preserves ac
       }),
     ),
   );
+
   expect(writes.filter((result) => result.status === "fulfilled")).toHaveLength(
     1,
   );
   expect(writes.filter((result) => result.status === "rejected")).toHaveLength(
     1,
   );
+
   const current = ReviewDocumentFileResponseSchema.parse(
     await requestReviewLifecycle("/lifecycle/document/read", target),
   );
+
   expect(await readFile(path.join(review.dir, "review.mdx"), "utf8")).toBe(
     current.source,
   );
@@ -97,11 +106,13 @@ it("serializes source edits, rejects stale writes and symlinks, and preserves ac
 
 it("persists metadata with a title precondition and isolates each Review's comments", async () => {
   const review = await fixture();
+
   const other = await createReviewDir({
     worktreePath: review.review.worktreePath,
     baseRef: "main",
     baseCommit: "b".repeat(40),
   });
+
   await requestReviewLifecycle("/lifecycle/metadata", {
     reviewUuid: review.review.uuid,
     expectedTitle: review.review.title,
@@ -118,6 +129,7 @@ it("persists metadata with a title precondition and isolates each Review's comme
     title: "API title",
     titleOverride: "API title",
   });
+
   const created = await commandThreadsClient(review.review.uuid, {
     command: "comment.create",
     mutationId: randomUUID(),
@@ -128,12 +140,14 @@ it("persists metadata with a title precondition and isolates each Review's comme
       target: { kind: "document" },
     },
   });
+
   const resolved = await commandThreadsClient(review.review.uuid, {
     command: "comment.update",
     mutationId: randomUUID(),
     threadId: "question",
     update: { status: "resolved" },
   });
+
   expect(resolved.revision).toBe(created.revision + 1);
   expect((await readThreadsClient(other.review.uuid)).comments).toEqual({});
   await server!.close();
@@ -150,6 +164,7 @@ it("MCP reads and writes source through the desktop and reports conflicts as too
   stdout.on("data", (chunk) => {
     output += String(chunk);
   });
+
   const messages = [
     { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
     { jsonrpc: "2.0", method: "notifications/initialized" },
@@ -178,14 +193,17 @@ it("MCP reads and writes source through the desktop and reports conflicts as too
       },
     },
   ];
+
   await runReviewMcp({
     stdin: Readable.from(messages.map((value) => `${JSON.stringify(value)}\n`)),
     stdout,
   });
+
   const responses = output
     .trim()
     .split("\n")
     .map((line) => JSON.parse(line));
+
   expect(responses.map((response) => response.id)).toEqual([1, 2, 3, 4]);
   expect(responses[1].result.tools).toEqual(
     expect.arrayContaining([
@@ -203,9 +221,11 @@ it("MCP reads and writes source through the desktop and reports conflicts as too
 it("the document CLI accepts stdin and returns the API's updated source hash", async () => {
   const review = await fixture();
   const target = { reviewUuid: review.review.uuid, name: "review.mdx" };
+
   const initial = ReviewDocumentFileResponseSchema.parse(
     await requestReviewLifecycle("/lifecycle/document/read", target),
   );
+
   const stdout = new PassThrough();
   let output = "";
   stdout.on("data", (chunk) => {

--- a/packages/progressive-review/src/review-lifecycle.test.ts
+++ b/packages/progressive-review/src/review-lifecycle.test.ts
@@ -1,0 +1,236 @@
+import { randomUUID } from "node:crypto";
+import { readFile, rm, symlink } from "node:fs/promises";
+import path from "node:path";
+import { PassThrough, Readable } from "node:stream";
+
+import { afterEach, expect, it } from "vitest";
+
+import { runProgressiveReviewCli } from "./cli-runner";
+import { createReviewDir, findReview } from "./review-home";
+import {
+  commandThreadsClient,
+  readThreadsClient,
+  requestReviewLifecycle,
+} from "./review-lifecycle-client";
+import { ReviewDocumentFileResponseSchema } from "./review-lifecycle-contracts";
+import { startLifecycleTestServer } from "./review-lifecycle-test-utils";
+import { runReviewMcp } from "./review-mcp";
+import {
+  cleanupTempDirs,
+  gitRepository,
+  reviewHome,
+} from "./review-test-utils";
+import { closeAllReviewThreadStores } from "./review-thread-store-backend";
+
+let server: Awaited<ReturnType<typeof startLifecycleTestServer>> | undefined;
+afterEach(async () => {
+  await server?.close();
+  server = undefined;
+  closeAllReviewThreadStores();
+  await cleanupTempDirs();
+});
+
+async function fixture() {
+  await reviewHome();
+  const worktreePath = await gitRepository();
+  const review = await createReviewDir({
+    worktreePath,
+    baseRef: "main",
+    baseCommit: "a".repeat(40),
+  });
+  server = await startLifecycleTestServer();
+  return review;
+}
+
+it("serializes source edits, rejects stale writes and symlinks, and preserves accepted content", async () => {
+  const review = await fixture();
+  const target = { reviewUuid: review.review.uuid, name: "review.mdx" };
+  const initial = ReviewDocumentFileResponseSchema.parse(
+    await requestReviewLifecycle("/lifecycle/document/read", target),
+  );
+  const writes = await Promise.allSettled(
+    ["# One\n", "# Two\n"].map((source) =>
+      requestReviewLifecycle("/lifecycle/document/write", {
+        ...target,
+        source,
+        expectedSourceHash: initial.sourceHash,
+      }),
+    ),
+  );
+  expect(writes.filter((result) => result.status === "fulfilled")).toHaveLength(
+    1,
+  );
+  expect(writes.filter((result) => result.status === "rejected")).toHaveLength(
+    1,
+  );
+  const current = ReviewDocumentFileResponseSchema.parse(
+    await requestReviewLifecycle("/lifecycle/document/read", target),
+  );
+  expect(await readFile(path.join(review.dir, "review.mdx"), "utf8")).toBe(
+    current.source,
+  );
+  // A lost-response retry is successful even with the old precondition.
+  expect(
+    await requestReviewLifecycle("/lifecycle/document/write", {
+      ...target,
+      source: current.source,
+      expectedSourceHash: initial.sourceHash,
+    }),
+  ).toEqual(current);
+  await rm(path.join(review.dir, "data.ts"));
+  await symlink(
+    path.join(review.dir, "review.mdx"),
+    path.join(review.dir, "data.ts"),
+  );
+  await expect(
+    requestReviewLifecycle("/lifecycle/document/write", {
+      ...target,
+      name: "data.ts",
+      source: "bad",
+      expectedSourceHash: null,
+    }),
+  ).rejects.toThrow("regular file");
+  expect(await readFile(path.join(review.dir, "review.mdx"), "utf8")).toBe(
+    current.source,
+  );
+});
+
+it("persists metadata with a title precondition and isolates each Review's comments", async () => {
+  const review = await fixture();
+  const other = await createReviewDir({
+    worktreePath: review.review.worktreePath,
+    baseRef: "main",
+    baseCommit: "b".repeat(40),
+  });
+  await requestReviewLifecycle("/lifecycle/metadata", {
+    reviewUuid: review.review.uuid,
+    expectedTitle: review.review.title,
+    title: "API title",
+  });
+  await expect(
+    requestReviewLifecycle("/lifecycle/metadata", {
+      reviewUuid: review.review.uuid,
+      expectedTitle: review.review.title,
+      title: "Lost update",
+    }),
+  ).rejects.toThrow("title changed");
+  expect((await findReview(review.review.uuid))?.review).toMatchObject({
+    title: "API title",
+    titleOverride: "API title",
+  });
+  const created = await commandThreadsClient(review.review.uuid, {
+    command: "comment.create",
+    mutationId: randomUUID(),
+    input: {
+      threadId: "question",
+      messageId: "message",
+      body: "Why?",
+      target: { kind: "document" },
+    },
+  });
+  const resolved = await commandThreadsClient(review.review.uuid, {
+    command: "comment.update",
+    mutationId: randomUUID(),
+    threadId: "question",
+    update: { status: "resolved" },
+  });
+  expect(resolved.revision).toBe(created.revision + 1);
+  expect((await readThreadsClient(other.review.uuid)).comments).toEqual({});
+  await server!.close();
+  server = await startLifecycleTestServer();
+  expect(
+    (await readThreadsClient(review.review.uuid)).comments.question?.status,
+  ).toBe("resolved");
+});
+
+it("MCP reads and writes source through the desktop and reports conflicts as tool errors", async () => {
+  const review = await fixture();
+  const stdout = new PassThrough();
+  let output = "";
+  stdout.on("data", (chunk) => {
+    output += String(chunk);
+  });
+  const messages = [
+    { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+    { jsonrpc: "2.0", method: "notifications/initialized" },
+    { jsonrpc: "2.0", id: 2, method: "tools/list" },
+    {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: {
+        name: "review_get_document_file",
+        arguments: { reviewUuid: review.review.uuid, name: "review.mdx" },
+      },
+    },
+    {
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: {
+        name: "review_write_document_file",
+        arguments: {
+          reviewUuid: review.review.uuid,
+          name: "review.mdx",
+          expectedSourceHash: "stale",
+          source: "# Stale\n",
+        },
+      },
+    },
+  ];
+  await runReviewMcp({
+    stdin: Readable.from(messages.map((value) => `${JSON.stringify(value)}\n`)),
+    stdout,
+  });
+  const responses = output
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  expect(responses.map((response) => response.id)).toEqual([1, 2, 3, 4]);
+  expect(responses[1].result.tools).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: "review_publish",
+        inputSchema: expect.objectContaining({ type: "object" }),
+      }),
+    ]),
+  );
+  expect(responses[2].result.structuredContent.source).toContain("#");
+  expect(responses[3].result.isError).toBe(true);
+  expect(responses[3].result.content[0].text).toContain("source changed");
+});
+
+it("the document CLI accepts stdin and returns the API's updated source hash", async () => {
+  const review = await fixture();
+  const target = { reviewUuid: review.review.uuid, name: "review.mdx" };
+  const initial = ReviewDocumentFileResponseSchema.parse(
+    await requestReviewLifecycle("/lifecycle/document/read", target),
+  );
+  const stdout = new PassThrough();
+  let output = "";
+  stdout.on("data", (chunk) => {
+    output += String(chunk);
+  });
+  expect(
+    await runProgressiveReviewCli({
+      argv: [
+        "document",
+        "write",
+        "review.mdx",
+        "--review",
+        target.reviewUuid,
+        "--expected-hash",
+        initial.sourceHash!,
+      ],
+      stdin: Readable.from(["# Authored via stdin\n"]),
+      stdout,
+      stderr: new PassThrough(),
+    }),
+  ).toBe(0);
+  const written = ReviewDocumentFileResponseSchema.parse(JSON.parse(output));
+  expect(written.source).toBe("# Authored via stdin\n");
+  expect(written.sourceHash).not.toBe(initial.sourceHash);
+  expect(
+    await requestReviewLifecycle("/lifecycle/document/read", target),
+  ).toEqual(written);
+});

--- a/packages/progressive-review/src/review-map-publish.test.ts
+++ b/packages/progressive-review/src/review-map-publish.test.ts
@@ -13,6 +13,7 @@ import { bundleReviewSoftwareMap } from "./software-map-bundle";
 import { defineSoftwareMap } from "./software-map-model";
 
 const roots: string[] = [];
+
 afterEach(async () => {
   vi.unstubAllEnvs();
   await Promise.all(
@@ -26,8 +27,10 @@ it("takes the mutation lock around software-map write and seal", async () => {
   vi.stubEnv("DEV_REVIEW_HOME", home);
   const source = path.join(home, "source");
   await mkdir(source);
+
   const git = (args: string[]) =>
     execFileSync("git", ["-C", source, ...args], { encoding: "utf8" }).trim();
+
   git(["init", "-q", "-b", "main"]);
   git(["config", "user.email", "review@example.test"]);
   git(["config", "user.name", "Review Test"]);
@@ -35,6 +38,7 @@ it("takes the mutation lock around software-map write and seal", async () => {
   git(["add", "."]);
   git(["commit", "-qm", "source"]);
   const commit = git(["rev-parse", "HEAD"]);
+
   const review = await createReviewDir({
     worktreePath: source,
     baseRef: "main",
@@ -42,27 +46,35 @@ it("takes the mutation lock around software-map write and seal", async () => {
     sourceCommit: commit,
     sourceIdentity: { kind: "git-branch", name: "main" },
   });
+
   const model = defineSoftwareMap({ systems: { app: { label: "App" } } });
+
   const bundle = bundleReviewSoftwareMap({
     head: model,
     base: model,
     headCommit: commit,
     baseCommit: commit,
   });
+
   const entered = Promise.withResolvers<void>();
   const release = Promise.withResolvers<void>();
+
   const holding = withReviewMutationLock(review.dir, async () => {
     entered.resolve();
     await release.promise;
   });
+
   await entered.promise;
   let finished = false;
+
   const sealing = sealReviewSoftwareMapPublication({ review, bundle }).then(
     (revision) => {
       finished = true;
+
       return revision;
     },
   );
+
   for (let attempt = 0; attempt < 30; attempt++) await setImmediate();
   const bypassed = finished;
   release.resolve();

--- a/packages/progressive-review/src/review-map-publish.test.ts
+++ b/packages/progressive-review/src/review-map-publish.test.ts
@@ -7,8 +7,8 @@ import { setImmediate } from "node:timers/promises";
 import { afterEach, expect, it, vi } from "vitest";
 
 import { createReviewDir } from "./review-home";
-import { sealReviewSoftwareMapPublication } from "./review-map-publish";
 import { withReviewMutationLock } from "./review-mutation-lock";
+import { sealReviewSoftwareMapPublication } from "./server/review-lifecycle";
 import { bundleReviewSoftwareMap } from "./software-map-bundle";
 import { defineSoftwareMap } from "./software-map-model";
 

--- a/packages/progressive-review/src/review-map-publish.ts
+++ b/packages/progressive-review/src/review-map-publish.ts
@@ -1,43 +1,9 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
 import type { Writable } from "node:stream";
 
-import { z } from "zod";
-
-import {
-  authoringSessionKey,
-  resolveAuthoringSessionRef,
-} from "./authoring-session";
+import { resolveAuthoringSessionRef } from "./authoring-session";
 import { type CliJsonEvent, emitJsonEvent } from "./cli-output";
-import { readReviewDesktopDiscovery } from "./desktop-discovery";
-import {
-  type StoredReview,
-  parseAnyStoredReviewRecord,
-  sealReviewCandidate,
-  touchReviewAgentSession,
-} from "./review-home";
-import {
-  assertReviewUnchanged,
-  withReviewMutationLock,
-} from "./review-mutation-lock";
-import {
-  ReviewPublicationValidationError,
-  prepareReviewSoftwareMapBundle,
-} from "./review-publication-preparation";
-import { resolveReviewRoot } from "./runtime";
-import { resolvePublishReview } from "./server/publish-preparation";
-import { materializePublishRevision } from "./server/publish-stage";
-import {
-  type ReviewSoftwareMapBundle,
-  readReviewSoftwareMapBundle,
-  sameReviewSoftwareMapBundle,
-  writeReviewSoftwareMapBundle,
-} from "./software-map-bundle";
-
-const MapPublishReadyResponseSchema = z.object({
-  ok: z.boolean().optional(),
-  error: z.string().optional(),
-});
+import { requestReviewLifecycle } from "./review-lifecycle-client";
+import { ReviewPublicationResultSchema } from "./review-lifecycle-contracts";
 
 export async function runReviewMapPublish(input: {
   cwd: string;
@@ -49,106 +15,34 @@ export async function runReviewMapPublish(input: {
 }): Promise<number> {
   const report = mapPublishReporter(input);
   try {
-    const reviewRoot = await resolveReviewRoot(input.cwd);
-    const review = await resolvePublishReview(reviewRoot, input.reviewUuid);
-    const agent = resolveAuthoringSessionRef(input.env ?? process.env);
-    const documentRevision = review.review.presentedDocumentRevision;
-    if (!documentRevision) {
-      throw new Error(
-        "The Review document is not published. Run `review publish` first.",
-      );
-    }
-    const documentBuildDir = await materializePublishRevision({
-      review,
-      revision: documentRevision,
-    });
-    const presentedDocument = parseAnyStoredReviewRecord(
-      JSON.parse(
-        await readFile(path.join(documentBuildDir, "review.json"), "utf8"),
-      ),
-    );
-    if (!presentedDocument.sourceCommit) {
-      throw new Error(
-        "The published Review document has no pinned head commit.",
-      );
-    }
-
-    report.stage("validate", "running");
-    let bundle;
-    try {
-      bundle = await prepareReviewSoftwareMapBundle({
-        review,
-        baseCommit: presentedDocument.baseCommit,
-        headCommit: presentedDocument.sourceCommit,
-      });
-    } catch (error) {
-      if (error instanceof ReviewPublicationValidationError) {
-        report.error("validate", error.errors);
-        return 1;
-      }
-      throw error;
-    }
-    report.stage("validate", "complete");
-
-    const existingRevision = review.review.presentedSoftwareMapRevision;
-    if (existingRevision) {
-      const existingDir = await materializePublishRevision({
-        review,
-        revision: existingRevision,
-      });
-      const existing = await readReviewSoftwareMapBundle(existingDir);
-      if (existing && sameReviewSoftwareMapBundle(existing, bundle)) {
-        if (agent) {
-          await touchReviewAgentSession(
-            review,
-            authoringSessionKey(agent),
-            "publisher",
-          );
-        }
-        report.published(existingRevision, documentRevision, true);
-        return 0;
-      }
-    }
-
-    report.stage("revision", "running");
-    const revision = await sealReviewSoftwareMapPublication({
-      review,
-      bundle,
-    });
-    report.stage("revision", "complete", { revision });
-
-    const discovery = await readReviewDesktopDiscovery();
-    if (!discovery) {
-      throw new Error(
-        "Review Desktop is not running. Run `review app launch`, then retry `review map publish`.",
-      );
-    }
-    report.stage("load", "running");
-    const response = await fetch(`${discovery.url}/map-publish-ready`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-review-token": discovery.token,
-      },
-      body: JSON.stringify({
-        reviewUuid: review.review.uuid,
-        revision,
-        agent,
+    const result = ReviewPublicationResultSchema.parse(
+      await requestReviewLifecycle("/lifecycle/map/publish", {
+        cwd: input.cwd,
+        reviewUuid: input.reviewUuid,
+        agent: resolveAuthoringSessionRef(input.env ?? process.env),
       }),
-    });
-    const result =
-      MapPublishReadyResponseSchema.safeParse(
-        await response.json().catch(() => null),
-      ).data ?? null;
-    if (!response.ok || !result?.ok) {
-      throw new Error(
-        result?.error ??
-          `Review Desktop returned ${response.status} for map-publish-ready.`,
-      );
+    );
+    for (const event of result.events) {
+      switch (event.event) {
+        case "stage":
+          report.stage(event.name, event.status, event);
+          break;
+        case "error":
+        case "warning":
+          report.error(event.stage, event.diagnostics);
+          break;
+        case "map-published":
+          report.published(
+            event.revision,
+            event.documentRevision,
+            event.unchanged,
+          );
+          break;
+        default:
+          throw new Error("Unexpected document publication result.");
+      }
     }
-    report.stage("load", "complete");
-    report.published(revision, documentRevision, false);
-    return 0;
+    return result.ok ? 0 : 1;
   } catch (error) {
     report.error("publish", [
       error instanceof Error ? error.message : String(error),
@@ -157,24 +51,13 @@ export async function runReviewMapPublish(input: {
   }
 }
 
-export async function sealReviewSoftwareMapPublication(input: {
-  review: StoredReview;
-  bundle: ReviewSoftwareMapBundle;
-}): Promise<string> {
-  return withReviewMutationLock(input.review.dir, async () => {
-    await assertReviewUnchanged(input.review.dir, input.review.review);
-    await writeReviewSoftwareMapBundle(input.review.dir, input.bundle);
-    return sealReviewCandidate(input.review.dir, "Publish Review software map");
-  });
-}
-
 interface MapPublishStageDetails {
   revision?: string;
 }
 
-interface MapPublishReporter {
+export interface MapPublishReporter {
   stage(
-    name: string,
+    name: "validate" | "revision" | "mount" | "load",
     status: "running" | "complete",
     details?: MapPublishStageDetails,
   ): void;

--- a/packages/progressive-review/src/review-map-publish.ts
+++ b/packages/progressive-review/src/review-map-publish.ts
@@ -14,6 +14,7 @@ export async function runReviewMapPublish(input: {
   env?: NodeJS.ProcessEnv;
 }): Promise<number> {
   const report = mapPublishReporter(input);
+
   try {
     const result = ReviewPublicationResultSchema.parse(
       await requestReviewLifecycle("/lifecycle/map/publish", {
@@ -22,6 +23,7 @@ export async function runReviewMapPublish(input: {
         agent: resolveAuthoringSessionRef(input.env ?? process.env),
       }),
     );
+
     for (const event of result.events) {
       switch (event.event) {
         case "stage":
@@ -42,11 +44,13 @@ export async function runReviewMapPublish(input: {
           throw new Error("Unexpected document publication result.");
       }
     }
+
     return result.ok ? 0 : 1;
   } catch (error) {
     report.error("publish", [
       error instanceof Error ? error.message : String(error),
     ]);
+
     return 1;
   }
 }
@@ -77,6 +81,7 @@ function mapPublishReporter(input: {
   if (input.json) {
     const emit = <T extends CliJsonEvent>(event: T) =>
       emitJsonEvent(input, event);
+
     return {
       stage: (name, status, details = {}) =>
         emit({
@@ -98,13 +103,16 @@ function mapPublishReporter(input: {
         }),
     };
   }
+
   return {
     stage(name, status, details = {}) {
       if (status !== "complete") return;
+
       const suffix =
         details.revision === undefined
           ? ""
           : ` ${details.revision.slice(0, 12)}`;
+
       input.stdout.write(
         `${name === "load" ? "Load map" : name}: ok${suffix}\n`,
       );
@@ -117,6 +125,7 @@ function mapPublishReporter(input: {
     published(revision, documentRevision, unchanged) {
       input.stdout.write(`Software map published: ${revision}\n`);
       input.stdout.write(`Review document remains: ${documentRevision}\n`);
+
       if (unchanged) input.stdout.write("Software map bytes are unchanged.\n");
     },
   };

--- a/packages/progressive-review/src/review-mcp.ts
+++ b/packages/progressive-review/src/review-mcp.ts
@@ -24,6 +24,7 @@ import {
 } from "./review-lifecycle-contracts";
 
 const reviewTarget = z.strictObject({ reviewUuid: z.uuid() });
+
 const tools = [
   {
     name: "review_create",
@@ -106,12 +107,14 @@ const tools = [
     }),
   },
 ];
+
 const requestSchema = z.object({
   jsonrpc: z.literal("2.0"),
   id: z.union([z.string(), z.number(), z.null()]).optional(),
   method: z.string(),
   params: z.record(z.string(), z.json()).optional(),
 });
+
 const callSchema = z.object({
   name: z.string(),
   arguments: z.record(z.string(), z.json()).default({}),
@@ -124,9 +127,11 @@ export async function runReviewMcp(input: {
   request?: typeof requestReviewLifecycle;
 }): Promise<number> {
   const lines = createInterface({ input: input.stdin, crlfDelay: Infinity });
+
   for await (const line of lines) {
     if (!line.trim()) continue;
     let value: JsonValue;
+
     try {
       value = parseJsonText(line);
     } catch {
@@ -137,7 +142,9 @@ export async function runReviewMcp(input: {
       });
       continue;
     }
+
     const parsed = requestSchema.safeParse(value);
+
     if (!parsed.success) {
       write({
         jsonrpc: "2.0",
@@ -146,10 +153,14 @@ export async function runReviewMcp(input: {
       });
       continue;
     }
+
     const request = parsed.data;
+
     if (request.id === undefined) continue;
+
     try {
       let result: JsonValue;
+
       switch (request.method) {
         case "initialize":
           result = {
@@ -175,27 +186,36 @@ export async function runReviewMcp(input: {
         case "tools/call": {
           const call = callSchema.parse(request.params);
           const tool = tools.find((entry) => entry.name === call.name);
+
           if (!tool) throw new Error(`Unknown Review tool: ${call.name}`);
+
           const agent = tool.agent
             ? resolveAuthoringSessionRef(process.env)
             : undefined;
+
           if (agent && call.arguments.agent === undefined)
             call.arguments.agent = {
               harness: agent.harness,
               sessionId: agent.sessionId,
             };
           const args = tool.schema.parse(call.arguments);
+
           const data = await (input.request ?? requestReviewLifecycle)(
             tool.path,
             args,
           );
+
           result = { content: [{ type: "text", text: JSON.stringify(data) }] };
+
           if (isJsonObject(data)) {
             result.structuredContent = data;
+
             if (data.ok === false) result.isError = true;
           }
+
           break;
         }
+
         default:
           write({
             jsonrpc: "2.0",
@@ -204,6 +224,7 @@ export async function runReviewMcp(input: {
           });
           continue;
       }
+
       write({ jsonrpc: "2.0", id: request.id, result });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -225,7 +246,9 @@ export async function runReviewMcp(input: {
       );
     }
   }
+
   return 0;
+
   function write(value: JsonValue) {
     input.stdout.write(`${JSON.stringify(value)}\n`);
   }

--- a/packages/progressive-review/src/review-mcp.ts
+++ b/packages/progressive-review/src/review-mcp.ts
@@ -1,0 +1,232 @@
+import { createInterface } from "node:readline";
+import type { Readable, Writable } from "node:stream";
+
+import {
+  type JsonValue,
+  ReviewThreadsCommandSchema,
+  isJsonObject,
+  jsonObject,
+  parseJsonText,
+} from "@dev.fast/review-protocol";
+import { z } from "zod";
+
+import { resolveAuthoringSessionRef } from "./authoring-session";
+import { requestReviewLifecycle } from "./review-lifecycle-client";
+import {
+  ReviewDocumentFileNameSchema,
+  ReviewDocumentFileWriteSchema,
+  ReviewLifecycleTargetSchema,
+  ReviewListRequestSchema,
+  ReviewMetadataUpdateSchema,
+  ReviewPublishRequestSchema,
+  ReviewRebindRequestSchema,
+  ReviewScaffoldRequestSchema,
+} from "./review-lifecycle-contracts";
+
+const reviewTarget = z.strictObject({ reviewUuid: z.uuid() });
+const tools = [
+  {
+    name: "review_create",
+    description: "Create or update a Review bound to a source checkout.",
+    path: "/lifecycle/scaffold",
+    schema: ReviewScaffoldRequestSchema,
+    agent: true,
+  },
+  {
+    name: "review_list",
+    description: "List Reviews owned by the desktop.",
+    path: "/lifecycle/list",
+    schema: ReviewListRequestSchema,
+  },
+  {
+    name: "review_get",
+    description: "Read a Review's metadata and pinned source revisions.",
+    path: "/lifecycle/resolve",
+    schema: ReviewLifecycleTargetSchema,
+  },
+  {
+    name: "review_update_metadata",
+    description:
+      "Change the title, checking the previously read title for conflicts.",
+    path: "/lifecycle/metadata",
+    schema: ReviewMetadataUpdateSchema.extend({ reviewUuid: z.uuid() }),
+  },
+  {
+    name: "review_rebind",
+    description: "Move a Review to a different source change.",
+    path: "/lifecycle/rebind",
+    schema: ReviewRebindRequestSchema,
+    agent: true,
+  },
+  {
+    name: "review_publish",
+    description: "Validate, seal, and present the Review document.",
+    path: "/lifecycle/publish",
+    schema: ReviewPublishRequestSchema,
+    agent: true,
+  },
+  {
+    name: "review_get_document_file",
+    description:
+      "Read review.mdx or data.ts and its source hash through the desktop.",
+    path: "/lifecycle/document/read",
+    schema: reviewTarget.extend({ name: ReviewDocumentFileNameSchema }),
+  },
+  {
+    name: "review_write_document_file",
+    description:
+      "Replace Review source using the hash from the last read. Publish to present the changes.",
+    path: "/lifecycle/document/write",
+    schema: ReviewDocumentFileWriteSchema.extend({ reviewUuid: z.uuid() }),
+  },
+  {
+    name: "review_list_comments",
+    description: "Read submitted comments and pending drafts.",
+    path: "/lifecycle/threads/snapshot",
+    schema: reviewTarget,
+  },
+  {
+    name: "review_comment_command",
+    description:
+      "Create, update, or remove comments and drafts through the Review's shared service.",
+    path: "/lifecycle/threads/command",
+    schema: reviewTarget.extend({ command: ReviewThreadsCommandSchema }),
+  },
+  {
+    name: "review_reply_comment",
+    description: "Save an agent answer to a comment thread.",
+    path: "/lifecycle/threads/reply",
+    schema: reviewTarget.extend({
+      mutationId: z.uuid(),
+      threadId: z.string().min(1),
+      messageId: z.uuid(),
+      author: z.string().trim().min(1),
+      body: z.string().trim().min(1),
+      format: z.enum(["plain", "markdown"]),
+    }),
+  },
+];
+const requestSchema = z.object({
+  jsonrpc: z.literal("2.0"),
+  id: z.union([z.string(), z.number(), z.null()]).optional(),
+  method: z.string(),
+  params: z.record(z.string(), z.json()).optional(),
+});
+const callSchema = z.object({
+  name: z.string(),
+  arguments: z.record(z.string(), z.json()).default({}),
+});
+
+/** Stdio transport only: the desktop owns validation, storage, and publication. */
+export async function runReviewMcp(input: {
+  stdin: Readable;
+  stdout: Writable;
+  request?: typeof requestReviewLifecycle;
+}): Promise<number> {
+  const lines = createInterface({ input: input.stdin, crlfDelay: Infinity });
+  for await (const line of lines) {
+    if (!line.trim()) continue;
+    let value: JsonValue;
+    try {
+      value = parseJsonText(line);
+    } catch {
+      write({
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32700, message: "Parse error" },
+      });
+      continue;
+    }
+    const parsed = requestSchema.safeParse(value);
+    if (!parsed.success) {
+      write({
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32600, message: "Invalid request" },
+      });
+      continue;
+    }
+    const request = parsed.data;
+    if (request.id === undefined) continue;
+    try {
+      let result: JsonValue;
+      switch (request.method) {
+        case "initialize":
+          result = {
+            protocolVersion: "2025-06-18",
+            capabilities: { tools: {} },
+            serverInfo: { name: "review", version: "1.0.0" },
+          };
+          break;
+        case "ping":
+          result = {};
+          break;
+        case "tools/list":
+          result = {
+            tools: tools.map(({ name, description, schema }) => ({
+              name,
+              description,
+              inputSchema: jsonObject(
+                parseJsonText(JSON.stringify(z.toJSONSchema(schema))),
+              )!,
+            })),
+          };
+          break;
+        case "tools/call": {
+          const call = callSchema.parse(request.params);
+          const tool = tools.find((entry) => entry.name === call.name);
+          if (!tool) throw new Error(`Unknown Review tool: ${call.name}`);
+          const agent = tool.agent
+            ? resolveAuthoringSessionRef(process.env)
+            : undefined;
+          if (agent && call.arguments.agent === undefined)
+            call.arguments.agent = {
+              harness: agent.harness,
+              sessionId: agent.sessionId,
+            };
+          const args = tool.schema.parse(call.arguments);
+          const data = await (input.request ?? requestReviewLifecycle)(
+            tool.path,
+            args,
+          );
+          result = { content: [{ type: "text", text: JSON.stringify(data) }] };
+          if (isJsonObject(data)) {
+            result.structuredContent = data;
+            if (data.ok === false) result.isError = true;
+          }
+          break;
+        }
+        default:
+          write({
+            jsonrpc: "2.0",
+            id: request.id,
+            error: { code: -32601, message: "Method not found" },
+          });
+          continue;
+      }
+      write({ jsonrpc: "2.0", id: request.id, result });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      write(
+        request.method === "tools/call"
+          ? {
+              jsonrpc: "2.0",
+              id: request.id,
+              result: {
+                content: [{ type: "text", text: message }],
+                isError: true,
+              },
+            }
+          : {
+              jsonrpc: "2.0",
+              id: request.id,
+              error: { code: -32602, message },
+            },
+      );
+    }
+  }
+  return 0;
+  function write(value: JsonValue) {
+    input.stdout.write(`${JSON.stringify(value)}\n`);
+  }
+}

--- a/packages/progressive-review/src/review-publish-thread-gate.test.ts
+++ b/packages/progressive-review/src/review-publish-thread-gate.test.ts
@@ -22,6 +22,7 @@ import {
 } from "./review-state-store";
 
 const cleanupPaths: string[] = [];
+
 let server: Awaited<ReturnType<typeof startLifecycleTestServer>> | undefined;
 
 afterEach(async () => {
@@ -47,6 +48,7 @@ describe("requireClosedThreadsForRepublish", () => {
     const review = await createTestReview();
     addComment(review.dir, "thread-z");
     addComment(review.dir, "thread-a");
+
     const published = {
       ...review,
       review: {
@@ -199,11 +201,14 @@ async function createTestReview() {
   const worktreePath = await mkdtemp(
     path.join(os.tmpdir(), "review-thread-gate-worktree-"),
   );
+
   const reviewHome = await mkdtemp(
     path.join(os.tmpdir(), "review-thread-gate-home-"),
   );
+
   cleanupPaths.push(worktreePath, reviewHome);
   vi.stubEnv("DEV_REVIEW_HOME", reviewHome);
+
   return createReviewDir({
     worktreePath,
     baseRef: "base",

--- a/packages/progressive-review/src/review-publish-thread-gate.test.ts
+++ b/packages/progressive-review/src/review-publish-thread-gate.test.ts
@@ -5,7 +5,8 @@ import { PassThrough } from "node:stream";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createReviewDir } from "./review-home";
+import { createReviewDir, persistStoredReviewRecord } from "./review-home";
+import { startLifecycleTestServer } from "./review-lifecycle-test-utils";
 import { runReviewPublish } from "./review-publish";
 import {
   ReviewMissingAgentResponsesError,
@@ -21,8 +22,11 @@ import {
 } from "./review-state-store";
 
 const cleanupPaths: string[] = [];
+let server: Awaited<ReturnType<typeof startLifecycleTestServer>> | undefined;
 
 afterEach(async () => {
+  await server?.close();
+  server = undefined;
   vi.unstubAllEnvs();
   await Promise.all(
     cleanupPaths
@@ -83,15 +87,12 @@ describe("requireClosedThreadsForRepublish", () => {
 
   it("reports the blocked re-publish as an NDJSON publish error", async () => {
     const review = await createTestReview();
+    server = await startLifecycleTestServer();
     addComment(review.dir, "thread-1");
-    await writeFile(
-      path.join(review.dir, "review.json"),
-      `${JSON.stringify({
-        ...review.review,
-        presentedDocumentRevision: "published-revision",
-      })}\n`,
-      "utf8",
-    );
+    await persistStoredReviewRecord(review.dir, {
+      ...review.review,
+      presentedDocumentRevision: "published-revision",
+    });
     const stdout = new PassThrough();
     let output = "";
     stdout.on("data", (chunk) => (output += String(chunk)));

--- a/packages/progressive-review/src/review-publish.ts
+++ b/packages/progressive-review/src/review-publish.ts
@@ -1,41 +1,12 @@
 import type { Writable } from "node:stream";
 
-import type {
-  ReviewPublishReadyRequest,
-  ReviewView,
-} from "@dev.fast/review-protocol";
-import { z } from "zod";
+import type { ReviewView } from "@dev.fast/review-protocol";
 
 import { resolveAuthoringSessionRef } from "./authoring-session";
 import { type CliJsonEvent, emitJsonEvent } from "./cli-output";
-import { requireHealthyReviewDesktop } from "./desktop-discovery";
 import type { ReviewDocumentDiagnostic } from "./document/diagnostics";
-import { ReviewPublicationValidationError } from "./review-publication-preparation";
-import {
-  sealReviewDocumentPublication,
-  stageReviewDocumentPublication,
-} from "./review-publication-staging";
-import { resolveReviewRoot } from "./runtime";
-import { prepareReviewPublish } from "./server/publish-preparation";
-import { recordSpan, span, startSpan } from "./startup-trace";
-
-const PublishReadyResponseSchema = z.object({
-  ok: z.boolean().optional(),
-  sessionId: z.string().optional(),
-  url: z.string().optional(),
-  focusWarning: z.string().optional(),
-  error: z.string().optional(),
-  // Mount step timings the desktop measured, folded into the CLI spans.
-  timings: z
-    .array(
-      z.object({
-        name: z.string(),
-        startEpochMs: z.number(),
-        endEpochMs: z.number(),
-      }),
-    )
-    .optional(),
-});
+import { requestReviewLifecycle } from "./review-lifecycle-client";
+import { ReviewPublicationResultSchema } from "./review-lifecycle-contracts";
 
 interface PublishDiagnosticEvent extends CliJsonEvent {
   event: "error";
@@ -45,9 +16,7 @@ interface PublishDiagnosticEvent extends CliJsonEvent {
   message: string;
 }
 
-// The CLI owns the whole publish flow: it validates, bundles, resolves every
-// code reference, and seals the revision. The desktop is only notified via
-// /publish-ready and then serves the sealed bytes.
+// The CLI formats the desktop-owned publication result.
 export async function runReviewPublish(input: {
   cwd: string;
   reviewUuid?: string;
@@ -66,7 +35,44 @@ export async function runReviewPublish(input: {
   });
 
   try {
-    return await publish(input, reporter);
+    const result = ReviewPublicationResultSchema.parse(
+      await requestReviewLifecycle("/lifecycle/publish", {
+        cwd: input.cwd,
+        reviewUuid: input.reviewUuid,
+        view: input.view,
+        agent: resolveAuthoringSessionRef(input.env ?? process.env),
+      }),
+    );
+    for (const event of result.events) {
+      switch (event.event) {
+        case "review-bound":
+          await input.onReviewBound?.(event.reviewUuid);
+          break;
+        case "stage":
+          if (event.name !== "load")
+            reporter.stage(event.name, event.status, event);
+          break;
+        case "warning":
+          reporter.warning(event.stage, event.diagnostics);
+          break;
+        case "error":
+          reporter.error(event.stage, event.diagnostics);
+          break;
+        case "diagnostics":
+          reporter.validationErrors(event.diagnostics);
+          break;
+        case "document-published":
+          reporter.published(
+            event.revision,
+            event.sessionId,
+            event.softwareMapRevision,
+          );
+          break;
+        case "map-published":
+          throw new Error("Unexpected map publication result.");
+      }
+    }
+    return result.ok ? 0 : 1;
   } catch (error) {
     reporter.error("publish", [
       error instanceof Error ? error.message : String(error),
@@ -74,130 +80,6 @@ export async function runReviewPublish(input: {
 
     return 1;
   }
-}
-
-async function publish(
-  input: {
-    cwd: string;
-    reviewUuid?: string;
-    view?: ReviewView;
-    toolingRoot?: string;
-    env?: NodeJS.ProcessEnv;
-    onReviewBound?: (uuid: string) => void | Promise<void>;
-  },
-  reporter: PublishReporter,
-): Promise<number> {
-  const reviewRoot = await resolveReviewRoot(input.cwd);
-
-  const prepared = await span("publish: prepare", () =>
-    prepareReviewPublish({
-      cwd: reviewRoot,
-      reviewUuid: input.reviewUuid,
-      onReviewBound: input.onReviewBound,
-    }),
-  );
-
-  const review = prepared.review;
-
-  if (prepared.warnings?.length) {
-    reporter.warning("prepare", prepared.warnings);
-  }
-
-  reporter.stage("validate", "running");
-  let revision: string;
-
-  try {
-    const document = await span("publish: validate document", () =>
-      stageReviewDocumentPublication({ review }),
-    );
-
-    if (document.warnings.length > 0)
-      reporter.warning("validate", document.warnings);
-    reporter.stage("validate", "complete");
-    reporter.stage("revision", "running");
-    revision = await span("publish: seal revision", () =>
-      sealReviewDocumentPublication({ review, document }),
-    );
-  } catch (error) {
-    if (error instanceof ReviewPublicationValidationError) {
-      if (error.warnings.length > 0) {
-        reporter.warning("validate", error.warnings);
-      }
-
-      if (error.diagnostics) {
-        reporter.validationErrors(error.diagnostics);
-      } else {
-        reporter.error("validate", error.errors);
-      }
-    } else {
-      reporter.error("validate", [
-        error instanceof Error ? error.message : String(error),
-      ]);
-    }
-
-    return 1;
-  }
-
-  reporter.stage("revision", "complete", { revision });
-
-  const discovery = await span("publish: desktop health", () =>
-    requireHealthyReviewDesktop("review publish"),
-  );
-
-  reporter.stage("mount", "running");
-
-  const publishReady: ReviewPublishReadyRequest = {
-    reviewUuid: prepared.uuid,
-    revision,
-    agent: resolveAuthoringSessionRef(input.env ?? process.env),
-  };
-
-  if (input.view) publishReady.view = input.view;
-  const mountSpan = startSpan("publish: POST /publish-ready");
-
-  const response = await fetch(`${discovery.url}/publish-ready`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-review-token": discovery.token,
-    },
-    body: JSON.stringify(publishReady),
-  });
-
-  const result =
-    PublishReadyResponseSchema.safeParse(
-      await response.json().catch(() => null),
-    ).data ?? null;
-
-  if (response.ok) mountSpan.end();
-  else mountSpan.fail(`HTTP ${response.status}`);
-
-  for (const timing of result?.timings ?? []) {
-    recordSpan(`desktop: ${timing.name}`, timing, { parentId: mountSpan.id });
-  }
-
-  if (!response.ok || !result?.ok || !result.sessionId) {
-    throw new Error(
-      result?.error ??
-        `Review Desktop returned ${response.status} for publish-ready.`,
-    );
-  }
-
-  reporter.published(
-    revision,
-    result.sessionId,
-    review.review.presentedSoftwareMapRevision,
-  );
-
-  // The revision is promoted and on screen by now: a focus failure cannot
-  // make the publish a failure, so it reports as a warning with exit 0.
-  if (result.focusWarning) {
-    reporter.warning("mount", [result.focusWarning]);
-  }
-
-  reporter.stage("mount", "complete", { sessionId: result.sessionId });
-
-  return 0;
 }
 
 type PublishStage = "validate" | "revision" | "mount";
@@ -208,7 +90,7 @@ interface PublishStageDetails {
   skipped?: boolean;
 }
 
-interface PublishReporter {
+export interface PublishReporter {
   stage(
     name: PublishStage,
     status: "running" | "complete",

--- a/packages/progressive-review/src/review-publish.ts
+++ b/packages/progressive-review/src/review-publish.ts
@@ -43,6 +43,7 @@ export async function runReviewPublish(input: {
         agent: resolveAuthoringSessionRef(input.env ?? process.env),
       }),
     );
+
     for (const event of result.events) {
       switch (event.event) {
         case "review-bound":
@@ -72,6 +73,7 @@ export async function runReviewPublish(input: {
           throw new Error("Unexpected map publication result.");
       }
     }
+
     return result.ok ? 0 : 1;
   } catch (error) {
     reporter.error("publish", [

--- a/packages/progressive-review/src/review-rebind.ts
+++ b/packages/progressive-review/src/review-rebind.ts
@@ -36,6 +36,8 @@ export async function runReviewRebind(input: {
       agent: resolveAuthoringSessionRef(input.env ?? process.env),
     }),
   );
+
   input.stdout.write(`${JSON.stringify(output)}\n`);
+
   return 0;
 }

--- a/packages/progressive-review/src/review-rebind.ts
+++ b/packages/progressive-review/src/review-rebind.ts
@@ -1,13 +1,9 @@
 import type { Writable } from "node:stream";
 
-import {
-  changeIdentityForRevision,
-  resolveRevision,
-} from "@dev.fast/local-vcs";
-
-import { type RunReviewScaffoldInput, repinReview } from "./review-scaffold";
-import { resolveReviewRoot } from "./runtime";
-import { resolvePublishReview } from "./server/publish-preparation";
+import { resolveAuthoringSessionRef } from "./authoring-session";
+import { requestReviewLifecycle } from "./review-lifecycle-client";
+import { ReviewRebindResultSchema } from "./review-lifecycle-contracts";
+import type { RunReviewScaffoldInput } from "./review-scaffold";
 
 /**
  * Move a review to a different unit of change and re-pin from it
@@ -15,7 +11,7 @@ import { resolvePublishReview } from "./server/publish-preparation";
  * worktree and graph re-materialize. Publish never moves pins, so rebind
  * must finish the job itself.
  */
-interface ReviewRebindJsonOutput {
+export interface ReviewRebindJsonOutput {
   event: "rebound";
   uuid: string;
   change: string;
@@ -32,41 +28,14 @@ export async function runReviewRebind(input: {
   stdout: Writable;
   createSourceAgentSession?: RunReviewScaffoldInput["createSourceAgentSession"];
 }): Promise<number> {
-  const reviewRoot = await resolveReviewRoot(input.cwd);
-  const review = await resolvePublishReview(reviewRoot, input.reviewUuid);
-  const resolved = await resolveRevision(
-    review.review.worktreePath,
-    input.change,
+  const output = ReviewRebindResultSchema.parse(
+    await requestReviewLifecycle("/lifecycle/rebind", {
+      cwd: input.cwd,
+      reviewUuid: input.reviewUuid,
+      change: input.change,
+      agent: resolveAuthoringSessionRef(input.env ?? process.env),
+    }),
   );
-  if (!resolved) {
-    throw new Error(
-      `Change does not resolve in ${review.review.worktreePath}: ${input.change}`,
-    );
-  }
-  const sourceIdentity = await changeIdentityForRevision(
-    review.review.worktreePath,
-    input.change,
-  );
-  if (!sourceIdentity) {
-    throw new Error(`Change does not resolve to one identity: ${input.change}`);
-  }
-  const repinned = await repinReview(
-    review,
-    {
-      cwd: reviewRoot,
-      toolingRoot: input.toolingRoot,
-      progress: input.progress,
-      env: input.env,
-      createSourceAgentSession: input.createSourceAgentSession,
-    },
-    sourceIdentity,
-  );
-  const output: ReviewRebindJsonOutput = {
-    event: "rebound",
-    uuid: review.review.uuid,
-    change: input.change,
-  };
-  if (repinned.warnings) output.warnings = repinned.warnings;
   input.stdout.write(`${JSON.stringify(output)}\n`);
   return 0;
 }

--- a/packages/progressive-review/src/review-repair-state.test.ts
+++ b/packages/progressive-review/src/review-repair-state.test.ts
@@ -15,10 +15,13 @@ import {
 } from "./review-thread-store-backend";
 
 let root: string | undefined;
+
 afterEach(async () => {
   closeAllReviewThreadStores();
+
   if (root) await rm(root, { recursive: true, force: true });
 });
+
 it("fingerprints editable inputs and blocks pending agent writes without changing threads", async () => {
   root = await mkdtemp(path.join(tmpdir(), "review-repair-state-"));
   await writeFile(path.join(root, "review.mdx"), "# One");

--- a/packages/progressive-review/src/review-repair-state.test.ts
+++ b/packages/progressive-review/src/review-repair-state.test.ts
@@ -9,7 +9,10 @@ import {
   fingerprintReviewRepairInputs,
 } from "./review-repair-state";
 import { appendReviewCommentDraft } from "./review-state-store";
-import { closeAllReviewThreadStores } from "./review-thread-store-backend";
+import {
+  closeAllReviewThreadStores,
+  reviewThreadDbPath,
+} from "./review-thread-store-backend";
 
 let root: string | undefined;
 afterEach(async () => {
@@ -32,7 +35,8 @@ it("fingerprints editable inputs and blocks pending agent writes without changin
     agentInput: true,
   });
   closeAllReviewThreadStores();
-  const bytes = await readFile(path.join(root, "review.db"));
+  const dbPath = reviewThreadDbPath(path.join(root, "review.mdx"));
+  const bytes = await readFile(dbPath);
   expect(() => assertNoActiveReviewAgentWrites(root!)).toThrow("pending agent");
-  expect(await readFile(path.join(root, "review.db"))).toEqual(bytes);
+  expect(await readFile(dbPath)).toEqual(bytes);
 });

--- a/packages/progressive-review/src/review-repair-state.ts
+++ b/packages/progressive-review/src/review-repair-state.ts
@@ -1,7 +1,8 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 
-import { ReviewStatusSchema } from "@dev.fast/review-protocol";
+import { ReviewRepairReadyResponseSchema } from "./review-lifecycle-contracts";
+export { ReviewRepairReadyResponseSchema } from "./review-lifecycle-contracts";
 import { z } from "zod";
 
 import { isDerivedReviewPath } from "./review-derived-paths";
@@ -29,16 +30,6 @@ export type ReviewRepairReadyRequest = z.infer<
   typeof ReviewRepairReadyRequestSchema
 >;
 
-export const ReviewRepairReadyResponseSchema = z.strictObject({
-  ok: z.literal(true),
-  status: ReviewStatusSchema,
-  oldDocumentRevision: z.string().min(1).nullable(),
-  oldMapRevision: z.string().min(1).nullable(),
-  newDocumentRevision: revisionSchema,
-  newMapRevision: revisionSchema.nullable(),
-  sessionId: z.string().min(1),
-  url: z.string().min(1),
-});
 export type ReviewRepairReadyResponse = z.infer<
   typeof ReviewRepairReadyResponseSchema
 >;

--- a/packages/progressive-review/src/review-repair-state.ts
+++ b/packages/progressive-review/src/review-repair-state.ts
@@ -2,7 +2,9 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 
 import { ReviewRepairReadyResponseSchema } from "./review-lifecycle-contracts";
+
 export { ReviewRepairReadyResponseSchema } from "./review-lifecycle-contracts";
+
 import { z } from "zod";
 
 import { isDerivedReviewPath } from "./review-derived-paths";
@@ -13,6 +15,7 @@ import {
 import { fingerprintReviewTree } from "./review-tree-fingerprint";
 
 const revisionSchema = z.string().regex(/^[0-9a-f]{40}$/);
+
 export const ReviewRepairReadyRequestSchema = z.strictObject({
   reviewUuid: z.uuid(),
   stagingDir: z.string().min(1),
@@ -26,6 +29,7 @@ export const ReviewRepairReadyRequestSchema = z.strictObject({
   newMapRevision: revisionSchema.nullable(),
   sourceFallback: z.strictObject({ document: z.boolean(), map: z.boolean() }),
 });
+
 export type ReviewRepairReadyRequest = z.infer<
   typeof ReviewRepairReadyRequestSchema
 >;
@@ -48,7 +52,9 @@ export async function fingerprintReviewRepairInputs(
  * open reviewer threads are intentionally not a repair gate. */
 export function assertNoActiveReviewAgentWrites(dir: string): void {
   const reviewPath = path.join(dir, "review.mdx");
+
   if (!existsSync(reviewThreadDbPath(reviewPath))) return;
+
   if (hasPendingReviewAgentWrites(reviewPath))
     throw new Error(
       "Review repair is blocked by pending agent writes; wait for the active agent response to finish, then retry.",

--- a/packages/progressive-review/src/review-repair.test.ts
+++ b/packages/progressive-review/src/review-repair.test.ts
@@ -46,7 +46,9 @@ import { defineSoftwareMap } from "./software-map-model";
 import { migrateStoredReview } from "./stored-review-migration";
 
 const roots: string[] = [];
+
 let server: Awaited<ReturnType<typeof startLifecycleTestServer>> | undefined;
+
 afterEach(async () => {
   await server?.close();
   server = undefined;
@@ -61,6 +63,7 @@ async function fixture(legacy = false) {
   roots.push(root);
   const source = path.join(root, "source");
   await mkdir(source);
+
   for (const args of [
     ["init", "-b", "main"],
     ["config", "user.name", "Test"],
@@ -68,10 +71,12 @@ async function fixture(legacy = false) {
     ["commit", "--allow-empty", "-m", "Initial"],
   ])
     execFileSync("git", args, { cwd: source, stdio: "ignore" });
+
   const commit = execFileSync("git", ["rev-parse", "HEAD"], {
     cwd: source,
     encoding: "utf8",
   }).trim();
+
   const stored = await createReviewDir({
     reviewsHomePath: path.join(root, "home"),
     worktreePath: source,
@@ -80,6 +85,7 @@ async function fixture(legacy = false) {
     sourceCommit: commit,
     sourceIdentity: { kind: "git-branch", name: "main" },
   });
+
   if (legacy) {
     const bundle = path.join(stored.dir, ".bundle/document");
     await mkdir(bundle, { recursive: true });
@@ -106,6 +112,7 @@ async function fixture(legacy = false) {
       }),
     );
   const revision = await sealReviewCandidate(stored.dir, "Presented");
+
   const record = {
     ...stored.review,
     schemaVersion: legacy ? 4 : 5,
@@ -113,7 +120,9 @@ async function fixture(legacy = false) {
     presentedDocumentRevision: revision,
     dismissedAt: "2026-09-01T00:00:00.000Z",
   };
+
   await writeFile(path.join(stored.dir, "review.json"), JSON.stringify(record));
+
   return { ...stored, record, revision };
 }
 
@@ -123,10 +132,12 @@ describe("prepareReviewRepair", () => {
     async () => {
       const stored = await fixture(true);
       const recordBefore = await readFile(path.join(stored.dir, "review.json"));
+
       const refsBefore = execFileSync("git", ["show-ref"], {
         cwd: stored.dir,
         encoding: "utf8",
       });
+
       execFileSync("mkfifo", [path.join(stored.dir, ".bundle", "pipe")]);
       await expect(
         prepareReviewRepair({ reviewDir: stored.dir }),
@@ -159,18 +170,24 @@ describe("prepareReviewRepair", () => {
     "rejects internal %s symlinks before touching their external targets",
     async (relative) => {
       const stored = await fixture(true);
+
       const external = await mkdtemp(
         path.join(os.tmpdir(), "review-repair-external-"),
       );
+
       roots.push(external);
+
       const target =
         relative === ".git/index" ? path.join(external, "index") : external;
+
       const marker =
         relative === ".git/index" ? target : path.join(target, "manifest.json");
+
       const originalBytes =
         relative === ".git/index"
           ? await readFile(path.join(stored.dir, relative))
           : Buffer.from("External bytes must not change");
+
       await writeFile(marker, originalBytes);
       await rm(path.join(stored.dir, relative), {
         recursive: true,
@@ -181,6 +198,7 @@ describe("prepareReviewRepair", () => {
       await expect(
         prepareReviewRepair({ reviewDir: stored.dir }).then(async (result) => {
           if (result.kind === "prepared") await result.cleanup();
+
           return result;
         }),
       ).rejects.toThrow(/Repair internal.*symbolic link/);
@@ -204,15 +222,19 @@ describe("prepareReviewRepair", () => {
         presentedSoftwareMapRevision: "e".repeat(40),
       }),
     );
+
     const refs = () =>
       execFileSync("git", ["show-ref"], {
         cwd: stored.review.worktreePath,
         encoding: "utf8",
       });
+
     const before = refs();
     const result = await prepareReviewRepair({ reviewDir: stored.dir });
+
     if (result.kind !== "prepared")
       throw new Error("Expected map notes repair");
+
     try {
       expect(result.request.newDocumentRevision).toBe(stored.revision);
       expect(result.request.sourceFallback).toEqual({
@@ -236,10 +258,12 @@ describe("prepareReviewRepair", () => {
         headCommit: "d".repeat(40),
       }),
     );
+
     const mapRevision = await sealReviewCandidate(
       stored.dir,
       "Contradictory map pins",
     );
+
     await writeFile(
       path.join(stored.dir, "review.json"),
       JSON.stringify({
@@ -269,19 +293,23 @@ describe("prepareReviewRepair", () => {
     const before = await readFile(path.join(stored.dir, "review.json"), "utf8");
     const result = await prepareReviewRepair({ reviewDir: stored.dir });
     expect(result.kind).toBe("prepared");
+
     if (result.kind !== "prepared") throw new Error("Expected repair");
+
     try {
       expect(result.request.newDocumentRevision).not.toBe(stored.revision);
       expect(result.request.sourceFallback).toEqual({
         document: false,
         map: false,
       });
+
       const staged = JSON.parse(
         await readFile(
           path.join(result.request.stagingDir, "review.json"),
           "utf8",
         ),
       );
+
       expect(staged).toMatchObject({
         status: "accepted",
         dismissedAt: stored.record.dismissedAt,
@@ -314,10 +342,12 @@ describe("prepareReviewRepair", () => {
       path.join(stored.dir, ".bundle/document/review-document.js"),
       "broken javascript",
     );
+
     const revision = await sealReviewCandidate(
       stored.dir,
       "Broken current artifact",
     );
+
     await writeFile(
       path.join(stored.dir, "review.json"),
       JSON.stringify({ ...stored.record, presentedDocumentRevision: revision }),
@@ -328,11 +358,14 @@ describe("prepareReviewRepair", () => {
     );
     const before = await fingerprintReviewRepairInputs(stored.dir);
     const warnings: string[] = [];
+
     const result = await prepareReviewRepair({
       reviewDir: stored.dir,
       warning: (message) => warnings.push(message),
     });
+
     if (result.kind !== "prepared") throw new Error("Expected repair");
+
     try {
       expect(result.request.sourceFallback.document).toBe(true);
       expect(warnings.join(" ")).toContain("semantic equivalence");
@@ -371,10 +404,12 @@ describe("prepareReviewRepair", () => {
         baseCommit: stored.review.baseCommit,
       }),
     );
+
     const mapRevision = await sealReviewCandidate(
       stored.dir,
       "Independent JSON map",
     );
+
     await writeFile(
       path.join(stored.dir, "review.json"),
       JSON.stringify({
@@ -383,7 +418,9 @@ describe("prepareReviewRepair", () => {
       }),
     );
     const result = await prepareReviewRepair({ reviewDir: stored.dir });
+
     if (result.kind !== "prepared") throw new Error("Expected repair");
+
     try {
       expect(result.request.newMapRevision).toBe(mapRevision);
     } finally {
@@ -392,12 +429,14 @@ describe("prepareReviewRepair", () => {
   });
   it("requires an explicit UUID before looking up a review", async () => {
     let output = "";
+
     const stdout = new Writable({
       write(chunk, _encoding, callback) {
         output += chunk.toString();
         callback();
       },
     });
+
     expect(
       await runReviewRepair({
         cwd: process.cwd(),
@@ -414,18 +453,21 @@ describe("prepareReviewRepair", () => {
     server = await startLifecycleTestServer();
     let out = "";
     let err = "";
+
     const stdout = new Writable({
       write(chunk, _encoding, callback) {
         out += chunk.toString();
         callback();
       },
     });
+
     const stderr = new Writable({
       write(chunk, _encoding, callback) {
         err += chunk.toString();
         callback();
       },
     });
+
     expect(
       await runReviewRepair({
         cwd: path.join(path.dirname(stored.dir), "elsewhere"),
@@ -448,18 +490,21 @@ describe("prepareReviewRepair", () => {
       server = await startLifecycleTestServer();
       let out = "";
       let err = "";
+
       const stdout = new Writable({
         write(chunk, _encoding, callback) {
           out += chunk.toString();
           callback();
         },
       });
+
       const stderr = new Writable({
         write(chunk, _encoding, callback) {
           err += chunk.toString();
           callback();
         },
       });
+
       const originalDevReviewHome = process.env.DEV_REVIEW_HOME;
       const cwd = path.join(stored.review.worktreePath, relativeCwd);
       await mkdir(cwd, { recursive: true });
@@ -500,10 +545,12 @@ describe("prepareReviewRepair", () => {
       path.join(stored.dir, "review.json"),
       JSON.stringify({ ...stored.record, sourceCommit: "c".repeat(40) }),
     );
+
     const mapRevision = await sealReviewCandidate(
       stored.dir,
       "Legacy map only",
     );
+
     await writeFile(
       path.join(stored.dir, "review.json"),
       JSON.stringify({
@@ -513,14 +560,18 @@ describe("prepareReviewRepair", () => {
     );
     const before = await fingerprintReviewRepairInputs(stored.dir);
     const result = await prepareReviewRepair({ reviewDir: stored.dir });
+
     if (result.kind !== "prepared") throw new Error("Expected repair");
+
     try {
       expect(result.request.newDocumentRevision).toBe(stored.revision);
       expect(result.request.newMapRevision).not.toBe(mapRevision);
+
       const sealedMap = path.join(
         result.request.stagingDir,
         ".build/map-verification",
       );
+
       await materializeReviewRevision(
         result.request.stagingDir,
         result.request.newMapRevision!,
@@ -561,7 +612,9 @@ describe("prepareReviewRepair", () => {
       JSON.stringify({ ...stored.record, schemaVersion: 4 }),
     );
     const result = await prepareReviewRepair({ reviewDir: stored.dir });
+
     if (result.kind !== "prepared") throw new Error("Expected metadata repair");
+
     try {
       expect(result.request.newDocumentRevision).toBe(stored.revision);
       expect(result.request.newMapRevision).toBeNull();
@@ -586,7 +639,9 @@ describe("prepareReviewRepair", () => {
       JSON.stringify({ ...stored.record, schemaVersion: 4 }),
     );
     const result = await prepareReviewRepair({ reviewDir: stored.dir });
+
     if (result.kind !== "prepared") throw new Error("Expected metadata repair");
+
     try {
       expect(
         await readFile(
@@ -627,10 +682,12 @@ it("repairs broken sealed artifacts with a legacy DB by upgrading only the isola
     path.join(stored.dir, ".bundle/document/review-document.js"),
     "throw new Error('broken sealed');",
   );
+
   const broken = await sealReviewCandidate(
     stored.dir,
     "Broken sealed document",
   );
+
   await writeFile(
     path.join(stored.dir, "review.json"),
     JSON.stringify({ ...stored.record, presentedDocumentRevision: broken }),
@@ -640,13 +697,16 @@ it("repairs broken sealed artifacts with a legacy DB by upgrading only the isola
   );
   const prepared = await prepareReviewRepair({ reviewDir: stored.dir });
   expect(prepared.kind).toBe("prepared");
+
   if (prepared.kind !== "prepared") throw new Error("Expected repair");
+
   try {
     expect(prepared.request.sourceFallback.document).toBe(true);
     expect(prepared.request.expectedThreadDbFingerprint).toMatch(
       /^[0-9a-f]{64}$/,
     );
     expect(await readFile(dbPath)).toEqual(bytes);
+
     for (const suffix of ["-wal", "-shm"])
       await expect(
         readFile(path.join(prepared.request.stagingDir, `review.db${suffix}`)),
@@ -673,10 +733,12 @@ it("rejects changes to legacy threads while preparing artifact repair", async ()
     path.join(stored.dir, ".bundle/document/review-document.js"),
     "throw new Error('broken sealed');",
   );
+
   const broken = await sealReviewCandidate(
     stored.dir,
     "Broken sealed document",
   );
+
   await writeFile(
     path.join(stored.dir, "review.json"),
     JSON.stringify({ ...stored.record, presentedDocumentRevision: broken }),

--- a/packages/progressive-review/src/review-repair.test.ts
+++ b/packages/progressive-review/src/review-repair.test.ts
@@ -14,7 +14,7 @@ import { DatabaseSync } from "node:sqlite";
 import { Writable } from "node:stream";
 
 import { remoteNotesRef, writeNote } from "@dev.fast/local-vcs";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   bundleReviewDocument,
@@ -25,13 +25,17 @@ import {
   materializeReviewRevision,
   sealReviewCandidate,
 } from "./review-home";
+import { startLifecycleTestServer } from "./review-lifecycle-test-utils";
 import { runReviewRepair } from "./review-repair";
 import { prepareReviewRepair } from "./review-repair-preparation";
 import { fingerprintReviewRepairInputs } from "./review-repair-state";
+import { deleteReviewState } from "./review-state-db";
 import { appendReviewComment } from "./review-state-store";
 import { SOFTWARE_MAP_NOTES_REF } from "./review-storage";
 import {
   closeAllReviewThreadStores,
+  copyReviewThreadDatabaseSnapshot,
+  createLegacyReviewThreadDb,
   readReviewThreadsReadOnly,
 } from "./review-thread-store-backend";
 import {
@@ -42,7 +46,11 @@ import { defineSoftwareMap } from "./software-map-model";
 import { migrateStoredReview } from "./stored-review-migration";
 
 const roots: string[] = [];
+let server: Awaited<ReturnType<typeof startLifecycleTestServer>> | undefined;
 afterEach(async () => {
+  await server?.close();
+  server = undefined;
+  vi.unstubAllEnvs();
   await Promise.all(
     roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
   );
@@ -402,6 +410,8 @@ describe("prepareReviewRepair", () => {
   });
   it("keeps the human report on stderr under --json and refuses another checkout", async () => {
     const stored = await fixture();
+    vi.stubEnv("DEV_REVIEW_HOME", path.dirname(path.dirname(stored.dir)));
+    server = await startLifecycleTestServer();
     let out = "";
     let err = "";
     const stdout = new Writable({
@@ -423,7 +433,7 @@ describe("prepareReviewRepair", () => {
         json: true,
         stdout,
         stderr,
-        env: { DEV_REVIEW_HOME: path.dirname(path.dirname(stored.dir)) },
+        env: { DEV_REVIEW_HOME: "/not-the-desktop-home" },
       }),
     ).toBe(1);
     expect(out).toContain('"event":"error"');
@@ -431,9 +441,11 @@ describe("prepareReviewRepair", () => {
     expect(out).not.toContain("Review repaired:");
   });
   it.each([".", "nested/package"])(
-    "repairs from %s with an explicit storage home",
+    "repairs from %s using desktop-owned storage",
     async (relativeCwd) => {
       const stored = await fixture();
+      vi.stubEnv("DEV_REVIEW_HOME", path.dirname(path.dirname(stored.dir)));
+      server = await startLifecycleTestServer();
       let out = "";
       let err = "";
       const stdout = new Writable({
@@ -451,18 +463,16 @@ describe("prepareReviewRepair", () => {
       const originalDevReviewHome = process.env.DEV_REVIEW_HOME;
       const cwd = path.join(stored.review.worktreePath, relativeCwd);
       await mkdir(cwd, { recursive: true });
-      const exitCode = await runReviewRepair({
-        cwd,
-        reviewUuid: stored.review.uuid,
-        json: true,
-        stdout,
-        stderr,
-        env: { DEV_REVIEW_HOME: path.dirname(path.dirname(stored.dir)) },
-      });
-      expect({ exitCode, err }).toMatchObject({
-        exitCode: 0,
-        err: expect.stringContaining("no repair needed"),
-      });
+      expect(
+        await runReviewRepair({
+          cwd,
+          reviewUuid: stored.review.uuid,
+          json: true,
+          stdout,
+          stderr,
+          env: { DEV_REVIEW_HOME: "/not-the-desktop-home" },
+        }),
+      ).toBe(0);
       expect(out).toContain('"event":"repaired"');
       expect(err).toContain(
         "Current Review artifacts are healthy; no repair needed.",
@@ -606,6 +616,9 @@ it("repairs broken sealed artifacts with a legacy DB by upgrading only the isola
   });
   closeAllReviewThreadStores();
   const dbPath = path.join(stored.dir, "review.db");
+  const document = path.join(stored.dir, "review.mdx");
+  copyReviewThreadDatabaseSnapshot(document, document);
+  deleteReviewState(stored.dir);
   const db = new DatabaseSync(dbPath);
   db.exec("UPDATE meta SET value = '5' WHERE key = 'schema_version'");
   db.close();
@@ -650,6 +663,8 @@ it("repairs broken sealed artifacts with a legacy DB by upgrading only the isola
 
 it("rejects changes to legacy threads while preparing artifact repair", async () => {
   const stored = await fixture(true);
+  createLegacyReviewThreadDb(stored.dir);
+  deleteReviewState(stored.dir);
   const dbPath = path.join(stored.dir, "review.db");
   const db = new DatabaseSync(dbPath);
   db.exec("UPDATE meta SET value = '5' WHERE key = 'schema_version'");

--- a/packages/progressive-review/src/review-repair.ts
+++ b/packages/progressive-review/src/review-repair.ts
@@ -17,22 +17,26 @@ export async function runReviewRepair(input: {
       throw new Error(
         "Review repair requires an explicit UUID (--review <uuid>).",
       );
+
     const result = ReviewRepairResultSchema.parse(
       await requestReviewLifecycle("/lifecycle/repair", {
         cwd: input.cwd,
         reviewUuid: input.reviewUuid,
       }),
     );
+
     for (const message of result.warnings) {
       emitJsonEvent(input, { event: "warning", message });
       input.stderr.write(`warning: ${message}\n`);
     }
+
     emitJsonEvent(input, { ...result, event: "repaired" });
     humanStream(input).write(
       result.noop
         ? "Current Review artifacts are healthy; no repair needed.\n"
         : `Review repaired: ${result.reviewUuid}\nStatus preserved: ${result.status}\nDocument: ${result.oldDocumentRevision} → ${result.newDocumentRevision}\nMap: ${result.oldMapRevision ?? "absent"} → ${result.newMapRevision ?? "absent"}\n`,
     );
+
     return 0;
   } catch (error) {
     return failWithJsonError(

--- a/packages/progressive-review/src/review-repair.ts
+++ b/packages/progressive-review/src/review-repair.ts
@@ -1,19 +1,8 @@
-import os from "node:os";
 import type { Writable } from "node:stream";
 
-import {
-  jsonObject,
-  jsonString,
-  parseJsonText,
-} from "@dev.fast/review-protocol";
-
 import { emitJsonEvent, failWithJsonError, humanStream } from "./cli-output";
-import { requireHealthyReviewDesktop } from "./desktop-discovery";
-import { UUID_PATTERN, findScopedReview } from "./review-home";
-import { prepareReviewRepair } from "./review-repair-preparation";
-import { ReviewRepairReadyResponseSchema } from "./review-repair-state";
-import { devReviewHome } from "./review-storage";
-import { resolveReviewRoot } from "./runtime";
+import { requestReviewLifecycle } from "./review-lifecycle-client";
+import { ReviewRepairResultSchema } from "./review-lifecycle-contracts";
 
 export async function runReviewRepair(input: {
   cwd: string;
@@ -24,71 +13,27 @@ export async function runReviewRepair(input: {
   env?: NodeJS.ProcessEnv;
 }): Promise<number> {
   try {
-    if (!input.reviewUuid || !UUID_PATTERN.test(input.reviewUuid))
+    if (!input.reviewUuid)
       throw new Error(
-        "Repair requires an explicit UUID: review repair --review <uuid>.",
+        "Review repair requires an explicit UUID (--review <uuid>).",
       );
-    const review = await findScopedReview(input.reviewUuid, {
-      worktreePath: await resolveReviewRoot(input.cwd),
-      includeTerminal: true,
-      includeLegacySchema: true,
-      devHome: devReviewHome(input.env ?? process.env, os.homedir()),
-    });
-    if (!review)
-      throw new Error(`Review not found in this checkout: ${input.reviewUuid}`);
-    const prepared = await prepareReviewRepair({
-      reviewDir: review.dir,
-      warning: (message) => {
-        emitJsonEvent(input, { event: "warning", message });
-        input.stderr.write(`warning: ${message}\n`);
-      },
-    });
-    if (prepared.kind === "noop") {
-      emitJsonEvent(input, {
-        event: "repaired",
-        noop: true,
-        reviewUuid: prepared.review.uuid,
-        status: prepared.review.status,
-        oldDocumentRevision: prepared.review.presentedDocumentRevision,
-        oldMapRevision: prepared.review.presentedSoftwareMapRevision,
-        newDocumentRevision: prepared.review.presentedDocumentRevision,
-        newMapRevision: prepared.review.presentedSoftwareMapRevision,
-      });
-      humanStream(input).write(
-        "Current Review artifacts are healthy; no repair needed.\n",
-      );
-      return 0;
+    const result = ReviewRepairResultSchema.parse(
+      await requestReviewLifecycle("/lifecycle/repair", {
+        cwd: input.cwd,
+        reviewUuid: input.reviewUuid,
+      }),
+    );
+    for (const message of result.warnings) {
+      emitJsonEvent(input, { event: "warning", message });
+      input.stderr.write(`warning: ${message}\n`);
     }
-    try {
-      const discovery = await requireHealthyReviewDesktop("review repair");
-      const response = await fetch(`${discovery.url}/repair-ready`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-review-token": discovery.token,
-        },
-        body: JSON.stringify(prepared.request),
-      });
-      const body = jsonObject(parseJsonText(await response.text()));
-      const parsed = ReviewRepairReadyResponseSchema.safeParse(body);
-      if (!response.ok || !parsed.success)
-        throw new Error(
-          jsonString(body?.error) ??
-            `Review Desktop repair failed (${response.status}).`,
-        );
-      emitJsonEvent(input, {
-        ...parsed.data,
-        event: "repaired",
-        noop: false,
-        sourceFallback: prepared.request.sourceFallback,
-      });
-      humanStream(input).write(
-        `Review repaired: ${prepared.review.uuid}\nStatus preserved: ${prepared.review.status}\nDocument: ${prepared.review.presentedDocumentRevision} → ${prepared.request.newDocumentRevision}\nMap: ${prepared.review.presentedSoftwareMapRevision ?? "absent"} → ${prepared.request.newMapRevision ?? "absent"}\n`,
-      );
-      return 0;
-    } finally {
-      await prepared.cleanup();
-    }
+    emitJsonEvent(input, { ...result, event: "repaired" });
+    humanStream(input).write(
+      result.noop
+        ? "Current Review artifacts are healthy; no repair needed.\n"
+        : `Review repaired: ${result.reviewUuid}\nStatus preserved: ${result.status}\nDocument: ${result.oldDocumentRevision} → ${result.newDocumentRevision}\nMap: ${result.oldMapRevision ?? "absent"} → ${result.newMapRevision ?? "absent"}\n`,
+    );
+    return 0;
   } catch (error) {
     return failWithJsonError(
       input,

--- a/packages/progressive-review/src/review-scope-errors.test.ts
+++ b/packages/progressive-review/src/review-scope-errors.test.ts
@@ -23,7 +23,9 @@ import {
   listReviews,
   sealReviewCandidate,
 } from "./review-home";
+import { startLifecycleTestServer } from "./review-lifecycle-test-utils";
 import { runReviewScaffold } from "./review-scaffold";
+import { deleteReviewState } from "./review-state-db";
 import { closeAllReviewThreadStores } from "./review-thread-store-backend";
 import { resolvePublishReview } from "./server/publish-preparation";
 import { resolveReviewInfo } from "./server/review-info";
@@ -31,8 +33,11 @@ import { runReviewThreadsList } from "./threads-cli";
 
 const execFilePromise = promisify(execFile);
 const roots: string[] = [];
+let server: Awaited<ReturnType<typeof startLifecycleTestServer>> | undefined;
 
 afterEach(async () => {
+  await server?.close();
+  server = undefined;
   closeAllReviewThreadStores();
   vi.unstubAllEnvs();
   await Promise.all(
@@ -132,6 +137,7 @@ describe("scoped review diagnostics", () => {
         baseCommit: kind === "malformed" ? 42 : badRecord.baseCommit,
       });
       await writeFile(badPath, bytes);
+      deleteReviewState(other.stored.dir);
       await expect(
         resolvePublishReview(healthy.root, undefined),
       ).resolves.toMatchObject({ dir: healthy.stored.dir });
@@ -166,6 +172,7 @@ describe("scoped review diagnostics", () => {
       await expect(
         resolvePublishReview(other.root, healthy.stored.review.uuid),
       ).rejects.toThrow("Active review not found");
+      server = await startLifecycleTestServer();
       await expect(
         runReviewThreadsList({ cwd: healthy.root, stdout: new PassThrough() }),
       ).resolves.toBe(0);
@@ -226,7 +233,7 @@ describe("scoped review diagnostics", () => {
           reviewUuid: other.stored.review.uuid,
           stdout: new PassThrough(),
         }),
-      ).rejects.toBeInstanceOf(ReviewHomeScanError);
+      ).rejects.toThrow("Could not read reviews");
       await expect(findReview(unknownUuid)).rejects.toBeInstanceOf(
         ReviewHomeScanError,
       );

--- a/packages/progressive-review/src/review-scope-errors.test.ts
+++ b/packages/progressive-review/src/review-scope-errors.test.ts
@@ -32,7 +32,9 @@ import { resolveReviewInfo } from "./server/review-info";
 import { runReviewThreadsList } from "./threads-cli";
 
 const execFilePromise = promisify(execFile);
+
 const roots: string[] = [];
+
 let server: Awaited<ReturnType<typeof startLifecycleTestServer>> | undefined;
 
 afterEach(async () => {
@@ -49,9 +51,11 @@ async function fixture() {
   const home = await realpath(
     await mkdtemp(path.join(os.tmpdir(), "review-scope-errors-")),
   );
+
   roots.push(home);
   vi.stubEnv("DEV_REVIEW_HOME", home);
   vi.stubEnv("DEV_FAST_REVIEW_TELEMETRY_DISABLED", "1");
+
   async function create(label: string) {
     const root = path.join(home, label);
     await mkdir(root);
@@ -67,9 +71,11 @@ async function fixture() {
     await writeFile(path.join(root, "README.md"), `${label}\n`);
     await execFilePromise("git", ["add", "."], { cwd: root });
     await execFilePromise("git", ["commit", "-m", "Initial"], { cwd: root });
+
     const commit = (
       await execFilePromise("git", ["rev-parse", "HEAD"], { cwd: root })
     ).stdout.trim();
+
     const stored = await createReviewDir({
       worktreePath: root,
       baseRef: "main",
@@ -78,8 +84,10 @@ async function fixture() {
       sourceIdentity: { kind: "git-branch", name: "main" },
       sourceSession: "disabled:review",
     });
+
     return { root, stored };
   }
+
   return {
     home,
     healthy: await create("healthy"),
@@ -107,6 +115,7 @@ describe("scoped review diagnostics", () => {
       const { home, healthy, other } = await fixture();
       const badPath = path.join(other.stored.dir, "review.json");
       let badRecord = { ...other.stored.review };
+
       if (kind === "failed-conversion") {
         const bundle = path.join(other.stored.dir, ".bundle", "document");
         await mkdir(bundle, { recursive: true });
@@ -130,12 +139,14 @@ describe("scoped review diagnostics", () => {
           ),
         };
       }
+
       const bytes = JSON.stringify({
         ...badRecord,
         schemaVersion:
           kind === "unsupported" ? 6 : kind === "failed-conversion" ? 4 : 5,
         baseCommit: kind === "malformed" ? 42 : badRecord.baseCommit,
       });
+
       await writeFile(badPath, bytes);
       deleteReviewState(other.stored.dir);
       await expect(
@@ -151,9 +162,11 @@ describe("scoped review diagnostics", () => {
       expect(scoped.reviews.map((entry) => entry.review.uuid)).toEqual([
         healthy.stored.review.uuid,
       ]);
+
       const repository = await listReviews({
         repoKey: healthy.stored.review.repoKey,
       });
+
       expect(repository.errors).toEqual([]);
       expect(repository.reviews.map((entry) => entry.review.uuid)).toEqual([
         healthy.stored.review.uuid,
@@ -179,9 +192,11 @@ describe("scoped review diagnostics", () => {
 
       const stdin = new PassThrough();
       stdin.end(JSON.stringify({ cwd: healthy.stored.dir }));
+
       const checkpoint = vi.fn<typeof sealReviewCandidate>(
         async () => "checkpoint",
       );
+
       await expect(
         runProgressiveReviewCli({
           argv: ["stop-hook"],
@@ -246,11 +261,13 @@ describe("scoped review diagnostics", () => {
 
   it("does not create an ambiguous binding when unknown metadata exists", async () => {
     const { home, healthy } = await fixture();
+
     const unknownDir = path.join(
       home,
       "reviews",
       "11111111-1111-4111-8111-111111111111",
     );
+
     await mkdir(unknownDir);
     await writeFile(path.join(unknownDir, "review.json"), "{broken");
     const before = await readdir(path.join(home, "reviews"));

--- a/packages/progressive-review/src/review-state-db.test.ts
+++ b/packages/progressive-review/src/review-state-db.test.ts
@@ -36,6 +36,7 @@ afterEach(() => {
   closeAllReviewThreadStores();
   closeAllReviewStateDatabases();
   vi.unstubAllEnvs();
+
   for (const root of roots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
   }
@@ -45,12 +46,14 @@ function setupHome(): string {
   const home = mkdtempSync(path.join(tmpdir(), "review-state-db-"));
   roots.push(home);
   vi.stubEnv("DEV_REVIEW_HOME", home);
+
   return home;
 }
 
 function reviewPath(home: string, reviewId: string): string {
   const dir = path.join(home, "reviews", reviewId);
   mkdirSync(dir, { recursive: true });
+
   return path.join(dir, "review.mdx");
 }
 
@@ -73,6 +76,7 @@ describe("global review state database", () => {
     const home = setupHome();
     const first = reviewPath(home, "review-a");
     const second = reviewPath(home, "review-b");
+
     for (const document of [first, second]) {
       appendReviewComment(document, {
         threadId: "shared-id",
@@ -82,6 +86,7 @@ describe("global review state database", () => {
         author: "Reviewer",
       });
     }
+
     const candidate = path.join(home, "candidate");
     mkdirSync(candidate);
     const candidateDocument = path.join(candidate, "review.mdx");
@@ -117,6 +122,7 @@ describe("global review state database", () => {
     );
     createLegacyReviewThreadDb(dir);
     const legacy = new DatabaseSync(legacyReviewThreadDbPath(document));
+
     const thread = {
       threadId: "thread-a",
       target: { kind: "document" },
@@ -135,6 +141,7 @@ describe("global review state database", () => {
         },
       ],
     };
+
     legacy
       .prepare("INSERT INTO comments(thread_id, record_json) VALUES (?, ?)")
       .run("thread-a", JSON.stringify(thread));

--- a/packages/progressive-review/src/review-state-db.test.ts
+++ b/packages/progressive-review/src/review-state-db.test.ts
@@ -1,0 +1,308 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ReviewStateDbVersionError,
+  closeAllReviewStateDatabases,
+  deleteReviewState,
+  importLegacyReview,
+  openReviewStateDb,
+  putReviewRecord,
+  readReviewRecord,
+  reviewStateDbPath,
+} from "./review-state-db";
+import {
+  appendReviewComment,
+  readReviewCommentDrafts,
+  readReviewComments,
+} from "./review-state-store";
+import {
+  ReviewThreadDbVersionError,
+  closeAllReviewThreadStores,
+  copyReviewThreadDatabaseSnapshot,
+  createLegacyReviewThreadDb,
+  legacyReviewThreadDbPath,
+  migrateReviewThreadDb,
+  readReviewThreadsReadOnly,
+} from "./review-thread-store-backend";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  closeAllReviewThreadStores();
+  closeAllReviewStateDatabases();
+  vi.unstubAllEnvs();
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function setupHome(): string {
+  const home = mkdtempSync(path.join(tmpdir(), "review-state-db-"));
+  roots.push(home);
+  vi.stubEnv("DEV_REVIEW_HOME", home);
+  return home;
+}
+
+function reviewPath(home: string, reviewId: string): string {
+  const dir = path.join(home, "reviews", reviewId);
+  mkdirSync(dir, { recursive: true });
+  return path.join(dir, "review.mdx");
+}
+
+describe("global review state database", () => {
+  it("rejects unsupported shared schemas during read-only recovery", () => {
+    const home = setupHome();
+    const document = reviewPath(home, "review-a");
+    putReviewRecord(path.dirname(document), { title: "A" });
+    closeAllReviewStateDatabases();
+    const db = new DatabaseSync(reviewStateDbPath(home));
+    db.exec(
+      "UPDATE review_state_meta SET value = '999' WHERE key = 'schema_version'",
+    );
+    db.close();
+    expect(() => readReviewThreadsReadOnly(document)).toThrow(
+      ReviewStateDbVersionError,
+    );
+  });
+  it("exports only the requested Review's threads into a repair candidate", () => {
+    const home = setupHome();
+    const first = reviewPath(home, "review-a");
+    const second = reviewPath(home, "review-b");
+    for (const document of [first, second]) {
+      appendReviewComment(document, {
+        threadId: "shared-id",
+        messageId: "message",
+        target: { kind: "document" },
+        body: document,
+        author: "Reviewer",
+      });
+    }
+    const candidate = path.join(home, "candidate");
+    mkdirSync(candidate);
+    const candidateDocument = path.join(candidate, "review.mdx");
+    copyReviewThreadDatabaseSnapshot(first, candidateDocument);
+    expect(
+      readReviewThreadsReadOnly(candidateDocument).comments["shared-id"]
+        ?.messages[0]?.body,
+    ).toBe(first);
+    expect(
+      readReviewThreadsReadOnly(second).comments["shared-id"]?.messages[0]
+        ?.body,
+    ).toBe(second);
+    appendReviewComment(second, {
+      threadId: "new",
+      messageId: "new-message",
+      target: { kind: "document" },
+      body: "Still writable",
+      author: "Reviewer",
+    });
+    expect(Object.keys(readReviewComments(first))).toEqual(["shared-id"]);
+    expect(Object.keys(readReviewComments(second)).sort()).toEqual([
+      "new",
+      "shared-id",
+    ]);
+  });
+  it("defers legacy comment and draft import until after migration, even after metadata reads and writes", async () => {
+    const home = setupHome();
+    const document = reviewPath(home, "review-a");
+    const dir = path.dirname(document);
+    writeFileSync(
+      path.join(dir, "review.json"),
+      JSON.stringify({ uuid: "review-a", title: "Legacy" }),
+    );
+    createLegacyReviewThreadDb(dir);
+    const legacy = new DatabaseSync(legacyReviewThreadDbPath(document));
+    const thread = {
+      threadId: "thread-a",
+      target: { kind: "document" },
+      status: "open",
+      agentSession: {
+        harness: "codex",
+        sessionId: "child",
+        sourceSessionId: "obsolete",
+      },
+      messages: [
+        {
+          id: "message-a",
+          by: "Reviewer",
+          at: "2026-01-01T00:00:00.000Z",
+          body: "Preserve me",
+        },
+      ],
+    };
+    legacy
+      .prepare("INSERT INTO comments(thread_id, record_json) VALUES (?, ?)")
+      .run("thread-a", JSON.stringify(thread));
+    legacy
+      .prepare(
+        "INSERT INTO comment_drafts(thread_id, record_json) VALUES (?, ?)",
+      )
+      .run(
+        "thread-a",
+        JSON.stringify({
+          thread,
+          inputs: [
+            {
+              threadId: "thread-a",
+              messageId: "message-a",
+              target: { kind: "document" },
+              body: "Preserve me",
+            },
+          ],
+        }),
+      );
+    legacy
+      .prepare("UPDATE meta SET value = '4' WHERE key = 'schema_version'")
+      .run();
+    legacy.close();
+    expect(readReviewRecord(dir)).toMatchObject({ title: "Legacy" });
+    putReviewRecord(dir, { uuid: "review-a", title: "Updated metadata" });
+    expect(() => importLegacyReview(dir)).toThrow(ReviewThreadDbVersionError);
+    expect(
+      openReviewStateDb()
+        .prepare("SELECT count(*) AS count FROM legacy_review_imports")
+        .get(),
+    ).toEqual({ count: 0 });
+    expect(
+      openReviewStateDb()
+        .prepare("SELECT count(*) AS count FROM comments")
+        .get(),
+    ).toEqual({ count: 0 });
+    expect(await migrateReviewThreadDb(document)).toBe("upgraded");
+    expect(readReviewComments(document)["thread-a"]).toMatchObject({
+      agentSession: { harness: "codex", sessionId: "child" },
+      messages: [{ body: "Preserve me" }],
+    });
+    expect(
+      readReviewCommentDrafts(document)["thread-a"].thread.messages[0].body,
+    ).toBe("Preserve me");
+    expect(readReviewRecord(dir)).toMatchObject({ title: "Updated metadata" });
+    expect(
+      openReviewStateDb()
+        .prepare("SELECT count(*) AS count FROM legacy_review_imports")
+        .get(),
+    ).toEqual({ count: 1 });
+  });
+  it("isolates comment rows for multiple reviews in one database", () => {
+    const home = setupHome();
+    const first = reviewPath(home, "review-a");
+    const second = reviewPath(home, "review-b");
+
+    appendReviewComment(first, {
+      threadId: "thread-a",
+      messageId: "message-a",
+      target: { kind: "document" },
+      body: "First review",
+      author: "Reviewer",
+    });
+    appendReviewComment(second, {
+      threadId: "thread-b",
+      messageId: "message-b",
+      target: { kind: "document" },
+      body: "Second review",
+      author: "Reviewer",
+    });
+
+    expect(Object.keys(readReviewComments(first))).toEqual(["thread-a"]);
+    expect(Object.keys(readReviewComments(second))).toEqual(["thread-b"]);
+    const db = new DatabaseSync(reviewStateDbPath(home), { readOnly: true });
+    expect(
+      db
+        .prepare("SELECT count(DISTINCT review_id) AS count FROM comments")
+        .get(),
+    ).toEqual({ count: 2 });
+    db.close();
+  });
+
+  it("treats the database record as authoritative over its JSON mirror", () => {
+    const home = setupHome();
+    const document = reviewPath(home, "review-a");
+    const dir = path.dirname(document);
+    putReviewRecord(dir, { uuid: "review-a", title: "Database" });
+    writeFileSync(
+      path.join(dir, "review.json"),
+      JSON.stringify({ uuid: "review-a", title: "Stale mirror" }),
+    );
+
+    expect(readReviewRecord(dir)).toEqual({
+      uuid: "review-a",
+      title: "Database",
+    });
+  });
+
+  it("imports legacy metadata and comments once without deleting the source", () => {
+    const home = setupHome();
+    const document = reviewPath(home, "review-a");
+    const dir = path.dirname(document);
+    writeFileSync(
+      path.join(dir, "review.json"),
+      JSON.stringify({ uuid: "review-a", title: "Legacy" }),
+    );
+    createLegacyReviewThreadDb(dir);
+    const legacy = new DatabaseSync(legacyReviewThreadDbPath(document));
+    legacy
+      .prepare("INSERT INTO comments (thread_id, record_json) VALUES (?, ?)")
+      .run(
+        "thread-a",
+        JSON.stringify({
+          threadId: "thread-a",
+          target: { kind: "document" },
+          status: "open",
+          messages: [
+            {
+              id: "message-a",
+              by: "Reviewer",
+              at: "2026-01-01T00:00:00.000Z",
+              body: "Imported",
+            },
+          ],
+        }),
+      );
+    legacy.close();
+
+    expect(readReviewRecord(dir)).toEqual({
+      uuid: "review-a",
+      title: "Legacy",
+    });
+    expect(Object.keys(readReviewComments(document))).toEqual(["thread-a"]);
+    expect(legacyReviewThreadDbPath(document)).not.toBe(
+      reviewStateDbPath(home),
+    );
+  });
+
+  it("cascades all review-owned state when a review is deleted", () => {
+    const home = setupHome();
+    const document = reviewPath(home, "review-a");
+    appendReviewComment(document, {
+      threadId: "thread-a",
+      messageId: "message-a",
+      target: { kind: "document" },
+      body: "Delete me",
+      author: "Reviewer",
+    });
+
+    deleteReviewState(path.dirname(document));
+    const db = openReviewStateDb(home);
+    expect(db.prepare("SELECT count(*) AS count FROM comments").get()).toEqual({
+      count: 0,
+    });
+    expect(db.prepare("SELECT count(*) AS count FROM reviews").get()).toEqual({
+      count: 0,
+    });
+  });
+
+  it("rejects an unsupported global schema version", () => {
+    const home = setupHome();
+    const db = openReviewStateDb(home);
+    db.prepare(
+      "UPDATE review_state_meta SET value = '999' WHERE key = 'schema_version'",
+    ).run();
+    closeAllReviewStateDatabases();
+    expect(() => openReviewStateDb(home)).toThrow(ReviewStateDbVersionError);
+  });
+});

--- a/packages/progressive-review/src/review-state-db.ts
+++ b/packages/progressive-review/src/review-state-db.ts
@@ -9,6 +9,7 @@ import { devReviewHome } from "./review-storage";
 import { requireCurrentThreadDbSchema } from "./review-thread-db-schema";
 
 export const REVIEW_STATE_DB_FILENAME = "review.db";
+
 export const REVIEW_STATE_DB_SCHEMA_VERSION = 1;
 
 const REVIEW_STATE_DB_DDL = `
@@ -75,6 +76,7 @@ export class ReviewStateDbVersionError extends Error {
 
 export function reviewHomeForDir(reviewDir: string): string {
   const parent = path.dirname(path.resolve(reviewDir));
+
   return path.basename(parent) === "reviews"
     ? path.dirname(parent)
     : devReviewHome();
@@ -86,23 +88,28 @@ export function reviewStateDbPath(home = devReviewHome()): string {
 
 export function reviewIdForDir(reviewDir: string): string {
   const reviewId = path.basename(path.resolve(reviewDir));
+
   if (!reviewId)
     throw new Error(`Review directory has no identifier: ${reviewDir}`);
+
   return reviewId;
 }
 
 export function openReviewStateDb(home = devReviewHome()): DatabaseSync {
   const dbPath = reviewStateDbPath(home);
   const cached = connections.get(dbPath);
+
   if (cached) return cached;
   mkdirSync(path.dirname(dbPath), { recursive: true, mode: 0o700 });
   const existed = existsSync(dbPath);
   const db = new DatabaseSync(dbPath);
+
   try {
     db.exec(
       "PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; " +
         "PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;",
     );
+
     if (!existed) {
       db.exec(REVIEW_STATE_DB_DDL);
       db.prepare(
@@ -110,16 +117,20 @@ export function openReviewStateDb(home = devReviewHome()): DatabaseSync {
       ).run(String(REVIEW_STATE_DB_SCHEMA_VERSION));
     } else {
       const version = readReviewStateDbSchemaVersion(db);
+
       if (version !== String(REVIEW_STATE_DB_SCHEMA_VERSION)) {
         throw new ReviewStateDbVersionError(dbPath, version);
       }
+
       db.exec(REVIEW_STATE_DB_DDL);
     }
   } catch (error) {
     db.close();
     throw error;
   }
+
   connections.set(dbPath, db);
+
   return db;
 }
 
@@ -132,7 +143,9 @@ export function readReviewStateDbSchemaVersion(
       "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'review_state_meta'",
     )
     .get() as { present: number } | undefined;
+
   if (!hasMeta) return null;
+
   // SAFETY: review_state_meta.value is declared TEXT NOT NULL above.
   return (
     (
@@ -165,6 +178,7 @@ export function putReviewRecord(
   const reviewId = reviewIdForDir(reviewDir);
   const recordJson = JSON.stringify(record);
   db.exec("BEGIN IMMEDIATE");
+
   try {
     db.prepare(
       `INSERT INTO reviews (review_id, review_dir, record_json) VALUES (?, ?, ?)
@@ -185,18 +199,23 @@ export function readReviewRecord(
 ): JsonValue | null {
   const dbPath = reviewStateDbPath(home);
   const recordPath = path.join(reviewDir, "review.json");
+
   if (!existsSync(dbPath) && !existsSync(recordPath)) return null;
+
   // SAFETY: reviews.record_json is a nullable TEXT column in the schema above.
   const row = openReviewStateDb(home)
     .prepare("SELECT record_json FROM reviews WHERE review_id = ?")
     .get(reviewIdForDir(reviewDir)) as
     | { record_json: string | null }
     | undefined;
+
   if (row?.record_json) return parseJsonText(row.record_json);
+
   if (!existsSync(recordPath)) return null;
   // Discovery must not import comment records before their schema migration.
   const record = parseJsonText(readFileSync(recordPath, "utf8"));
   putReviewRecord(reviewDir, record, home);
+
   return record;
 }
 
@@ -207,8 +226,10 @@ export function importLegacyReview(
   const reviewId = reviewIdForDir(reviewDir);
   const recordPath = path.join(reviewDir, "review.json");
   const legacyDbPath = path.join(reviewDir, REVIEW_STATE_DB_FILENAME);
+
   if (!existsSync(recordPath) && !existsSync(legacyDbPath)) return;
   const db = openReviewStateDb(home);
+
   if (
     db
       .prepare("SELECT 1 FROM legacy_review_imports WHERE review_id = ?")
@@ -216,20 +237,26 @@ export function importLegacyReview(
   ) {
     return;
   }
+
   const recordJson = existsSync(recordPath)
     ? readFileSync(recordPath, "utf8")
     : null;
+
   if (recordJson !== null) JSON.parse(recordJson);
+
   const legacy = existsSync(legacyDbPath)
     ? new DatabaseSync(legacyDbPath, { readOnly: true })
     : null;
+
   try {
     if (legacy) requireCurrentThreadDbSchema(legacy, legacyDbPath);
   } catch (error) {
     legacy?.close();
     throw error;
   }
+
   db.exec("BEGIN IMMEDIATE");
+
   try {
     db.prepare(
       `INSERT INTO reviews (review_id, review_dir, record_json) VALUES (?, ?, ?)
@@ -237,6 +264,7 @@ export function importLegacyReview(
          review_dir = excluded.review_dir,
          record_json = COALESCE(reviews.record_json, excluded.record_json)`,
     ).run(reviewId, path.resolve(reviewDir), recordJson);
+
     if (legacy) importLegacyCommentRows(db, legacy, reviewId);
     db.prepare(
       "INSERT INTO legacy_review_imports (review_id, imported_at) VALUES (?, ?)",
@@ -263,12 +291,15 @@ function importLegacyCommentRows(
         .all() as Array<{ name: string }>
     ).map((row) => row.name),
   );
+
   for (const table of ["comments", "comment_drafts"] as const) {
     if (!tables.has(table)) continue;
+
     const insert = target.prepare(
       `INSERT OR IGNORE INTO ${table}
        (review_id, route_path, thread_id, record_json) VALUES (?, '/', ?, ?)`,
     );
+
     // SAFETY: legacy Review v1-v6 tables declare both projected columns TEXT
     // NOT NULL; callers validate the legacy schema version before import.
     for (const row of legacy
@@ -284,6 +315,7 @@ export function deleteReviewState(
   home = reviewHomeForDir(reviewDir),
 ): void {
   const dbPath = reviewStateDbPath(home);
+
   if (!existsSync(dbPath)) return;
   openReviewStateDb(home)
     .prepare("DELETE FROM reviews WHERE review_id = ?")
@@ -298,5 +330,6 @@ export function closeAllReviewStateDatabases(): void {
       // Already closed.
     }
   }
+
   connections.clear();
 }

--- a/packages/progressive-review/src/review-state-db.ts
+++ b/packages/progressive-review/src/review-state-db.ts
@@ -1,0 +1,302 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import type { JsonValue } from "@dev.fast/review-protocol";
+import { parseJsonText } from "@dev.fast/review-protocol";
+
+import { devReviewHome } from "./review-storage";
+import { requireCurrentThreadDbSchema } from "./review-thread-db-schema";
+
+export const REVIEW_STATE_DB_FILENAME = "review.db";
+export const REVIEW_STATE_DB_SCHEMA_VERSION = 1;
+
+const REVIEW_STATE_DB_DDL = `
+CREATE TABLE IF NOT EXISTS review_state_meta (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+) STRICT;
+CREATE TABLE IF NOT EXISTS reviews (
+  review_id  TEXT PRIMARY KEY,
+  review_dir TEXT NOT NULL UNIQUE,
+  record_json TEXT CHECK (record_json IS NULL OR json_valid(record_json))
+) STRICT;
+CREATE TABLE IF NOT EXISTS documents (
+  review_id       TEXT NOT NULL REFERENCES reviews(review_id) ON DELETE CASCADE,
+  route_path      TEXT NOT NULL,
+  mode            TEXT NOT NULL CHECK (mode IN ('compiled', 'incremental')),
+  revision        INTEGER NOT NULL CHECK (revision >= 0),
+  source_hash     TEXT,
+  projection_json TEXT CHECK (projection_json IS NULL OR json_valid(projection_json)),
+  PRIMARY KEY (review_id, route_path)
+) STRICT;
+CREATE TABLE IF NOT EXISTS comments (
+  review_id   TEXT NOT NULL REFERENCES reviews(review_id) ON DELETE CASCADE,
+  route_path  TEXT NOT NULL,
+  thread_id   TEXT NOT NULL,
+  record_json TEXT NOT NULL CHECK (json_valid(record_json)),
+  status      TEXT GENERATED ALWAYS AS (json_extract(record_json, '$.status')) STORED,
+  PRIMARY KEY (review_id, route_path, thread_id)
+) STRICT;
+CREATE TABLE IF NOT EXISTS comment_drafts (
+  review_id   TEXT NOT NULL REFERENCES reviews(review_id) ON DELETE CASCADE,
+  route_path  TEXT NOT NULL,
+  thread_id   TEXT NOT NULL,
+  record_json TEXT NOT NULL CHECK (json_valid(record_json)),
+  PRIMARY KEY (review_id, route_path, thread_id)
+) STRICT;
+CREATE TABLE IF NOT EXISTS mutation_receipts (
+  review_id    TEXT NOT NULL REFERENCES reviews(review_id) ON DELETE CASCADE,
+  mutation_id  TEXT NOT NULL,
+  revision     INTEGER NOT NULL CHECK (revision >= 0),
+  response_json TEXT NOT NULL CHECK (json_valid(response_json)),
+  created_at   TEXT NOT NULL,
+  PRIMARY KEY (review_id, mutation_id)
+) STRICT;
+CREATE TABLE IF NOT EXISTS legacy_review_imports (
+  review_id  TEXT PRIMARY KEY REFERENCES reviews(review_id) ON DELETE CASCADE,
+  imported_at TEXT NOT NULL
+) STRICT;
+`;
+
+const connections = new Map<string, DatabaseSync>();
+
+export class ReviewStateDbVersionError extends Error {
+  override readonly name = "ReviewStateDbVersionError";
+
+  constructor(dbPath: string, found: string | null) {
+    super(
+      `Review state database ${dbPath} has schema version ` +
+        `${found ?? "(missing)"}; this version of Review supports ` +
+        `${REVIEW_STATE_DB_SCHEMA_VERSION}. Run \`review migrate apply\`.`,
+    );
+  }
+}
+
+export function reviewHomeForDir(reviewDir: string): string {
+  const parent = path.dirname(path.resolve(reviewDir));
+  return path.basename(parent) === "reviews"
+    ? path.dirname(parent)
+    : devReviewHome();
+}
+
+export function reviewStateDbPath(home = devReviewHome()): string {
+  return path.join(path.resolve(home), REVIEW_STATE_DB_FILENAME);
+}
+
+export function reviewIdForDir(reviewDir: string): string {
+  const reviewId = path.basename(path.resolve(reviewDir));
+  if (!reviewId)
+    throw new Error(`Review directory has no identifier: ${reviewDir}`);
+  return reviewId;
+}
+
+export function openReviewStateDb(home = devReviewHome()): DatabaseSync {
+  const dbPath = reviewStateDbPath(home);
+  const cached = connections.get(dbPath);
+  if (cached) return cached;
+  mkdirSync(path.dirname(dbPath), { recursive: true, mode: 0o700 });
+  const existed = existsSync(dbPath);
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec(
+      "PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; " +
+        "PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;",
+    );
+    if (!existed) {
+      db.exec(REVIEW_STATE_DB_DDL);
+      db.prepare(
+        "INSERT INTO review_state_meta (key, value) VALUES ('schema_version', ?)",
+      ).run(String(REVIEW_STATE_DB_SCHEMA_VERSION));
+    } else {
+      const version = readReviewStateDbSchemaVersion(db);
+      if (version !== String(REVIEW_STATE_DB_SCHEMA_VERSION)) {
+        throw new ReviewStateDbVersionError(dbPath, version);
+      }
+      db.exec(REVIEW_STATE_DB_DDL);
+    }
+  } catch (error) {
+    db.close();
+    throw error;
+  }
+  connections.set(dbPath, db);
+  return db;
+}
+
+export function readReviewStateDbSchemaVersion(
+  db: DatabaseSync,
+): string | null {
+  // SAFETY: sqlite_master projects the integer literal `present`.
+  const hasMeta = db
+    .prepare(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'review_state_meta'",
+    )
+    .get() as { present: number } | undefined;
+  if (!hasMeta) return null;
+  // SAFETY: review_state_meta.value is declared TEXT NOT NULL above.
+  return (
+    (
+      db
+        .prepare(
+          "SELECT value FROM review_state_meta WHERE key = 'schema_version'",
+        )
+        .get() as { value: string } | undefined
+    )?.value ?? null
+  );
+}
+
+export function ensureReviewRegistration(
+  reviewDir: string,
+  home = reviewHomeForDir(reviewDir),
+): void {
+  const db = openReviewStateDb(home);
+  db.prepare(
+    `INSERT INTO reviews (review_id, review_dir, record_json) VALUES (?, ?, NULL)
+     ON CONFLICT(review_id) DO UPDATE SET review_dir = excluded.review_dir`,
+  ).run(reviewIdForDir(reviewDir), path.resolve(reviewDir));
+}
+
+export function putReviewRecord(
+  reviewDir: string,
+  record: JsonValue,
+  home = reviewHomeForDir(reviewDir),
+): void {
+  const db = openReviewStateDb(home);
+  const reviewId = reviewIdForDir(reviewDir);
+  const recordJson = JSON.stringify(record);
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.prepare(
+      `INSERT INTO reviews (review_id, review_dir, record_json) VALUES (?, ?, ?)
+       ON CONFLICT(review_id) DO UPDATE SET
+         review_dir = excluded.review_dir,
+         record_json = excluded.record_json`,
+    ).run(reviewId, path.resolve(reviewDir), recordJson);
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+export function readReviewRecord(
+  reviewDir: string,
+  home = reviewHomeForDir(reviewDir),
+): JsonValue | null {
+  const dbPath = reviewStateDbPath(home);
+  const recordPath = path.join(reviewDir, "review.json");
+  if (!existsSync(dbPath) && !existsSync(recordPath)) return null;
+  // SAFETY: reviews.record_json is a nullable TEXT column in the schema above.
+  const row = openReviewStateDb(home)
+    .prepare("SELECT record_json FROM reviews WHERE review_id = ?")
+    .get(reviewIdForDir(reviewDir)) as
+    | { record_json: string | null }
+    | undefined;
+  if (row?.record_json) return parseJsonText(row.record_json);
+  if (!existsSync(recordPath)) return null;
+  // Discovery must not import comment records before their schema migration.
+  const record = parseJsonText(readFileSync(recordPath, "utf8"));
+  putReviewRecord(reviewDir, record, home);
+  return record;
+}
+
+export function importLegacyReview(
+  reviewDir: string,
+  home = reviewHomeForDir(reviewDir),
+): void {
+  const reviewId = reviewIdForDir(reviewDir);
+  const recordPath = path.join(reviewDir, "review.json");
+  const legacyDbPath = path.join(reviewDir, REVIEW_STATE_DB_FILENAME);
+  if (!existsSync(recordPath) && !existsSync(legacyDbPath)) return;
+  const db = openReviewStateDb(home);
+  if (
+    db
+      .prepare("SELECT 1 FROM legacy_review_imports WHERE review_id = ?")
+      .get(reviewId)
+  ) {
+    return;
+  }
+  const recordJson = existsSync(recordPath)
+    ? readFileSync(recordPath, "utf8")
+    : null;
+  if (recordJson !== null) JSON.parse(recordJson);
+  const legacy = existsSync(legacyDbPath)
+    ? new DatabaseSync(legacyDbPath, { readOnly: true })
+    : null;
+  try {
+    if (legacy) requireCurrentThreadDbSchema(legacy, legacyDbPath);
+  } catch (error) {
+    legacy?.close();
+    throw error;
+  }
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.prepare(
+      `INSERT INTO reviews (review_id, review_dir, record_json) VALUES (?, ?, ?)
+       ON CONFLICT(review_id) DO UPDATE SET
+         review_dir = excluded.review_dir,
+         record_json = COALESCE(reviews.record_json, excluded.record_json)`,
+    ).run(reviewId, path.resolve(reviewDir), recordJson);
+    if (legacy) importLegacyCommentRows(db, legacy, reviewId);
+    db.prepare(
+      "INSERT INTO legacy_review_imports (review_id, imported_at) VALUES (?, ?)",
+    ).run(reviewId, new Date().toISOString());
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  } finally {
+    legacy?.close();
+  }
+}
+
+function importLegacyCommentRows(
+  target: DatabaseSync,
+  legacy: DatabaseSync,
+  reviewId: string,
+): void {
+  // SAFETY: sqlite_master.name is TEXT for every table row.
+  const tables = new Set(
+    (
+      legacy
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+        .all() as Array<{ name: string }>
+    ).map((row) => row.name),
+  );
+  for (const table of ["comments", "comment_drafts"] as const) {
+    if (!tables.has(table)) continue;
+    const insert = target.prepare(
+      `INSERT OR IGNORE INTO ${table}
+       (review_id, route_path, thread_id, record_json) VALUES (?, '/', ?, ?)`,
+    );
+    // SAFETY: legacy Review v1-v6 tables declare both projected columns TEXT
+    // NOT NULL; callers validate the legacy schema version before import.
+    for (const row of legacy
+      .prepare(`SELECT thread_id, record_json FROM ${table}`)
+      .all() as Array<{ thread_id: string; record_json: string }>) {
+      insert.run(reviewId, row.thread_id, row.record_json);
+    }
+  }
+}
+
+export function deleteReviewState(
+  reviewDir: string,
+  home = reviewHomeForDir(reviewDir),
+): void {
+  const dbPath = reviewStateDbPath(home);
+  if (!existsSync(dbPath)) return;
+  openReviewStateDb(home)
+    .prepare("DELETE FROM reviews WHERE review_id = ?")
+    .run(reviewIdForDir(reviewDir));
+}
+
+export function closeAllReviewStateDatabases(): void {
+  for (const db of connections.values()) {
+    try {
+      db.close();
+    } catch {
+      // Already closed.
+    }
+  }
+  connections.clear();
+}

--- a/packages/progressive-review/src/review-state-store.test.ts
+++ b/packages/progressive-review/src/review-state-store.test.ts
@@ -8,7 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   appendReviewAgentMessage,
@@ -35,6 +35,7 @@ import type { ReviewSubmissionEvent, ThreadTarget } from "./types";
 const roots: string[] = [];
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   closeAllReviewThreadStores();
   for (const root of roots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
@@ -54,7 +55,9 @@ const target: ThreadTarget = {
 };
 
 function makeReviewPath(): string {
-  const reviewPath = path.join(tempRoot(), "current", "review.mdx");
+  const root = tempRoot();
+  vi.stubEnv("DEV_REVIEW_HOME", root);
+  const reviewPath = path.join(root, "reviews", "current", "review.mdx");
   return reviewPath;
 }
 

--- a/packages/progressive-review/src/review-state-store.test.ts
+++ b/packages/progressive-review/src/review-state-store.test.ts
@@ -37,6 +37,7 @@ const roots: string[] = [];
 afterEach(() => {
   vi.unstubAllEnvs();
   closeAllReviewThreadStores();
+
   for (const root of roots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
   }
@@ -45,6 +46,7 @@ afterEach(() => {
 function tempRoot(): string {
   const root = mkdtempSync(path.join(tmpdir(), "review-state-store-"));
   roots.push(root);
+
   return root;
 }
 
@@ -58,6 +60,7 @@ function makeReviewPath(): string {
   const root = tempRoot();
   vi.stubEnv("DEV_REVIEW_HOME", root);
   const reviewPath = path.join(root, "reviews", "current", "review.mdx");
+
   return reviewPath;
 }
 
@@ -73,9 +76,11 @@ describe("reviewStateDir", () => {
       "3b241101-e2bb-4255-8caf-4136c566a962",
       "review.mdx",
     );
+
     expect(reviewStateDir(mdx)).toBe(path.dirname(mdx));
   });
 });
+
 describe("comment persistence", () => {
   it("returns an empty map before anything is written", () => {
     const reviewPath = makeReviewPath();
@@ -92,6 +97,7 @@ describe("comment persistence", () => {
       body: "First note",
       author: "Reviewer",
     });
+
     expect(created.threadId).toBe("thread-a");
     expect(created.thread.status).toBe("open");
     expect(created.thread.messages).toHaveLength(1);
@@ -137,6 +143,7 @@ describe("comment persistence", () => {
       body: "First delivery",
       author: "Reviewer",
     });
+
     const retried = appendReviewComment(reviewPath, {
       threadId: "thread-a",
       messageId: "message-a1",
@@ -144,6 +151,7 @@ describe("comment persistence", () => {
       body: "Retry body is ignored",
       author: "Reviewer",
     });
+
     expect(retried.thread.messages).toHaveLength(1);
     expect(retried.thread.messages[0]?.body).toBe("First delivery");
   });
@@ -357,12 +365,14 @@ describe("comment persistence", () => {
 describe("agent comment messages", () => {
   it("keeps agent replies out of inputs before and after submission", () => {
     const reviewPath = makeReviewPath();
+
     const input = {
       threadId: "thread-agent",
       messageId: "message-reviewer",
       target,
       body: "Why does this work?",
     };
+
     appendReviewCommentDraft(reviewPath, { ...input, author: "Reviewer" });
 
     expect(
@@ -426,6 +436,7 @@ describe("document history + submission audit", () => {
 
   it("appends a submission event to the audit trail", () => {
     const reviewPath = path.join(tempRoot(), "current", "review.mdx");
+
     const event: ReviewSubmissionEvent = {
       id: "submission-1",
       decision: "request-changes",

--- a/packages/progressive-review/src/review-thread-db-schema.ts
+++ b/packages/progressive-review/src/review-thread-db-schema.ts
@@ -1,0 +1,39 @@
+import type { DatabaseSync } from "node:sqlite";
+
+export const REVIEW_THREAD_DB_SCHEMA_VERSION = 9;
+
+export class ReviewThreadDbVersionError extends Error {
+  override readonly name = "ReviewThreadDbVersionError";
+
+  constructor(dbPath: string, found: string | null) {
+    super(
+      `Review thread database ${dbPath} has schema version ` +
+        `${found ?? "(missing)"}; this version of Review supports ` +
+        `${REVIEW_THREAD_DB_SCHEMA_VERSION}. Run \`review migrate apply\`.`,
+    );
+  }
+}
+
+export function readThreadDbSchemaVersion(db: DatabaseSync): string | null {
+  // SAFETY: the query projects the integer literal `present`.
+  const hasMeta = db
+    .prepare(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'meta'",
+    )
+    .get() as { present: number } | undefined;
+  if (!hasMeta) return null;
+  // SAFETY: the legacy meta table declares value TEXT NOT NULL.
+  const row = db
+    .prepare("SELECT value FROM meta WHERE key = 'schema_version'")
+    .get() as { value: string } | undefined;
+  return row?.value ?? null;
+}
+
+export function requireCurrentThreadDbSchema(
+  db: DatabaseSync,
+  dbPath: string,
+): void {
+  const version = readThreadDbSchemaVersion(db);
+  if (version !== String(REVIEW_THREAD_DB_SCHEMA_VERSION))
+    throw new ReviewThreadDbVersionError(dbPath, version);
+}

--- a/packages/progressive-review/src/review-thread-db-schema.ts
+++ b/packages/progressive-review/src/review-thread-db-schema.ts
@@ -21,11 +21,14 @@ export function readThreadDbSchemaVersion(db: DatabaseSync): string | null {
       "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'meta'",
     )
     .get() as { present: number } | undefined;
+
   if (!hasMeta) return null;
+
   // SAFETY: the legacy meta table declares value TEXT NOT NULL.
   const row = db
     .prepare("SELECT value FROM meta WHERE key = 'schema_version'")
     .get() as { value: string } | undefined;
+
   return row?.value ?? null;
 }
 
@@ -34,6 +37,7 @@ export function requireCurrentThreadDbSchema(
   dbPath: string,
 ): void {
   const version = readThreadDbSchemaVersion(db);
+
   if (version !== String(REVIEW_THREAD_DB_SCHEMA_VERSION))
     throw new ReviewThreadDbVersionError(dbPath, version);
 }

--- a/packages/progressive-review/src/review-thread-store-backend.test.ts
+++ b/packages/progressive-review/src/review-thread-store-backend.test.ts
@@ -18,8 +18,10 @@ import {
   REVIEW_THREAD_DB_SCHEMA_VERSION,
   ReviewThreadDbVersionError,
   closeAllReviewThreadStores,
+  createLegacyReviewThreadDb,
   createReviewThreadDb,
   hasPendingReviewAgentWrites,
+  legacyReviewThreadDbPath,
   migrateReviewThreadDb,
   readReviewThreadsReadOnly,
   reviewThreadDbPath,
@@ -30,6 +32,7 @@ const roots: string[] = [];
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   closeAllReviewThreadStores();
   for (const root of roots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
@@ -39,7 +42,8 @@ afterEach(() => {
 function makeReviewPath(): string {
   const root = mkdtempSync(path.join(tmpdir(), "review-thread-backend-"));
   roots.push(root);
-  const dir = path.join(root, "review");
+  vi.stubEnv("DEV_REVIEW_HOME", root);
+  const dir = path.join(root, "reviews", "review");
   mkdirSync(dir, { recursive: true });
   return path.join(dir, "review.mdx");
 }
@@ -52,6 +56,15 @@ function seedComment(reviewPath: string): void {
     body: "note",
     author: "Reviewer",
   });
+}
+
+function seedLegacyComment(reviewPath: string): void {
+  createLegacyReviewThreadDb(path.dirname(reviewPath));
+  const db = new DatabaseSync(legacyReviewThreadDbPath(reviewPath));
+  db.prepare(
+    "INSERT INTO comments (thread_id, record_json) VALUES ('thread-1', ?)",
+  ).run(JSON.stringify({ messages: [] }));
+  db.close();
 }
 
 describe("sqlite thread store", () => {
@@ -79,8 +92,8 @@ describe("sqlite thread store", () => {
   it("reads committed WAL threads without changing original DB, WAL or SHM bytes", () => {
     const source = makeReviewPath();
     seedComment(source);
-    const target = makeReviewPath();
     const sourceDb = reviewThreadDbPath(source);
+    const target = makeReviewPath();
     const targetDb = reviewThreadDbPath(target);
     const suffixes = ["", "-wal", "-shm"];
     for (const suffix of suffixes)
@@ -111,7 +124,7 @@ describe("sqlite thread store", () => {
     expect(readFileSync(dbPath)).toEqual(before);
     const db = new DatabaseSync(dbPath);
     db.prepare(
-      "INSERT INTO comments(thread_id, record_json) VALUES (?, ?)",
+      "INSERT INTO comments(review_id, route_path, thread_id, record_json) VALUES ('review', '/', ?, ?)",
     ).run("broken", "{}");
     db.close();
     const malformed = readFileSync(dbPath);
@@ -164,8 +177,8 @@ describe("sqlite thread store", () => {
 
   it("rejects a database with an unsupported schema version", () => {
     const reviewPath = makeReviewPath();
-    const dbPath = reviewThreadDbPath(reviewPath);
-    createReviewThreadDb(path.dirname(reviewPath));
+    const dbPath = legacyReviewThreadDbPath(reviewPath);
+    createLegacyReviewThreadDb(path.dirname(reviewPath));
     const db = new DatabaseSync(dbPath);
     db.prepare(
       "UPDATE meta SET value = '999' WHERE key = 'schema_version'",
@@ -178,8 +191,8 @@ describe("sqlite thread store", () => {
 
   it("drops the question table through the managed v2 upgrade", async () => {
     const reviewPath = makeReviewPath();
-    const dbPath = reviewThreadDbPath(reviewPath);
-    createReviewThreadDb(path.dirname(reviewPath));
+    const dbPath = legacyReviewThreadDbPath(reviewPath);
+    createLegacyReviewThreadDb(path.dirname(reviewPath));
     closeAllReviewThreadStores();
     const db = new DatabaseSync(dbPath);
     db.exec(`
@@ -211,8 +224,8 @@ describe("sqlite thread store", () => {
 
   it("normalizes message markers and removes native provenance", async () => {
     const reviewPath = makeReviewPath();
-    const dbPath = reviewThreadDbPath(reviewPath);
-    createReviewThreadDb(path.dirname(reviewPath));
+    const dbPath = legacyReviewThreadDbPath(reviewPath);
+    createLegacyReviewThreadDb(path.dirname(reviewPath));
     closeAllReviewThreadStores();
     const db = new DatabaseSync(dbPath);
     db.prepare(
@@ -464,8 +477,8 @@ describe("sqlite thread store", () => {
 
   it("drops a malformed database record and emits a diagnostic", () => {
     const reviewPath = makeReviewPath();
-    const dbPath = reviewThreadDbPath(reviewPath);
-    createReviewThreadDb(path.dirname(reviewPath));
+    const dbPath = legacyReviewThreadDbPath(reviewPath);
+    createLegacyReviewThreadDb(path.dirname(reviewPath));
     const db = new DatabaseSync(dbPath);
     db.prepare(
       "INSERT INTO comments (thread_id, record_json) VALUES (?, ?)",
@@ -479,11 +492,16 @@ describe("sqlite thread store", () => {
     );
 
     closeAllReviewThreadStores();
-    const reopened = new DatabaseSync(dbPath);
+    const reopened = new DatabaseSync(reviewThreadDbPath(reviewPath));
     expect(
       reopened.prepare("SELECT count(*) AS count FROM comments").get(),
     ).toEqual({ count: 0 });
     reopened.close();
+    const legacy = new DatabaseSync(dbPath, { readOnly: true });
+    expect(
+      legacy.prepare("SELECT count(*) AS count FROM comments").get(),
+    ).toEqual({ count: 1 });
+    legacy.close();
   });
 });
 
@@ -497,7 +515,7 @@ it.each(pendingWriteCases)(
   "inspects pending $table in schema $version without changing files",
   ({ version, table }) => {
     const reviewPath = makeReviewPath();
-    seedComment(reviewPath);
+    seedLegacyComment(reviewPath);
     closeAllReviewThreadStores();
     const dbPath = reviewThreadDbPath(reviewPath);
     const db = new DatabaseSync(dbPath);
@@ -552,21 +570,16 @@ it("detects pending WAL writes without changing source DB, WAL or SHM bytes", ()
     author: "Reviewer",
     agentInput: true,
   });
+  const sourceDb = reviewThreadDbPath(source);
   const target = makeReviewPath();
+  const targetDb = reviewThreadDbPath(target);
   const suffixes = ["", "-wal", "-shm"];
   for (const suffix of suffixes)
-    copyFileSync(
-      `${reviewThreadDbPath(source)}${suffix}`,
-      `${reviewThreadDbPath(target)}${suffix}`,
-    );
-  const before = suffixes.map((suffix) =>
-    readFileSync(`${reviewThreadDbPath(target)}${suffix}`),
-  );
+    copyFileSync(`${sourceDb}${suffix}`, `${targetDb}${suffix}`);
+  const before = suffixes.map((suffix) => readFileSync(`${targetDb}${suffix}`));
   expect(hasPendingReviewAgentWrites(target)).toBe(true);
   expect(
-    suffixes.map((suffix) =>
-      readFileSync(`${reviewThreadDbPath(target)}${suffix}`),
-    ),
+    suffixes.map((suffix) => readFileSync(`${targetDb}${suffix}`)),
   ).toEqual(before);
 });
 
@@ -574,9 +587,9 @@ it.each([null, "", "09", "invalid", "10", "999"])(
   "rejects unsupported schema %s without changing the database",
   (version) => {
     const reviewPath = makeReviewPath();
-    seedComment(reviewPath);
+    seedLegacyComment(reviewPath);
     closeAllReviewThreadStores();
-    const dbPath = reviewThreadDbPath(reviewPath);
+    const dbPath = legacyReviewThreadDbPath(reviewPath);
     const db = new DatabaseSync(dbPath);
     if (version === null)
       db.exec("DELETE FROM meta WHERE key = 'schema_version'");
@@ -595,7 +608,7 @@ it.each([null, "", "09", "invalid", "10", "999"])(
 
 it("rejects unknown database versions and malformed message arrays during pending-write inspection", () => {
   const reviewPath = makeReviewPath();
-  seedComment(reviewPath);
+  seedLegacyComment(reviewPath);
   closeAllReviewThreadStores();
   const db = new DatabaseSync(reviewThreadDbPath(reviewPath));
   db.exec("UPDATE meta SET value = '999' WHERE key = 'schema_version'");

--- a/packages/progressive-review/src/review-thread-store-backend.test.ts
+++ b/packages/progressive-review/src/review-thread-store-backend.test.ts
@@ -324,9 +324,9 @@ describe("sqlite thread store", () => {
     "preserves saved and draft conversations upgrading $version $boundary",
     async ({ version, boundary }) => {
       const reviewPath = makeReviewPath();
-      createReviewThreadDb(path.dirname(reviewPath));
+      createLegacyReviewThreadDb(path.dirname(reviewPath));
       closeAllReviewThreadStores();
-      const db = new DatabaseSync(reviewThreadDbPath(reviewPath));
+      const db = new DatabaseSync(legacyReviewThreadDbPath(reviewPath));
       const records = ["codex", "claude-code", "pi", "opencode"].map(
         (harness) => ({
           threadId: harness,
@@ -391,7 +391,7 @@ describe("sqlite thread store", () => {
 
       await migrateReviewThreadDb(reviewPath);
       const comments = readReviewComments(reviewPath);
-      const upgraded = new DatabaseSync(reviewThreadDbPath(reviewPath));
+      const upgraded = new DatabaseSync(legacyReviewThreadDbPath(reviewPath));
       for (const original of records) {
         const comment = comments[original.threadId];
         expect(comment).toEqual({
@@ -421,9 +421,22 @@ describe("sqlite thread store", () => {
 
   it("leaves every record and version unchanged if a binding is invalid", async () => {
     const reviewPath = makeReviewPath();
-    seedComment(reviewPath);
+    createLegacyReviewThreadDb(path.dirname(reviewPath));
+    const seed = new DatabaseSync(legacyReviewThreadDbPath(reviewPath));
+    seed
+      .prepare("INSERT INTO comments (thread_id, record_json) VALUES (?, ?)")
+      .run(
+        "thread-1",
+        JSON.stringify({
+          threadId: "thread-1",
+          target: { kind: "document" },
+          status: "open",
+          messages: [],
+        }),
+      );
+    seed.close();
     closeAllReviewThreadStores();
-    const db = new DatabaseSync(reviewThreadDbPath(reviewPath));
+    const db = new DatabaseSync(legacyReviewThreadDbPath(reviewPath));
     const original = db
       .prepare("SELECT record_json FROM comments WHERE thread_id = 'thread-1'")
       .get() as { record_json: string };
@@ -442,7 +455,7 @@ describe("sqlite thread store", () => {
     await expect(migrateReviewThreadDb(reviewPath)).rejects.toThrow(
       "sessionId",
     );
-    const unchanged = new DatabaseSync(reviewThreadDbPath(reviewPath));
+    const unchanged = new DatabaseSync(legacyReviewThreadDbPath(reviewPath));
     expect(
       unchanged
         .prepare(

--- a/packages/progressive-review/src/review-thread-store-backend.test.ts
+++ b/packages/progressive-review/src/review-thread-store-backend.test.ts
@@ -34,6 +34,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
   closeAllReviewThreadStores();
+
   for (const root of roots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
   }
@@ -45,6 +46,7 @@ function makeReviewPath(): string {
   vi.stubEnv("DEV_REVIEW_HOME", root);
   const dir = path.join(root, "reviews", "review");
   mkdirSync(dir, { recursive: true });
+
   return path.join(dir, "review.mdx");
 }
 
@@ -96,11 +98,14 @@ describe("sqlite thread store", () => {
     const target = makeReviewPath();
     const targetDb = reviewThreadDbPath(target);
     const suffixes = ["", "-wal", "-shm"];
+
     for (const suffix of suffixes)
       copyFileSync(`${sourceDb}${suffix}`, `${targetDb}${suffix}`);
+
     const before = suffixes.map((suffix) =>
       readFileSync(`${targetDb}${suffix}`),
     );
+
     expect(
       readReviewThreadsReadOnly(target).comments["thread-1"]?.messages,
     ).toHaveLength(1);
@@ -327,6 +332,7 @@ describe("sqlite thread store", () => {
       createLegacyReviewThreadDb(path.dirname(reviewPath));
       closeAllReviewThreadStores();
       const db = new DatabaseSync(legacyReviewThreadDbPath(reviewPath));
+
       const records = ["codex", "claude-code", "pi", "opencode"].map(
         (harness) => ({
           threadId: harness,
@@ -364,6 +370,7 @@ describe("sqlite thread store", () => {
           ],
         }),
       );
+
       const drafts = records.map((thread) => ({
         thread,
         inputs: [
@@ -376,10 +383,12 @@ describe("sqlite thread store", () => {
           },
         ],
       }));
+
       for (const record of records)
         db.prepare(
           "INSERT INTO comments (thread_id, record_json) VALUES (?, ?)",
         ).run(record.threadId, JSON.stringify(record));
+
       for (const draft of drafts)
         db.prepare(
           "INSERT INTO comment_drafts (thread_id, record_json) VALUES (?, ?)",
@@ -392,6 +401,7 @@ describe("sqlite thread store", () => {
       await migrateReviewThreadDb(reviewPath);
       const comments = readReviewComments(reviewPath);
       const upgraded = new DatabaseSync(legacyReviewThreadDbPath(reviewPath));
+
       for (const original of records) {
         const comment = comments[original.threadId];
         expect(comment).toEqual({
@@ -404,9 +414,11 @@ describe("sqlite thread store", () => {
             ({ agentMessage: _obsolete, ...message }) => message,
           ),
         });
+
         const row = upgraded
           .prepare("SELECT record_json FROM comment_drafts WHERE thread_id = ?")
           .get(original.threadId) as { record_json: string };
+
         expect(JSON.parse(row.record_json)).toEqual({
           thread: comment,
           inputs: drafts.find(
@@ -414,6 +426,7 @@ describe("sqlite thread store", () => {
           )!.inputs,
         });
       }
+
       upgraded.close();
       await expect(migrateReviewThreadDb(reviewPath)).resolves.toBe("current");
     },
@@ -437,14 +450,17 @@ describe("sqlite thread store", () => {
     seed.close();
     closeAllReviewThreadStores();
     const db = new DatabaseSync(legacyReviewThreadDbPath(reviewPath));
+
     const original = db
       .prepare("SELECT record_json FROM comments WHERE thread_id = 'thread-1'")
       .get() as { record_json: string };
+
     const broken = {
       ...JSON.parse(original.record_json),
       threadId: "broken",
       agentSession: { harness: "pi", sessionId: "", firstMessageId: "ask" },
     };
+
     db.prepare(
       "INSERT INTO comments (thread_id, record_json) VALUES (?, ?)",
     ).run("broken", JSON.stringify(broken));
@@ -520,10 +536,11 @@ describe("sqlite thread store", () => {
 
 const pendingWriteCases = ["1", "2", "3", "4", "5", "6", "7", "8", "9"].flatMap(
   (version) =>
-    (["comments", "comment_drafts"] as const)
-      .filter((table) => version !== "1" || table === "comments")
-      .map((table) => ({ version, table })),
+    (["comments", "comment_drafts"] as const).flatMap((table) =>
+      version !== "1" || table === "comments" ? [{ version, table }] : [],
+    ),
 );
+
 it.each(pendingWriteCases)(
   "inspects pending $table in schema $version without changing files",
   ({ version, table }) => {
@@ -536,8 +553,10 @@ it.each(pendingWriteCases)(
       version,
     );
     db.exec("DELETE FROM comments; DELETE FROM comment_drafts;");
+
     if (version === "1") db.exec("DROP TABLE comment_drafts");
     db.close();
+
     for (const { messages, pending } of [
       { messages: [], pending: false },
       { messages: [{ role: "reviewer", agentInput: false }], pending: false },
@@ -587,6 +606,7 @@ it("detects pending WAL writes without changing source DB, WAL or SHM bytes", ()
   const target = makeReviewPath();
   const targetDb = reviewThreadDbPath(target);
   const suffixes = ["", "-wal", "-shm"];
+
   for (const suffix of suffixes)
     copyFileSync(`${sourceDb}${suffix}`, `${targetDb}${suffix}`);
   const before = suffixes.map((suffix) => readFileSync(`${targetDb}${suffix}`));
@@ -604,6 +624,7 @@ it.each([null, "", "09", "invalid", "10", "999"])(
     closeAllReviewThreadStores();
     const dbPath = legacyReviewThreadDbPath(reviewPath);
     const db = new DatabaseSync(dbPath);
+
     if (version === null)
       db.exec("DELETE FROM meta WHERE key = 'schema_version'");
     else

--- a/packages/progressive-review/src/review-thread-store-backend.ts
+++ b/packages/progressive-review/src/review-thread-store-backend.ts
@@ -26,17 +26,39 @@ import {
 } from "@dev.fast/review-protocol";
 import { z } from "zod";
 
+import {
+  REVIEW_THREAD_DB_SCHEMA_VERSION,
+  ReviewThreadDbVersionError,
+  readThreadDbSchemaVersion,
+  requireCurrentThreadDbSchema,
+} from "./review-thread-db-schema";
+export {
+  REVIEW_THREAD_DB_SCHEMA_VERSION,
+  ReviewThreadDbVersionError,
+} from "./review-thread-db-schema";
+
+import {
+  REVIEW_STATE_DB_SCHEMA_VERSION,
+  ReviewStateDbVersionError,
+  closeAllReviewStateDatabases,
+  ensureReviewRegistration,
+  importLegacyReview,
+  openReviewStateDb,
+  readReviewStateDbSchemaVersion,
+  reviewHomeForDir,
+  reviewIdForDir,
+  reviewStateDbPath,
+} from "./review-state-db";
 import type {
   ReviewCommentDraftThreadMap,
   ReviewCommentThreadMap,
 } from "./types";
 
-// The review thread store persists comments in a per-review SQLite database.
-// Its synchronous mutators rely on read-modify-write with no interleaving
-// await. See review-state-store.ts.
+// Comments for every review share the Review home database. All queries are
+// scoped by review_id and route_path; the per-review review.db name is retained
+// only as a legacy migration input.
 
 export const REVIEW_THREAD_DB_FILENAME = "review.db";
-export const REVIEW_THREAD_DB_SCHEMA_VERSION = 9;
 const LEGACY_THREAD_DB_SCHEMA_VERSIONS = new Set([
   "1",
   "2",
@@ -60,19 +82,29 @@ export function reviewStateDir(reviewMdxPath: string): string {
 }
 
 export function reviewThreadDbPath(reviewMdxPath: string): string {
-  return path.join(reviewStateDir(reviewMdxPath), REVIEW_THREAD_DB_FILENAME);
+  const shared = reviewStateDbPath(
+    reviewHomeForDir(reviewStateDir(reviewMdxPath)),
+  );
+  const legacy = legacyReviewThreadDbPath(reviewMdxPath);
+  if (!existsSync(legacy)) return shared;
+  if (!existsSync(shared)) return legacy;
+  const imported = withDatabaseSnapshot(shared, (snapshotPath) => {
+    const db = new DatabaseSync(snapshotPath, { readOnly: true });
+    try {
+      return Boolean(
+        db
+          .prepare("SELECT 1 FROM legacy_review_imports WHERE review_id = ?")
+          .get(reviewIdForDir(reviewStateDir(reviewMdxPath))),
+      );
+    } finally {
+      db.close();
+    }
+  });
+  return imported ? shared : legacy;
 }
 
-export class ReviewThreadDbVersionError extends Error {
-  override readonly name = "ReviewThreadDbVersionError";
-
-  constructor(dbPath: string, found: string | null) {
-    super(
-      `Review thread database ${dbPath} has schema version ` +
-        `${found ?? "(missing)"}; this version of Review supports ` +
-        `${REVIEW_THREAD_DB_SCHEMA_VERSION}. Run \`review migrate apply\`.`,
-    );
-  }
+export function legacyReviewThreadDbPath(reviewMdxPath: string): string {
+  return path.join(reviewStateDir(reviewMdxPath), REVIEW_THREAD_DB_FILENAME);
 }
 
 export interface ReviewThreadStoreBackend {
@@ -162,33 +194,12 @@ function openThreadDb(
   return db;
 }
 
-function readThreadDbSchemaVersion(db: DatabaseSync): string | null {
-  // SAFETY: the query projects the single integer column `present`.
-  const hasMeta = db
-    .prepare(
-      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'meta'",
-    )
-    .get() as { present: number } | undefined;
-  if (!hasMeta) return null;
-  // SAFETY: meta.value is a TEXT NOT NULL column (see REVIEW_THREAD_DB_DDL).
-  return (
-    (
-      db
-        .prepare("SELECT value FROM meta WHERE key = 'schema_version'")
-        .get() as { value: string } | undefined
-    )?.value ?? null
-  );
-}
-
 export function checkReviewThreadDbVersion(reviewMdxPath: string): void {
-  const dbPath = reviewThreadDbPath(reviewMdxPath);
+  const dbPath = legacyReviewThreadDbPath(reviewMdxPath);
   if (!existsSync(dbPath)) return;
   const db = new DatabaseSync(dbPath, { readOnly: true });
   try {
-    const version = readThreadDbSchemaVersion(db);
-    if (version !== String(REVIEW_THREAD_DB_SCHEMA_VERSION)) {
-      throw new ReviewThreadDbVersionError(dbPath, version);
-    }
+    requireCurrentThreadDbSchema(db, dbPath);
   } finally {
     db.close();
   }
@@ -224,7 +235,13 @@ export function reviewThreadDbSnapshotToken(reviewMdxPath: string): string {
 export function readReviewThreadsReadOnly(
   reviewMdxPath: string,
 ): ReviewThreadsReadOnlySnapshot {
-  return withThreadDatabaseSnapshot(reviewMdxPath, readThreadDatabaseSnapshot);
+  return withThreadDatabaseSnapshot(reviewMdxPath, (snapshotPath, dbPath) =>
+    readThreadDatabaseSnapshot(
+      snapshotPath,
+      dbPath,
+      reviewIdForDir(reviewStateDir(reviewMdxPath)),
+    ),
+  );
 }
 
 function withThreadDatabaseSnapshot<T>(
@@ -232,6 +249,13 @@ function withThreadDatabaseSnapshot<T>(
   read: (snapshotPath: string, dbPath: string) => T,
 ): T {
   const dbPath = reviewThreadDbPath(reviewMdxPath);
+  return withDatabaseSnapshot(dbPath, read);
+}
+
+function withDatabaseSnapshot<T>(
+  dbPath: string,
+  read: (snapshotPath: string, dbPath: string) => T,
+): T {
   if (!existsSync(dbPath))
     throw new Error("The review thread database is unavailable.");
   const snapshot = stableThreadDatabaseSnapshot(dbPath);
@@ -275,9 +299,33 @@ export function copyReviewThreadDatabaseSnapshot(
   const snapshot = stableThreadDatabaseSnapshot(
     reviewThreadDbPath(reviewMdxPath),
   );
-  const destination = reviewThreadDbPath(destinationReviewMdxPath);
-  writeFileSync(destination, snapshot.database);
-  if (snapshot.wal) writeFileSync(`${destination}-wal`, snapshot.wal);
+  const destination = legacyReviewThreadDbPath(destinationReviewMdxPath);
+  if (
+    reviewThreadDbPath(reviewMdxPath) !==
+    legacyReviewThreadDbPath(reviewMdxPath)
+  ) {
+    const threads = readReviewThreadsReadOnly(reviewMdxPath);
+    createLegacyReviewThreadDb(reviewStateDir(destinationReviewMdxPath));
+    const db = new DatabaseSync(destination);
+    try {
+      for (const [table, records] of [
+        ["comments", threads.comments],
+        ["comment_drafts", threads.drafts],
+      ] as const) {
+        const insert = db.prepare(
+          `INSERT INTO ${table} (thread_id, record_json) VALUES (?, ?)`,
+        );
+        for (const [id, record] of Object.entries(records))
+          insert.run(id, JSON.stringify(record));
+      }
+      db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    } finally {
+      db.close();
+    }
+  } else {
+    writeFileSync(destination, snapshot.database);
+    if (snapshot.wal) writeFileSync(`${destination}-wal`, snapshot.wal);
+  }
   return threadDatabaseFingerprint(snapshot);
 }
 
@@ -290,6 +338,14 @@ const PendingAgentThreadSchema = z.object({
   ),
 });
 
+function isSharedThreadDatabase(db: DatabaseSync, dbPath: string): boolean {
+  const version = readReviewStateDbSchemaVersion(db);
+  if (version === null) return false;
+  if (version !== String(REVIEW_STATE_DB_SCHEMA_VERSION))
+    throw new ReviewStateDbVersionError(dbPath, version);
+  return true;
+}
+
 /** Inspect only message ordering, so legacy targets and provider metadata do
  * not require a live database migration before artifacts can be repaired. */
 export function hasPendingReviewAgentWrites(reviewMdxPath: string): boolean {
@@ -297,7 +353,8 @@ export function hasPendingReviewAgentWrites(reviewMdxPath: string): boolean {
     const db = new DatabaseSync(snapshotPath, { readOnly: true });
     try {
       const version = readThreadDbSchemaVersion(db);
-      if (!isSupportedThreadDbVersion(version))
+      const shared = isSharedThreadDatabase(db, dbPath);
+      if (!shared && !isSupportedThreadDbVersion(version))
         throw new ReviewThreadDbVersionError(dbPath, version);
       const tables =
         version === "1"
@@ -305,8 +362,12 @@ export function hasPendingReviewAgentWrites(reviewMdxPath: string): boolean {
           : (["comments", "comment_drafts"] as const);
       for (const table of tables) {
         for (const raw of db
-          .prepare(`SELECT thread_id, record_json FROM ${table}`)
-          .all()) {
+          .prepare(
+            `SELECT thread_id, record_json FROM ${table}${shared ? " WHERE review_id = ? AND route_path = '/'" : ""}`,
+          )
+          .all(
+            ...(shared ? [reviewIdForDir(reviewStateDir(reviewMdxPath))] : []),
+          )) {
           const row = StoredThreadRowSchema.parse(raw);
           const value = parseJsonText(row.record_json);
           const thread = PendingAgentThreadSchema.parse(
@@ -369,17 +430,27 @@ function readThreadWal(walPath: string): Buffer | null {
 function readThreadDatabaseSnapshot(
   snapshotPath: string,
   dbPath: string,
+  reviewId: string,
 ): ReviewThreadsReadOnlySnapshot {
   const db = new DatabaseSync(snapshotPath, { readOnly: true });
   try {
     const version = readThreadDbSchemaVersion(db);
-    if (version !== String(REVIEW_THREAD_DB_SCHEMA_VERSION))
+    const shared = isSharedThreadDatabase(db, dbPath);
+    if (!shared && version !== String(REVIEW_THREAD_DB_SCHEMA_VERSION))
       throw new ReviewThreadDbVersionError(dbPath, version);
+    if (
+      shared &&
+      !db.prepare("SELECT 1 FROM reviews WHERE review_id = ?").get(reviewId)
+    ) {
+      throw new Error("The review thread database is unavailable.");
+    }
     const read = (table: "comments" | "comment_drafts"): JsonObject => {
       const result: JsonObject = {};
       for (const raw of db
-        .prepare(`SELECT thread_id, record_json FROM ${table}`)
-        .all()) {
+        .prepare(
+          `SELECT thread_id, record_json FROM ${table}${shared ? " WHERE review_id = ? AND route_path = '/'" : ""}`,
+        )
+        .all(...(shared ? [reviewId] : []))) {
         const row = StoredThreadRowSchema.parse(raw);
         result[row.thread_id] = parseJsonText(row.record_json);
       }
@@ -418,7 +489,7 @@ export async function migrateReviewThreadDb(
   reviewMdxPath: string,
   options: ReviewThreadDbMigrationOptions = {},
 ): Promise<ReviewThreadDbMigrationResult> {
-  const dbPath = reviewThreadDbPath(reviewMdxPath);
+  const dbPath = legacyReviewThreadDbPath(reviewMdxPath);
   if (!existsSync(dbPath)) return "missing";
   const cached = openDatabases.get(dbPath);
   if (cached) {
@@ -670,17 +741,25 @@ function hasLegacyCodeTargets(db: DatabaseSync): boolean {
 }
 
 function readThreadTable(
-  dbPath: string,
+  reviewDir: string,
   table: "comments" | "comment_drafts",
   keyColumn: "thread_id",
 ): JsonObject {
-  const db = openThreadDb(dbPath, { create: false });
-  if (!db) return {};
+  const dbPath = reviewStateDbPath(reviewHomeForDir(reviewDir));
+  const legacyDbPath = path.join(reviewDir, REVIEW_THREAD_DB_FILENAME);
+  if (!existsSync(dbPath) && !existsSync(legacyDbPath)) return {};
+  checkReviewThreadDbVersion(path.join(reviewDir, "review.mdx"));
+  importLegacyReview(reviewDir);
+  const db = openReviewStateDb(reviewHomeForDir(reviewDir));
+  const reviewId = reviewIdForDir(reviewDir);
   // SAFETY: the key column is the TEXT PRIMARY KEY and record_json is TEXT NOT
   // NULL in both tables, and every insert binds strings for them.
   const rows = db
-    .prepare(`SELECT ${keyColumn} AS key, record_json FROM ${table}`)
-    .all() as Array<{ key: string; record_json: string }>;
+    .prepare(
+      `SELECT ${keyColumn} AS key, record_json FROM ${table}
+       WHERE review_id = ? AND route_path = '/'`,
+    )
+    .all(reviewId) as Array<{ key: string; record_json: string }>;
   const result: JsonObject = {};
   for (const row of rows) {
     result[row.key] = parseJsonText(row.record_json);
@@ -689,21 +768,27 @@ function readThreadTable(
 }
 
 function writeThreadTable(
-  dbPath: string,
+  reviewDir: string,
   table: "comments" | "comment_drafts",
   keyColumn: "thread_id",
   value: ReviewCommentThreadMap | ReviewCommentDraftThreadMap,
 ): void {
-  const db = openThreadDb(dbPath, { create: true });
-  if (!db) throw new Error(`Could not open ${dbPath}.`);
+  checkReviewThreadDbVersion(path.join(reviewDir, "review.mdx"));
+  importLegacyReview(reviewDir);
+  ensureReviewRegistration(reviewDir);
+  const db = openReviewStateDb(reviewHomeForDir(reviewDir));
+  const reviewId = reviewIdForDir(reviewDir);
   const insert = db.prepare(
-    `INSERT INTO ${table} (${keyColumn}, record_json) VALUES (?, ?)`,
+    `INSERT INTO ${table}
+     (review_id, route_path, ${keyColumn}, record_json) VALUES (?, '/', ?, ?)`,
   );
   db.exec("BEGIN IMMEDIATE");
   try {
-    db.exec(`DELETE FROM ${table}`);
+    db.prepare(
+      `DELETE FROM ${table} WHERE review_id = ? AND route_path = '/'`,
+    ).run(reviewId);
     for (const [key, record] of Object.entries(value)) {
-      insert.run(key, JSON.stringify(record));
+      insert.run(reviewId, key, JSON.stringify(record));
     }
     db.exec("COMMIT");
   } catch (error) {
@@ -713,30 +798,38 @@ function writeThreadTable(
 }
 
 function writeCommentState(
-  dbPath: string,
+  reviewDir: string,
   comments: ReviewCommentThreadMap,
   drafts: ReviewCommentDraftThreadMap,
 ): void {
-  const db = openThreadDb(dbPath, { create: true });
-  if (!db) throw new Error(`Could not open ${dbPath}.`);
+  checkReviewThreadDbVersion(path.join(reviewDir, "review.mdx"));
+  importLegacyReview(reviewDir);
+  ensureReviewRegistration(reviewDir);
+  const db = openReviewStateDb(reviewHomeForDir(reviewDir));
+  const reviewId = reviewIdForDir(reviewDir);
   const insertComment = db.prepare(
-    "INSERT INTO comments (thread_id, record_json) VALUES (?, ?)",
+    "INSERT INTO comments (review_id, route_path, thread_id, record_json) VALUES (?, '/', ?, ?)",
   );
   const insertDraft = db.prepare(
-    "INSERT INTO comment_drafts (thread_id, record_json) VALUES (?, ?)",
+    "INSERT INTO comment_drafts (review_id, route_path, thread_id, record_json) VALUES (?, '/', ?, ?)",
   );
   db.exec("BEGIN IMMEDIATE");
   try {
-    db.exec("DELETE FROM comments; DELETE FROM comment_drafts;");
+    db.prepare(
+      "DELETE FROM comments WHERE review_id = ? AND route_path = '/'",
+    ).run(reviewId);
+    db.prepare(
+      "DELETE FROM comment_drafts WHERE review_id = ? AND route_path = '/'",
+    ).run(reviewId);
     for (const [threadId, record] of Object.entries(
       parseStoredReviewCommentThreadMap(comments),
     )) {
-      insertComment.run(threadId, JSON.stringify(record));
+      insertComment.run(reviewId, threadId, JSON.stringify(record));
     }
     for (const [threadId, record] of Object.entries(
       ReviewCommentDraftThreadMapSchema.parse(drafts),
     )) {
-      insertDraft.run(threadId, JSON.stringify(record));
+      insertDraft.run(reviewId, threadId, JSON.stringify(record));
     }
     db.exec("COMMIT");
   } catch (error) {
@@ -748,50 +841,54 @@ function writeCommentState(
 function sqliteThreadStoreBackend(
   reviewMdxPath: string,
 ): ReviewThreadStoreBackend {
-  const dbPath = reviewThreadDbPath(reviewMdxPath);
+  const reviewDir = reviewStateDir(reviewMdxPath);
   return {
-    readComments: () => readValidComments(dbPath),
+    readComments: () => readValidComments(reviewDir),
     writeComments: (comments) =>
       writeThreadTable(
-        dbPath,
+        reviewDir,
         "comments",
         "thread_id",
         parseStoredReviewCommentThreadMap(comments),
       ),
     readCommentDrafts: () =>
       ReviewCommentDraftThreadMapSchema.parse(
-        readThreadTable(dbPath, "comment_drafts", "thread_id"),
+        readThreadTable(reviewDir, "comment_drafts", "thread_id"),
       ),
     writeCommentDrafts: (drafts) =>
       writeThreadTable(
-        dbPath,
+        reviewDir,
         "comment_drafts",
         "thread_id",
         ReviewCommentDraftThreadMapSchema.parse(drafts),
       ),
     writeCommentState: (comments, drafts) =>
-      writeCommentState(dbPath, comments, drafts),
+      writeCommentState(reviewDir, comments, drafts),
   };
 }
 
-function readValidComments(dbPath: string): ReviewCommentThreadMap {
-  const stored = readThreadTable(dbPath, "comments", "thread_id");
+function readValidComments(reviewDir: string): ReviewCommentThreadMap {
+  const stored = readThreadTable(reviewDir, "comments", "thread_id");
   const comments = parseReviewCommentThreadMap(stored);
   const dropped = Object.keys(stored).filter((key) => !(key in comments));
   if (dropped.length === 0) return comments;
   console.error(
-    `[Review] Dropped ${dropped.length} malformed comment record${dropped.length === 1 ? "" : "s"} from ${dbPath}: ${dropped.join(", ")}`,
+    `[Review] Dropped ${dropped.length} malformed comment record${dropped.length === 1 ? "" : "s"} from ${reviewStateDbPath()}: ${dropped.join(", ")}`,
   );
-  writeThreadTable(dbPath, "comments", "thread_id", comments);
+  writeThreadTable(reviewDir, "comments", "thread_id", comments);
   return comments;
 }
 
-/**
- * Create an empty thread database. Called while scaffolding a fresh review dir
- * so the database's presence marks the review sqlite-first from birth. Not
- * cached: the scaffold may be rolled back (rm -rf) on a later failure.
- */
-export function createReviewThreadDb(reviewDir: string): void {
+/** Register a new Review in the shared database without a per-Review file. */
+export function createReviewThreadDb(
+  reviewDir: string,
+  reviewHome?: string,
+): void {
+  ensureReviewRegistration(reviewDir, reviewHome);
+}
+
+/** Create the old per-review database shape for migration tests and tools. */
+export function createLegacyReviewThreadDb(reviewDir: string): void {
   const dbPath = path.join(reviewDir, REVIEW_THREAD_DB_FILENAME);
   const cached = openDatabases.get(dbPath);
   if (cached) {
@@ -815,4 +912,5 @@ export function closeAllReviewThreadStores(): void {
     }
   }
   openDatabases.clear();
+  closeAllReviewStateDatabases();
 }

--- a/packages/progressive-review/src/review-thread-store-backend.ts
+++ b/packages/progressive-review/src/review-thread-store-backend.ts
@@ -32,6 +32,7 @@ import {
   readThreadDbSchemaVersion,
   requireCurrentThreadDbSchema,
 } from "./review-thread-db-schema";
+
 export {
   REVIEW_THREAD_DB_SCHEMA_VERSION,
   ReviewThreadDbVersionError,
@@ -59,6 +60,7 @@ import type {
 // only as a legacy migration input.
 
 export const REVIEW_THREAD_DB_FILENAME = "review.db";
+
 const LEGACY_THREAD_DB_SCHEMA_VERSIONS = new Set([
   "1",
   "2",
@@ -85,11 +87,16 @@ export function reviewThreadDbPath(reviewMdxPath: string): string {
   const shared = reviewStateDbPath(
     reviewHomeForDir(reviewStateDir(reviewMdxPath)),
   );
+
   const legacy = legacyReviewThreadDbPath(reviewMdxPath);
+
   if (!existsSync(legacy)) return shared;
+
   if (!existsSync(shared)) return legacy;
+
   const imported = withDatabaseSnapshot(shared, (snapshotPath) => {
     const db = new DatabaseSync(snapshotPath, { readOnly: true });
+
     try {
       return Boolean(
         db
@@ -100,6 +107,7 @@ export function reviewThreadDbPath(reviewMdxPath: string): string {
       db.close();
     }
   });
+
   return imported ? shared : legacy;
 }
 
@@ -154,6 +162,7 @@ CREATE TABLE IF NOT EXISTS comment_drafts (
 const REVIEW_THREAD_DB_V2_TO_V3_DDL = "DROP TABLE IF EXISTS questions;";
 
 const openDatabases = new Map<string, DatabaseSync>();
+
 const StoredThreadRowSchema = z.object({
   thread_id: z.string(),
   record_json: z.string(),
@@ -164,17 +173,23 @@ function openThreadDb(
   options: { create: boolean },
 ): DatabaseSync | null {
   const cached = openDatabases.get(dbPath);
+
   if (cached) return cached;
   const existed = existsSync(dbPath);
+
   if (!options.create && !existed) return null;
+
   if (options.create) {
     mkdirSync(path.dirname(dbPath), { recursive: true });
   }
+
   const db = new DatabaseSync(dbPath);
+
   try {
     db.exec(
       "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;",
     );
+
     if (!existed) {
       db.exec(REVIEW_THREAD_DB_DDL);
       db.prepare(
@@ -182,6 +197,7 @@ function openThreadDb(
       ).run(String(REVIEW_THREAD_DB_SCHEMA_VERSION));
     } else {
       const version = readThreadDbSchemaVersion(db);
+
       if (version !== String(REVIEW_THREAD_DB_SCHEMA_VERSION)) {
         throw new ReviewThreadDbVersionError(dbPath, version);
       }
@@ -190,14 +206,18 @@ function openThreadDb(
     db.close();
     throw error;
   }
+
   openDatabases.set(dbPath, db);
+
   return db;
 }
 
 export function checkReviewThreadDbVersion(reviewMdxPath: string): void {
   const dbPath = legacyReviewThreadDbPath(reviewMdxPath);
+
   if (!existsSync(dbPath)) return;
   const db = new DatabaseSync(dbPath, { readOnly: true });
+
   try {
     requireCurrentThreadDbSchema(db, dbPath);
   } finally {
@@ -219,14 +239,17 @@ export interface ReviewThreadsReadOnlySnapshot {
  * changes the database file or its write-ahead log. */
 export function reviewThreadDbSnapshotToken(reviewMdxPath: string): string {
   const dbPath = reviewThreadDbPath(reviewMdxPath);
+
   const stamp = (filePath: string): string => {
     try {
       const stats = statSync(filePath);
+
       return `${stats.ino}:${stats.size}:${stats.mtimeMs}`;
     } catch {
       return "absent";
     }
   };
+
   return `${stamp(dbPath)}|${stamp(`${dbPath}-wal`)}`;
 }
 
@@ -249,6 +272,7 @@ function withThreadDatabaseSnapshot<T>(
   read: (snapshotPath: string, dbPath: string) => T,
 ): T {
   const dbPath = reviewThreadDbPath(reviewMdxPath);
+
   return withDatabaseSnapshot(dbPath, read);
 }
 
@@ -260,10 +284,13 @@ function withDatabaseSnapshot<T>(
     throw new Error("The review thread database is unavailable.");
   const snapshot = stableThreadDatabaseSnapshot(dbPath);
   const snapshotDir = mkdtempSync(path.join(tmpdir(), "review-threads-read-"));
+
   try {
     const snapshotPath = path.join(snapshotDir, REVIEW_THREAD_DB_FILENAME);
     writeFileSync(snapshotPath, snapshot.database);
+
     if (snapshot.wal) writeFileSync(`${snapshotPath}-wal`, snapshot.wal);
+
     return read(snapshotPath, dbPath);
   } finally {
     rmSync(snapshotDir, { recursive: true, force: true });
@@ -299,7 +326,9 @@ export function copyReviewThreadDatabaseSnapshot(
   const snapshot = stableThreadDatabaseSnapshot(
     reviewThreadDbPath(reviewMdxPath),
   );
+
   const destination = legacyReviewThreadDbPath(destinationReviewMdxPath);
+
   if (
     reviewThreadDbPath(reviewMdxPath) !==
     legacyReviewThreadDbPath(reviewMdxPath)
@@ -307,6 +336,7 @@ export function copyReviewThreadDatabaseSnapshot(
     const threads = readReviewThreadsReadOnly(reviewMdxPath);
     createLegacyReviewThreadDb(reviewStateDir(destinationReviewMdxPath));
     const db = new DatabaseSync(destination);
+
     try {
       for (const [table, records] of [
         ["comments", threads.comments],
@@ -315,17 +345,21 @@ export function copyReviewThreadDatabaseSnapshot(
         const insert = db.prepare(
           `INSERT INTO ${table} (thread_id, record_json) VALUES (?, ?)`,
         );
+
         for (const [id, record] of Object.entries(records))
           insert.run(id, JSON.stringify(record));
       }
+
       db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
     } finally {
       db.close();
     }
   } else {
     writeFileSync(destination, snapshot.database);
+
     if (snapshot.wal) writeFileSync(`${destination}-wal`, snapshot.wal);
   }
+
   return threadDatabaseFingerprint(snapshot);
 }
 
@@ -340,9 +374,12 @@ const PendingAgentThreadSchema = z.object({
 
 function isSharedThreadDatabase(db: DatabaseSync, dbPath: string): boolean {
   const version = readReviewStateDbSchemaVersion(db);
+
   if (version === null) return false;
+
   if (version !== String(REVIEW_STATE_DB_SCHEMA_VERSION))
     throw new ReviewStateDbVersionError(dbPath, version);
+
   return true;
 }
 
@@ -351,15 +388,19 @@ function isSharedThreadDatabase(db: DatabaseSync, dbPath: string): boolean {
 export function hasPendingReviewAgentWrites(reviewMdxPath: string): boolean {
   return withThreadDatabaseSnapshot(reviewMdxPath, (snapshotPath, dbPath) => {
     const db = new DatabaseSync(snapshotPath, { readOnly: true });
+
     try {
       const version = readThreadDbSchemaVersion(db);
       const shared = isSharedThreadDatabase(db, dbPath);
+
       if (!shared && !isSupportedThreadDbVersion(version))
         throw new ReviewThreadDbVersionError(dbPath, version);
+
       const tables =
         version === "1"
           ? (["comments"] as const)
           : (["comments", "comment_drafts"] as const);
+
       for (const table of tables) {
         for (const raw of db
           .prepare(
@@ -370,16 +411,19 @@ export function hasPendingReviewAgentWrites(reviewMdxPath: string): boolean {
           )) {
           const row = StoredThreadRowSchema.parse(raw);
           const value = parseJsonText(row.record_json);
+
           const thread = PendingAgentThreadSchema.parse(
             table === "comment_drafts" && isJsonObject(value)
               ? value.thread
               : value,
           );
+
           const lastInput = thread.messages.reduce(
             (last, message, index) =>
               message.agentInput && message.role !== "agent" ? index : last,
             -1,
           );
+
           if (
             lastInput >= 0 &&
             !thread.messages
@@ -389,6 +433,7 @@ export function hasPendingReviewAgentWrites(reviewMdxPath: string): boolean {
             return true;
         }
       }
+
       return false;
     } finally {
       db.close();
@@ -401,9 +446,11 @@ function stableThreadDatabaseSnapshot(dbPath: string) {
     database: readFileSync(dbPath),
     wal: readThreadWal(`${dbPath}-wal`),
   });
+
   for (let attempt = 0; attempt < 3; attempt++) {
     const first = read();
     const second = read();
+
     if (
       first.database.equals(second.database) &&
       (first.wal === null
@@ -412,6 +459,7 @@ function stableThreadDatabaseSnapshot(dbPath: string) {
     )
       return second;
   }
+
   throw new Error(
     "The review thread database changed while taking a read-only snapshot; retry.",
   );
@@ -433,19 +481,24 @@ function readThreadDatabaseSnapshot(
   reviewId: string,
 ): ReviewThreadsReadOnlySnapshot {
   const db = new DatabaseSync(snapshotPath, { readOnly: true });
+
   try {
     const version = readThreadDbSchemaVersion(db);
     const shared = isSharedThreadDatabase(db, dbPath);
+
     if (!shared && version !== String(REVIEW_THREAD_DB_SCHEMA_VERSION))
       throw new ReviewThreadDbVersionError(dbPath, version);
+
     if (
       shared &&
       !db.prepare("SELECT 1 FROM reviews WHERE review_id = ?").get(reviewId)
     ) {
       throw new Error("The review thread database is unavailable.");
     }
+
     const read = (table: "comments" | "comment_drafts"): JsonObject => {
       const result: JsonObject = {};
+
       for (const raw of db
         .prepare(
           `SELECT thread_id, record_json FROM ${table}${shared ? " WHERE review_id = ? AND route_path = '/'" : ""}`,
@@ -454,8 +507,10 @@ function readThreadDatabaseSnapshot(
         const row = StoredThreadRowSchema.parse(raw);
         result[row.thread_id] = parseJsonText(row.record_json);
       }
+
       return result;
     };
+
     return {
       readOnly: true,
       revision: 0,
@@ -490,33 +545,43 @@ export async function migrateReviewThreadDb(
   options: ReviewThreadDbMigrationOptions = {},
 ): Promise<ReviewThreadDbMigrationResult> {
   const dbPath = legacyReviewThreadDbPath(reviewMdxPath);
+
   if (!existsSync(dbPath)) return "missing";
   const cached = openDatabases.get(dbPath);
+
   if (cached) {
     cached.close();
     openDatabases.delete(dbPath);
   }
+
   const db = new DatabaseSync(dbPath);
   let inTransaction = false;
+
   try {
     db.exec("PRAGMA busy_timeout = 5000; BEGIN IMMEDIATE;");
     inTransaction = true;
     const version = readThreadDbSchemaVersion(db);
+
     if (version === String(REVIEW_THREAD_DB_SCHEMA_VERSION)) {
       db.exec("COMMIT");
       inTransaction = false;
+
       return "current";
     }
+
     if (!isSupportedThreadDbVersion(version)) {
       throw new ReviewThreadDbVersionError(dbPath, version);
     }
+
     if (version === "1") db.exec(REVIEW_THREAD_DB_V1_TO_V2_DDL);
+
     if (
       (version === "1" || version === "2") &&
       !options.preserveLegacyQuestions
     ) {
       db.exec(REVIEW_THREAD_DB_V2_TO_V3_DDL);
     }
+
     if (hasLegacyCodeTargets(db)) {
       if (!options.migrateLegacyCodeRecord) {
         throw new Error(
@@ -524,27 +589,34 @@ export async function migrateReviewThreadDb(
             "the diff-aware position migration.",
         );
       }
+
       await migrateLegacyCodeRecords(db, options.migrateLegacyCodeRecord, {
         force: options.force ?? false,
         onDrop: options.onDropLegacyCodeRecord,
       });
+
       if (hasLegacyCodeTargets(db)) {
         throw new Error(
           `Review thread database ${dbPath} still contains legacy code comments.`,
         );
       }
     }
+
     migrateNativeAgentSessionRecords(db, version);
+
     const updated = db
       .prepare(
         "UPDATE meta SET value = ? WHERE key = 'schema_version' AND value = ?",
       )
       .run(String(REVIEW_THREAD_DB_SCHEMA_VERSION), version);
+
     if (updated.changes !== 1) {
       throw new Error(`Could not update the schema version in ${dbPath}.`);
     }
+
     db.exec("COMMIT");
     inTransaction = false;
+
     return "upgraded";
   } catch (error) {
     if (inTransaction) db.exec("ROLLBACK");
@@ -565,18 +637,22 @@ function migrateNativeAgentSessionRecords(
     const rows = db
       .prepare(`SELECT thread_id, record_json FROM ${table}`)
       .all() as Array<{ thread_id: string; record_json: string }>;
+
     const update = db.prepare(
       `UPDATE ${table} SET record_json = ? WHERE thread_id = ?`,
     );
+
     for (const row of rows) {
       const value = parseJsonText(row.record_json);
       const migrated = migrateNativeAgentSessionRecord(value, table, version);
+
       // Validate before committing: invalid records block migration, never disappear.
       if (table === "comments") {
         parseStoredReviewCommentThreadMap({ [row.thread_id]: migrated });
       } else {
         ReviewCommentDraftThreadMapSchema.parse({ [row.thread_id]: migrated });
       }
+
       if (migrated !== value) {
         update.run(JSON.stringify(migrated), row.thread_id);
       }
@@ -590,11 +666,14 @@ function migrateNativeAgentSessionRecord(
   version: string,
 ): JsonValue {
   if (!isJsonObject(value)) return value;
+
   if (table === "comment_drafts") {
     if (!isJsonObject(value.thread)) return value;
     const thread = migrateNativeAgentSessionThread(value.thread, version);
+
     return thread === value.thread ? value : { ...value, thread };
   }
+
   return migrateNativeAgentSessionThread(value, version);
 }
 
@@ -616,6 +695,7 @@ const V7CommentAgentSessionSchema = z.discriminatedUnion("state", [
     state: z.literal("repair-required"),
   }),
 ]);
+
 const V8CommentAgentSessionSchema = ReviewCommentAgentSessionSchema.extend({
   firstMessageId: z.string().min(1),
 });
@@ -627,10 +707,12 @@ function migrateNativeAgentSessionThread(
   const originalMessages = Array.isArray(thread.messages)
     ? thread.messages
     : undefined;
+
   const migratedMessages = originalMessages
     ? originalMessages.map((message) => {
         if (!isJsonObject(message)) return message;
         const agentInput = message.agentInput === true;
+
         if (
           !("native" in message) &&
           !("agentMessage" in message) &&
@@ -638,25 +720,31 @@ function migrateNativeAgentSessionThread(
         ) {
           return message;
         }
+
         const {
           native: _native,
           agentMessage: _agentMessage,
           ...preserved
         } = message;
+
         return { ...preserved, agentInput };
       })
     : undefined;
+
   const messagesChanged =
     originalMessages !== undefined &&
     migratedMessages !== undefined &&
     migratedMessages.some(
       (message, index) => message !== originalMessages[index],
     );
+
   const migratedThread = messagesChanged
     ? { ...thread, messages: migratedMessages }
     : thread;
+
   if (!("agentSession" in migratedThread)) return migratedThread;
   const { agentSession, ...preserved } = migratedThread;
+
   const sourceSchema =
     version === "8"
       ? V8CommentAgentSessionSchema
@@ -665,7 +753,9 @@ function migrateNativeAgentSessionThread(
         : version === "6"
           ? ReviewCommentAgentSessionSchema
           : LegacyCommentAgentSessionSchema;
+
   const session = sourceSchema.parse(agentSession);
+
   return {
     ...preserved,
     agentSession: {
@@ -689,15 +779,18 @@ async function migrateLegacyCodeRecords(
     { name: "comments", kind: "comment" },
     { name: "comment_drafts", kind: "comment-draft" },
   ] as const;
+
   for (const table of tables) {
     // SAFETY: both tables declare thread_id TEXT PRIMARY KEY and record_json
     // TEXT NOT NULL, and every insert binds strings for them.
     const rows = db
       .prepare(`SELECT thread_id, record_json FROM ${table.name}`)
       .all() as Array<{ thread_id: string; record_json: string }>;
+
     for (const row of rows) {
       const current = parseJsonText(row.record_json);
       let migrated: JsonValue;
+
       try {
         migrated = await migrate(current, table.kind);
       } catch (error) {
@@ -712,6 +805,7 @@ async function migrateLegacyCodeRecords(
         });
         continue;
       }
+
       if (migrated === current) continue;
       db.prepare(
         `UPDATE ${table.name} SET record_json = ? WHERE thread_id = ?`,
@@ -728,7 +822,9 @@ function hasLegacyCodeTargets(db: DatabaseSync): boolean {
         "AND json_type(record_json, '$.target.position') IS NULL LIMIT 1",
     )
     .get();
+
   if (comment) return true;
+
   const draft = db
     .prepare(
       "SELECT 1 FROM comment_drafts " +
@@ -737,6 +833,7 @@ function hasLegacyCodeTargets(db: DatabaseSync): boolean {
         "LIMIT 1",
     )
     .get();
+
   return Boolean(draft);
 }
 
@@ -747,11 +844,13 @@ function readThreadTable(
 ): JsonObject {
   const dbPath = reviewStateDbPath(reviewHomeForDir(reviewDir));
   const legacyDbPath = path.join(reviewDir, REVIEW_THREAD_DB_FILENAME);
+
   if (!existsSync(dbPath) && !existsSync(legacyDbPath)) return {};
   checkReviewThreadDbVersion(path.join(reviewDir, "review.mdx"));
   importLegacyReview(reviewDir);
   const db = openReviewStateDb(reviewHomeForDir(reviewDir));
   const reviewId = reviewIdForDir(reviewDir);
+
   // SAFETY: the key column is the TEXT PRIMARY KEY and record_json is TEXT NOT
   // NULL in both tables, and every insert binds strings for them.
   const rows = db
@@ -760,10 +859,13 @@ function readThreadTable(
        WHERE review_id = ? AND route_path = '/'`,
     )
     .all(reviewId) as Array<{ key: string; record_json: string }>;
+
   const result: JsonObject = {};
+
   for (const row of rows) {
     result[row.key] = parseJsonText(row.record_json);
   }
+
   return result;
 }
 
@@ -778,18 +880,23 @@ function writeThreadTable(
   ensureReviewRegistration(reviewDir);
   const db = openReviewStateDb(reviewHomeForDir(reviewDir));
   const reviewId = reviewIdForDir(reviewDir);
+
   const insert = db.prepare(
     `INSERT INTO ${table}
      (review_id, route_path, ${keyColumn}, record_json) VALUES (?, '/', ?, ?)`,
   );
+
   db.exec("BEGIN IMMEDIATE");
+
   try {
     db.prepare(
       `DELETE FROM ${table} WHERE review_id = ? AND route_path = '/'`,
     ).run(reviewId);
+
     for (const [key, record] of Object.entries(value)) {
       insert.run(reviewId, key, JSON.stringify(record));
     }
+
     db.exec("COMMIT");
   } catch (error) {
     db.exec("ROLLBACK");
@@ -807,13 +914,17 @@ function writeCommentState(
   ensureReviewRegistration(reviewDir);
   const db = openReviewStateDb(reviewHomeForDir(reviewDir));
   const reviewId = reviewIdForDir(reviewDir);
+
   const insertComment = db.prepare(
     "INSERT INTO comments (review_id, route_path, thread_id, record_json) VALUES (?, '/', ?, ?)",
   );
+
   const insertDraft = db.prepare(
     "INSERT INTO comment_drafts (review_id, route_path, thread_id, record_json) VALUES (?, '/', ?, ?)",
   );
+
   db.exec("BEGIN IMMEDIATE");
+
   try {
     db.prepare(
       "DELETE FROM comments WHERE review_id = ? AND route_path = '/'",
@@ -821,16 +932,19 @@ function writeCommentState(
     db.prepare(
       "DELETE FROM comment_drafts WHERE review_id = ? AND route_path = '/'",
     ).run(reviewId);
+
     for (const [threadId, record] of Object.entries(
       parseStoredReviewCommentThreadMap(comments),
     )) {
       insertComment.run(reviewId, threadId, JSON.stringify(record));
     }
+
     for (const [threadId, record] of Object.entries(
       ReviewCommentDraftThreadMapSchema.parse(drafts),
     )) {
       insertDraft.run(reviewId, threadId, JSON.stringify(record));
     }
+
     db.exec("COMMIT");
   } catch (error) {
     db.exec("ROLLBACK");
@@ -842,6 +956,7 @@ function sqliteThreadStoreBackend(
   reviewMdxPath: string,
 ): ReviewThreadStoreBackend {
   const reviewDir = reviewStateDir(reviewMdxPath);
+
   return {
     readComments: () => readValidComments(reviewDir),
     writeComments: (comments) =>
@@ -871,11 +986,13 @@ function readValidComments(reviewDir: string): ReviewCommentThreadMap {
   const stored = readThreadTable(reviewDir, "comments", "thread_id");
   const comments = parseReviewCommentThreadMap(stored);
   const dropped = Object.keys(stored).filter((key) => !(key in comments));
+
   if (dropped.length === 0) return comments;
   console.error(
     `[Review] Dropped ${dropped.length} malformed comment record${dropped.length === 1 ? "" : "s"} from ${reviewStateDbPath()}: ${dropped.join(", ")}`,
   );
   writeThreadTable(reviewDir, "comments", "thread_id", comments);
+
   return comments;
 }
 
@@ -891,11 +1008,14 @@ export function createReviewThreadDb(
 export function createLegacyReviewThreadDb(reviewDir: string): void {
   const dbPath = path.join(reviewDir, REVIEW_THREAD_DB_FILENAME);
   const cached = openDatabases.get(dbPath);
+
   if (cached) {
     cached.close();
     openDatabases.delete(dbPath);
   }
+
   const db = openThreadDb(dbPath, { create: true });
+
   if (db) {
     db.close();
     openDatabases.delete(dbPath);
@@ -911,6 +1031,7 @@ export function closeAllReviewThreadStores(): void {
       // Already closed — nothing to release.
     }
   }
+
   openDatabases.clear();
   closeAllReviewStateDatabases();
 }

--- a/packages/progressive-review/src/review-threads-service.ts
+++ b/packages/progressive-review/src/review-threads-service.ts
@@ -32,7 +32,7 @@ export interface ReviewThreadsServiceOptions {
 }
 
 /**
- * Session-owned command boundary for durable Review comment state.
+ * Review-owned command boundary for durable Review comment state.
  *
  * SQLite commits first. The service then updates its projection and publishes
  * the exact committed change to every connected Review surface.
@@ -41,6 +41,7 @@ export class ReviewThreadsService {
   private comments: ReviewCommentThreadMap;
   private drafts: ReviewCommentDraftThreadMap;
   private revision = 0;
+  private readonly listeners = new Set<(commit: ReviewThreadsCommit) => void>();
 
   constructor(private readonly options: ReviewThreadsServiceOptions) {
     this.comments = readReviewComments(options.reviewPath);
@@ -52,6 +53,13 @@ export class ReviewThreadsService {
       revision: this.revision,
       comments: this.comments,
       drafts: this.drafts,
+    };
+  }
+
+  subscribe(listener: (commit: ReviewThreadsCommit) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
     };
   }
 
@@ -301,6 +309,7 @@ export class ReviewThreadsService {
       deletedDraftThreadIds,
     } satisfies ReviewThreadsCommit;
     this.options.onCommit?.(commit);
+    for (const listener of this.listeners) listener(commit);
     return commit;
   }
 }

--- a/packages/progressive-review/src/review-threads-service.ts
+++ b/packages/progressive-review/src/review-threads-service.ts
@@ -58,6 +58,7 @@ export class ReviewThreadsService {
 
   subscribe(listener: (commit: ReviewThreadsCommit) => void): () => void {
     this.listeners.add(listener);
+
     return () => {
       this.listeners.delete(listener);
     };
@@ -70,10 +71,12 @@ export class ReviewThreadsService {
           ...command.input,
           author: this.options.author,
         });
+
         return this.commit(command.mutationId, {
           upsertedThreads: [result.thread],
         });
       }
+
       case "comment.update": {
         if (
           !updateReviewComment(
@@ -84,22 +87,28 @@ export class ReviewThreadsService {
         ) {
           return null;
         }
+
         const thread = readReviewComments(this.options.reviewPath)[
           command.threadId
         ];
+
         if (!thread) return null;
+
         return this.commit(command.mutationId, {
           upsertedThreads: [thread],
         });
       }
+
       case "comment.delete": {
         if (!deleteReviewComment(this.options.reviewPath, command.threadId)) {
           return null;
         }
+
         return this.commit(command.mutationId, {
           deletedThreadIds: [command.threadId],
         });
       }
+
       case "comment-message.delete": {
         if (
           !deleteReviewCommentMessage(
@@ -110,53 +119,64 @@ export class ReviewThreadsService {
         ) {
           return null;
         }
+
         const thread = readReviewComments(this.options.reviewPath)[
           command.threadId
         ];
+
         return thread
           ? this.commit(command.mutationId, { upsertedThreads: [thread] })
           : this.commit(command.mutationId, {
               deletedThreadIds: [command.threadId],
             });
       }
+
       case "comment-draft.create": {
         const result = appendReviewCommentDraft(this.options.reviewPath, {
           ...command.input,
           author: this.options.author,
         });
+
         return this.commit(command.mutationId, {
           upsertedDrafts: [result],
         });
       }
+
       case "comment-draft.update": {
         const draft = updateReviewCommentDraft(
           this.options.reviewPath,
           command.threadId,
           command.update,
         );
+
         return draft
           ? this.commit(command.mutationId, {
               upsertedDrafts: [{ threadId: command.threadId, draft }],
             })
           : null;
       }
+
       case "comment-draft.delete": {
         if (
           !deleteReviewCommentDraft(this.options.reviewPath, command.threadId)
         ) {
           return null;
         }
+
         return this.commit(command.mutationId, {
           deletedDraftThreadIds: [command.threadId],
         });
       }
+
       case "comment-draft-message.delete": {
         const draft = deleteReviewCommentDraftMessage(
           this.options.reviewPath,
           command.threadId,
           command.messageId,
         );
+
         if (draft === false) return null;
+
         return draft
           ? this.commit(command.mutationId, {
               upsertedDrafts: [{ threadId: command.threadId, draft }],
@@ -173,7 +193,9 @@ export class ReviewThreadsService {
     inputs: CreateReviewCommentInput[],
   ): ReviewThreadsCommit | null {
     const result = submitReviewCommentDrafts(this.options.reviewPath, inputs);
+
     if (result.deletedDraftThreadIds.length === 0) return null;
+
     return this.commit(mutationId, {
       upsertedThreads: result.threads,
       deletedDraftThreadIds: result.deletedDraftThreadIds,
@@ -201,7 +223,9 @@ export class ReviewThreadsService {
         agentInput: false,
       },
     );
+
     if (!result) return null;
+
     return result.location === "draft"
       ? this.commit(input.mutationId, {
           upsertedDrafts: [
@@ -226,9 +250,11 @@ export class ReviewThreadsService {
   }): ReviewThreadsCommit | null {
     const current =
       this.drafts[input.threadId]?.thread ?? this.comments[input.threadId];
+
     const existing = current?.messages.find(
       (message) => message.id === input.messageId,
     );
+
     const result = upsertReviewAgentSessionMessage(
       this.options.reviewPath,
       input.threadId,
@@ -245,7 +271,9 @@ export class ReviewThreadsService {
         agentInput: input.agentInput,
       },
     );
+
     if (!result?.changed) return null;
+
     return result.location === "draft"
       ? this.commit(input.mutationId, {
           upsertedDrafts: [{ threadId: input.threadId, draft: result.draft }],
@@ -263,7 +291,9 @@ export class ReviewThreadsService {
       input.threadId,
       input.agentSession,
     );
+
     if (!result) return null;
+
     return result.location === "draft"
       ? this.commit(input.mutationId, {
           upsertedDrafts: [{ threadId: input.threadId, draft: result.draft }],
@@ -286,20 +316,26 @@ export class ReviewThreadsService {
     const deletedDraftThreadIds = change.deletedDraftThreadIds ?? [];
     const comments = { ...this.comments };
     const drafts = { ...this.drafts };
+
     for (const thread of upsertedThreads) {
       comments[thread.threadId] = thread;
     }
+
     for (const threadId of deletedThreadIds) {
       delete comments[threadId];
     }
+
     for (const { threadId, draft } of upsertedDrafts) {
       drafts[threadId] = draft;
     }
+
     for (const threadId of deletedDraftThreadIds) {
       delete drafts[threadId];
     }
+
     this.comments = comments;
     this.drafts = drafts;
+
     const commit = {
       mutationId,
       revision: ++this.revision,
@@ -308,8 +344,11 @@ export class ReviewThreadsService {
       upsertedDrafts,
       deletedDraftThreadIds,
     } satisfies ReviewThreadsCommit;
+
     this.options.onCommit?.(commit);
+
     for (const listener of this.listeners) listener(commit);
+
     return commit;
   }
 }

--- a/packages/progressive-review/src/review-wait.ts
+++ b/packages/progressive-review/src/review-wait.ts
@@ -16,14 +16,17 @@ import { resolveReviewRoot } from "./runtime";
 const DEFAULT_TIMEOUT_SECONDS = 3600;
 
 type ReviewStatus = StoredReview["review"]["status"];
+
 type ReviewStatusChange = Extract<
   ReviewDesktopGlobalEvent,
   { event: "review-status-changed" }
 >;
+
 type ReviewDeleted = Extract<
   ReviewDesktopGlobalEvent,
   { event: "review-deleted" }
 >;
+
 /* Dismissal ends the reader's involvement, so a waiting agent must stop. It
    replaced the old "rejected" close, which the desktop no longer writes. */
 type ReviewAttentionChanged = Extract<
@@ -112,7 +115,9 @@ export async function runReviewWait(
     },
     dependencies,
   );
+
   writeWaitResult(input.stdout, result);
+
   return result.event === "timeout" ? 1 : 0;
 }
 
@@ -124,14 +129,18 @@ export async function validateReviewWait(
   dependencies: ReviewWaitDependencies = defaultReviewWaitDependencies,
 ): Promise<StoredReview> {
   const discovery = await requireReviewDesktop(dependencies);
+
   const response = await dependencies.fetch(`${discovery.url}/events`, {
     headers: { "x-review-token": discovery.token },
   });
+
   if (!response.ok || !response.body) {
     throw new Error(`Review Desktop returned ${response.status} for events.`);
   }
+
   await response.body.cancel();
   const reviewRoot = await dependencies.resolveReviewRoot(input.cwd);
+
   return await dependencies.resolvePublishReview(reviewRoot, input.reviewUuid, {
     includeTerminal: true,
   });
@@ -149,25 +158,30 @@ export async function waitForReviewAction(
 ): Promise<ReviewWaitResult> {
   const timeoutSeconds = input.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS;
   const discovery = await requireReviewDesktop(dependencies);
+
   const response = await dependencies.fetch(`${discovery.url}/events`, {
     headers: { "x-review-token": discovery.token },
   });
+
   if (!response.ok || !response.body) {
     throw new Error(`Review Desktop returned ${response.status} for events.`);
   }
 
   const reviewRoot = await dependencies.resolveReviewRoot(input.cwd);
+
   const review = await dependencies.resolvePublishReview(
     reviewRoot,
     input.reviewUuid,
     { includeTerminal: true },
   );
+
   if (
     input.requiresAgent
       ? reviewWaitRequiresAgentStatus(review.review.status)
       : review.review.status !== "awaiting-review"
   ) {
     await response.body.cancel();
+
     return {
       event: "review-status",
       uuid: review.review.uuid,
@@ -187,6 +201,7 @@ export async function waitForReviewAction(
   // so a terminal `status` still wins.
   if (review.review.dismissedAt) {
     await response.body.cancel();
+
     return {
       event: "review-dismissed",
       uuid: review.review.uuid,
@@ -201,9 +216,11 @@ export async function waitForReviewAction(
     timeoutSeconds,
     input.requiresAgent ? reviewWaitRequiresAgentResult : () => true,
   );
+
   if (result.event === "timeout") {
     return { ...result, occurredAtMs: dependencies.now(), review };
   }
+
   if (result.event === "review-deleted") {
     // The review directory is gone; do not read thread state from it.
     return {
@@ -213,6 +230,7 @@ export async function waitForReviewAction(
       review,
     };
   }
+
   if (result.event === "review-attention-changed") {
     return {
       event: "review-dismissed",
@@ -230,7 +248,9 @@ export async function waitForReviewAction(
     occurredAtMs: dependencies.now(),
     review,
   };
+
   if (result.decision) status.decision = result.decision;
+
   return status;
 }
 
@@ -265,8 +285,10 @@ function writeWaitResult(stdout: Writable, result: ReviewWaitResult): void {
         timeoutSeconds: result.timeoutSeconds,
       })}\n`,
     );
+
     return;
   }
+
   if (
     result.event === "review-deleted" ||
     result.event === "review-dismissed"
@@ -277,8 +299,10 @@ function writeWaitResult(stdout: Writable, result: ReviewWaitResult): void {
         uuid: result.uuid,
       })}\n`,
     );
+
     return;
   }
+
   // JSON.stringify omits an undefined decision; the key order is the CLI's
   // documented output shape.
   const output: ReviewWaitJsonOutput = {
@@ -288,16 +312,19 @@ function writeWaitResult(stdout: Writable, result: ReviewWaitResult): void {
     decision: result.decision,
     openThreads: result.openThreads,
   };
+
   stdout.write(`${JSON.stringify(output)}\n`);
 }
 
 async function requireReviewDesktop(dependencies: ReviewWaitDependencies) {
   const discovery = await dependencies.readDesktopDiscovery();
+
   if (!discovery) {
     throw new Error(
       "Review Desktop is not running. Run `review app launch`, then retry `review wait`.",
     );
   }
+
   return discovery;
 }
 
@@ -310,8 +337,10 @@ async function waitForReviewStatusChange(
   ReviewWaitEvent | { event: "timeout"; uuid: string; timeoutSeconds: number }
 > {
   const reader = body.getReader();
+
   return new Promise((resolve, reject) => {
     let settled = false;
+
     const finish = (
       result:
         | ReviewWaitEvent
@@ -323,10 +352,12 @@ async function waitForReviewStatusChange(
       void reader.cancel();
       resolve(result);
     };
+
     const timeout = setTimeout(
       () => finish({ event: "timeout", uuid, timeoutSeconds }),
       timeoutSeconds * 1000,
     );
+
     consumeSse(reader, (event) => {
       if (
         (event.event === "review-status-changed" ||
@@ -363,6 +394,7 @@ async function consumeSse(
   const decoder = new TextDecoder();
   let buffer = "";
   let data: string[] = [];
+
   const consumeLine = (line: string) => {
     if (!line) {
       if (data.length > 0) {
@@ -371,9 +403,12 @@ async function consumeSse(
         );
         data = [];
       }
+
       return;
     }
+
     if (line.startsWith(":")) return;
+
     if (line.startsWith("data:")) {
       data.push(line.slice("data:".length).replace(/^ /, ""));
     }
@@ -383,14 +418,18 @@ async function consumeSse(
     const { done, value } = await reader.read();
     buffer += decoder.decode(value, { stream: !done });
     let newline = buffer.indexOf("\n");
+
     while (newline >= 0) {
       consumeLine(buffer.slice(0, newline).replace(/\r$/, ""));
       buffer = buffer.slice(newline + 1);
       newline = buffer.indexOf("\n");
     }
+
     if (done) break;
   }
+
   if (buffer) consumeLine(buffer.replace(/\r$/, ""));
+
   if (data.length > 0) {
     consume(ReviewDesktopGlobalEventSchema.parse(JSON.parse(data.join("\n"))));
   }

--- a/packages/progressive-review/src/review-wait.ts
+++ b/packages/progressive-review/src/review-wait.ts
@@ -7,9 +7,11 @@ import {
 
 import { readReviewDesktopDiscovery } from "./desktop-discovery";
 import type { StoredReview } from "./review-home";
-import { readOpenReviewThreadCount } from "./review-storage";
+import {
+  openThreadCountClient as readOpenReviewThreadCount,
+  resolveReviewClient as resolvePublishReview,
+} from "./review-lifecycle-client";
 import { resolveReviewRoot } from "./runtime";
-import { resolvePublishReview } from "./server/publish-preparation";
 
 const DEFAULT_TIMEOUT_SECONDS = 3600;
 
@@ -68,7 +70,7 @@ export interface ReviewWaitDependencies {
   fetch: typeof fetch;
   now(): number;
   readDesktopDiscovery: typeof readReviewDesktopDiscovery;
-  readOpenReviewThreadCount: typeof readOpenReviewThreadCount;
+  readOpenReviewThreadCount(reviewDir: string): number | Promise<number>;
   resolvePublishReview: typeof resolvePublishReview;
   resolveReviewRoot: typeof resolveReviewRoot;
 }

--- a/packages/progressive-review/src/server/desktop-server-registration.test.ts
+++ b/packages/progressive-review/src/server/desktop-server-registration.test.ts
@@ -29,6 +29,7 @@ import { materializePublishRevision } from "./publish-stage";
 import { createReviewSessionHandler } from "./session-handler";
 
 const roots: string[] = [];
+
 afterEach(async () => {
   closeAllReviewThreadStores();
   vi.unstubAllEnvs();
@@ -46,6 +47,7 @@ async function fixture(options: Partial<GlobalReviewServerInput> = {}) {
   await reviewVcs.init(source);
   await writeFile(path.join(source, "one.ts"), "export const one = 1;\n");
   const commit = await reviewVcs.seal(source, "Source");
+
   const review = await createReviewDir({
     worktreePath: source,
     baseRef: "main",
@@ -53,6 +55,7 @@ async function fixture(options: Partial<GlobalReviewServerInput> = {}) {
     sourceCommit: commit,
     sourceIdentity: { kind: "git-branch", name: "main" },
   });
+
   await writeReviewDocumentBundle(
     review.dir,
     bundleReviewDocument({
@@ -73,10 +76,12 @@ async function fixture(options: Partial<GlobalReviewServerInput> = {}) {
     presentedDocumentRevision: revision,
     lastPublishedAt: new Date().toISOString(),
   });
+
   const packageRoot = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     "../..",
   );
+
   const server = createGlobalReviewServer({
     appPid: process.pid,
     packageRoot,
@@ -86,7 +91,9 @@ async function fixture(options: Partial<GlobalReviewServerInput> = {}) {
     discoveryPath: path.join(root, "desktop.json"),
     ...options,
   });
+
   await server.listen();
+
   const request = (route: string, body?: JsonObject) =>
     fetch(`${server.url}${route}`, {
       method: body ? "POST" : "GET",
@@ -96,6 +103,7 @@ async function fixture(options: Partial<GlobalReviewServerInput> = {}) {
       },
       body: body ? JSON.stringify(body) : undefined,
     });
+
   return {
     server,
     review,
@@ -108,6 +116,7 @@ async function fixture(options: Partial<GlobalReviewServerInput> = {}) {
 
 async function within<T>(promise: Promise<T>): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
+
   try {
     return await Promise.race([
       promise,
@@ -127,16 +136,21 @@ async function within<T>(promise: Promise<T>): Promise<T> {
 it("allows another process and a server mutation to acquire the review lock during slow checkout preparation", async () => {
   const entered = Promise.withResolvers<void>();
   const release = Promise.withResolvers<void>();
+
   const setup = await fixture({
     pinnedCheckoutFactory: async (input) => {
       entered.resolve();
       await release.promise;
+
       return ensureReviewPinnedCheckout(input);
     },
   });
+
   const opening = setup.open();
+
   try {
     await within(entered.promise);
+
     // Acquire the same atomic directory lock from another process.
     const acquired = execFileSync(
       process.execPath,
@@ -148,6 +162,7 @@ it("allows another process and a server mutation to acquire the review lock duri
       ],
       { encoding: "utf8" },
     );
+
     expect(acquired).toBe("acquired");
     expect(
       (
@@ -170,12 +185,15 @@ it.each(["stale", "duplicate", "closing"] as const)(
     let closed = 0;
     const entered = Promise.withResolvers<void>();
     const release = Promise.withResolvers<void>();
+
     const setup = await fixture({
       sessionHandlerFactory: async (input) => {
         const handler = await createReviewSessionHandler(input);
         created += 1;
+
         if (created === (scenario === "duplicate" ? 2 : 1)) entered.resolve();
         await release.promise;
+
         return {
           ...handler,
           close: async () => {
@@ -185,11 +203,15 @@ it.each(["stale", "duplicate", "closing"] as const)(
         };
       },
     });
+
     const requests = [setup.open()];
+
     if (scenario === "duplicate") requests.push(setup.open());
     let shutdown: Promise<void> | undefined;
+
     try {
       await within(entered.promise);
+
       if (scenario === "stale")
         await withReviewMutationLock(setup.review.dir, async () => {
           const recordPath = path.join(setup.review.dir, "review.json");
@@ -197,12 +219,15 @@ it.each(["stale", "duplicate", "closing"] as const)(
           // Keep the compatibility mirror stale; the database is authoritative.
           putReviewRecord(setup.review.dir, { ...record, baseRef: "changed" });
         });
+
       if (scenario === "closing") shutdown = setup.server.close();
       release.resolve();
       const responses = await Promise.all(requests);
+
       const bodies = await Promise.all(
         responses.map((response) => response.json()),
       );
+
       expect(closed).toBe(1);
       expect(responses.map((response) => response.status)).toEqual(
         scenario === "duplicate" ? [201, 201] : [409],
@@ -218,10 +243,12 @@ it.each(["stale", "duplicate", "closing"] as const)(
           ? [undefined, undefined]
           : [scenario === "stale" ? "review_changed" : "server_closing"],
       );
+
       const installed =
         scenario === "closing"
           ? []
           : (await (await setup.request("/sessions")).json()).items;
+
       expect(installed).toHaveLength(scenario === "duplicate" ? 1 : 0);
     } finally {
       release.resolve();
@@ -233,32 +260,39 @@ it.each(["stale", "duplicate", "closing"] as const)(
 
 it("reopens an unavailable revision after materialization recovers without a poisoned cache", async () => {
   let fail = true;
+
   const setup = await fixture({
     publishRuntime: {
       materializePublishRevision: (input) => {
         if (fail)
           return Promise.reject(new Error("temporary object read failure"));
+
         return materializePublishRevision(input);
       },
     },
   });
+
   try {
     const first = await setup.open();
     expect(first.status).toBe(201);
     const firstSession = await first.json();
+
     const document = await setup.request(
       `/sessions/${firstSession.sessionId}/__progressive-review/document`,
     );
+
     expect(document.status).toBe(409);
     await expect(
       readFile(
         path.join(setup.review.dir, ".build", setup.revision, "review.json"),
       ),
     ).rejects.toMatchObject({ code: "ENOENT" });
+
     const closed = await fetch(
       `${setup.server.url}/sessions/${firstSession.sessionId}?terminal=false`,
       { method: "DELETE", headers: { "x-review-token": "test-secret" } },
     );
+
     expect(closed.status).toBe(200);
     fail = false;
     const reopened = await setup.open();

--- a/packages/progressive-review/src/server/desktop-server-registration.test.ts
+++ b/packages/progressive-review/src/server/desktop-server-registration.test.ts
@@ -12,8 +12,13 @@ import {
   writeReviewDocumentBundle,
 } from "../review-bundle";
 import { ensureReviewPinnedCheckout } from "../review-head-checkout";
-import { createReviewDir, sealReviewCandidate } from "../review-home";
+import {
+  createReviewDir,
+  persistStoredReviewRecord,
+  sealReviewCandidate,
+} from "../review-home";
 import { withReviewMutationLock } from "../review-mutation-lock";
+import { putReviewRecord } from "../review-state-db";
 import { closeAllReviewThreadStores } from "../review-thread-store-backend";
 import { reviewVcs } from "../review-vcs";
 import {
@@ -62,15 +67,12 @@ async function fixture(options: Partial<GlobalReviewServerInput> = {}) {
     }),
   );
   const revision = await sealReviewCandidate(review.dir, "Published");
-  await writeFile(
-    path.join(review.dir, "review.json"),
-    JSON.stringify({
-      ...review.review,
-      status: "awaiting-review",
-      presentedDocumentRevision: revision,
-      lastPublishedAt: new Date().toISOString(),
-    }),
-  );
+  await persistStoredReviewRecord(review.dir, {
+    ...review.review,
+    status: "awaiting-review",
+    presentedDocumentRevision: revision,
+    lastPublishedAt: new Date().toISOString(),
+  });
   const packageRoot = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     "../..",
@@ -192,10 +194,8 @@ it.each(["stale", "duplicate", "closing"] as const)(
         await withReviewMutationLock(setup.review.dir, async () => {
           const recordPath = path.join(setup.review.dir, "review.json");
           const record = JSON.parse(await readFile(recordPath, "utf8"));
-          await writeFile(
-            recordPath,
-            JSON.stringify({ ...record, baseRef: "changed" }),
-          );
+          // Keep the compatibility mirror stale; the database is authoritative.
+          putReviewRecord(setup.review.dir, { ...record, baseRef: "changed" });
         });
       if (scenario === "closing") shutdown = setup.server.close();
       release.resolve();

--- a/packages/progressive-review/src/server/desktop-server-repair.test.ts
+++ b/packages/progressive-review/src/server/desktop-server-repair.test.ts
@@ -34,10 +34,12 @@ import {
   type ReviewRepairReadyRequest,
   fingerprintReviewRepairInputs,
 } from "../review-repair-state";
+import { deleteReviewState, putReviewRecord } from "../review-state-db";
 import { appendReviewCommentDraft } from "../review-state-store";
 import {
   checkReviewThreadDbVersion,
   closeAllReviewThreadStores,
+  copyReviewThreadDatabaseSnapshot,
 } from "../review-thread-store-backend";
 import { reviewVcs } from "../review-vcs";
 import { createGlobalReviewServer } from "./desktop-server";
@@ -122,6 +124,7 @@ async function fixture(schemaVersion: 4 | 5 = 4) {
     presentedDocumentRevision: oldRevision,
   });
   await writeFile(path.join(stored.dir, "review.json"), expectedRecord);
+  deleteReviewState(stored.dir);
   const expectedFingerprint = await fingerprintReviewRepairInputs(stored.dir);
   const stagingDir = path.join(root, "stage");
   await cp(stored.dir, stagingDir, { recursive: true });
@@ -191,6 +194,10 @@ async function fixture(schemaVersion: 4 | 5 = 4) {
     visible.dir,
     "Review publish candidate",
   );
+  putReviewRecord(visible.dir, {
+    ...visible.review,
+    presentedDocumentRevision: visibleRevision,
+  });
   await writeFile(
     path.join(visible.dir, "review.json"),
     JSON.stringify({
@@ -240,6 +247,8 @@ it.each(["success", "mount-failure", "live-change", "stage-change"])(
       author: "Reviewer",
     });
     closeAllReviewThreadStores();
+    copyReviewThreadDatabaseSnapshot(reviewPath, reviewPath);
+    deleteReviewState(stored.dir);
     const db = new DatabaseSync(path.join(stored.dir, "review.db"));
     db.prepare(
       "UPDATE meta SET value = '5' WHERE key = 'schema_version'",

--- a/packages/progressive-review/src/server/desktop-server-repair.test.ts
+++ b/packages/progressive-review/src/server/desktop-server-repair.test.ts
@@ -49,6 +49,7 @@ import {
 } from "./global-verb-relay";
 
 let root: string | undefined;
+
 type DispatchVerb = (
   sessionId: string,
   value: JsonValue,
@@ -58,6 +59,7 @@ let dispatchVerb: DispatchVerb = async () => ({ ok: true });
 
 function recordingRelay(): ReviewDesktopVerbRelay {
   const inner = new GlobalReviewDesktopVerbRelay();
+
   return {
     get attached() {
       return inner.attached;
@@ -74,12 +76,15 @@ afterEach(async () => {
   vi.unstubAllEnvs();
   closeAllReviewThreadStores();
   dispatchVerb = async () => ({ ok: true });
+
   if (root) await rm(root, { recursive: true, force: true });
 });
+
 const packageRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../..",
 );
+
 async function fixture(schemaVersion: 4 | 5 = 4) {
   root = await mkdtemp(path.join(tmpdir(), "repair-server-"));
   vi.stubEnv("DEV_REVIEW_HOME", root);
@@ -88,6 +93,7 @@ async function fixture(schemaVersion: 4 | 5 = 4) {
   await reviewVcs.init(source);
   await writeFile(path.join(source, "one.ts"), "export const one = 1;\n");
   const commit = await reviewVcs.seal(source, "source");
+
   const stored = await createReviewDir({
     worktreePath: source,
     baseRef: "main",
@@ -95,6 +101,7 @@ async function fixture(schemaVersion: 4 | 5 = 4) {
     sourceCommit: commit,
     title: "Keep title",
   });
+
   const record = {
     ...stored.review,
     schemaVersion,
@@ -103,6 +110,7 @@ async function fixture(schemaVersion: 4 | 5 = 4) {
     dismissedAt: schemaVersion === 4 ? "2026-09-01T01:00:00Z" : null,
     viewedAt: "2026-09-01T00:01:00Z",
   };
+
   await mkdir(path.join(stored.dir, ".bundle", "document"), {
     recursive: true,
   });
@@ -115,24 +123,29 @@ async function fixture(schemaVersion: 4 | 5 = 4) {
     "throw new Error('never execute server');",
   );
   await writeFile(path.join(stored.dir, "review.json"), JSON.stringify(record));
+
   const oldRevision = await reviewVcs.seal(
     stored.dir,
     "Review publish candidate",
   );
+
   const expectedRecord = JSON.stringify({
     ...record,
     presentedDocumentRevision: oldRevision,
   });
+
   await writeFile(path.join(stored.dir, "review.json"), expectedRecord);
   deleteReviewState(stored.dir);
   const expectedFingerprint = await fingerprintReviewRepairInputs(stored.dir);
   const stagingDir = path.join(root, "stage");
   await cp(stored.dir, stagingDir, { recursive: true });
+
   const normalized = {
     ...record,
     schemaVersion: 5,
     presentedDocumentRevision: oldRevision,
   };
+
   await writeFile(
     path.join(stagingDir, "review.json"),
     JSON.stringify(normalized),
@@ -150,10 +163,12 @@ async function fixture(schemaVersion: 4 | 5 = 4) {
       softwareModels: [],
     }),
   );
+
   const newDocumentRevision = await reviewVcs.seal(
     stagingDir,
     "Repair current Review document",
   );
+
   await writeFile(
     path.join(stagingDir, "review.json"),
     JSON.stringify({
@@ -161,6 +176,7 @@ async function fixture(schemaVersion: 4 | 5 = 4) {
       presentedDocumentRevision: newDocumentRevision,
     }),
   );
+
   const request: ReviewRepairReadyRequest = {
     reviewUuid: record.uuid,
     stagingDir,
@@ -170,6 +186,7 @@ async function fixture(schemaVersion: 4 | 5 = 4) {
     newMapRevision: null,
     sourceFallback: { document: false, map: false },
   };
+
   const visible = await createReviewDir({
     worktreePath: source,
     baseRef: "main",
@@ -177,6 +194,7 @@ async function fixture(schemaVersion: 4 | 5 = 4) {
     sourceCommit: commit,
     title: "Visible review",
   });
+
   await writeReviewDocumentBundle(
     visible.dir,
     bundleReviewDocument({
@@ -190,10 +208,12 @@ async function fixture(schemaVersion: 4 | 5 = 4) {
       softwareModels: [],
     }),
   );
+
   const visibleRevision = await reviewVcs.seal(
     visible.dir,
     "Review publish candidate",
   );
+
   putReviewRecord(visible.dir, {
     ...visible.review,
     presentedDocumentRevision: visibleRevision,
@@ -206,6 +226,7 @@ async function fixture(schemaVersion: 4 | 5 = 4) {
     }),
   );
   const token = "repair-secret";
+
   const server = createGlobalReviewServer({
     appPid: process.pid,
     packageRoot,
@@ -215,7 +236,9 @@ async function fixture(schemaVersion: 4 | 5 = 4) {
     discoveryPath: path.join(root, "desktop.json"),
     relay: recordingRelay(),
   });
+
   await server.listen();
+
   const post = (
     route: string,
     body: ReviewRepairReadyRequest | ReviewThreadsCommand | JsonObject,
@@ -225,12 +248,15 @@ async function fixture(schemaVersion: 4 | 5 = 4) {
       headers: { "content-type": "application/json", "x-review-token": token },
       body: JSON.stringify(body),
     });
+
   const list = () =>
     fetch(`${server.url}/sessions`, {
       headers: { "x-review-token": token },
     }).then((response) => response.json());
+
   const get = (route: string) =>
     fetch(`${server.url}${route}`, { headers: { "x-review-token": token } });
+
   return { stored, record, request, server, post, list, visible, get };
 }
 
@@ -257,6 +283,7 @@ it.each(["success", "mount-failure", "live-change", "stage-change"])(
     const before = await snapshotReviewTree(stored.dir);
     let expectedAfterFailure = before;
     const prepared = await prepareReviewRepair({ reviewDir: stored.dir });
+
     if (prepared.kind !== "prepared") throw new Error("Expected legacy repair");
     expect(prepared.request.expectedThreadDbFingerprint).toBeDefined();
     expect(prepared.request.sourceFallback.document).toBe(true);
@@ -269,9 +296,11 @@ it.each(["success", "mount-failure", "live-change", "stage-change"])(
       expect((await get(`${prefix}/session`)).status).toBe(200);
       const response = await get(`${prefix}/comments`);
       expect(response.status).toBe(200);
+
       const snapshot = ReviewThreadsSnapshotResponseSchema.parse(
         await response.json(),
       );
+
       if (!snapshot.ok) throw new Error(snapshot.error);
       expect(Object.keys(snapshot.snapshot.drafts)).toEqual([
         "preserved-draft",
@@ -284,9 +313,11 @@ it.each(["success", "mount-failure", "live-change", "stage-change"])(
           ),
         ),
       ).toEqual(before);
+
       if (outcome === "live-change" || outcome === "stage-change") {
         const changedDir =
           outcome === "live-change" ? stored.dir : prepared.request.stagingDir;
+
         if (outcome === "stage-change") {
           appendReviewCommentDraft(path.join(changedDir, "review.mdx"), {
             threadId: "concurrent-draft",
@@ -295,9 +326,11 @@ it.each(["success", "mount-failure", "live-change", "stage-change"])(
             body: "Concurrent staged draft",
             author: "Reviewer",
           });
+
           const refreshed = ReviewThreadsSnapshotResponseSchema.parse(
             await (await get(`${prefix}/comments`)).json(),
           );
+
           if (!refreshed.ok) throw new Error(refreshed.error);
           refreshedDraftIds = Object.keys(refreshed.snapshot.drafts).sort();
         } else {
@@ -309,6 +342,7 @@ it.each(["success", "mount-failure", "live-change", "stage-change"])(
             .run();
           changed.close();
         }
+
         if (outcome === "live-change") {
           const latest = await snapshotReviewTree(stored.dir);
           expectedAfterFailure = Object.fromEntries(
@@ -318,36 +352,45 @@ it.each(["success", "mount-failure", "live-change", "stage-change"])(
           );
         }
       }
+
       expect(refreshedDraftIds).toEqual(
         outcome === "stage-change"
           ? ["concurrent-draft", "preserved-draft"]
           : undefined,
       );
       validated = true;
+
       return outcome === "mount-failure"
         ? { ok: false, error: "test mount failure" }
         : { ok: true };
     };
+
     try {
       const response = await post("/repair-ready", prepared.request);
       expect(validated).toBe(true);
       expect(response.status).toBe(
         outcome === "success" ? 201 : outcome === "mount-failure" ? 422 : 400,
       );
+
       if (outcome !== "success") {
         await expectReviewTree(stored.dir, expectedAfterFailure);
+
         return;
       }
+
       checkReviewThreadDbVersion(reviewPath);
       const { sessionId } = await response.json();
       const prefix = `/sessions/${sessionId}/__progressive-review`;
+
       const snapshot = ReviewThreadsSnapshotResponseSchema.parse(
         await (await get(`${prefix}/comments`)).json(),
       );
+
       if (!snapshot.ok) throw new Error(snapshot.error);
       expect(Object.keys(snapshot.snapshot.drafts)).toEqual([
         "preserved-draft",
       ]);
+
       const created = await post(`${prefix}/thread-commands`, {
         command: "comment.create",
         mutationId: "after-legacy-repair",
@@ -358,6 +401,7 @@ it.each(["success", "mount-failure", "live-change", "stage-change"])(
           body: "Works after repair",
         },
       });
+
       expect(created.status).toBe(200);
     } finally {
       await server.close();
@@ -368,6 +412,7 @@ it.each(["success", "mount-failure", "live-change", "stage-change"])(
 
 it("switches repaired comments to live snapshots for resynchronization after promotion", async () => {
   const { stored, record, request, server, post, get } = await fixture(5);
+
   const comment = (index: number): ReviewThreadsCommand => ({
     command: "comment.create",
     mutationId: `repair-message-${index}`,
@@ -378,14 +423,17 @@ it("switches repaired comments to live snapshots for resynchronization after pro
       body: `Repair comment ${index}`,
     },
   });
+
   const validationReads: Array<{ writeStatus: number; revision: number }> = [];
   dispatchVerb = async (sessionId, value) => {
     if (jsonObject(value)?.name !== "validateCanvasMount") return { ok: true };
     const before = await snapshotReviewTree(stored.dir);
     const prefix = `/sessions/${sessionId}/__progressive-review`;
+
     const snapshot = ReviewThreadsSnapshotResponseSchema.parse(
       await (await get(`${prefix}/comments`)).json(),
     );
+
     if (!snapshot.ok) throw new Error(snapshot.error);
     const blocked = await post(`${prefix}/thread-commands`, comment(0));
     validationReads.push({
@@ -393,34 +441,43 @@ it("switches repaired comments to live snapshots for resynchronization after pro
       revision: snapshot.snapshot.revision,
     });
     expect(await snapshotReviewTree(stored.dir)).toEqual(before);
+
     return { ok: true };
   };
+
   try {
     const repaired = await post("/repair-ready", request);
     expect(repaired.status).toBe(201);
     expect(validationReads).toEqual([{ writeStatus: 409, revision: 0 }]);
     const { sessionId } = await repaired.json();
     const prefix = `/sessions/${sessionId}/__progressive-review`;
+
     const liveThreads = async () => {
       const snapshot = ReviewThreadsSnapshotResponseSchema.parse(
         await (await get(`${prefix}/comments`)).json(),
       );
+
       if (!snapshot.ok) throw new Error(snapshot.error);
+
       return {
         revision: snapshot.snapshot.revision,
         threadIds: Object.keys(snapshot.snapshot.comments),
       };
     };
+
     // The promoted session must own a fresh live store: revision 0, no
     // carried-over threads, and one revision per accepted mutation.
     expect(await liveThreads()).toEqual({ revision: 0, threadIds: [] });
     const revisions: number[] = [];
+
     for (const index of [1, 2, 3]) {
       const response = await post(`${prefix}/thread-commands`, comment(index));
       expect(response.status).toBe(200);
+
       const result = ReviewThreadsCommandResponseSchema.parse(
         await response.json(),
       );
+
       if (!result.ok) throw new Error(result.error);
       revisions.push(result.commit.revision);
       expect(await liveThreads()).toEqual({
@@ -431,17 +488,21 @@ it("switches repaired comments to live snapshots for resynchronization after pro
         ),
       });
     }
+
     expect(revisions).toEqual([1, 2, 3]);
 
     const historical = await post(`/reviews/${record.uuid}/open`, {
       revision: JSON.parse(request.expectedRecord).presentedDocumentRevision,
     });
+
     expect(historical.status).toBe(201);
     const historicalPrefix = `/sessions/${(await historical.json()).sessionId}/__progressive-review`;
     const beforeHistoricalRead = await snapshotReviewTree(stored.dir);
+
     const historicalSnapshot = ReviewThreadsSnapshotResponseSchema.parse(
       await (await get(`${historicalPrefix}/comments`)).json(),
     );
+
     if (!historicalSnapshot.ok) throw new Error(historicalSnapshot.error);
     expect(historicalSnapshot.snapshot.revision).toBe(0);
     expect(
@@ -458,17 +519,21 @@ it.each([true, false])(
   async (mountSucceeds) => {
     const { stored, record, request, server, post, list, get } =
       await fixture(5);
+
     dispatchVerb = async (_sessionId, value) =>
       jsonObject(value)?.name === "validateCanvasMount" && !mountSucceeds
         ? { ok: false, error: "test mount failure" }
         : { ok: true };
+
     try {
       const opened = await post(`/reviews/${record.uuid}/open`, {});
       expect(opened.status).toBe(201);
       const old = await opened.json();
+
       const document = await get(
         `/sessions/${old.sessionId}/__progressive-review/document`,
       );
+
       expect(document.status).toBe(409);
       expect(await document.json()).toMatchObject({
         detail: { code: "needs_republish" },
@@ -482,6 +547,7 @@ it.each([true, false])(
         ),
       ).toEqual([mountSucceeds ? result.sessionId : old.sessionId]);
       const expectedRecord = JSON.parse(request.expectedRecord);
+
       if (mountSucceeds)
         expectedRecord.presentedDocumentRevision = request.newDocumentRevision;
       expect(
@@ -510,6 +576,7 @@ it.each([
   async (outcome) => {
     const { stored, record, request, server, post, list, visible, get } =
       await fixture();
+
     if (outcome === "changed-pins") {
       const recordPath = path.join(request.stagingDir, "review.json");
       const finalRecord = JSON.parse(await readFile(recordPath, "utf8"));
@@ -529,31 +596,38 @@ it.each([
         }),
       );
     }
+
     if (outcome === "staging-link") {
       const index = path.join(request.stagingDir, ".git", "index");
       await rm(index);
       await symlink("HEAD", index);
     }
+
     const validationReads: Array<{ status: number; record: string }> = [];
     dispatchVerb = async (sessionId, value) => {
       if (jsonObject(value)?.name === "validateCanvasMount") {
         const versions = await get(
           `/sessions/${sessionId}/__progressive-review/revisions`,
         );
+
         validationReads.push({
           status: versions.status,
           record: await readFile(path.join(stored.dir, "review.json"), "utf8"),
         });
+
         if (outcome === "mount-failure")
           return { ok: false, error: "test mount failure" };
+
         if (outcome === "concurrent-edit")
           await writeFile(
             path.join(stored.dir, "data.ts"),
             "export const concurrent = true;\n",
           );
       }
+
       return { ok: true };
     };
+
     try {
       const failedOpen = await post(`/reviews/${record.uuid}/open`, {});
       expect(failedOpen.status).toBe(409);
@@ -611,6 +685,7 @@ it.each([
         ),
       );
       expect((await list()).items).toHaveLength(success ? 2 : 1);
+
       if (outcome === "concurrent-edit")
         await writeFile(path.join(stored.dir, "data.ts"), "export {};\n");
       expect(

--- a/packages/progressive-review/src/server/desktop-server.test.ts
+++ b/packages/progressive-review/src/server/desktop-server.test.ts
@@ -33,6 +33,7 @@ import {
 import { GlobalReviewDesktopVerbRelay } from "./global-verb-relay";
 
 let directory: string | undefined;
+
 const packageRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../..",
@@ -85,6 +86,7 @@ describe("reviewAgentKind", () => {
         },
       },
     };
+
     expect(reviewAgentKind(review)).toBe("claude");
     expect(
       reviewAgentKind({
@@ -118,6 +120,7 @@ describe("Review Desktop open requests", () => {
     await mkdir(dir, { recursive: true });
     await reviewVcs.init(dir);
     const source = await makeSourceRepository(directory);
+
     const record = {
       schemaVersion: 4,
       uuid,
@@ -136,6 +139,7 @@ describe("Review Desktop open requests", () => {
       lastPublishedAt: "2026-09-01T00:00:00Z",
       dismissedAt: "2026-01-01T00:00:00Z",
     };
+
     await writeFile(path.join(dir, "review.mdx"), "# Recovery");
     await writeFile(path.join(dir, ".gitignore"), ".build/\nreview.db*\n");
     await writeFile(path.join(dir, "review.json"), JSON.stringify(record));
@@ -157,10 +161,12 @@ describe("Review Desktop open requests", () => {
       path.join(dir, "review.json"),
       JSON.stringify({ ...record, sourceCommit: "f".repeat(40) }),
     );
+
     const historicalJsonRevision = await reviewVcs.seal(
       dir,
       "Review publish candidate",
     );
+
     await writeFile(path.join(dir, "review.json"), JSON.stringify(record));
     await writeFile(
       path.join(dir, "review.mdx"),
@@ -180,10 +186,12 @@ describe("Review Desktop open requests", () => {
       `import { createActiveReviewDocument, jsx } from "review-doc-runtime";
 export default createActiveReviewDocument({ title: "Legacy", routePath: "/", filePath: "review.mdx", modelNames: [], models: {}, Component: () => jsx("h1", { children: "Legacy sealed" }), isDefault: true });`,
     );
+
     const currentRevision = await reviewVcs.seal(
       dir,
       "Review publish candidate",
     );
+
     await writeFile(
       path.join(dir, "review.json"),
       JSON.stringify({ ...record, presentedDocumentRevision: currentRevision }),
@@ -197,16 +205,20 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
       author: "Reviewer",
     });
     closeAllReviewThreadStores();
+
     const files = [
       "review.json",
       "review.mdx",
       "review.db",
       ".git/refs/heads/main",
     ];
+
     const before = await Promise.all(
       files.map((file) => readFile(path.join(dir, file))),
     );
+
     const token = "recovery-secret";
+
     const server = createGlobalReviewServer({
       appPid: process.pid,
       packageRoot,
@@ -215,8 +227,10 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
       token,
       discoveryPath: path.join(directory, "desktop.json"),
     });
+
     try {
       await server.listen();
+
       const request = (route: string, body?: JsonObject) =>
         fetch(`${server.url}${route}`, {
           method: body ? "POST" : "GET",
@@ -226,13 +240,16 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
           },
           body: body ? JSON.stringify(body) : undefined,
         });
+
       const current = await request(`/reviews/${uuid}/open`, {});
       expect(current.status).toBe(201);
       const opened = await current.json();
       expect(opened.review).not.toHaveProperty("recovery");
+
       const migrated = JSON.parse(
         await readFile(path.join(dir, "review.json"), "utf8"),
       );
+
       expect(migrated).toMatchObject({
         schemaVersion: 5,
         status: "accepted",
@@ -254,9 +271,11 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
       expect(
         (await comments.json()).snapshot.comments["recovery-thread"].messages,
       ).toHaveLength(1);
+
       const historical = await request(`/reviews/${uuid}/open`, {
         revision: oldRevision,
       });
+
       expect(historical.status).toBe(201);
       const old = await historical.json();
       expect(
@@ -269,9 +288,11 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
         error: "This older revision is unavailable in this version of Review",
         detail: { code: "historical_revision_unavailable", reviewUuid: uuid },
       });
+
       const historicalJson = await request(`/reviews/${uuid}/open`, {
         revision: historicalJsonRevision,
       });
+
       expect(historicalJson.status).toBe(201);
       const jsonVersion = await historicalJson.json();
       expect(jsonVersion.session.historicalRevision).toBe(
@@ -295,16 +316,20 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
       ).toBeUndefined();
       const refreshedReviews = await (await request("/reviews")).json();
       expect(refreshedReviews.reviews[0].sourceUnavailable).toBeUndefined();
+
       const reopened = await (
         await request(`/reviews/${uuid}/open`, {
           revision: historicalJsonRevision,
         })
       ).json();
+
       expect(reopened.session).toEqual(jsonVersion.session);
+
       const unavailableDiff = await request(
         `/sessions/${jsonVersion.sessionId}/__progressive-review/diff-files`,
         {},
       );
+
       expect(unavailableDiff.status).toBe(400);
       expect((await unavailableDiff.json()).error).toBe(
         jsonVersion.session.sourceUnavailable,
@@ -342,6 +367,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
     await mkdir(dir, { recursive: true });
     await reviewVcs.init(dir);
     const source = await makeSourceRepository(directory);
+
     const record = {
       schemaVersion: 4,
       uuid,
@@ -360,6 +386,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
       lastPublishedAt: "2026-09-01T00:00:00Z",
       dismissedAt: "2026-01-01T00:00:00Z",
     };
+
     await writeFile(path.join(dir, "review.mdx"), "# Recovery");
     await writeFile(path.join(dir, ".gitignore"), ".build/\nreview.db*\n");
     await writeFile(path.join(dir, "review.json"), JSON.stringify(record));
@@ -395,10 +422,12 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
       path.join(dir, ".bundle/document/review-document.js"),
       'throw new Error("corrupt sealed document");',
     );
+
     const currentRevision = await reviewVcs.seal(
       dir,
       "Review publish candidate",
     );
+
     await writeFile(
       path.join(dir, "review.json"),
       JSON.stringify({ ...record, presentedDocumentRevision: currentRevision }),
@@ -412,16 +441,20 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
       author: "Reviewer",
     });
     closeAllReviewThreadStores();
+
     const files = [
       "review.json",
       "review.mdx",
       "review.db",
       ".git/refs/heads/main",
     ];
+
     const before = await Promise.all(
       files.map((file) => readFile(path.join(dir, file))),
     );
+
     const token = "recovery-secret";
+
     const server = createGlobalReviewServer({
       appPid: process.pid,
       packageRoot,
@@ -430,8 +463,10 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
       token,
       discoveryPath: path.join(directory, "desktop.json"),
     });
+
     try {
       await server.listen();
+
       const request = (route: string, body?: JsonObject) =>
         fetch(`${server.url}${route}`, {
           method: body ? "POST" : "GET",
@@ -441,6 +476,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
           },
           body: body ? JSON.stringify(body) : undefined,
         });
+
       const current = await request(`/reviews/${uuid}/open`, {});
       expect(current.status).toBe(409);
       expect(await current.json()).toMatchObject({
@@ -464,6 +500,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
   it("rejects an unknown Review view before opening a session", async () => {
     directory = await mkdtemp(path.join(tmpdir(), "review-view-server-"));
     const token = "review-view-test-token";
+
     const server = createGlobalReviewServer({
       appPid: process.pid,
       packageRoot,
@@ -475,6 +512,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
 
     try {
       await server.listen();
+
       const response = await fetch(
         `${server.url}/reviews/11111111-1111-4111-8111-111111111111/open`,
         {
@@ -502,6 +540,7 @@ it("rejects a publication whose review moved its base ref during the command", a
   directory = await mkdtemp(path.join(tmpdir(), "review-publish-race-"));
   vi.stubEnv("DEV_REVIEW_HOME", directory);
   const source = await makeSourceRepository(directory);
+
   const stored = await createReviewDir({
     worktreePath: source.root,
     baseRef: "main",
@@ -509,6 +548,7 @@ it("rejects a publication whose review moved its base ref during the command", a
     sourceCommit: source.commit,
     sourceIdentity: { kind: "git-branch", name: "main" },
   });
+
   await writeReviewDocumentBundle(
     stored.dir,
     bundleReviewDocument({
@@ -532,9 +572,12 @@ it("rejects a publication whose review moved its base ref during the command", a
       );
       putReviewRecord(stored.dir, { ...stored.review, baseRef: "release" });
     }
+
     return { ok: true };
   };
+
   const token = "publication-race-secret";
+
   const server = createGlobalReviewServer({
     appPid: process.pid,
     packageRoot,
@@ -544,8 +587,10 @@ it("rejects a publication whose review moved its base ref during the command", a
     discoveryPath: path.join(directory, "desktop.json"),
     relay,
   });
+
   try {
     await server.listen();
+
     const response = await fetch(`${server.url}/publish-ready`, {
       method: "POST",
       headers: {
@@ -589,16 +634,19 @@ describe("real legacy fixtures open end to end", () => {
           ["-C", repositoryRoot, "cat-file", "-e", `${commit}^{commit}`],
           { stdio: "pipe" },
         );
+
         return true;
       } catch {
         return false;
       }
     };
+
     const missing = legacyOpenFixtures.flatMap((fixture) =>
-      [fixture.baseCommit, fixture.sourceCommit]
-        .filter((commit) => !hasCommit(commit))
-        .map((commit) => `${fixture.name} ${commit}`),
+      [fixture.baseCommit, fixture.sourceCommit].flatMap((commit) =>
+        hasCommit(commit) ? [] : [`${fixture.name} ${commit}`],
+      ),
     );
+
     if (missing.length > 0)
       throw new Error(
         `Legacy fixture commits are missing from ${repositoryRoot}. Run \`git fetch --unshallow origin\` (or \`git fetch origin\`) and retry: ${missing.join(", ")}`,
@@ -610,6 +658,7 @@ describe("real legacy fixtures open end to end", () => {
       const { home, uuid, originalRecord } = await extractLegacyReviewFixture(
         fixture.name,
       );
+
       directory = home;
       const sourcePath = String(originalRecord.worktreePath);
       // Only the two pinned commits are needed. Cloning the monorepo copied
@@ -636,6 +685,7 @@ describe("real legacy fixtures open end to end", () => {
       );
       vi.stubEnv("DEV_REVIEW_HOME", home);
       const token = "fixture-secret";
+
       const server = createGlobalReviewServer({
         appPid: process.pid,
         packageRoot,
@@ -644,8 +694,10 @@ describe("real legacy fixtures open end to end", () => {
         token,
         discoveryPath: path.join(home, "desktop.json"),
       });
+
       try {
         await server.listen();
+
         const request = (route: string, body?: JsonObject) =>
           fetch(new URL(route, server.url), {
             method: body ? "POST" : "GET",
@@ -655,6 +707,7 @@ describe("real legacy fixtures open end to end", () => {
             },
             body: body ? JSON.stringify(body) : undefined,
           });
+
         const opened = await request(`/reviews/${uuid}/open`, {});
         expect(opened.status).toBe(201);
         const session = await opened.json();
@@ -662,9 +715,11 @@ describe("real legacy fixtures open end to end", () => {
         const documentResponse = await request(`${prefix}/document`);
         expect(documentResponse.status).toBe(200);
         const document = await documentResponse.json();
+
         const golden = reviewDocumentDataSchema.parse(
           await readLegacyReviewGolden(fixture.name, "document"),
         );
+
         expect(document).toMatchObject({
           ok: true,
           contentHash: bundleReviewDocument(golden).contentHash,
@@ -675,9 +730,11 @@ describe("real legacy fixtures open end to end", () => {
         const mapResponse = await request(`${prefix}/software-map`);
         expect(mapResponse.status).toBe(fixture.hasMap ? 200 : 404);
         const map = await mapResponse.json();
+
         const mapGolden = fixture.hasMap
           ? await readLegacyReviewGolden(fixture.name, "map")
           : null;
+
         expect(map).toMatchObject(
           fixture.hasMap
             ? { ok: true, contentHash: (mapGolden as JsonObject).contentHash }
@@ -703,13 +760,16 @@ describe("real legacy fixtures open end to end", () => {
 async function makeSourceRepository(parent: string) {
   const root = path.join(parent, "source");
   await mkdir(root, { recursive: true });
+
   const git = (args: string[]) =>
     execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+
   git(["init", "-q", "-b", "main"]);
   git(["config", "user.email", "test@example.com"]);
   git(["config", "user.name", "Test"]);
   await writeFile(path.join(root, "README.md"), "# Source\n");
   git(["add", "README.md"]);
   git(["commit", "-q", "-m", "Initial"]);
+
   return { root, commit: git(["rev-parse", "HEAD"]) };
 }

--- a/packages/progressive-review/src/server/desktop-server.test.ts
+++ b/packages/progressive-review/src/server/desktop-server.test.ts
@@ -18,10 +18,11 @@ import {
 } from "../review-bundle";
 import { reviewDocumentDataSchema } from "../review-document-data";
 import { createReviewDir, reviewTitleFromDocument } from "../review-home";
+import { putReviewRecord } from "../review-state-db";
 import { appendReviewComment } from "../review-state-store";
 import {
   closeAllReviewThreadStores,
-  createReviewThreadDb,
+  createLegacyReviewThreadDb,
 } from "../review-thread-store-backend";
 import { reviewVcs } from "../review-vcs";
 import {
@@ -187,7 +188,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
       path.join(dir, "review.json"),
       JSON.stringify({ ...record, presentedDocumentRevision: currentRevision }),
     );
-    createReviewThreadDb(dir);
+    createLegacyReviewThreadDb(dir);
     appendReviewComment(path.join(dir, "review.mdx"), {
       threadId: "recovery-thread",
       messageId: "recovery-message",
@@ -402,7 +403,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
       path.join(dir, "review.json"),
       JSON.stringify({ ...record, presentedDocumentRevision: currentRevision }),
     );
-    createReviewThreadDb(dir);
+    createLegacyReviewThreadDb(dir);
     appendReviewComment(path.join(dir, "review.mdx"), {
       threadId: "recovery-thread",
       messageId: "recovery-message",
@@ -529,6 +530,7 @@ it("rejects a publication whose review moved its base ref during the command", a
         path.join(stored.dir, "review.json"),
         JSON.stringify({ ...stored.review, baseRef: "release" }),
       );
+      putReviewRecord(stored.dir, { ...stored.review, baseRef: "release" });
     }
     return { ok: true };
   };

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -10,6 +10,7 @@ import {
   type JsonObject,
   type JsonValue,
   REVIEW_DESKTOP_DISCOVERY_VERSION,
+  ReviewAgentSessionRoleSchema,
   type ReviewCliInstallApplyResponse,
   type ReviewDescriptor,
   type ReviewDesktopDiscovery,
@@ -17,6 +18,7 @@ import {
   type ReviewRecord,
   type ReviewSessionDescriptor,
   type ReviewSessionWire,
+  ReviewThreadsCommandSchema,
   type ReviewTutorialOpenResponse,
   type ReviewVerbRequest,
   type ReviewVerbResponse,
@@ -62,6 +64,10 @@ import {
   reviewReapsAt,
   selectReapableReviews,
 } from "../review-attention";
+import {
+  readReviewDocumentFile,
+  writeReviewDocumentFile,
+} from "../review-document-files";
 import { listReviewDocumentVersions } from "../review-document-versions";
 import {
   ensureReviewPinnedCheckout,
@@ -75,15 +81,29 @@ import {
   countReviewComments,
   findReview,
   findReviewForRepair,
+  findScopedReview,
   listReviews,
   parseAnyStoredReviewRecord,
   parseStoredReviewRecord,
+  persistStoredReviewRecord,
   reviewDescriptor,
   reviewTitleFromDocument,
   reviewsHomeDir,
+  sealReviewCandidate,
   touchReviewAgentSession,
 } from "../review-home";
 import type { RunReviewInfoInput } from "../review-info";
+import {
+  ReviewDocumentFileNameSchema,
+  ReviewDocumentFileWriteSchema,
+  ReviewLifecycleTargetSchema,
+  ReviewListRequestSchema,
+  ReviewMetadataUpdateSchema,
+  ReviewPublishRequestSchema,
+  ReviewRebindRequestSchema,
+  ReviewResolveRequestSchema,
+  ReviewScaffoldRequestSchema,
+} from "../review-lifecycle-contracts";
 import {
   ReviewBusyError,
   reviewBusyResponse,
@@ -100,7 +120,10 @@ import {
 } from "../review-publish-thread-gate";
 import { clearReopenPending, markReopenPending } from "../review-reopen-marker";
 import { ReviewRepairReadyRequestSchema } from "../review-repair-state";
-import { devReviewHome } from "../review-storage";
+import { runReviewScaffold } from "../review-scaffold";
+import { deleteReviewState } from "../review-state-db";
+import { devReviewHome, readOpenReviewThreadCount } from "../review-storage";
+import { ReviewThreadsService } from "../review-threads-service";
 import { readReviewSoftwareMapBundle } from "../software-map-bundle";
 import { createTutorialAuthoringSession } from "../tutorial-authoring-session";
 import type { ReviewSubmissionEvent } from "../types";
@@ -136,13 +159,22 @@ import {
   readBoundedRequestJson,
 } from "./hono-http";
 import { HttpJsonError, ReviewServerError } from "./http-json";
+import { resolvePublishReview } from "./publish-preparation";
 import {
   materializePublishRevision,
   reviewWithPresentedDocumentPins,
 } from "./publish-stage";
 import { captureSanitizedUiTelemetry } from "./review-api";
 import { resolveReviewInfo } from "./review-info";
+import {
+  agentEnvironment,
+  publishReview,
+  publishReviewSoftwareMap,
+  rebindReview,
+  repairReview,
+} from "./review-lifecycle";
 import { promoteReviewRepair } from "./review-repair-promotion";
+import { resolveThreadsReview } from "./review-threads-target";
 import {
   type ReviewSessionHandler,
   createReviewSessionHandler,
@@ -316,6 +348,18 @@ export function createGlobalReviewServer(
   const telemetry = input.telemetry ?? ProgressiveReviewTelemetry.fromEnv();
   const relay = input.relay ?? new GlobalReviewDesktopVerbRelay();
   const sessions = new Map<string, ActiveReviewSession>();
+  const threadServices = new Map<string, ReviewThreadsService>();
+  function threadsFor(review: StoredReview): ReviewThreadsService {
+    let service = threadServices.get(review.review.uuid);
+    if (!service) {
+      service = new ReviewThreadsService({
+        reviewPath: path.join(review.dir, "review.mdx"),
+        author: process.env.USER ?? "Reviewer",
+      });
+      threadServices.set(review.review.uuid, service);
+    }
+    return service;
+  }
   const reviewLocks = new Map<string, Promise<void>>();
   const globalClients = new Set<ReviewDesktopEventClient>();
   const tutorial = createTutorialService({
@@ -914,76 +958,282 @@ export function createGlobalReviewServer(
     await resetCliInstall();
     return globalJson(200, { ok: true });
   });
+  app.post("/lifecycle/scaffold", async (context) => {
+    const request = ReviewScaffoldRequestSchema.parse(
+      await readBoundedRequestJson(context.req.raw),
+    );
+    return globalJson(
+      200,
+      await runReviewScaffold({
+        ...request,
+        env: agentEnvironment(request.agent),
+        toolingRoot: input.toolingRoot,
+      }),
+    );
+  });
+  app.post("/lifecycle/open-thread-count", async (context) => {
+    const request = z
+      .strictObject({ reviewUuid: z.uuid() })
+      .parse(await readBoundedRequestJson(context.req.raw));
+    const review = await findReview(request.reviewUuid);
+    if (!review) throw new ReviewServerError("Review not found.", 404);
+    return globalJson(200, readOpenReviewThreadCount(review.dir));
+  });
+  app.post("/lifecycle/document/read", async (context) => {
+    const request = z
+      .strictObject({
+        reviewUuid: z.uuid(),
+        name: ReviewDocumentFileNameSchema,
+      })
+      .parse(await readBoundedRequestJson(context.req.raw));
+    const review = await findReview(request.reviewUuid);
+    if (!review) throw new ReviewServerError("Review not found.", 404);
+    return globalJson(200, await readReviewDocumentFile(review, request.name));
+  });
+  app.post("/lifecycle/metadata", async (context) => {
+    const request = ReviewMetadataUpdateSchema.extend({
+      reviewUuid: z.uuid(),
+    }).parse(await readBoundedRequestJson(context.req.raw));
+    const record = await withReviewLock(request.reviewUuid, async () => {
+      const stored = await findReview(request.reviewUuid);
+      if (!stored) throw new ReviewServerError("Review not found.", 404);
+      if (stored.review.title !== request.expectedTitle)
+        throw new ReviewServerError(
+          "Review title changed; read metadata again before updating.",
+          409,
+        );
+      const review = {
+        ...stored.review,
+        title: request.title,
+        titleOverride: request.title,
+      };
+      await persistStoredReviewRecord(stored.dir, review);
+      for (const session of sessions.values()) {
+        if (session.review.review.uuid === request.reviewUuid)
+          session.review = {
+            ...session.review,
+            review: {
+              ...session.review.review,
+              title: review.title,
+              titleOverride: review.titleOverride,
+            },
+          };
+      }
+      return review;
+    });
+    broadcastGlobal({
+      event: "review-metadata-changed",
+      uuid: request.reviewUuid,
+      title: record.title,
+    });
+    return globalJson(200, record);
+  });
+  app.post("/lifecycle/document/write", async (context) => {
+    const request = ReviewDocumentFileWriteSchema.extend({
+      reviewUuid: z.uuid(),
+    }).parse(await readBoundedRequestJson(context.req.raw));
+    return withReviewLock(request.reviewUuid, async () => {
+      const review = await findReview(request.reviewUuid);
+      if (!review) throw new ReviewServerError("Review not found.", 404);
+      return globalJson(200, await writeReviewDocumentFile(review, request));
+    });
+  });
+  app.post("/lifecycle/threads/resolve-target", async (context) => {
+    const request = ReviewLifecycleTargetSchema.parse(
+      await readBoundedRequestJson(context.req.raw),
+    );
+    return globalJson(
+      200,
+      await resolveThreadsReview(request.cwd, request.reviewUuid),
+    );
+  });
+  app.post("/lifecycle/threads/snapshot", async (context) => {
+    const request = z
+      .strictObject({ reviewUuid: z.uuid() })
+      .parse(await readBoundedRequestJson(context.req.raw));
+    const review = await findReview(request.reviewUuid);
+    if (!review) throw new ReviewServerError("Review not found.", 404);
+    return globalJson(200, {
+      ok: true,
+      snapshot: threadsFor(review).snapshot(),
+    });
+  });
+  app.post("/lifecycle/threads/command", async (context) => {
+    const request = z
+      .strictObject({
+        reviewUuid: z.uuid(),
+        command: ReviewThreadsCommandSchema,
+      })
+      .parse(await readBoundedRequestJson(context.req.raw));
+    return withReviewLock(request.reviewUuid, async () => {
+      const review = await findReview(request.reviewUuid);
+      if (!review) throw new ReviewServerError("Review not found.", 404);
+      const commit = threadsFor(review).dispatch(request.command);
+      if (!commit)
+        throw new ReviewServerError(
+          `Comment thread not found: ${"threadId" in request.command ? request.command.threadId : "unknown"}`,
+          404,
+        );
+      return globalJson(200, { ok: true, commit });
+    });
+  });
+  app.post("/lifecycle/threads/reply", async (context) => {
+    const request = z
+      .strictObject({
+        reviewUuid: z.uuid(),
+        mutationId: z.uuid(),
+        threadId: z.string().min(1),
+        messageId: z.uuid(),
+        author: z.string().trim().min(1),
+        body: z.string().trim().min(1),
+        format: z.enum(["plain", "markdown"]),
+      })
+      .parse(await readBoundedRequestJson(context.req.raw));
+    return withReviewLock(request.reviewUuid, async () => {
+      const review = await findReview(request.reviewUuid);
+      if (!review) throw new ReviewServerError("Review not found.", 404);
+      const commit = threadsFor(review).appendAgentMessage(request);
+      if (!commit)
+        throw new ReviewServerError(
+          `Comment thread not found: ${request.threadId}`,
+          404,
+        );
+      return globalJson(200, { ok: true, commit });
+    });
+  });
+  app.post("/lifecycle/rebind", async (context) => {
+    const request = ReviewRebindRequestSchema.parse(
+      await readBoundedRequestJson(context.req.raw),
+    );
+    return globalJson(
+      200,
+      await rebindReview({
+        ...request,
+        env: agentEnvironment(request.agent),
+        toolingRoot: input.toolingRoot,
+      }),
+    );
+  });
+  app.post("/lifecycle/resolve", async (context) => {
+    const request = ReviewResolveRequestSchema.parse(
+      await readBoundedRequestJson(context.req.raw),
+    );
+    return globalJson(
+      200,
+      await resolvePublishReview(request.cwd, request.reviewUuid, {
+        includeTerminal: request.includeTerminal,
+      }),
+    );
+  });
+  app.post("/lifecycle/find", async (context) => {
+    const request = z
+      .strictObject({
+        reviewUuid: z.uuid(),
+        worktreePath: z.string(),
+        includeTerminal: z.boolean().optional(),
+        includeLegacySchema: z.boolean().optional(),
+      })
+      .parse(await readBoundedRequestJson(context.req.raw));
+    return globalJson(200, await findScopedReview(request.reviewUuid, request));
+  });
+  app.post("/lifecycle/list", async (context) =>
+    globalJson(
+      200,
+      await listReviews(
+        ReviewListRequestSchema.parse(
+          await readBoundedRequestJson(context.req.raw),
+        ),
+      ),
+    ),
+  );
+  app.post("/lifecycle/checkpoint", async (context) => {
+    const request = z
+      .strictObject({ reviewUuid: z.uuid(), message: z.string().min(1) })
+      .parse(await readBoundedRequestJson(context.req.raw));
+    const review = await findReview(request.reviewUuid);
+    if (!review) throw new ReviewServerError("Review not found.", 404);
+    return globalJson(
+      200,
+      await withReviewLock(request.reviewUuid, () =>
+        sealReviewCandidate(review.dir, request.message),
+      ),
+    );
+  });
+  app.post("/lifecycle/agent-session", async (context) => {
+    const request = z
+      .strictObject({
+        reviewUuid: z.uuid(),
+        session: z.string(),
+        role: ReviewAgentSessionRoleSchema,
+      })
+      .parse(await readBoundedRequestJson(context.req.raw));
+    const review = await findReview(request.reviewUuid);
+    if (!review) throw new ReviewServerError("Review not found.", 404);
+    return globalJson(
+      200,
+      await withReviewLock(request.reviewUuid, () =>
+        touchReviewAgentSession(review, request.session, request.role),
+      ),
+    );
+  });
+  app.post("/lifecycle/publish", async (context) =>
+    globalJson(
+      200,
+      await publishReview(
+        ReviewPublishRequestSchema.parse(
+          await readBoundedRequestJson(context.req.raw),
+        ),
+        completeDocumentPublication,
+      ),
+    ),
+  );
+  app.post("/lifecycle/map/publish", async (context) =>
+    globalJson(
+      200,
+      await publishReviewSoftwareMap(
+        ReviewPublishRequestSchema.parse(
+          await readBoundedRequestJson(context.req.raw),
+        ),
+        async (request) => {
+          await completeMapPublication(request);
+        },
+      ),
+    ),
+  );
   app.post("/publish-ready", async (context) => {
     try {
       const request = parseReviewPublishReadyRequest(
         await readBoundedRequestJson(context.req.raw),
       );
-      let review = await findReview(request.reviewUuid);
-      if (!review) throw new ReviewServerError("Review not found.", 404);
-      const agent = request.agent;
-      if (agent) {
-        const found = review;
-        review = await withReviewLock(request.reviewUuid, () =>
-          touchReviewAgentSession(
-            found,
-            authoringSessionKey(agent),
-            "publisher",
-          ),
-        );
-      }
-      return globalJson(
-        201,
-        await mountPublishedDocument(review, request.revision, request.view),
-      );
+      return globalJson(201, await completeDocumentPublication(request));
     } catch (error) {
       await telemetry.capturePublishGateRejected({ gate: "publish_ready" });
       throw error;
     }
   });
+  app.post("/lifecycle/repair", async (context) =>
+    globalJson(
+      200,
+      await repairReview(
+        ReviewLifecycleTargetSchema.extend({ reviewUuid: z.uuid() }).parse(
+          await readBoundedRequestJson(context.req.raw),
+        ),
+        completeReviewRepair,
+      ),
+    ),
+  );
   app.post("/repair-ready", async (context) => {
     const request = ReviewRepairReadyRequestSchema.parse(
       await readBoundedRequestJson(context.req.raw),
     );
-    const review = await findReviewForRepair(request.reviewUuid);
-    if (!review) throw new ReviewServerError("Review not found.", 404);
-    return globalJson(
-      201,
-      await promoteReviewRepair({
-        review,
-        request,
-        sessions,
-        registerSerialized,
-        withReviewLock,
-        dispatch: (sessionId, verb) => relay.dispatch(sessionId, verb),
-        startSessionTelemetry,
-        closeSession: (session, reason) => closeSession(session, reason, false),
-        broadcast: broadcastGlobal,
-      }),
-    );
+    return globalJson(201, await completeReviewRepair(request));
   });
   app.post("/map-publish-ready", async (context) => {
     try {
       const request = parseReviewPublishReadyRequest(
         await readBoundedRequestJson(context.req.raw),
       );
-      let review = await findReview(request.reviewUuid);
-      if (!review) throw new ReviewServerError("Review not found.", 404);
-      const agent = request.agent;
-      if (agent) {
-        const found = review;
-        review = await withReviewLock(request.reviewUuid, () =>
-          touchReviewAgentSession(
-            found,
-            authoringSessionKey(agent),
-            "publisher",
-          ),
-        );
-      }
-      return globalJson(
-        201,
-        await mountPublishedSoftwareMap(review, request.revision),
-      );
+      return globalJson(201, await completeMapPublication(request));
     } catch (error) {
       await telemetry.capturePublishGateRejected({
         gate: "map_publish_ready",
@@ -1121,7 +1371,7 @@ export function createGlobalReviewServer(
     return response;
   }
 
-  // The CLI already validated, bundled, and sealed the revision; the server
+  // Publication preparation validated, bundled, and sealed the revision; the server
   // materializes it, has the app mount it off-screen, and promotes it only
   // when that mount is clean.
   function mountStepTimings(
@@ -1130,6 +1380,57 @@ export function createGlobalReviewServer(
     if (!validation.ok) return [];
     const parsed = MountVerbResultSchema.safeParse(validation.result);
     return parsed.success ? (parsed.data.timings ?? []) : [];
+  }
+
+  async function completeReviewRepair(
+    request: ReturnType<typeof ReviewRepairReadyRequestSchema.parse>,
+  ) {
+    const review = await findReviewForRepair(request.reviewUuid);
+    if (!review) throw new ReviewServerError("Review not found.", 404);
+    return promoteReviewRepair({
+      review,
+      request,
+      sessions,
+      registerSerialized,
+      withReviewLock,
+      dispatch: (sessionId, verb) => relay.dispatch(sessionId, verb),
+      startSessionTelemetry,
+      closeSession: (session, reason) => closeSession(session, reason, false),
+      broadcast: broadcastGlobal,
+      onPromoted: () => {
+        threadServices.delete(request.reviewUuid);
+      },
+    });
+  }
+
+  async function completeDocumentPublication(
+    request: ReturnType<typeof parseReviewPublishReadyRequest>,
+  ) {
+    let review = await findReview(request.reviewUuid);
+    if (!review) throw new ReviewServerError("Review not found.", 404);
+    const agent = request.agent;
+    if (agent) {
+      const found = review;
+      review = await withReviewLock(request.reviewUuid, () =>
+        touchReviewAgentSession(found, authoringSessionKey(agent), "publisher"),
+      );
+    }
+    return mountPublishedDocument(review, request.revision, request.view);
+  }
+
+  async function completeMapPublication(
+    request: ReturnType<typeof parseReviewPublishReadyRequest>,
+  ) {
+    let review = await findReview(request.reviewUuid);
+    if (!review) throw new ReviewServerError("Review not found.", 404);
+    const agent = request.agent;
+    if (agent) {
+      const found = review;
+      review = await withReviewLock(request.reviewUuid, () =>
+        touchReviewAgentSession(found, authoringSessionKey(agent), "publisher"),
+      );
+    }
+    return mountPublishedSoftwareMap(review, request.revision);
   }
 
   async function mountPublishedDocument(
@@ -1770,6 +2071,8 @@ export function createGlobalReviewServer(
         open.map((session) => closeSession(session, "closed", false)),
       );
       await rm(dir, { recursive: true, force: true });
+      deleteReviewState(dir);
+      threadServices.delete(uuid);
       const worktreePath = open[0]?.review.review.worktreePath;
       if (worktreePath) {
         await clearReopenPending(worktreePath).catch(() => undefined);
@@ -1798,6 +2101,8 @@ export function createGlobalReviewServer(
       reviewUuid: review.review.uuid,
     });
     await rm(review.dir, { recursive: true, force: true });
+    deleteReviewState(review.dir);
+    threadServices.delete(review.review.uuid);
     await clearReopenPending(review.review.worktreePath).catch(() => undefined);
     broadcastGlobal({ event: "review-deleted", uuid: review.review.uuid });
   }
@@ -1963,6 +2268,9 @@ export function createGlobalReviewServer(
       reviewPath: registration.documentPath,
       softwareMapRootPath: registration.softwareMapRootPath,
       stateReviewPath: path.join(registration.review.dir, "review.mdx"),
+      threadsService: registration.historicalRevision
+        ? undefined
+        : () => threadsFor(active.review),
       readOnlyThreadsPath: registration.readOnlyThreadsPath,
       routePath: "/",
       token,
@@ -2422,6 +2730,7 @@ export function createGlobalReviewServer(
         ),
       );
       relay.close();
+      threadServices.clear();
       for (const client of globalClients) client.close();
       globalClients.clear();
       await Promise.all(
@@ -2651,8 +2960,9 @@ async function promoteReview(
     viewedAt: null,
     dismissedAt: null,
   };
-  if (title) review.title = title;
-  await writePrivateJsonAtomic(path.join(stored.dir, "review.json"), review);
+  if (stored.review.titleOverride) review.title = stored.review.titleOverride;
+  else if (title) review.title = title;
+  await persistStoredReviewRecord(stored.dir, review);
   return { ...stored, review };
 }
 
@@ -2664,7 +2974,7 @@ async function promoteSoftwareMap(
     ...stored.review,
     presentedSoftwareMapRevision: revision,
   };
-  await writePrivateJsonAtomic(path.join(stored.dir, "review.json"), review);
+  await persistStoredReviewRecord(stored.dir, review);
   return { ...stored, review };
 }
 
@@ -2718,7 +3028,7 @@ async function setReviewStatus(
   status: ReviewRecord["status"],
 ): Promise<StoredReview> {
   const review: StoredReviewRecord = { ...stored.review, status };
-  await writePrivateJsonAtomic(path.join(stored.dir, "review.json"), review);
+  await persistStoredReviewRecord(stored.dir, review);
   return { ...stored, review };
 }
 

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -202,7 +202,9 @@ const MountVerbResultSchema = z.object({
 });
 
 const REVIEW_REAPER_INTERVAL_MS = 60 * 60 * 1_000;
+
 const TUTORIAL_LIFECYCLE_LOCK_KEY = "tutorial-lifecycle";
+
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -332,25 +334,33 @@ export function createGlobalReviewServer(
   let boundPort = input.port;
   const urlForBoundPort = () => `http://127.0.0.1:${boundPort}`;
   const discoveryPath = input.discoveryPath ?? reviewDesktopDiscoveryPath();
+
   const sessionHandlerFactory =
     input.sessionHandlerFactory ?? createReviewSessionHandler;
+
   const tutorialAuthoringSessionFactory =
     input.tutorialAuthoringSessionFactory ?? createTutorialAuthoringSession;
+
   const tutorialAuthorSessionBinder =
     input.tutorialAuthorSessionBinder ?? bindReviewAuthorSession;
+
   const tutorialAgentResolver =
     input.tutorialAgentResolver ??
     (async () =>
       preferredInstalledReviewAgent(await resolveInstalledReviewAgentStatus()));
+
   const publishRuntime = input.publishRuntime ?? {
     materializePublishRevision,
   };
+
   const telemetry = input.telemetry ?? ProgressiveReviewTelemetry.fromEnv();
   const relay = input.relay ?? new GlobalReviewDesktopVerbRelay();
   const sessions = new Map<string, ActiveReviewSession>();
   const threadServices = new Map<string, ReviewThreadsService>();
+
   function threadsFor(review: StoredReview): ReviewThreadsService {
     let service = threadServices.get(review.review.uuid);
+
     if (!service) {
       service = new ReviewThreadsService({
         reviewPath: path.join(review.dir, "review.mdx"),
@@ -358,14 +368,18 @@ export function createGlobalReviewServer(
       });
       threadServices.set(review.review.uuid, service);
     }
+
     return service;
   }
+
   const reviewLocks = new Map<string, Promise<void>>();
   const globalClients = new Set<ReviewDesktopEventClient>();
+
   const tutorial = createTutorialService({
     packageRoot: input.packageRoot,
     deleteReview: deleteStoredReview,
   });
+
   let preparedTutorial: PreparedTutorial | null = null;
   const tutorialAuthoringStates = new Map<string, TutorialAuthoringState>();
   let reviewReaper: ReturnType<typeof setInterval> | undefined;
@@ -373,8 +387,10 @@ export function createGlobalReviewServer(
   let agentPreparation: Promise<void> | undefined;
   const harnesses = { "claude-code": claudeCode, codex, opencode, pi } as const;
   const agentServers = new Map<ReviewAgentHarness, AgentServer>();
+
   const agentServerFor = (harness: ReviewAgentHarness): AgentServer => {
     let server = agentServers.get(harness);
+
     if (!server) {
       server = harnesses[harness].server({
         runtimeDirectory: path.join(devReviewHome(), "native-agent"),
@@ -384,8 +400,10 @@ export function createGlobalReviewServer(
       });
       agentServers.set(harness, server);
     }
+
     return server;
   };
+
   async function prepareAgentServers(): Promise<void> {
     const status = await resolveInstalledReviewAgentStatus();
     await Promise.all(
@@ -397,8 +415,10 @@ export function createGlobalReviewServer(
           )
         )
           return;
+
         if (!(await executableOnPath(harness)) || closing) return;
         const startedAt = Date.now();
+
         try {
           await agentServerFor(harness).prepare?.();
           console.info(
@@ -411,6 +431,7 @@ export function createGlobalReviewServer(
       }),
     );
   }
+
   const openNativeAgentTerminal = async (
     reviewSessionId: string,
     terminal: Extract<
@@ -422,10 +443,12 @@ export function createGlobalReviewServer(
       name: "openNativeAgentTerminal",
       args: terminal,
     });
+
     if (!opened.ok) throw new Error(opened.error);
   };
 
   const cliPath = path.join(input.packageRoot, "dist", "cli.js");
+
   const discovery: ReviewDesktopDiscovery = {
     version: REVIEW_DESKTOP_DISCOVERY_VERSION,
     instanceId,
@@ -435,12 +458,14 @@ export function createGlobalReviewServer(
     token,
     startedAt: Date.now(),
   };
+
   // A source-run dev server has no built CLI to advertise.
   if (existsSync(cliPath)) {
     discovery.cliPath = cliPath;
     discovery.cliVersion = readProgressiveReviewPackageVersion(
       pathToFileURL(cliPath).href,
     );
+
     if (input.cliRuntimePath && existsSync(input.cliRuntimePath)) {
       discovery.cliRuntimePath = input.cliRuntimePath;
     }
@@ -464,16 +489,20 @@ export function createGlobalReviewServer(
     if (!isAuthorizedRequest(context.req.raw, token)) {
       return globalJson(401, { ok: false, error: "Unauthorized" });
     }
+
     await next();
   });
   // Native agents can read their draft before launch returns and a session is bound.
   // Every lookup is authenticated by the desktop token above.
   app.get("/agent-threads/:threadId", (context) => {
     const threadId = context.req.param("threadId");
+
     for (const session of sessions.values()) {
       const found = session.handler.findAgentThread(threadId);
+
       if (found) return globalJson(200, found);
     }
+
     return globalJson(404, {
       ok: false,
       error: `Comment thread not found: ${threadId}`,
@@ -484,6 +513,7 @@ export function createGlobalReviewServer(
       name: "focusWindow",
       args: {},
     });
+
     return globalJson(result.ok ? 200 : 409, result);
   });
   app.post("/telemetry/event", async (context) => {
@@ -504,27 +534,32 @@ export function createGlobalReviewServer(
         },
         payload.error,
       );
+
       if (flushBeforeOptOut) await telemetry.flush(500);
     } catch (error) {
       console.error(error);
     }
+
     return globalJson(200, { ok: true });
   });
   app.get("/reviews", async () => {
     const { dismissedRetentionDays } = await readReviewPreferences();
     await reapDismissedReviews(dismissedRetentionDays);
     const listed = await listReviews();
+
     const reviews = await Promise.all(
       listed.reviews.map((stored) =>
         reviewDescriptor(stored, { retentionDays: dismissedRetentionDays }),
       ),
     );
+
     reviews.sort(
       (left, right) =>
         (right.lastPublishedAt ?? "").localeCompare(
           left.lastPublishedAt ?? "",
         ) || left.uuid.localeCompare(right.uuid),
     );
+
     return globalJson(200, { reviews, errors: listed.errors });
   });
   app.get("/sessions", () =>
@@ -542,6 +577,7 @@ export function createGlobalReviewServer(
       TUTORIAL_LIFECYCLE_LOCK_KEY,
       prepareTutorialLocked,
     );
+
     return globalJson(200, {
       ok: true,
       reviewUuid: prepared.review.review.uuid,
@@ -551,9 +587,11 @@ export function createGlobalReviewServer(
   // integration checks fetch it here.
   app.get("/tutorial/review", async () => {
     const stored = await tutorial.find();
+
     if (!stored) {
       throw new ReviewServerError("Review not found.", 404);
     }
+
     return globalJson(200, await reviewDescriptor(stored));
   });
   app.post("/tutorial/open", async () => {
@@ -564,13 +602,16 @@ export function createGlobalReviewServer(
   });
   app.delete("/tutorial", async () => {
     await withReviewLock(TUTORIAL_LIFECYCLE_LOCK_KEY, deleteTutorialLocked);
+
     return globalJson(200, { ok: true });
   });
   app.post("/reviews/:uuid/open", async (context) => {
     const uuid = context.req.param("uuid");
+
     if (!UUID_PATTERN.test(uuid)) {
       throw new ReviewServerError("Review not found.", 404);
     }
+
     /* A background open keeps the canvas where it is: the Source tab opens
        sessions purely to root its file tree. Body-less requests (the CLI)
        stay foreground. */
@@ -579,9 +620,11 @@ export function createGlobalReviewServer(
       undefined,
       null,
     );
+
     const openBody = isJsonObject(openBodyValue) ? openBodyValue : null;
     const background = openBody?.background === true;
     const parsedView = reviewViewSchema.safeParse(openBody?.view);
+
     if (openBody?.view !== undefined && !parsedView.success) {
       throw new ReviewServerError(
         "Review view must be one of review, commits, diff, map, or trace.",
@@ -589,13 +632,16 @@ export function createGlobalReviewServer(
         "invalid_view",
       );
     }
+
     const view = parsedView.success ? parsedView.data : undefined;
     let review: StoredReview | null;
+
     try {
       review = await findReview(uuid);
     } catch (error) {
       if (error instanceof ReviewHomeScanError) {
         const first = error.errors[0];
+
         if (first?.code === "REVIEW_BUSY") throw error;
         throw new ReviewServerError(
           first?.message ?? error.message,
@@ -605,16 +651,21 @@ export function createGlobalReviewServer(
             : "migration_required",
         );
       }
+
       throw error;
     }
+
     if (!review) {
       throw new ReviewServerError("Review not found.", 404);
     }
+
     const descriptor = await reviewDescriptor(review);
     const appSessionIdHeader = context.req.header(REVIEW_APP_SESSION_ID_HEADER);
+
     const appSessionId = isValidReviewAppSessionId(appSessionIdHeader)
       ? appSessionIdHeader
       : undefined;
+
     if (!descriptor.available) {
       throw new ReviewServerError(
         "The review worktree or document is unavailable.",
@@ -622,6 +673,7 @@ export function createGlobalReviewServer(
         "review_unavailable",
       );
     }
+
     if (!review.review.presentedDocumentRevision) {
       throw new ReviewServerError(
         "Review has no published revision yet. Run `review publish` first.",
@@ -629,10 +681,13 @@ export function createGlobalReviewServer(
         "review_unpublished",
       );
     }
+
     const revisionValue = openBody
       ? jsonProperty(openBody, "revision")
       : undefined;
+
     const revision = jsonString(revisionValue);
+
     if (
       revisionValue !== undefined &&
       (revision === undefined || !/^[0-9a-f]{40}$/.test(revision))
@@ -643,11 +698,13 @@ export function createGlobalReviewServer(
         "invalid_revision",
       );
     }
+
     const requestedRevision =
       revision !== undefined &&
       revision !== review.review.presentedDocumentRevision
         ? revision
         : undefined;
+
     if (requestedRevision) {
       return openHistoricalReviewSession(
         review,
@@ -657,21 +714,25 @@ export function createGlobalReviewServer(
         view,
       );
     }
+
     const documentRevision = review.review.presentedDocumentRevision;
     /* Opening is what "viewed" means. Stamping here rather than on first
        render keeps the rule in one place and survives a canvas that never
        finishes loading. A dismissed review the reader reopens comes back. */
     const wasDismissed = Boolean(review.review.dismissedAt);
     const viewed = await restoreReview(await markReviewViewed(review));
+
     if (viewed.review !== review.review) {
       await broadcastReviewAttention(viewed, "viewed");
     }
+
     const homeReview: ReviewDescriptor = {
       ...descriptor,
       viewedAt: viewed.review.viewedAt ?? null,
       dismissedAt: viewed.review.dismissedAt ?? null,
       reapsAt: null,
     };
+
     if (wasDismissed) {
       await captureSanitizedUiTelemetry(
         telemetry,
@@ -680,12 +741,16 @@ export function createGlobalReviewServer(
         { via: "open" },
       );
     }
+
     const existing = activeSessionForReview(review.review.uuid);
+
     if (existing) {
       existing.appSessionId ??= appSessionId;
+
       if (!background) {
         void relay.dispatch(existing.descriptor.sessionId, revealVerb(view));
       }
+
       return globalJson(200, {
         sessionId: existing.descriptor.sessionId,
         url: existing.descriptor.sessionUrl,
@@ -693,7 +758,9 @@ export function createGlobalReviewServer(
         review: homeReview,
       });
     }
+
     let documentUnavailable: string | undefined;
+
     const documentBuildDir = await publishRuntime
       .materializePublishRevision({
         review: viewed,
@@ -701,12 +768,16 @@ export function createGlobalReviewServer(
       })
       .catch(() => {
         documentUnavailable = `The presented document revision ${documentRevision} is unavailable.`;
+
         return path.join(review.dir, ".build", documentRevision);
       });
+
     const presentedReview = documentUnavailable
       ? viewed
       : await reviewWithPresentedDocumentPins(viewed, documentBuildDir);
+
     let softwareMapUnavailable: string | undefined;
+
     const softwareMapRootPath = viewed.review.presentedSoftwareMapRevision
       ? await publishRuntime
           .materializePublishRevision({
@@ -716,9 +787,11 @@ export function createGlobalReviewServer(
           .then((root) => presentedMapRoot(root, false))
           .catch(() => {
             softwareMapUnavailable = `The presented software map revision ${viewed.review.presentedSoftwareMapRevision} is unavailable.`;
+
             return undefined;
           })
       : undefined;
+
     const active = await registerSerialized({
       review: presentedReview,
       canonicalRecord: viewed.review,
@@ -733,6 +806,7 @@ export function createGlobalReviewServer(
       background,
       appSessionId,
     });
+
     return globalJson(201, {
       sessionId: active.descriptor.sessionId,
       url: active.descriptor.sessionUrl,
@@ -753,9 +827,11 @@ export function createGlobalReviewServer(
         session.review.review.uuid === review.review.uuid &&
         session.historicalRevision === revision,
     );
+
     if (existing) {
       existing.appSessionId ??= appSessionId;
       void relay.dispatch(existing.descriptor.sessionId, revealVerb(view));
+
       return globalJson(200, {
         sessionId: existing.descriptor.sessionId,
         url: existing.descriptor.sessionUrl,
@@ -763,7 +839,9 @@ export function createGlobalReviewServer(
         review: homeReview,
       });
     }
+
     let documentBuildDir: string;
+
     try {
       documentBuildDir = await publishRuntime.materializePublishRevision({
         review,
@@ -776,16 +854,21 @@ export function createGlobalReviewServer(
         "revision_not_found",
       );
     }
+
     const presentedValue = JSON.parse(
       await readFile(path.join(documentBuildDir, "review.json"), "utf8"),
     );
+
     const presentedRecord = parseAnyStoredReviewRecord(presentedValue);
+
     const presentedReview = await reviewWithPresentedDocumentPins(
       review,
       documentBuildDir,
       presentedRecord,
     );
+
     let softwareMapUnavailable: string | undefined;
+
     const softwareMapRootPath = presentedRecord.presentedSoftwareMapRevision
       ? await publishRuntime
           .materializePublishRevision({
@@ -797,9 +880,11 @@ export function createGlobalReviewServer(
           )
           .catch(() => {
             softwareMapUnavailable = `The historical software map revision ${presentedRecord.presentedSoftwareMapRevision} is unavailable.`;
+
             return undefined;
           })
       : undefined;
+
     const active = await registerSerialized({
       review: presentedReview,
       canonicalRecord: review.review,
@@ -813,6 +898,7 @@ export function createGlobalReviewServer(
       view,
       appSessionId,
     });
+
     return globalJson(201, {
       sessionId: active.descriptor.sessionId,
       url: active.descriptor.sessionUrl,
@@ -820,17 +906,20 @@ export function createGlobalReviewServer(
       review: homeReview,
     });
   }
+
   app.post("/reviews/:uuid/dismiss", async (context) => {
     const descriptor = await setReviewDismissed(
       context.req.param("uuid"),
       true,
     );
+
     await captureSanitizedUiTelemetry(
       telemetry,
       context.req.raw,
       "review_dismissed",
       { via: "home" },
     );
+
     return globalJson(200, descriptor);
   });
   app.post("/reviews/:uuid/restore", async (context) => {
@@ -838,12 +927,14 @@ export function createGlobalReviewServer(
       context.req.param("uuid"),
       false,
     );
+
     await captureSanitizedUiTelemetry(
       telemetry,
       context.req.raw,
       "review_restored",
       { via: "home" },
     );
+
     return globalJson(200, descriptor);
   });
   app.get("/preferences", async () =>
@@ -851,48 +942,62 @@ export function createGlobalReviewServer(
   );
   app.put("/preferences", async (context) => {
     const body = await readBoundedRequestJson(context.req.raw);
+
     const value = isJsonObject(body)
       ? jsonProperty(body, "dismissedRetentionDays")
       : undefined;
+
     const dismissedRetentionDays = value === null ? null : jsonNumber(value);
+
     if (dismissedRetentionDays === undefined) {
       throw new ReviewServerError(
         "dismissedRetentionDays must be a number or null.",
         400,
       );
     }
+
     const saved = await writeReviewPreferences({ dismissedRetentionDays });
     broadcastGlobal({ event: "preferences-changed", preferences: saved });
+
     return globalJson(200, saved);
   });
   app.delete("/reviews/:uuid", async (context) => {
     const uuid = context.req.param("uuid");
+
     if (!UUID_PATTERN.test(uuid)) {
       throw new ReviewServerError("Review not found.", 404);
     }
+
     const referencesTutorial =
       preparedTutorial?.review.review.uuid === uuid ||
       tutorialAuthoringStates.has(uuid) ||
       (await tutorial.referencesReview(uuid));
+
     if (referencesTutorial) {
       await withReviewLock(TUTORIAL_LIFECYCLE_LOCK_KEY, async () => {
         const stillReferencesTutorial =
           preparedTutorial?.review.review.uuid === uuid ||
           tutorialAuthoringStates.has(uuid) ||
           (await tutorial.referencesReview(uuid));
+
         if (stillReferencesTutorial) {
           await deleteTutorialLocked();
+
           if (existsSync(path.join(reviewsHomeDir(), uuid))) {
             await deleteReviewByUuid(uuid);
           }
+
           return;
         }
+
         await deleteReviewByUuid(uuid);
       });
     } else {
       await deleteReviewByUuid(uuid);
     }
+
     await telemetry.captureReviewDeleted();
+
     return globalJson(200, { ok: true });
   });
   app.post("/info", async (context) =>
@@ -913,55 +1018,75 @@ export function createGlobalReviewServer(
     const request = parseReviewCliInstallApplyRequest(
       await readBoundedRequestJson(context.req.raw),
     );
+
     const applyInput: Parameters<typeof applyCliInstall>[0] = {
       packageRoot: input.packageRoot,
       targets: request.targets,
     };
+
     if (request.shim !== undefined) applyInput.shim = request.shim;
+
     if (request.autoUpdate) applyInput.autoUpdate = true;
+
     if (request.fff) applyInput.fff = true;
+
     if (request.trace !== undefined) applyInput.trace = request.trace;
+
     if (discovery.cliPath) applyInput.cliPath = discovery.cliPath;
+
     if (discovery.cliRuntimePath) {
       applyInput.cliRuntimePath = discovery.cliRuntimePath;
     }
+
     const result = await applyCliInstall(applyInput);
+
     const body: ReviewCliInstallApplyResponse = {
       ok: result.code === 0,
       output: result.output,
     };
+
     if (result.shimPath) body.shimPath = result.shimPath;
+
     return globalJson(result.code === 0 ? 200 : 500, body);
   });
   app.post("/install/remove", async (context) => {
     const request = parseReviewCliInstallApplyRequest(
       await readBoundedRequestJson(context.req.raw),
     );
+
     const removeInput: Parameters<typeof removeCliInstall>[0] = {
       targets: request.targets,
     };
+
     if (request.shim) removeInput.shim = true;
+
     if (request.fff) removeInput.fff = true;
+
     if (request.trace) removeInput.trace = true;
     const result = await removeCliInstall(removeInput);
+
     return globalJson(200, { ok: true, output: result.output });
   });
   app.post("/install/decline", async () => {
     await declineCliInstall();
+
     return globalJson(200, { ok: true });
   });
   app.post("/install/skip", async () => {
     await skipCliInstall();
+
     return globalJson(200, { ok: true });
   });
   app.post("/install/reset", async () => {
     await resetCliInstall();
+
     return globalJson(200, { ok: true });
   });
   app.post("/lifecycle/scaffold", async (context) => {
     const request = ReviewScaffoldRequestSchema.parse(
       await readBoundedRequestJson(context.req.raw),
     );
+
     return globalJson(
       200,
       await runReviewScaffold({
@@ -975,8 +1100,11 @@ export function createGlobalReviewServer(
     const request = z
       .strictObject({ reviewUuid: z.uuid() })
       .parse(await readBoundedRequestJson(context.req.raw));
+
     const review = await findReview(request.reviewUuid);
+
     if (!review) throw new ReviewServerError("Review not found.", 404);
+
     return globalJson(200, readOpenReviewThreadCount(review.dir));
   });
   app.post("/lifecycle/document/read", async (context) => {
@@ -986,28 +1114,37 @@ export function createGlobalReviewServer(
         name: ReviewDocumentFileNameSchema,
       })
       .parse(await readBoundedRequestJson(context.req.raw));
+
     const review = await findReview(request.reviewUuid);
+
     if (!review) throw new ReviewServerError("Review not found.", 404);
+
     return globalJson(200, await readReviewDocumentFile(review, request.name));
   });
   app.post("/lifecycle/metadata", async (context) => {
     const request = ReviewMetadataUpdateSchema.extend({
       reviewUuid: z.uuid(),
     }).parse(await readBoundedRequestJson(context.req.raw));
+
     const record = await withReviewLock(request.reviewUuid, async () => {
       const stored = await findReview(request.reviewUuid);
+
       if (!stored) throw new ReviewServerError("Review not found.", 404);
+
       if (stored.review.title !== request.expectedTitle)
         throw new ReviewServerError(
           "Review title changed; read metadata again before updating.",
           409,
         );
+
       const review = {
         ...stored.review,
         title: request.title,
         titleOverride: request.title,
       };
+
       await persistStoredReviewRecord(stored.dir, review);
+
       for (const session of sessions.values()) {
         if (session.review.review.uuid === request.reviewUuid)
           session.review = {
@@ -1019,22 +1156,28 @@ export function createGlobalReviewServer(
             },
           };
       }
+
       return review;
     });
+
     broadcastGlobal({
       event: "review-metadata-changed",
       uuid: request.reviewUuid,
       title: record.title,
     });
+
     return globalJson(200, record);
   });
   app.post("/lifecycle/document/write", async (context) => {
     const request = ReviewDocumentFileWriteSchema.extend({
       reviewUuid: z.uuid(),
     }).parse(await readBoundedRequestJson(context.req.raw));
+
     return withReviewLock(request.reviewUuid, async () => {
       const review = await findReview(request.reviewUuid);
+
       if (!review) throw new ReviewServerError("Review not found.", 404);
+
       return globalJson(200, await writeReviewDocumentFile(review, request));
     });
   });
@@ -1042,6 +1185,7 @@ export function createGlobalReviewServer(
     const request = ReviewLifecycleTargetSchema.parse(
       await readBoundedRequestJson(context.req.raw),
     );
+
     return globalJson(
       200,
       await resolveThreadsReview(request.cwd, request.reviewUuid),
@@ -1051,8 +1195,11 @@ export function createGlobalReviewServer(
     const request = z
       .strictObject({ reviewUuid: z.uuid() })
       .parse(await readBoundedRequestJson(context.req.raw));
+
     const review = await findReview(request.reviewUuid);
+
     if (!review) throw new ReviewServerError("Review not found.", 404);
+
     return globalJson(200, {
       ok: true,
       snapshot: threadsFor(review).snapshot(),
@@ -1065,15 +1212,19 @@ export function createGlobalReviewServer(
         command: ReviewThreadsCommandSchema,
       })
       .parse(await readBoundedRequestJson(context.req.raw));
+
     return withReviewLock(request.reviewUuid, async () => {
       const review = await findReview(request.reviewUuid);
+
       if (!review) throw new ReviewServerError("Review not found.", 404);
       const commit = threadsFor(review).dispatch(request.command);
+
       if (!commit)
         throw new ReviewServerError(
           `Comment thread not found: ${"threadId" in request.command ? request.command.threadId : "unknown"}`,
           404,
         );
+
       return globalJson(200, { ok: true, commit });
     });
   });
@@ -1089,15 +1240,19 @@ export function createGlobalReviewServer(
         format: z.enum(["plain", "markdown"]),
       })
       .parse(await readBoundedRequestJson(context.req.raw));
+
     return withReviewLock(request.reviewUuid, async () => {
       const review = await findReview(request.reviewUuid);
+
       if (!review) throw new ReviewServerError("Review not found.", 404);
       const commit = threadsFor(review).appendAgentMessage(request);
+
       if (!commit)
         throw new ReviewServerError(
           `Comment thread not found: ${request.threadId}`,
           404,
         );
+
       return globalJson(200, { ok: true, commit });
     });
   });
@@ -1105,6 +1260,7 @@ export function createGlobalReviewServer(
     const request = ReviewRebindRequestSchema.parse(
       await readBoundedRequestJson(context.req.raw),
     );
+
     return globalJson(
       200,
       await rebindReview({
@@ -1118,6 +1274,7 @@ export function createGlobalReviewServer(
     const request = ReviewResolveRequestSchema.parse(
       await readBoundedRequestJson(context.req.raw),
     );
+
     return globalJson(
       200,
       await resolvePublishReview(request.cwd, request.reviewUuid, {
@@ -1134,6 +1291,7 @@ export function createGlobalReviewServer(
         includeLegacySchema: z.boolean().optional(),
       })
       .parse(await readBoundedRequestJson(context.req.raw));
+
     return globalJson(200, await findScopedReview(request.reviewUuid, request));
   });
   app.post("/lifecycle/list", async (context) =>
@@ -1150,8 +1308,11 @@ export function createGlobalReviewServer(
     const request = z
       .strictObject({ reviewUuid: z.uuid(), message: z.string().min(1) })
       .parse(await readBoundedRequestJson(context.req.raw));
+
     const review = await findReview(request.reviewUuid);
+
     if (!review) throw new ReviewServerError("Review not found.", 404);
+
     return globalJson(
       200,
       await withReviewLock(request.reviewUuid, () =>
@@ -1167,8 +1328,11 @@ export function createGlobalReviewServer(
         role: ReviewAgentSessionRoleSchema,
       })
       .parse(await readBoundedRequestJson(context.req.raw));
+
     const review = await findReview(request.reviewUuid);
+
     if (!review) throw new ReviewServerError("Review not found.", 404);
+
     return globalJson(
       200,
       await withReviewLock(request.reviewUuid, () =>
@@ -1205,6 +1369,7 @@ export function createGlobalReviewServer(
       const request = parseReviewPublishReadyRequest(
         await readBoundedRequestJson(context.req.raw),
       );
+
       return globalJson(201, await completeDocumentPublication(request));
     } catch (error) {
       await telemetry.capturePublishGateRejected({ gate: "publish_ready" });
@@ -1226,6 +1391,7 @@ export function createGlobalReviewServer(
     const request = ReviewRepairReadyRequestSchema.parse(
       await readBoundedRequestJson(context.req.raw),
     );
+
     return globalJson(201, await completeReviewRepair(request));
   });
   app.post("/map-publish-ready", async (context) => {
@@ -1233,6 +1399,7 @@ export function createGlobalReviewServer(
       const request = parseReviewPublishReadyRequest(
         await readBoundedRequestJson(context.req.raw),
       );
+
       return globalJson(201, await completeMapPublication(request));
     } catch (error) {
       await telemetry.capturePublishGateRejected({
@@ -1247,23 +1414,31 @@ export function createGlobalReviewServer(
     const accepted = relay.acceptResult(
       await readBoundedRequestJson(context.req.raw),
     );
+
     return globalJson(accepted ? 200 : 404, { ok: accepted });
   });
   app.post("/sessions/:sessionId/verb", async (context) => {
     const active = sessions.get(context.req.param("sessionId"));
+
     if (!active) throw new ReviewServerError("Session not found.", 404);
+
     const result = await relay.dispatch(
       active.descriptor.sessionId,
       await readBoundedRequestJson(context.req.raw),
     );
+
     return globalJson(result.ok ? 200 : 409, result);
   });
   app.delete("/sessions/:sessionId", async (context) => {
     const active = sessions.get(context.req.param("sessionId"));
+
     if (!active) throw new ReviewServerError("Session not found.", 404);
+
     const terminal =
       active.promoted && context.req.query("terminal") !== "false";
+
     await closeSession(active, "closed", terminal);
+
     return globalJson(200, { ok: true });
   });
   app.all("/sessions/:sessionId", (context) =>
@@ -1281,19 +1456,24 @@ export function createGlobalReviewServer(
       error instanceof ReviewHomeScanError
         ? error.errors.find((failure) => failure.code === "REVIEW_BUSY")
         : undefined;
+
     const busyError =
       error instanceof ReviewBusyError
         ? error
         : busyScan
           ? new ReviewBusyError(busyScan.reviewDir)
           : undefined;
+
     if (busyError) return globalJson(409, reviewBusyResponse(busyError));
+
     const serverError =
       error instanceof ReviewServerError ||
       error instanceof ReviewOpenThreadsError
         ? error
         : undefined;
+
     const message = toError(error).message;
+
     return globalJson(
       serverError?.statusCode ?? httpJsonStatus(error),
       serverError?.code
@@ -1309,9 +1489,12 @@ export function createGlobalReviewServer(
     suffix: string,
   ): Promise<Response> {
     const sessionId = context.req.param("sessionId");
+
     if (!sessionId) throw new ReviewServerError("Session not found.", 404);
     const active = sessions.get(sessionId);
+
     if (!active) throw new ReviewServerError("Session not found.", 404);
+
     return dispatchToSession(
       active.handler,
       context.req.raw,
@@ -1322,15 +1505,20 @@ export function createGlobalReviewServer(
 
   function openControlEvents(context: Context<ReviewHonoEnv>): Response {
     let attached = false;
+
     const response = streamSSE(context, async (output) => {
       let finish!: () => void;
+
       const disconnected = new Promise<void>((resolve) => {
         finish = resolve;
       });
+
       const abort = new AbortController();
+
       let pending: Promise<void> = output
         .write(": attached\n\n")
         .then(() => undefined);
+
       const writer = {
         signal: abort.signal,
         write(frame: string) {
@@ -1343,15 +1531,19 @@ export function createGlobalReviewServer(
           void output.close();
         },
       };
+
       output.onAbort(() => {
         abort.abort();
         finish();
       });
       attached = relay.attach(writer);
+
       if (!attached) {
         finish();
+
         return;
       }
+
       try {
         await disconnected;
         await pending;
@@ -1359,15 +1551,19 @@ export function createGlobalReviewServer(
         abort.abort();
       }
     });
+
     if (!attached) {
       void response.body?.cancel();
+
       return globalJson(409, {
         ok: false,
         error: "A Review Desktop control client is already attached.",
       });
     }
+
     response.headers.set("cache-control", "no-cache, no-transform");
     response.headers.set("content-type", "text/event-stream; charset=utf-8");
+
     return response;
   }
 
@@ -1379,6 +1575,7 @@ export function createGlobalReviewServer(
   ): PublishMountTiming[] {
     if (!validation.ok) return [];
     const parsed = MountVerbResultSchema.safeParse(validation.result);
+
     return parsed.success ? (parsed.data.timings ?? []) : [];
   }
 
@@ -1386,7 +1583,9 @@ export function createGlobalReviewServer(
     request: ReturnType<typeof ReviewRepairReadyRequestSchema.parse>,
   ) {
     const review = await findReviewForRepair(request.reviewUuid);
+
     if (!review) throw new ReviewServerError("Review not found.", 404);
+
     return promoteReviewRepair({
       review,
       request,
@@ -1407,14 +1606,17 @@ export function createGlobalReviewServer(
     request: ReturnType<typeof parseReviewPublishReadyRequest>,
   ) {
     let review = await findReview(request.reviewUuid);
+
     if (!review) throw new ReviewServerError("Review not found.", 404);
     const agent = request.agent;
+
     if (agent) {
       const found = review;
       review = await withReviewLock(request.reviewUuid, () =>
         touchReviewAgentSession(found, authoringSessionKey(agent), "publisher"),
       );
     }
+
     return mountPublishedDocument(review, request.revision, request.view);
   }
 
@@ -1422,14 +1624,17 @@ export function createGlobalReviewServer(
     request: ReturnType<typeof parseReviewPublishReadyRequest>,
   ) {
     let review = await findReview(request.reviewUuid);
+
     if (!review) throw new ReviewServerError("Review not found.", 404);
     const agent = request.agent;
+
     if (agent) {
       const found = review;
       review = await withReviewLock(request.reviewUuid, () =>
         touchReviewAgentSession(found, authoringSessionKey(agent), "publisher"),
       );
     }
+
     return mountPublishedSoftwareMap(review, request.revision);
   }
 
@@ -1448,16 +1653,20 @@ export function createGlobalReviewServer(
     // Each mount step reports its wall-clock interval so the publishing CLI
     // can show where desktop time went; the CLI only sees the round-trip.
     const timings: PublishMountTiming[] = [];
+
     const timed = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
       const startEpochMs = Date.now();
+
       try {
         return await fn();
       } finally {
         timings.push({ name, startEpochMs, endEpochMs: Date.now() });
       }
     };
+
     const sourceCommit = review.review.sourceCommit;
     const sourceBranch = review.review.sourceIdentity?.name;
+
     if (!sourceCommit || !sourceBranch) {
       throw new ReviewServerError(
         `Review ${review.review.uuid} is not bound to a source commit.`,
@@ -1465,19 +1674,24 @@ export function createGlobalReviewServer(
         "review_unbound",
       );
     }
+
     const source = { sourceCommit, sourceBranch };
+
     const buildDir = await timed("materialize document revision", () =>
       publishRuntime.materializePublishRevision({ review, revision }),
     );
+
     // A revision this server sealed is current by construction; a legacy record here
     // is a bug, not something to upgrade silently.
     const preparedRecord = parseStoredReviewRecord(
       JSON.parse(await readFile(path.join(buildDir, "review.json"), "utf8")),
     );
+
     rejectConcurrentPublication(review, {
       dir: buildDir,
       review: preparedRecord,
     });
+
     const softwareMapRootPath = review.review.presentedSoftwareMapRevision
       ? await timed("materialize software map revision", () =>
           publishRuntime.materializePublishRevision({
@@ -1486,7 +1700,9 @@ export function createGlobalReviewServer(
           }),
         )
       : undefined;
+
     const documentPath = path.join(buildDir, "review.mdx");
+
     const successor = await timed("register session", () =>
       registerSerialized({
         review,
@@ -1498,6 +1714,7 @@ export function createGlobalReviewServer(
         promoted: false,
       }),
     );
+
     try {
       // The app mounts the unpromoted session off-screen first. A failed
       // mount fails the publish before promotion, so the reviewer keeps the
@@ -1508,6 +1725,7 @@ export function createGlobalReviewServer(
           args: {},
         }),
       );
+
       if (!validation.ok) {
         throw new ReviewServerError(
           `Review document failed to mount: ${validation.error ?? "unknown error"}`,
@@ -1515,11 +1733,13 @@ export function createGlobalReviewServer(
           "mount_validation_failed",
         );
       }
+
       // The renderer reports the mount's own steps (asset load, session and
       // module fetches, first commit, settle timer) inside the verb result.
       for (const step of mountStepTimings(validation)) {
         timings.push({ ...step, name: `mount: ${step.name}` });
       }
+
       await timed("promote", () =>
         withReviewLock(review.review.uuid, async () => {
           if (
@@ -1530,7 +1750,9 @@ export function createGlobalReviewServer(
           ) {
             throw new ReviewServerError("Review session is unavailable.", 404);
           }
+
           const latest = await findReview(review.review.uuid);
+
           if (!latest) throw new ReviewServerError("Review not found.", 404);
           rejectTerminalPublication(latest);
           rejectConcurrentPublication(latest, review);
@@ -1557,12 +1779,14 @@ export function createGlobalReviewServer(
                 .dismissedRetentionDays,
             }),
           });
+
           const replaced = [...sessions.values()].filter(
             (session) =>
               session !== successor &&
               session.review.review.uuid === successor.review.review.uuid &&
               session.promoted,
           );
+
           await Promise.all(
             replaced.map((session) => closeSession(session, "replaced", false)),
           );
@@ -1573,12 +1797,14 @@ export function createGlobalReviewServer(
         await closeSession(successor, "closed", false);
       }
     }
+
     // Promotion already happened: from here on nothing can fail the publish.
     // A focus failure is a warning — the promoted revision is live either
     // way — and a prune failure is ignored.
     const focus = await timed("focus canvas", () =>
       relay.dispatch(successor.descriptor.sessionId, revealVerb(view)),
     );
+
     await timed("prune builds", () =>
       pruneReviewBuilds(review.dir, [
         revision,
@@ -1587,6 +1813,7 @@ export function createGlobalReviewServer(
           : []),
       ]).catch(() => undefined),
     );
+
     const mounted: Awaited<ReturnType<typeof mountPublishedDocument>> = {
       ok: true,
       revision,
@@ -1594,7 +1821,9 @@ export function createGlobalReviewServer(
       url: successor.descriptor.sessionUrl,
       timings,
     };
+
     if (!focus.ok) mounted.focusWarning = focus.error;
+
     return mounted;
   }
 
@@ -1603,6 +1832,7 @@ export function createGlobalReviewServer(
     revision: string,
   ): Promise<{ ok: true; revision: string }> {
     const documentRevision = review.review.presentedDocumentRevision;
+
     if (!documentRevision) {
       throw new ReviewServerError(
         "The Review document is not published.",
@@ -1610,6 +1840,7 @@ export function createGlobalReviewServer(
         "review_unpublished",
       );
     }
+
     const [documentBuildDir, softwareMapRootPath] = await Promise.all([
       publishRuntime.materializePublishRevision({
         review,
@@ -1617,6 +1848,7 @@ export function createGlobalReviewServer(
       }),
       publishRuntime.materializePublishRevision({ review, revision }),
     ]);
+
     // A revision this server sealed is current by construction; a legacy record here
     // is a bug, not something to upgrade silently.
     const preparedMapRecord = parseStoredReviewRecord(
@@ -1624,11 +1856,13 @@ export function createGlobalReviewServer(
         await readFile(path.join(softwareMapRootPath, "review.json"), "utf8"),
       ),
     );
+
     rejectConcurrentPublication(review, {
       dir: softwareMapRootPath,
       review: preparedMapRecord,
     });
     const mapBundle = await readReviewSoftwareMapBundle(softwareMapRootPath);
+
     if (!mapBundle) {
       throw new ReviewServerError(
         "The published software map bundle is missing.",
@@ -1636,10 +1870,12 @@ export function createGlobalReviewServer(
         "map_bundle_missing",
       );
     }
+
     const presentedReview = await reviewWithPresentedDocumentPins(
       review,
       documentBuildDir,
     );
+
     if (
       mapBundle.headCommit !== presentedReview.review.sourceCommit ||
       mapBundle.baseCommit !== presentedReview.review.baseCommit
@@ -1650,8 +1886,10 @@ export function createGlobalReviewServer(
         "map_pins_mismatch",
       );
     }
+
     const sourceCommit = presentedReview.review.sourceCommit;
     const sourceBranch = presentedReview.review.sourceIdentity?.name;
+
     if (!sourceCommit || !sourceBranch) {
       throw new ReviewServerError(
         "The published Review document has no source pins.",
@@ -1659,6 +1897,7 @@ export function createGlobalReviewServer(
         "review_unbound",
       );
     }
+
     const successor = await registerSerialized({
       review: presentedReview,
       canonicalRecord: review.review,
@@ -1668,11 +1907,13 @@ export function createGlobalReviewServer(
       source: { sourceCommit, sourceBranch },
       promoted: false,
     });
+
     try {
       const validation = await relay.dispatch(successor.descriptor.sessionId, {
         name: "validateCanvasMount",
         args: {},
       });
+
       if (!validation.ok) {
         throw new ReviewServerError(
           `Software map failed to load: ${validation.error ?? "unknown error"}`,
@@ -1680,8 +1921,10 @@ export function createGlobalReviewServer(
           "map_validation_failed",
         );
       }
+
       await withReviewLock(review.review.uuid, async () => {
         const latest = await findReview(review.review.uuid);
+
         if (!latest) throw new ReviewServerError("Review not found.", 404);
         rejectTerminalPublication(latest);
         rejectConcurrentPublication(latest, review);
@@ -1696,12 +1939,14 @@ export function createGlobalReviewServer(
               .dismissedRetentionDays,
           }),
         });
+
         const replaced = [...sessions.values()].filter(
           (session) =>
             session !== successor &&
             session.review.review.uuid === successor.review.review.uuid &&
             session.promoted,
         );
+
         await Promise.all(
           replaced.map((session) => closeSession(session, "replaced", false)),
         );
@@ -1711,6 +1956,7 @@ export function createGlobalReviewServer(
         await closeSession(successor, "closed", false);
       }
     }
+
     void relay.dispatch(successor.descriptor.sessionId, {
       name: "focusCanvas",
       args: {},
@@ -1718,6 +1964,7 @@ export function createGlobalReviewServer(
     await pruneReviewBuilds(review.dir, [documentRevision, revision]).catch(
       () => undefined,
     );
+
     return { ok: true, revision };
   }
 
@@ -1725,17 +1972,21 @@ export function createGlobalReviewServer(
      not leave a session serving files that cleanup is about to delete. */
   async function closeTutorialSessions(): Promise<void> {
     const tutorialRoot = path.resolve(devReviewHome(), "tutorial");
+
     const open = [...sessions.values()].filter((session) => {
       if (session.tutorialPreparation) return true;
+
       const relative = path.relative(
         tutorialRoot,
         path.resolve(session.review.review.worktreePath),
       );
+
       return (
         relative === "" ||
         (!relative.startsWith("..") && !path.isAbsolute(relative))
       );
     });
+
     await Promise.all(
       open.map((session) => closeSession(session, "closed", false)),
     );
@@ -1743,6 +1994,7 @@ export function createGlobalReviewServer(
 
   async function prepareTutorialLocked(): Promise<PreparedTutorial> {
     const tutorialAgent = await tutorialAgentResolver();
+
     if (!tutorialAgent) {
       throw new ReviewServerError(
         "Install Claude Code, Codex, or Pi before opening the tutorial.",
@@ -1750,10 +2002,13 @@ export function createGlobalReviewServer(
         "tutorial_agent_unavailable",
       );
     }
+
     const cached = await validPreparedTutorial(tutorialAgent);
+
     if (cached) return cached;
     const prepared = await prepareTutorialLocally(tutorialAgent);
     preparedTutorial = prepared;
+
     return prepared;
   }
 
@@ -1761,19 +2016,24 @@ export function createGlobalReviewServer(
     tutorialAgent: ReviewAgentHarness,
   ): Promise<PreparedTutorial | null> {
     const cached = preparedTutorial;
+
     if (!cached) return null;
+
     const current = await withReviewLock(cached.review.review.uuid, () =>
       tutorial.find().catch(() => null),
     );
+
     const currentReview = current?.review;
     const cachedReview = cached.review.review;
     const documentExists = existsSync(cached.documentPath);
     const softwareMapExists = existsSync(cached.softwareMapRootPath);
+
     const pathsExist =
       documentExists &&
       softwareMapExists &&
       existsSync(cached.checkoutRoots.baseRootPath) &&
       existsSync(cached.checkoutRoots.headRootPath);
+
     if (
       !currentReview ||
       currentReview.uuid !== cachedReview.uuid ||
@@ -1787,6 +2047,7 @@ export function createGlobalReviewServer(
       preparedTutorial = null;
       await abortTutorialAuthoringState(cachedReview.uuid);
       await closeTutorialSessions();
+
       if (!documentExists) {
         await rm(path.dirname(cached.documentPath), {
           recursive: true,
@@ -1795,10 +2056,13 @@ export function createGlobalReviewServer(
       } else if (!softwareMapExists) {
         await rm(cached.softwareMapRootPath, { recursive: true, force: true });
       }
+
       return null;
     }
+
     cached.review = current;
     cached.canonicalRecord = current.review;
+
     return cached;
   }
 
@@ -1809,6 +2073,7 @@ export function createGlobalReviewServer(
     tutorialAgent: ReviewAgentHarness,
   ): Promise<PreparedTutorial> {
     const startedAt = Date.now();
+
     const review = await tutorial.prepare(tutorialAgent, {
       beforeReset: async () => {
         preparedTutorial = null;
@@ -1816,8 +2081,10 @@ export function createGlobalReviewServer(
         await closeTutorialSessions();
       },
     });
+
     const documentRevision = review.review.presentedDocumentRevision;
     const softwareMapRevision = review.review.presentedSoftwareMapRevision;
+
     if (!documentRevision || !softwareMapRevision) {
       throw new ReviewServerError(
         "Tutorial Review has no published revision.",
@@ -1825,24 +2092,29 @@ export function createGlobalReviewServer(
         "review_unpublished",
       );
     }
+
     const documentBuildDir = await publishRuntime.materializePublishRevision({
       review,
       revision: documentRevision,
     });
+
     const softwareMapRootPath = await publishRuntime.materializePublishRevision(
       {
         review,
         revision: softwareMapRevision,
       },
     );
+
     const presentedReview = await reviewWithPresentedDocumentPins(
       review,
       documentBuildDir,
     );
+
     const checkoutRoots = await ensureReviewCheckouts(presentedReview);
     console.info(
       `[Review tutorial] local preparation completed in ${Date.now() - startedAt}ms.`,
     );
+
     return {
       review: presentedReview,
       canonicalRecord: review.review,
@@ -1858,6 +2130,7 @@ export function createGlobalReviewServer(
   async function openTutorialLocked(): Promise<ReviewTutorialOpenResponse> {
     const prepared = await prepareTutorialLocked();
     let existing = activeSessionForReview(prepared.review.review.uuid);
+
     if (
       existing &&
       (existing.tutorialPreparation !== prepared ||
@@ -1867,14 +2140,17 @@ export function createGlobalReviewServer(
       await closeSession(existing, "replaced", false);
       existing = undefined;
     }
+
     if (existing) {
       void relay.dispatch(existing.descriptor.sessionId, {
         name: "focusCanvas",
         args: {},
       });
     }
+
     const resolveQuestionSourceSession = (signal?: AbortSignal) =>
       ensureTutorialAuthoringSession(prepared, true, signal);
+
     const session =
       existing ??
       (await registerSerialized({
@@ -1888,7 +2164,9 @@ export function createGlobalReviewServer(
         promoted: true,
         focusCanvas: true,
       }));
+
     void ensureTutorialAuthoringSession(prepared, false);
+
     return {
       reviewUuid: session.review.review.uuid,
       sessionId: session.descriptor.sessionId,
@@ -1904,38 +2182,49 @@ export function createGlobalReviewServer(
     signal?: AbortSignal,
   ): Promise<SessionRef | undefined> {
     if (signal?.aborted) return undefined;
+
     const persisted = parseAuthoringSessionKey(
       prepared.review.review.sourceSession,
     );
+
     if (persisted) return persisted;
     const uuid = prepared.review.review.uuid;
     let state = tutorialAuthoringStates.get(uuid);
+
     if (!state) {
       state = { attempts: 0 };
       tutorialAuthoringStates.set(uuid, state);
     }
+
     while (true) {
       if (signal?.aborted || tutorialAuthoringStates.get(uuid) !== state) {
         return undefined;
       }
+
       if (state.session) return state.session;
+
       if (state.operation) {
         const session = await waitForTutorialAuthoringOperation(
           state.operation.promise,
           signal,
         );
+
         if (signal?.aborted || tutorialAuthoringStates.get(uuid) !== state) {
           return undefined;
         }
+
         if (session) return session;
         continue;
       }
+
       if (state.attempts > 0 && (!allowRetry || state.attempts >= 2)) {
         return undefined;
       }
+
       if (signal?.aborted || tutorialAuthoringStates.get(uuid) !== state) {
         return undefined;
       }
+
       const operation = startTutorialAuthoringAttempt(prepared, state);
       state.operation = operation;
     }
@@ -1948,56 +2237,70 @@ export function createGlobalReviewServer(
     const controller = new AbortController();
     const attempt = ++state.attempts;
     const startedAt = Date.now();
+
     const operation: NonNullable<TutorialAuthoringState["operation"]> = {
       controller,
       promise: Promise.resolve(undefined),
     };
+
     const isCurrent = () =>
       !controller.signal.aborted &&
       tutorialAuthoringStates.get(prepared.review.review.uuid) === state;
+
     operation.promise = (async (): Promise<SessionRef | undefined> => {
       console.info(
         `[Review tutorial] source-session handoff attempt ${attempt} started (${prepared.harness}).`,
       );
+
       try {
         const session = await tutorialAuthoringSessionFactory({
           harness: prepared.harness,
           rootPath: prepared.checkoutRoots.headRootPath,
           signal: controller.signal,
         });
+
         if (!isCurrent()) return undefined;
+
         const updated = await withReviewLock(
           prepared.review.review.uuid,
           async () => {
             if (!isCurrent()) return undefined;
             const latest = await findReview(prepared.review.review.uuid);
+
             if (!latest) return undefined;
             const bound = await tutorialAuthorSessionBinder(latest, session);
             prepared.review = bound;
             prepared.canonicalRecord = bound.review;
+
             for (const active of sessions.values()) {
               if (active.review.review.uuid === bound.review.uuid) {
                 active.review = bound;
               }
             }
+
             return bound;
           },
         );
+
         if (!updated || !isCurrent()) return undefined;
         state.session = session;
         console.info(
           `[Review tutorial] source-session handoff completed in ${Date.now() - startedAt}ms.`,
         );
+
         return session;
       } catch {
         const outcome = controller.signal.aborted ? "canceled" : "failed";
+
         const fallback =
           attempt < 2
             ? "Ask now will retry once before falling back."
             : "Ask now will start a fresh session.";
+
         console.warn(
           `[Review tutorial] source-session handoff ${outcome} after ${Date.now() - startedAt}ms; ${fallback}`,
         );
+
         return undefined;
       } finally {
         if (
@@ -2008,14 +2311,17 @@ export function createGlobalReviewServer(
         }
       }
     })();
+
     return operation;
   }
 
   async function abortTutorialAuthoringState(uuid: string): Promise<void> {
     const state = tutorialAuthoringStates.get(uuid);
+
     if (!state) return;
     tutorialAuthoringStates.delete(uuid);
     state.operation?.controller.abort();
+
     if (state.operation) await Promise.allSettled([state.operation.promise]);
   }
 
@@ -2024,7 +2330,9 @@ export function createGlobalReviewServer(
     signal?: AbortSignal,
   ): Promise<SessionRef | undefined> {
     if (!signal) return operation;
+
     if (signal.aborted) return undefined;
+
     return new Promise((resolve) => {
       const aborted = () => resolve(undefined);
       signal.addEventListener("abort", aborted, { once: true });
@@ -2056,17 +2364,23 @@ export function createGlobalReviewServer(
     // review.json must still be deletable.
     await withReviewLock(uuid, async () => {
       const dir = path.join(reviewsHomeDir(), uuid);
+
       if (!existsSync(dir)) {
         throw new ReviewServerError("Review not found.", 404);
       }
+
       const stored = await findReview(uuid).catch(() => null);
+
       if (stored) {
         await deleteStoredReviewUnlocked(stored);
+
         return;
       }
+
       const open = [...sessions.values()].filter(
         (session) => session.review.review.uuid === uuid,
       );
+
       await Promise.all(
         open.map((session) => closeSession(session, "closed", false)),
       );
@@ -2074,9 +2388,11 @@ export function createGlobalReviewServer(
       deleteReviewState(dir);
       threadServices.delete(uuid);
       const worktreePath = open[0]?.review.review.worktreePath;
+
       if (worktreePath) {
         await clearReopenPending(worktreePath).catch(() => undefined);
       }
+
       broadcastGlobal({ event: "review-deleted", uuid });
     });
   }
@@ -2093,6 +2409,7 @@ export function createGlobalReviewServer(
     const open = [...sessions.values()].filter(
       (session) => session.review.review.uuid === review.review.uuid,
     );
+
     await Promise.all(
       open.map((session) => closeSession(session, "closed", false)),
     );
@@ -2113,14 +2430,17 @@ export function createGlobalReviewServer(
     const expected = reviewMutationFingerprint(registration.canonicalRecord);
     const prepared = await prepareSession(registration);
     let installed = false;
+
     try {
       const active = await withReviewLock(
         registration.review.review.uuid,
         async () => {
           assertServerOpen();
+
           const latest = await findReviewForRepair(
             registration.review.review.uuid,
           );
+
           if (
             !latest ||
             reviewMutationFingerprint(latest.review) !== expected
@@ -2131,30 +2451,38 @@ export function createGlobalReviewServer(
               "review_changed",
             );
           }
+
           const existing = matchingSession(registration);
+
           if (existing) return existing;
           sessions.set(prepared.descriptor.sessionId, prepared);
           installed = true;
+
           return prepared;
         },
       );
+
       if (!installed) return active;
       await startSessionTelemetry(active).catch((error) =>
         console.error("Could not start Review session telemetry:", error),
       );
+
       if (registration.announce) {
         const event: ReviewDesktopGlobalEvent = {
           event: "session-registered",
           session: active.descriptor,
         };
+
         if (registration.background) event.background = true;
         broadcastGlobal(event);
       }
+
       if (registration.focusCanvas)
         void relay.dispatch(
           active.descriptor.sessionId,
           revealVerb(registration.view),
         );
+
       return active;
     } finally {
       if (!installed) await prepared.handler.close();
@@ -2194,6 +2522,7 @@ export function createGlobalReviewServer(
         "review_unbound",
       );
     }
+
     const baseRootPath = await (
       input.pinnedCheckoutFactory ?? ensureReviewPinnedCheckout
     )({
@@ -2202,6 +2531,7 @@ export function createGlobalReviewServer(
       reviewUuid: review.review.uuid,
       role: "base",
     });
+
     const headRootPath = await (
       input.pinnedCheckoutFactory ?? ensureReviewPinnedCheckout
     )({
@@ -2210,6 +2540,7 @@ export function createGlobalReviewServer(
       reviewUuid: review.review.uuid,
       role: "head",
     });
+
     if (!baseRootPath || !headRootPath) {
       throw new ReviewServerError(
         `Review ${review.review.uuid} cannot create its managed checkout.`,
@@ -2217,6 +2548,7 @@ export function createGlobalReviewServer(
         "review_checkout_unavailable",
       );
     }
+
     return { baseRootPath, headRootPath };
   }
 
@@ -2227,6 +2559,7 @@ export function createGlobalReviewServer(
     assertServerOpen();
     const sessionId = crypto.randomUUID();
     const sessionUrl = `${urlForBoundPort()}/sessions/${encodeURIComponent(sessionId)}`;
+
     const descriptor: ReviewSessionDescriptor = {
       sessionId,
       sessionUrl,
@@ -2234,23 +2567,30 @@ export function createGlobalReviewServer(
       routePath: "/",
       startedAt: Date.now(),
     };
+
     if (registration.historicalRevision) {
       descriptor.historicalRevision = registration.historicalRevision;
     }
+
     const sourceCommit =
       registration.source?.sourceCommit ??
       registration.review.review.sourceCommit;
+
     let sourceUnavailable: string | undefined;
+
     const { baseRootPath, headRootPath } =
       registration.checkoutRoots ??
       (await ensureReviewCheckouts(registration.review, sourceCommit).catch(
         (error) => {
           if (!registration.historicalRevision) throw error;
           sourceUnavailable = `The pinned source commits are unavailable: ${error instanceof Error ? error.message : String(error)}`;
+
           return { baseRootPath: undefined, headRootPath: undefined };
         },
       ));
+
     if (sourceUnavailable) descriptor.sourceUnavailable = sourceUnavailable;
+
     const sessionWire = sessionWireFor(
       registration.review,
       descriptor,
@@ -2260,7 +2600,9 @@ export function createGlobalReviewServer(
       baseRootPath,
       headRootPath,
     );
+
     let active!: ActiveReviewSession;
+
     const handler = await sessionHandlerFactory({
       rootPath: registration.review.review.worktreePath,
       reviewRootPath: registration.review.dir,
@@ -2300,6 +2642,7 @@ export function createGlobalReviewServer(
             ? findReviewForRepair
             : findReview
         )(registration.review.review.uuid);
+
         return latest ? listReviewDocumentVersions(latest) : [];
       },
       session: sessionWire,
@@ -2324,6 +2667,7 @@ export function createGlobalReviewServer(
           threadId,
           status,
         };
+
         if (error !== undefined) event.error = error;
         broadcastGlobal(event);
       },
@@ -2349,6 +2693,7 @@ export function createGlobalReviewServer(
       onQuestionAgentSession: (agent) =>
         withReviewLock(registration.review.review.uuid, async () => {
           const latest = await findReview(registration.review.review.uuid);
+
           if (!latest) throw new Error("Review not found.");
           active.review = await touchReviewAgentSession(
             latest,
@@ -2358,6 +2703,7 @@ export function createGlobalReviewServer(
         }),
       telemetry,
     });
+
     active = {
       descriptor,
       review: registration.review,
@@ -2376,6 +2722,7 @@ export function createGlobalReviewServer(
       tutorialPreparation: registration.tutorialPreparation,
       resolveQuestionSourceSession: registration.resolveQuestionSourceSession,
     };
+
     return active;
   }
 
@@ -2386,8 +2733,10 @@ export function createGlobalReviewServer(
     if (!active.promoted) {
       throw new Error("An unpromoted Review session cannot be submitted.");
     }
+
     await withReviewLock(active.review.review.uuid, async () => {
       const latest = await findReview(active.review.review.uuid);
+
       if (
         !latest ||
         active.closing ||
@@ -2398,19 +2747,24 @@ export function createGlobalReviewServer(
           "Only a review awaiting human action can be submitted.",
         );
       }
+
       active.review = latest;
       active.terminal = true;
+
       const status =
         submission.decision === "approve"
           ? "accepted"
           : "awaiting-agent-updates";
+
       active.review = await setReviewStatus(latest, status);
+
       if (submission.decision === "request-changes") {
         await markReopenPending(
           active.review.review.worktreePath,
           submission.createdAt,
         );
       }
+
       broadcastGlobal({
         event: "review-status-changed",
         uuid: active.review.review.uuid,
@@ -2434,8 +2788,10 @@ export function createGlobalReviewServer(
     if (!active.promoted) {
       throw new Error("An unpromoted Review session cannot be dismissed.");
     }
+
     await withReviewLock(active.review.review.uuid, async () => {
       const latest = await findReview(active.review.review.uuid);
+
       if (
         !latest ||
         active.closing ||
@@ -2444,6 +2800,7 @@ export function createGlobalReviewServer(
       ) {
         return;
       }
+
       active.review = await dismissReview(latest);
       await clearReopenPending(active.review.review.worktreePath);
       await broadcastReviewAttention(active.review, "dismissed");
@@ -2473,23 +2830,29 @@ export function createGlobalReviewServer(
     if (!UUID_PATTERN.test(uuid)) {
       throw new ReviewServerError("Review not found.", 404);
     }
+
     return withReviewLock(uuid, async () => {
       const stored = await findReview(uuid);
+
       if (!stored) throw new ReviewServerError("Review not found.", 404);
+
       const next = dismissed
         ? await dismissReview(stored)
         : await restoreReview(stored);
+
       const attention = dismissed
         ? "dismissed"
         : next.review.viewedAt
           ? "viewed"
           : "new";
+
       const patch = await reviewAttentionPatch(next);
       broadcastGlobal({
         event: "review-attention-changed",
         attention,
         ...patch,
       });
+
       return {
         ok: true as const,
         ...patch,
@@ -2504,6 +2867,7 @@ export function createGlobalReviewServer(
     reapsAt: string | null;
   }> {
     const { dismissedRetentionDays } = await readReviewPreferences();
+
     return {
       uuid: review.review.uuid,
       viewedAt: review.review.viewedAt ?? null,
@@ -2533,11 +2897,15 @@ export function createGlobalReviewServer(
   ): Promise<void> {
     if (retentionDays === null) return;
     const listed = await listReviews().catch(() => null);
+
     if (!listed) return;
+
     for (const stored of selectReapableReviews(listed.reviews, retentionDays)) {
       const { uuid } = stored.review;
+
       // A review that is open must not vanish under the reader.
       if (activeSessionForReview(uuid)) continue;
+
       try {
         await withReviewLock(uuid, async () => {
           await rm(stored.dir, { recursive: true, force: true });
@@ -2600,6 +2968,7 @@ export function createGlobalReviewServer(
     if (active.closing) return;
     active.closing = true;
     sessions.delete(active.descriptor.sessionId);
+
     /* Closing the window ends the session, never the review. Dismissal is the
        only reader action that ends a review, and it has its own endpoint. This
        branch used to reject the review, which made closing a tab and finishing
@@ -2607,6 +2976,7 @@ export function createGlobalReviewServer(
     if (terminal && active.promoted && !active.terminal) {
       active.terminal = true;
     }
+
     broadcastGlobal({
       event: "session-closed",
       sessionId: active.descriptor.sessionId,
@@ -2630,12 +3000,15 @@ export function createGlobalReviewServer(
   ): Promise<T> {
     const previous = reviewLocks.get(reviewUuid) ?? Promise.resolve();
     let release: () => void = () => {};
+
     const current = new Promise<void>((resolve) => {
       release = resolve;
     });
+
     const chain = previous.then(() => current);
     reviewLocks.set(reviewUuid, chain);
     await previous;
+
     try {
       return await withReviewMutationLock(
         path.join(reviewsHomeDir(), reviewUuid),
@@ -2643,6 +3016,7 @@ export function createGlobalReviewServer(
       );
     } finally {
       release();
+
       if (reviewLocks.get(reviewUuid) === chain) reviewLocks.delete(reviewUuid);
     }
   }
@@ -2650,12 +3024,15 @@ export function createGlobalReviewServer(
   function openGlobalEvents(context: Context<ReviewHonoEnv>): Response {
     const response = streamSSE(context, async (output) => {
       let finish!: () => void;
+
       const disconnected = new Promise<void>((resolve) => {
         finish = resolve;
       });
+
       let pending: Promise<void> = output
         .write(": connected\n\n")
         .then(() => undefined);
+
       const client: ReviewDesktopEventClient = {
         write(frame) {
           pending = pending.then(async () => {
@@ -2667,13 +3044,17 @@ export function createGlobalReviewServer(
           void output.close();
         },
       };
+
       output.onAbort(finish);
       globalClients.add(client);
+
       const heartbeat = setInterval(
         () => client.write(": heartbeat\n\n"),
         15_000,
       );
+
       heartbeat.unref?.();
+
       try {
         await disconnected;
         await pending;
@@ -2682,13 +3063,16 @@ export function createGlobalReviewServer(
         globalClients.delete(client);
       }
     });
+
     response.headers.set("cache-control", "no-cache, no-transform");
     response.headers.set("content-type", "text/event-stream; charset=utf-8");
+
     return response;
   }
 
   function broadcastGlobal(event: ReviewDesktopGlobalEvent): void {
     const frame = `data: ${JSON.stringify(event)}\n\n`;
+
     for (const client of globalClients) client.write(frame);
   }
 
@@ -2719,6 +3103,7 @@ export function createGlobalReviewServer(
     close: async () => {
       if (closing) return;
       closing = true;
+
       if (reviewReaper) clearInterval(reviewReaper);
       reviewReaper = undefined;
       await removeMatchingDiscovery(discoveryPath, discovery);
@@ -2731,6 +3116,7 @@ export function createGlobalReviewServer(
       );
       relay.close();
       threadServices.clear();
+
       for (const client of globalClients) client.close();
       globalClients.clear();
       await Promise.all(
@@ -2744,9 +3130,13 @@ export function createGlobalReviewServer(
 
 function reviewSourceKind(review: ReviewRecord): ProgressiveReviewSourceKind {
   if (review.pullRequestNumber) return "pull_request";
+
   if (review.sourceIdentity?.kind === "git-commit") return "git_commit";
+
   if (review.sourceIdentity?.kind === "jj-bookmark") return "jj_bookmark";
+
   if (review.sourceIdentity?.kind === "jj-change") return "jj_change";
+
   return "git_branch";
 }
 
@@ -2763,14 +3153,22 @@ export function reviewAgentKind(
     latestAgentSessionWithRole(review, "publisher") ??
     latestAgentSessionWithRole(review, "author") ??
     review.sourceSession;
+
   const freshHarness = parseFreshSourceSessionHarness(sessionKey);
+
   if (freshHarness === "codex") return "codex";
+
   if (freshHarness === "claude-code") return "claude";
+
   if (freshHarness === "pi") return "pi";
   const kind = sessionKey?.split(":", 1)[0];
+
   if (kind === "codex") return "codex";
+
   if (kind === "claude" || kind === "claude-code") return "claude";
+
   if (kind === "pi") return "pi";
+
   return "other";
 }
 
@@ -2789,32 +3187,45 @@ function parseInfoRequest(input: JsonValue): RunReviewInfoInput {
   if (!isJsonObject(input)) {
     throw new HttpJsonError("Info request must be an object.", 400);
   }
+
   const allowed = new Set(["cwd", "all", "reviewUuid"]);
+
   if (Object.keys(input).some((key) => !allowed.has(key))) {
     throw new HttpJsonError("Info request has unexpected fields.", 400);
   }
+
   const cwd = jsonString(jsonProperty(input, "cwd"));
+
   if (cwd === undefined || !cwd.trim()) {
     throw new HttpJsonError("Info request requires cwd.", 400);
   }
+
   const all = jsonProperty(input, "all");
+
   if (all !== undefined && jsonBoolean(all) === undefined) {
     throw new HttpJsonError("Info all must be boolean.", 400);
   }
+
   const reviewUuidValue = jsonProperty(input, "reviewUuid");
   const reviewUuid = jsonString(reviewUuidValue);
+
   if (
     reviewUuidValue !== undefined &&
     (reviewUuid === undefined || !reviewUuid.trim())
   ) {
     throw new HttpJsonError("Info reviewUuid must be a non-empty string.", 400);
   }
+
   if (all === true && reviewUuidValue !== undefined) {
     throw new HttpJsonError("Info all and reviewUuid cannot be combined.", 400);
   }
+
   const request: RunReviewInfoInput = { cwd };
+
   if (all) request.all = true;
+
   if (reviewUuid !== undefined) request.reviewUuid = reviewUuid.trim();
+
   return request;
 }
 
@@ -2824,6 +3235,7 @@ async function pruneReviewBuilds(
 ): Promise<void> {
   const buildsPath = path.join(reviewDirPath, ".build");
   let entries;
+
   try {
     entries = await readdir(buildsPath, { withFileTypes: true });
   } catch (error) {
@@ -2831,6 +3243,7 @@ async function pruneReviewBuilds(
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
     throw error;
   }
+
   const builds = await Promise.all(
     entries
       .filter(
@@ -2841,11 +3254,14 @@ async function pruneReviewBuilds(
         modifiedAt: (await stat(path.join(buildsPath, entry.name))).mtimeMs,
       })),
   );
+
   const keep = new Set(currentRevisions);
+
   const previous = builds
     .filter((build) => !keep.has(build.name))
     .sort((left, right) => right.modifiedAt - left.modifiedAt)
     .at(0)?.name;
+
   await Promise.all(
     builds
       .filter((build) => !keep.has(build.name) && build.name !== previous)
@@ -2857,6 +3273,7 @@ async function pruneReviewBuilds(
 
 function sessionRouteSuffix(pathname: string): string {
   const match = pathname.match(/^\/sessions\/([^/]+)(\/.*)?$/);
+
   return match?.[2] ?? "";
 }
 
@@ -2873,21 +3290,27 @@ async function dispatchToSession(
       "invalid_session_path",
     );
   }
+
   const requestUrl = new URL(request.url);
+
   const target = new URL(
     `${suffix || "/"}${requestUrl.search}`,
     "http://review-session.internal",
   );
+
   const headers = new Headers(request.headers);
   headers.delete("host");
   const hasBody = request.method !== "GET" && request.method !== "HEAD";
+
   const init: RequestInit & { duplex?: "half" } = {
     method: request.method,
     headers,
     body: hasBody ? request.body : undefined,
     signal: request.signal,
   };
+
   if (hasBody) init.duplex = "half";
+
   return handler.handle(new Request(target, init), env);
 }
 
@@ -2901,6 +3324,7 @@ function sessionWireFor(
   headRootPath?: string,
 ): ReviewSessionWire {
   const headRef = source?.sourceCommit ?? review.review.sourceCommit;
+
   if (!headRef && !descriptor.historicalRevision) {
     throw new ReviewServerError(
       `Review ${review.review.uuid} is not bound to a source commit.`,
@@ -2908,10 +3332,13 @@ function sessionWireFor(
       "review_unbound",
     );
   }
+
   const authoringAgent = parseAuthoringSessionKey(review.review.sourceSession);
+
   const freshQuestionHarness = parseFreshSourceSessionHarness(
     review.review.sourceSession,
   );
+
   const wire: ReviewSessionWire = {
     sessionId: descriptor.sessionId,
     rootPath: review.review.worktreePath,
@@ -2936,9 +3363,11 @@ function sessionWireFor(
         : undefined,
     startedAt: descriptor.startedAt,
   };
+
   if (descriptor.historicalRevision) {
     wire.historicalRevision = descriptor.historicalRevision;
   }
+
   return wire;
 }
 
@@ -2960,9 +3389,11 @@ async function promoteReview(
     viewedAt: null,
     dismissedAt: null,
   };
+
   if (stored.review.titleOverride) review.title = stored.review.titleOverride;
   else if (title) review.title = title;
   await persistStoredReviewRecord(stored.dir, review);
+
   return { ...stored, review };
 }
 
@@ -2974,7 +3405,9 @@ async function promoteSoftwareMap(
     ...stored.review,
     presentedSoftwareMapRevision: revision,
   };
+
   await persistStoredReviewRecord(stored.dir, review);
+
   return { ...stored, review };
 }
 
@@ -2983,6 +3416,7 @@ async function presentedMapRoot(
   allowAbsent: boolean,
 ): Promise<string | undefined> {
   if (!allowAbsent) return root;
+
   try {
     await stat(path.join(root, ".bundle", "software-map"));
   } catch (error) {
@@ -2990,6 +3424,7 @@ async function presentedMapRoot(
       return undefined;
     throw error;
   }
+
   return root;
 }
 
@@ -3029,6 +3464,7 @@ async function setReviewStatus(
 ): Promise<StoredReview> {
   const review: StoredReviewRecord = { ...stored.review, status };
   await persistStoredReviewRecord(stored.dir, review);
+
   return { ...stored, review };
 }
 
@@ -3050,10 +3486,13 @@ function listen(server: Server, port: number): Promise<number> {
     server.listen(port, "127.0.0.1", () => {
       server.off("error", reject);
       const address = server.address();
+
       if (!isTcpAddress(address)) {
         reject(new Error("The Review server did not bind a TCP port."));
+
         return;
       }
+
       resolve(address.port);
     });
   });
@@ -3063,8 +3502,10 @@ function closeHttpServer(server: Server): Promise<void> {
   return new Promise((resolve, reject) => {
     if (!server.listening) {
       resolve();
+
       return;
     }
+
     server.close((error) => (error ? reject(error) : resolve()));
   });
 }
@@ -3075,6 +3516,7 @@ async function removeMatchingDiscovery(
 ): Promise<void> {
   try {
     const current: JsonValue = JSON.parse(await readFile(filePath, "utf8"));
+
     if (
       isJsonObject(current) &&
       current.instanceId === discovery.instanceId &&

--- a/packages/progressive-review/src/server/publish-preparation.test.ts
+++ b/packages/progressive-review/src/server/publish-preparation.test.ts
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createReviewDir } from "../review-home";
+import { deleteReviewState } from "../review-state-db";
 import {
   prepareReviewPublish,
   resolvePublishReview,
@@ -43,6 +44,7 @@ describe("prepareReviewPublish", () => {
       baseRef: "main",
       baseCommit: repo.baseCommit,
     });
+    deleteReviewState(corrupt.dir);
     await writeFile(path.join(corrupt.dir, "review.json"), "{");
     await expect(
       resolvePublishReview(repo.rootPath, undefined),
@@ -53,6 +55,29 @@ describe("prepareReviewPublish", () => {
     await expect(
       resolvePublishReview(home, healthy.review.uuid),
     ).rejects.toThrow(/Active review not found/);
+  });
+
+  it("selects the canonical record when the mirror has stale checkout scope", async () => {
+    const repo = await createDivergedGitRepository(cleanupPaths);
+    const home = await mkdtemp(path.join(os.tmpdir(), "review-publish-home-"));
+    cleanupPaths.push(home);
+    vi.stubEnv("DEV_REVIEW_HOME", home);
+    const review = await createReviewDir({
+      worktreePath: repo.rootPath,
+      baseRef: "main",
+      baseCommit: repo.baseCommit,
+      sourceCommit: repo.baseCommit,
+      sourceIdentity: { kind: "git-branch", name: "main" },
+    });
+    await writeFile(
+      path.join(review.dir, "review.json"),
+      JSON.stringify({ ...review.review, worktreePath: home }),
+    );
+    await expect(
+      resolvePublishReview(repo.rootPath, undefined),
+    ).resolves.toMatchObject({
+      review: { uuid: review.review.uuid, worktreePath: repo.rootPath },
+    });
   });
 
   it("prepares a publish from a checkout unrelated to the pinned head", async () => {

--- a/packages/progressive-review/src/server/publish-preparation.test.ts
+++ b/packages/progressive-review/src/server/publish-preparation.test.ts
@@ -29,21 +29,26 @@ describe("prepareReviewPublish", () => {
 
   it("reports unreadable records during implicit selection while allowing a healthy explicit UUID", async () => {
     const repo = await createDivergedGitRepository(cleanupPaths);
+
     const home = await mkdtemp(
       path.join(os.tmpdir(), "review-publish-unreadable-"),
     );
+
     cleanupPaths.push(home);
     vi.stubEnv("DEV_REVIEW_HOME", home);
+
     const healthy = await createReviewDir({
       worktreePath: repo.rootPath,
       baseRef: "main",
       baseCommit: repo.baseCommit,
     });
+
     const corrupt = await createReviewDir({
       worktreePath: repo.rootPath,
       baseRef: "main",
       baseCommit: repo.baseCommit,
     });
+
     deleteReviewState(corrupt.dir);
     await writeFile(path.join(corrupt.dir, "review.json"), "{");
     await expect(
@@ -62,6 +67,7 @@ describe("prepareReviewPublish", () => {
     const home = await mkdtemp(path.join(os.tmpdir(), "review-publish-home-"));
     cleanupPaths.push(home);
     vi.stubEnv("DEV_REVIEW_HOME", home);
+
     const review = await createReviewDir({
       worktreePath: repo.rootPath,
       baseRef: "main",
@@ -69,6 +75,7 @@ describe("prepareReviewPublish", () => {
       sourceCommit: repo.baseCommit,
       sourceIdentity: { kind: "git-branch", name: "main" },
     });
+
     await writeFile(
       path.join(review.dir, "review.json"),
       JSON.stringify({ ...review.review, worktreePath: home }),
@@ -82,11 +89,14 @@ describe("prepareReviewPublish", () => {
 
   it("prepares a publish from a checkout unrelated to the pinned head", async () => {
     const repo = await createDivergedGitRepository(cleanupPaths);
+
     const reviewHome = await mkdtemp(
       path.join(os.tmpdir(), "review-publish-home-"),
     );
+
     cleanupPaths.push(reviewHome);
     vi.stubEnv("DEV_REVIEW_HOME", reviewHome);
+
     const review = await createReviewDir({
       worktreePath: repo.rootPath,
       baseRef: repo.baseCommit,
@@ -99,17 +109,21 @@ describe("prepareReviewPublish", () => {
       cwd: repo.rootPath,
       reviewUuid: review.review.uuid,
     });
+
     expect(prepared.sourceCommit).toBe(repo.featureCommit);
     expect(prepared).not.toHaveProperty("warnings");
   });
 
   it("prepares without warnings when the pinned head is checked out exactly", async () => {
     const repo = await createDivergedGitRepository(cleanupPaths);
+
     const reviewHome = await mkdtemp(
       path.join(os.tmpdir(), "review-publish-home-"),
     );
+
     cleanupPaths.push(reviewHome);
     vi.stubEnv("DEV_REVIEW_HOME", reviewHome);
+
     const review = await createReviewDir({
       worktreePath: repo.rootPath,
       baseRef: repo.baseCommit,
@@ -133,11 +147,14 @@ describe("prepareReviewPublish", () => {
     await git(repo.rootPath, ["add", "."]);
     await git(repo.rootPath, ["commit", "-m", "descendant"]);
     const checkoutCommit = await git(repo.rootPath, ["rev-parse", "HEAD"]);
+
     const reviewHome = await mkdtemp(
       path.join(os.tmpdir(), "review-publish-home-"),
     );
+
     cleanupPaths.push(reviewHome);
     vi.stubEnv("DEV_REVIEW_HOME", reviewHome);
+
     const review = await createReviewDir({
       worktreePath: repo.rootPath,
       baseRef: repo.baseCommit,
@@ -150,6 +167,7 @@ describe("prepareReviewPublish", () => {
       cwd: repo.rootPath,
       reviewUuid: review.review.uuid,
     });
+
     expect(prepared).toMatchObject({
       sourceBranch: repo.baseCommit,
       sourceCommit: repo.baseCommit,
@@ -160,11 +178,14 @@ describe("prepareReviewPublish", () => {
 
   it("keeps the stored pins when the branch and base move, and warns to update", async () => {
     const repo = await createDivergedGitRepository(cleanupPaths);
+
     const reviewHome = await mkdtemp(
       path.join(os.tmpdir(), "review-publish-home-"),
     );
+
     cleanupPaths.push(reviewHome);
     vi.stubEnv("DEV_REVIEW_HOME", reviewHome);
+
     const review = await createReviewDir({
       worktreePath: repo.rootPath,
       baseRef: "main",
@@ -172,6 +193,7 @@ describe("prepareReviewPublish", () => {
       sourceCommit: repo.featureCommit,
       sourceIdentity: { kind: "git-branch", name: "feature" },
     });
+
     await writeFile(path.join(repo.rootPath, "main.txt"), "base moved\n");
     await git(repo.rootPath, ["add", "."]);
     await git(repo.rootPath, ["commit", "-m", "base moved"]);
@@ -198,21 +220,26 @@ describe("prepareReviewPublish", () => {
     expect(prepared.warnings).toEqual([
       "Pinned commits are behind feature. Run `review scaffold --update` and publish again to present the latest commits.",
     ]);
+
     const stored = JSON.parse(
       await readFile(path.join(review.dir, "review.json"), "utf8"),
     ) as { baseCommit: string; sourceCommit: string };
+
     expect(stored.baseCommit).toBe(repo.baseCommit);
     expect(stored.sourceCommit).toBe(repo.featureCommit);
   });
 
   it("rejects a publish when the pinned base commit no longer exists", async () => {
     const repo = await createDivergedGitRepository(cleanupPaths);
+
     const reviewHome = await mkdtemp(
       path.join(os.tmpdir(), "review-publish-home-"),
     );
+
     cleanupPaths.push(reviewHome);
     vi.stubEnv("DEV_REVIEW_HOME", reviewHome);
     const missingBase = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
     const review = await createReviewDir({
       worktreePath: repo.rootPath,
       baseRef: repo.baseCommit,
@@ -231,11 +258,14 @@ describe("prepareReviewPublish", () => {
 
   it("does not warn about stale pins for a positional binding", async () => {
     const repo = await createDivergedGitRepository(cleanupPaths);
+
     const reviewHome = await mkdtemp(
       path.join(os.tmpdir(), "review-publish-home-"),
     );
+
     cleanupPaths.push(reviewHome);
     vi.stubEnv("DEV_REVIEW_HOME", reviewHome);
+
     const review = await createReviewDir({
       worktreePath: repo.rootPath,
       baseRef: repo.baseCommit,
@@ -248,17 +278,21 @@ describe("prepareReviewPublish", () => {
       cwd: repo.rootPath,
       reviewUuid: review.review.uuid,
     });
+
     expect(prepared.sourceCommit).toBe(repo.baseCommit);
     expect(prepared).not.toHaveProperty("warnings");
   });
 
   it("presents the pins even when the bound head no longer resolves", async () => {
     const repo = await createDivergedGitRepository(cleanupPaths);
+
     const reviewHome = await mkdtemp(
       path.join(os.tmpdir(), "review-publish-home-"),
     );
+
     cleanupPaths.push(reviewHome);
     vi.stubEnv("DEV_REVIEW_HOME", reviewHome);
+
     const review = await createReviewDir({
       worktreePath: repo.rootPath,
       baseRef: repo.baseCommit,
@@ -271,6 +305,7 @@ describe("prepareReviewPublish", () => {
       cwd: repo.rootPath,
       reviewUuid: review.review.uuid,
     });
+
     expect(prepared.sourceCommit).toBe(repo.baseCommit);
     expect(prepared).not.toHaveProperty("warnings");
   });
@@ -284,6 +319,7 @@ async function createDivergedGitRepository(cleanupPaths: string[]): Promise<{
   const rootPath = await mkdtemp(
     path.join(os.tmpdir(), "review-publish-source-"),
   );
+
   cleanupPaths.push(rootPath);
   await git(rootPath, ["init", "-b", "main"]);
   await git(rootPath, ["config", "user.email", "review@example.test"]);
@@ -297,6 +333,7 @@ async function createDivergedGitRepository(cleanupPaths: string[]): Promise<{
   await git(rootPath, ["commit", "-am", "feature"]);
   const featureCommit = await git(rootPath, ["rev-parse", "HEAD"]);
   await git(rootPath, ["checkout", "main"]);
+
   return { rootPath, baseCommit, featureCommit };
 }
 
@@ -304,5 +341,6 @@ async function git(rootPath: string, args: string[]): Promise<string> {
   const { stdout } = await execFilePromise("git", ["-C", rootPath, ...args], {
     encoding: "utf8",
   });
+
   return stdout.trim();
 }

--- a/packages/progressive-review/src/server/review-api.ts
+++ b/packages/progressive-review/src/server/review-api.ts
@@ -110,11 +110,17 @@ import {
 } from "./review-session-mode";
 
 const REVIEW_SUBMIT_HOOK_ENV = "DEV_FAST_REVIEW_SUBMIT_HOOK";
+
 export const TUTORIAL_QUESTION_SOURCE_WAIT_MS = 5_000;
+
 const CODE_PEEK_DIFF_CONTEXT_LINES = 100_000;
+
 const defaultTelemetry = new ProgressiveReviewTelemetry();
+
 const MAX_CLIENT_ERROR_SESSIONS = 100;
+
 const MAX_CLIENT_ERRORS_PER_SESSION = 20;
+
 const clientErrorsBySession = new Map<string, string[]>();
 
 function recordClientError(
@@ -123,14 +129,18 @@ function recordClientError(
   if (event?.event !== "review_client_error") return;
   const sessionId = jsonString(event.properties.app_session_id);
   const errorName = jsonString(event.properties.error_name);
+
   if (sessionId === undefined || errorName === undefined) return;
   const names = clientErrorsBySession.get(sessionId) ?? [];
   names.push(errorName);
+
   if (names.length > MAX_CLIENT_ERRORS_PER_SESSION) names.shift();
   clientErrorsBySession.delete(sessionId);
   clientErrorsBySession.set(sessionId, names);
+
   while (clientErrorsBySession.size > MAX_CLIENT_ERROR_SESSIONS) {
     const oldest = clientErrorsBySession.keys().next().value;
+
     if (oldest === undefined) break;
     clientErrorsBySession.delete(oldest);
   }
@@ -138,10 +148,12 @@ function recordClientError(
 
 function clientErrorsForSession(sessionId: string): string[] {
   const names = clientErrorsBySession.get(sessionId) ?? [];
+
   if (names.length > 0) {
     clientErrorsBySession.delete(sessionId);
     clientErrorsBySession.set(sessionId, names);
   }
+
   return [...names];
 }
 
@@ -181,7 +193,9 @@ export async function captureSanitizedUiTelemetry(
 ): Promise<void> {
   const appSessionId =
     request.headers.get(REVIEW_APP_SESSION_ID_HEADER) ?? undefined;
+
   const rawProperties: JsonObject = isJsonObject(properties) ? properties : {};
+
   // The error fields come from the raw envelope and nowhere else; this
   // helper drops any a client tried to assert. It matters because the
   // allowlist cannot tell a cleaned message from a raw one.
@@ -189,13 +203,17 @@ export async function captureSanitizedUiTelemetry(
     rawProperties,
     rawError,
   );
+
   if (appSessionId) mergedProperties.app_session_id = appSessionId;
+
   const sanitized = sanitizeUiTelemetryEvent({
     name,
     properties: mergedProperties,
   });
+
   if (!sanitized) return;
   onSanitized?.(sanitized);
+
   try {
     await telemetry.captureUiEvent?.(sanitized.event, sanitized.properties);
   } catch (error) {
@@ -263,17 +281,21 @@ interface ActiveAgentRun {
   canceled: boolean;
   binding?: SessionRef;
 }
+
 const AgentInterruptRequestSchema = z.strictObject({
   messageId: z.string().min(1).nullable(),
 });
 
 export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   const readOnlyReview = reviewSessionModeRecord(options.mode);
+
   const reviewRootPath =
     options.reviewRootPath ??
     options.session.storageDir ??
     path.dirname(options.stateReviewPath ?? options.reviewPath);
+
   const app = new Hono<ReviewHonoEnv>();
+
   const {
     reviewPath,
     reviewDocumentsDir,
@@ -291,6 +313,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     stateReviewPath,
     session,
   } = options;
+
   const agentRootPath = session.headRootPath ?? rootPath;
   const threadServices = new Map<string, ReviewThreadsService>();
   const threadSubscriptions: Array<() => void> = [];
@@ -299,24 +322,30 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   const canceledAgentMessageIds = new Set<string>();
   const activeRuns = new Map<string, ActiveAgentRun>();
   const diffCorpora = new Map<string, Promise<ReviewDiffFilesResult>>();
+
   let readOnlyThreads: {
     key: string;
     snapshot: ReviewThreadsReadOnlySnapshot;
   } | null = null;
+
   const readOnlyThreadsSnapshot = (
     writableReviewPath: string,
   ): ReviewThreadsReadOnlySnapshot => {
     const readOnlyThreadsPath =
       options.readOnlyThreadsPath ?? writableReviewPath;
+
     const key = `${readOnlyThreadsPath}|${reviewThreadDbSnapshotToken(readOnlyThreadsPath)}`;
+
     if (readOnlyThreads?.key !== key) {
       readOnlyThreads = {
         key,
         snapshot: readReviewThreadsReadOnly(readOnlyThreadsPath),
       };
     }
+
     return readOnlyThreads.snapshot;
   };
+
   const startMirror = (
     writableReviewPath: string,
     service: ReviewThreadsService,
@@ -328,11 +357,15 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       onStatus: (threadId, update) =>
         options.onAgentStatus?.(threadId, update.status, update.error),
     });
+
     agentMirrors.set(writableReviewPath, mirror);
+
     return mirror;
   };
+
   const threadsFor = (writableReviewPath: string): ReviewThreadsService => {
     let service = threadServices.get(writableReviewPath);
+
     if (!service) {
       service =
         options.threadsService?.() ??
@@ -341,13 +374,17 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
           author: process.env.USER ?? "Reviewer",
         });
       threadServices.set(writableReviewPath, service);
+
       if (onReviewThreadsCommit)
         threadSubscriptions.push(service.subscribe(onReviewThreadsCommit));
     }
+
     return service;
   };
+
   const mirrorFor = (writableReviewPath: string): NativeMessageMirror => {
     const service = threadsFor(writableReviewPath);
+
     return (
       agentMirrors.get(writableReviewPath) ??
       startMirror(writableReviewPath, service)
@@ -373,10 +410,12 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
                 : "review_read_only",
           });
         }
+
         return await handler(context);
       } catch (err) {
         if (err instanceof ReviewBusyError)
           return reviewApiJsonResponse(409, reviewBusyResponse(err));
+
         return reviewApiJsonResponse(requestJsonErrorStatus(err), {
           ok: false,
           error: err instanceof Error ? err.message : String(err),
@@ -399,12 +438,14 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
           reviewPath,
           reviewDocumentsDir,
         });
+
       if (!writableReviewPath) {
         return reviewApiJsonResponse(404, {
           ok: false,
           error: "Review document not found.",
         });
       }
+
       return handler(context, writableReviewPath);
     });
 
@@ -465,6 +506,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     const review = readOnlyReview ?? readReviewStoreRecord(reviewRootPath);
     const repoRootPath = resolveReviewRepoRootFromStore(reviewRootPath, review);
     const headCommit = review.sourceCommit ?? review.baseCommit;
+
     return listReviewTraceSessions({
       rootPath: repoRootPath,
       baseCommit: review.baseCommit,
@@ -474,6 +516,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
 
   async function agentTraces(): Promise<Response> {
     const sessions = await resolveTraceSessionDescriptors();
+
     return reviewApiJsonResponse(200, {
       ok: true,
       configured: isTraceR2Configured(),
@@ -485,26 +528,32 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     context: Context<ReviewHonoEnv>,
   ): Promise<Response> {
     const sessionId = context.req.param("sessionId");
+
     if (!sessionId) {
       return reviewApiJsonResponse(404, {
         ok: false,
         error: "Session is required.",
       });
     }
+
     const trace =
       new URL(context.req.url).searchParams.get("trace") ?? undefined;
+
     const repoRootPath = resolveReviewRepoRootFromStore(reviewRootPath);
+
     const loaded = await loadReviewAgentTrace({
       sessionId,
       trace,
       cwd: repoRootPath,
     });
+
     if (!loaded) {
       return reviewApiJsonResponse(404, {
         ok: false,
         error: `Trace not found for session ${sessionId}${trace ? ` (subagent ${trace})` : ""}.`,
       });
     }
+
     const {
       parserVersion,
       descriptor,
@@ -512,6 +561,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       subagents,
       traceName,
     } = loaded;
+
     return reviewApiJsonResponse(200, {
       ok: true,
       parserVersion,
@@ -541,7 +591,9 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
         },
       ),
     );
+
     await telemetry.captureTabViewed(event);
+
     return reviewApiJsonResponse(200, { ok: true });
   }
 
@@ -562,6 +614,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     } catch (error) {
       console.error(error);
     }
+
     return reviewApiJsonResponse(200, { ok: true });
   }
 
@@ -570,6 +623,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       const report = parseReviewBugReportInput(
         await readBoundedRequestJson(context.req.raw, 6 * 1024 * 1024, {}),
       );
+
       const reviewDocumentPath = resolveReviewDocumentPath(
         new URL(context.req.url),
         {
@@ -577,18 +631,21 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
           reviewDocumentsDir,
         },
       );
+
       if (!reviewDocumentPath) {
         return reviewApiJsonResponse(404, {
           ok: false,
           error: "Review document not found.",
         });
       }
+
       const result = await submitReviewBugReport({
         report,
         reviewDocumentPath,
         reviewRootPath,
         clientErrorNames: clientErrorsForSession(report.app_session_id),
       });
+
       return reviewApiJsonResponse(200, result);
     } catch (error) {
       // An upstream rejection carries its own status; route() would flatten
@@ -597,6 +654,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
         error instanceof BugReportUpstreamError
           ? error.status
           : requestJsonErrorStatus(error);
+
       return reviewApiJsonResponse(status, {
         ok: false,
         error: error instanceof Error ? error.message : String(error),
@@ -608,16 +666,20 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     context: Context<ReviewHonoEnv>,
   ): Promise<Response> {
     const url = new URL(context.req.url);
+
     const documentPath = resolveReviewDocumentPath(url, {
       reviewPath,
       reviewDocumentsDir,
     });
+
     if (!documentPath) {
       throw new Error("Review document not found.");
     }
+
     const resolvedBaseRef = await resolveReviewSessionBaseCommit({
       reviewRootPath,
     });
+
     return reviewApiJsonResponse(200, {
       ok: true,
       session: stateReviewPath
@@ -644,6 +706,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   ): Promise<Response> {
     const command = parseReviewThreadsCommand(await readJson(context.req.raw));
     const commit = threadsFor(writableReviewPath).dispatch(command);
+
     return reviewApiJsonResponse(
       commit ? 200 : 404,
       commit
@@ -659,29 +722,36 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     const comment = parseReviewCommentInput(await readJson(context.req.raw));
     const service = threadsFor(writableReviewPath);
     const draft = service.snapshot().drafts[comment.threadId];
+
     if (!draft?.inputs.some((input) => input.messageId === comment.messageId)) {
       return reviewApiJsonResponse(409, {
         ok: false,
         error: "The Review agent comment is not in the durable draft store.",
       });
     }
+
     if (launchedAgentMessageIds.has(comment.messageId)) {
       return reviewApiJsonResponse(202, { ok: true });
     }
+
     if (canceledAgentMessageIds.has(comment.messageId))
       return reviewApiJsonResponse(202, { ok: true });
+
     if (activeRuns.has(comment.threadId))
       return reviewApiJsonResponse(409, {
         ok: false,
         error: "Close the current terminal before asking again.",
       });
     launchedAgentMessageIds.add(comment.messageId);
+
     const run: ActiveAgentRun = {
       messageId: comment.messageId,
       canceled: false,
     };
+
     activeRuns.set(comment.threadId, run);
     const mirror = mirrorFor(writableReviewPath);
+
     try {
       await answerReviewComment({
         comment,
@@ -695,9 +765,11 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
         onQuestionAgentSession,
         onLaunched: async (binding) => {
           run.binding = binding;
+
           if (!run.canceled) return true;
           await agentServer(binding.harness).interrupt(binding.sessionId);
           activeRuns.delete(comment.threadId);
+
           return false;
         },
       });
@@ -707,6 +779,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       options.onAgentStatus?.(comment.threadId, "failed", String(error));
       throw error;
     }
+
     return reviewApiJsonResponse(202, { ok: true });
   }
 
@@ -715,27 +788,37 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     writableReviewPath: string,
   ): Promise<Response> {
     const threadId = context.req.param("threadId");
+
     if (!threadId) throw new Error("A comment thread ID is required.");
+
     const body = AgentInterruptRequestSchema.parse(
       await readJson(context.req.raw),
     );
+
     if (body.messageId !== null) canceledAgentMessageIds.add(body.messageId);
     const run = activeRuns.get(threadId);
+
     if (run && body.messageId !== null && run.messageId !== body.messageId)
       return reviewApiJsonResponse(409, {
         ok: false,
         error: "This terminal belongs to another Ask.",
       });
+
     if (run) run.canceled = true;
     const snapshot = threadsFor(writableReviewPath).snapshot();
+
     const thread =
       snapshot.drafts[threadId]?.thread ?? snapshot.comments[threadId];
+
     const binding = run ? run.binding : thread?.agentSession;
+
     if (binding) {
       await agentServer(binding.harness).interrupt(binding.sessionId);
       activeRuns.delete(threadId);
     }
+
     options.onAgentStatus?.(threadId, "interrupted");
+
     return reviewApiJsonResponse(200, { ok: true });
   }
 
@@ -744,29 +827,36 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     writableReviewPath: string,
   ): Promise<Response> {
     const threadId = context.req.param("threadId");
+
     if (!threadId) {
       return reviewApiJsonResponse(400, {
         ok: false,
         error: "Thread ID is required.",
       });
     }
+
     const snapshot = threadsFor(writableReviewPath).snapshot();
+
     const agentSession =
       snapshot.drafts[threadId]?.thread.agentSession ??
       snapshot.comments[threadId]?.agentSession;
+
     if (!agentSession) {
       return reviewApiJsonResponse(404, {
         ok: false,
         error: "This thread has no agent terminal.",
       });
     }
+
     // SAFETY: thread records store agent sessions through the review
     // protocol schema, whose harness enum is the ReviewAgentHarness union.
     const binding = agentSession as SessionRef;
+
     const { command } = await agentServer(binding.harness).launch({
       session: { resume: binding.sessionId },
       cwd: agentRootPath,
     });
+
     await mirrorFor(writableReviewPath).watch(threadId, binding);
     await openNativeAgentTerminal({
       session: binding,
@@ -774,6 +864,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       command,
       askMessageId: null,
     });
+
     return reviewApiJsonResponse(200, { ok: true });
   }
 
@@ -795,6 +886,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
         )
         .catch((error) => console.error(error));
     });
+
     return reviewApiJsonResponse(200, { ok: true });
   }
 
@@ -810,6 +902,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
         body.comments,
       ),
     );
+
     const event = buildReviewSubmissionEvent({
       submission: body,
       rootPath,
@@ -817,6 +910,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       documentRoute: normalizeReviewRoutePath(url.searchParams.get("document")),
       session,
     });
+
     // Durable audit trail (best-effort — a write failure must never discard
     // an otherwise-valid submission).
     try {
@@ -824,6 +918,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     } catch (error) {
       console.error(error);
     }
+
     // Resolve the in-memory desktop submission before the response so a
     // browser tab close cannot race the durable review status.
     await onSubmission?.(event);
@@ -837,14 +932,17 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       },
       recordClientError,
     );
+
     const response = reviewApiJsonResponse(200, {
       ok: true,
       event,
       hook: { configured: Boolean(submitHook?.trim()) },
     });
+
     void runReviewSubmissionHook(event, submitHook).then((hook) => {
       if (hook.error) console.error(hook.error);
     });
+
     return response;
   }
 
@@ -858,6 +956,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       threadId: context.req.param("threadId") ?? "",
       messageId: context.req.param("messageId") ?? "",
     });
+
     return reviewApiJsonResponse(
       commit ? 200 : 404,
       commit
@@ -872,17 +971,21 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   ): Promise<Response> {
     const threadId = context.req.param("threadId") ?? "";
     const body = parseReviewCommentInput(await readJson(context.req.raw));
+
     if (threadId !== body.threadId) {
       throw new Error("Comment path threadId must match body threadId.");
     }
+
     const commit = threadsFor(writableReviewPath).dispatch({
       command: "comment.create",
       mutationId: body.messageId,
       input: body,
     });
+
     if (!commit) {
       throw new Error("The comment could not be created.");
     }
+
     return reviewApiJsonResponse(200, { ok: true, commit });
   }
 
@@ -892,12 +995,14 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   ): Promise<Response> {
     const threadId = context.req.param("threadId") ?? "";
     const body = parseUpdateReviewCommentInput(await readJson(context.req.raw));
+
     const commit = threadsFor(writableReviewPath).dispatch({
       command: "comment.update",
       mutationId: randomUUID(),
       threadId,
       update: body,
     });
+
     return reviewApiJsonResponse(
       commit ? 200 : 404,
       commit
@@ -911,11 +1016,13 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     writableReviewPath: string,
   ): Response {
     const threadId = context.req.param("threadId") ?? "";
+
     const commit = threadsFor(writableReviewPath).dispatch({
       command: "comment.delete",
       mutationId: randomUUID(),
       threadId,
     });
+
     return reviewApiJsonResponse(
       commit ? 200 : 404,
       commit
@@ -934,13 +1041,16 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     const includeDiff = body.includeDiff === true;
     const includeDiffSummary = body.includeDiffSummary === true;
     const primaryTarget = graph === "base" ? baseSourceTarget : sourceTarget;
+
     if (!primaryTarget) {
       throw new Error("The pinned base worktree is unavailable.");
     }
+
     const snapshot = await resolveReviewSourceRange({
       rootPath: primaryTarget.sourceRootPath,
       root: parseCodePeekRoot(body.root),
     });
+
     const diff =
       includeDiff || includeDiffSummary
         ? await resolveCodePeekDiff({
@@ -950,6 +1060,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
             includePatch: includeDiff,
           })
         : undefined;
+
     return reviewApiJsonResponse(
       200,
       diff ? { ok: true, snapshot, diff } : { ok: true, snapshot },
@@ -963,11 +1074,13 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     const codeElements = parseSoftwareMapCodeElements(body.codeElements);
     const coverageClaims = parseSoftwareMapCoverageClaims(body.coverageClaims);
     const sourceTarget = await requestSourceTarget();
+
     const result = await buildSoftwareMapResolvedData({
       sourceTarget,
       codeElements,
       coverageClaims,
     });
+
     return reviewApiJsonResponse(200, { ok: true, ...result });
   }
 
@@ -975,35 +1088,43 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     context: Context<ReviewHonoEnv>,
   ): Promise<Response> {
     const url = new URL(context.req.url);
+
     const reviewDocumentPath = resolveReviewDocumentPath(url, {
       reviewPath,
       reviewDocumentsDir,
     });
+
     if (!reviewDocumentPath) {
       return reviewApiJsonResponse(404, {
         ok: false,
         error: "Review document not found.",
       });
     }
+
     // Notes are the durable map state. Refreshing the canvas only
     // re-materializes note-backed artifacts; map edits are published by
     // `review map check` after validation succeeds.
     const result = await rematerializeReviewSoftwareMapArtifacts({
       reviewRootPath,
     });
+
     return reviewApiJsonResponse(200, { ok: true, refresh: result });
   }
 
   function documentMeta(context: Context<ReviewHonoEnv>): Response {
     const url = new URL(context.req.url);
+
     const documentPath = resolveReviewDocumentPath(url, {
       reviewPath,
       reviewDocumentsDir,
     });
+
     if (!documentPath) {
       throw new Error("Review document not found.");
     }
+
     const stats = statSync(documentPath);
+
     return reviewApiJsonResponse(200, {
       ok: true,
       updatedAtMs: stats.mtimeMs,
@@ -1014,9 +1135,11 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
 
   async function reviewStack(): Promise<Response> {
     const current = readOnlyReview ?? readReviewStoreRecord(reviewRootPath);
+
     if (!current.pullRequestNumber) {
       return reviewApiJsonResponse(200, { layers: [] });
     }
+
     const listed = await listReviews();
     const reviews = listed.reviews.map((stored) => stored.review);
     reviews.sort(
@@ -1025,6 +1148,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
           left.lastPublishedAt ?? "",
         ) || left.uuid.localeCompare(right.uuid),
     );
+
     return reviewApiJsonResponse(200, {
       layers: await resolveReviewStackLayers(current, reviews),
     });
@@ -1036,6 +1160,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     const diffTarget = await resolveScopedDiffTarget(url, body.commit);
     const corpus = await diffCorpus(diffTarget);
     const requestedPaths = new Set(body.paths ?? []);
+
     const files = corpus.files
       .filter(
         (file) =>
@@ -1047,7 +1172,9 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       .map(({ patch, ...file }) =>
         body.includePatch ? { ...file, patch } : file,
       );
+
     const result = { ...corpus, files };
+
     return reviewApiJsonResponse(200, { ok: true, ...result });
   }
 
@@ -1056,21 +1183,28 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   ): Promise<Response> {
     const url = new URL(context.req.url);
     const contentQuery: JsonObject = {};
+
     for (const key of ["path", "side", "commit"]) {
       const value = url.searchParams.get(key);
+
       if (value !== null) contentQuery[key] = value;
     }
+
     const contentRequest = parseReviewFileContentRequest(contentQuery);
+
     const diffTarget = await resolveScopedDiffTarget(
       url,
       contentRequest.commit,
     );
+
     const comparison = await diffCorpus(diffTarget);
+
     const result = await resolveReviewFileContent({
       ...diffTarget,
       ...contentRequest,
       comparison,
     });
+
     return reviewApiJsonResponse(200, { ok: true, ...result });
   }
 
@@ -1084,7 +1218,9 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       diffTarget.baseRef ?? "",
       diffTarget.headRef ?? "",
     ]);
+
     const cached = diffCorpora.get(key);
+
     if (cached) return cached;
     let pending: Promise<ReviewDiffFilesResult>;
     pending = resolveReviewDiffFiles({
@@ -1095,10 +1231,13 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       throw error;
     });
     diffCorpora.set(key, pending);
+
     if (diffCorpora.size > 32) {
       const oldest = diffCorpora.keys().next().value;
+
       if (oldest !== undefined) diffCorpora.delete(oldest);
     }
+
     return pending;
   }
 
@@ -1108,6 +1247,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     headCommit: string,
   ): Promise<LocalVcsCommitSummary[]> {
     if (baseCommit === headCommit) return [];
+
     return listCommitRange({
       rootPath: repoRootPath,
       baseRef: baseCommit,
@@ -1117,6 +1257,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
 
   async function resolveScopedDiffTarget(url: URL, commit?: string) {
     if (options.sourceUnavailable) throw new Error(options.sourceUnavailable);
+
     const target = resolveRequestDiffTarget(url, {
       reviewPath,
       reviewDocumentsDir,
@@ -1124,13 +1265,16 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       session,
       record: readOnlyReview,
     });
+
     if (!commit) return target;
     const review = readOnlyReview ?? readReviewStoreRecord(reviewRootPath);
     const headCommit = review.sourceCommit ?? review.baseCommit;
+
     const scope = resolveReviewCommitScope(
       await reviewCommits(target.rootPath, review.baseCommit, headCommit),
       commit,
     );
+
     return {
       rootPath: target.rootPath,
       ...scope,
@@ -1139,9 +1283,12 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
 
   async function requestSourceTarget() {
     if (!readOnlyReview) return resolveRequestSourceTarget({ reviewRootPath });
+
     if (options.sourceUnavailable) throw new Error(options.sourceUnavailable);
+
     if (!session.headRootPath || !session.baseRootPath)
       throw new Error("The pinned source worktrees are unavailable.");
+
     return {
       repoRoot: rootPath,
       sourceRootPath: session.headRootPath,
@@ -1162,7 +1309,9 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       const snapshot = threadsFor(stateReviewPath).snapshot();
       const draft = snapshot.drafts[threadId];
       const thread = draft?.thread ?? snapshot.comments[threadId];
+
       if (!thread) return undefined;
+
       return {
         review: path.basename(path.dirname(stateReviewPath)),
         state: draft ? "draft" : "submitted",
@@ -1201,9 +1350,11 @@ function readJson(request: Request): Promise<JsonValue> {
 
 async function readJsonObject(request: Request): Promise<JsonObject> {
   const body = await readJson(request);
+
   if (!isJsonObject(body)) {
     throw new Error("Request body must be a JSON object.");
   }
+
   return body;
 }
 
@@ -1258,21 +1409,27 @@ async function answerReviewComment(input: {
         stage,
       }),
     );
+
   timing("backend.answer-start");
   const snapshot = input.service.snapshot();
+
   const storedSession =
     snapshot.drafts[input.comment.threadId]?.thread.agentSession ??
     snapshot.comments[input.comment.threadId]?.agentSession;
+
   const launch = await resolveReviewQuestionLaunch({
     storedSession,
     agent: input.session.agent,
     freshQuestionHarness: input.session.freshQuestionHarness,
     resolveQuestionSourceSession: input.resolveQuestionSourceSession,
   });
+
   if (!launch) {
     throw new Error("This Review has no authoring agent session.");
   }
+
   timing("backend.source-resolved");
+
   const launchInput: LaunchInput = {
     prompt: {
       id: input.comment.messageId,
@@ -1280,24 +1437,31 @@ async function answerReviewComment(input: {
     },
     cwd: input.rootPath,
   };
+
   if (launch.session) launchInput.session = launch.session;
+
   const { sessionId, command } = await input
     .agentServer(launch.harness)
     .launch(launchInput);
+
   timing("backend.adapter-returned");
   const binding: SessionRef = { harness: launch.harness, sessionId };
+
   const commit = input.service.setAgentSession({
     mutationId: randomUUID(),
     threadId: input.comment.threadId,
     agentSession: binding,
   });
+
   if (!commit) {
     throw new Error(
       `Review comment thread ${input.comment.threadId} no longer exists.`,
     );
   }
+
   await input.mirror.watch(input.comment.threadId, binding);
   timing("backend.mirror-attached");
+
   if (!(await input.onLaunched(binding))) return;
   timing("backend.terminal-dispatch");
   await input.openNativeAgentTerminal({
@@ -1329,21 +1493,25 @@ export async function resolveReviewQuestionLaunch(input: {
       session: { resume: input.storedSession.sessionId },
     };
   }
+
   if (input.agent) {
     return {
       harness: input.agent.harness,
       session: { forkOf: input.agent.sessionId },
     };
   }
+
   if (input.resolveQuestionSourceSession) {
     const preparedSource = await resolveQuestionSourceWithinBudget(
       input.resolveQuestionSourceSession,
     );
+
     return {
       harness: preparedSource.harness,
       session: { forkOf: preparedSource.sessionId },
     };
   }
+
   if (input.freshQuestionHarness)
     return { harness: input.freshQuestionHarness };
   throw new Error("This Review has no authoring agent session.");
@@ -1353,6 +1521,7 @@ async function resolveQuestionSourceWithinBudget(
   resolveSource: (signal?: AbortSignal) => Promise<SessionRef | undefined>,
 ): Promise<SessionRef> {
   const signal = AbortSignal.timeout(TUTORIAL_QUESTION_SOURCE_WAIT_MS);
+
   const timedOut = new Promise<never>((_resolve, reject) => {
     signal.addEventListener(
       "abort",
@@ -1363,8 +1532,11 @@ async function resolveQuestionSourceWithinBudget(
       { once: true },
     );
   });
+
   const source = await Promise.race([resolveSource(signal), timedOut]);
+
   if (!source) throw new Error("The Review authoring session is not ready.");
+
   return source;
 }
 
@@ -1377,6 +1549,7 @@ function buildReviewSubmissionEvent(input: {
 }): ReviewSubmissionEvent {
   const session = input.session;
   const agent = session?.agent ?? resolveAuthoringSessionRef(process.env);
+
   return {
     id: input.submission.submissionId,
     decision: input.submission.decision,
@@ -1415,6 +1588,7 @@ function reviewSubmissionPrompt(input: {
       return `${index + 1}. Thread ${comment.threadId} targeting ${JSON.stringify(comment.target)}: ${comment.body}`;
     })
     .join("\n");
+
   return `The reviewer submitted comments in the progressive review.
 
 Repo root: ${input.rootPath}
@@ -1438,7 +1612,9 @@ async function runReviewSubmissionHook(
   error?: string;
 }> {
   const command = configuredCommand?.trim();
+
   if (!command) return { configured: false };
+
   return new Promise((resolve) => {
     const child = spawn(command, {
       cwd: event.rootPath,
@@ -1446,9 +1622,11 @@ async function runReviewSubmissionHook(
       shell: true,
       stdio: ["pipe", "ignore", "pipe"],
     });
+
     let stderr = "";
     let settled = false;
     let timeout: ReturnType<typeof setTimeout>;
+
     const finish = (result: {
       configured: boolean;
       exitCode?: number;
@@ -1459,6 +1637,7 @@ async function runReviewSubmissionHook(
       clearTimeout(timeout);
       resolve(result);
     };
+
     timeout = setTimeout(() => {
       child.kill();
       finish({
@@ -1478,9 +1657,11 @@ async function runReviewSubmissionHook(
         configured: true,
         exitCode: code ?? 1,
       };
+
       if (code !== 0) {
         result.error = stderr.trim() || `${REVIEW_SUBMIT_HOOK_ENV} failed`;
       }
+
       finish(result);
     });
     child.stdin?.end(`${JSON.stringify(event)}\n`);
@@ -1502,10 +1683,12 @@ async function rematerializeReviewSoftwareMapArtifacts(input: {
   artifactPath?: string | null;
 }> {
   const review = readReviewStoreRecord(input.reviewRootPath);
+
   const repoRootPath = resolveReviewRepoRootFromStore(
     input.reviewRootPath,
     review,
   );
+
   const headCommit = review.sourceCommit
     ? (
         await resolveRevision(repoRootPath, review.sourceCommit).catch(
@@ -1513,6 +1696,7 @@ async function rematerializeReviewSoftwareMapArtifacts(input: {
         )
       )?.commit
     : (await currentHead(repoRootPath).catch(() => null))?.commit;
+
   if (!headCommit) return { status: "skipped" };
 
   const [artifactPath] = await Promise.all([
@@ -1537,6 +1721,7 @@ async function rematerializeReviewSoftwareMapArtifacts(input: {
           )
       : Promise.resolve(null),
   ]);
+
   return { status: "rematerialized", headCommit, artifactPath };
 }
 
@@ -1572,19 +1757,23 @@ async function resolveCodePeekDiff(input: {
 
   const ranges = codePeekRootSourceRanges(input.snapshot);
   const paths = codePeekDiffRangeFiles(ranges);
+
   if (paths.length === 0) return undefined;
 
   const diffRootPath =
     input.sourceTarget.baseRef || input.sourceTarget.headRef
       ? input.sourceTarget.diffRootPath
       : input.sourceTarget.sourceRootPath;
+
   const diffFiles = await resolveCodePeekDiffFiles({
     diffRootPath,
     baseRef: input.sourceTarget.baseRef,
     headRef: input.sourceTarget.headRef,
     paths,
   });
+
   if (diffFiles.length === 0) return undefined;
+
   const files = diffFiles
     .map((file) =>
       sliceReviewDiffFileToCodePeekRanges({
@@ -1595,6 +1784,7 @@ async function resolveCodePeekDiff(input: {
       }),
     )
     .filter((file): file is ReviewDiffFile => file !== null);
+
   if (files.length === 0) return undefined;
 
   return {
@@ -1633,7 +1823,9 @@ export function serializeCodePeekDiffFile(
     additions: file.additions,
     deletions: file.deletions,
   };
+
   if (includePatch) serialized.patch = file.patch ?? "";
+
   return serialized;
 }
 
@@ -1658,6 +1850,7 @@ async function buildSoftwareMapResolvedData(input: {
     input.sourceTarget.baseRef || input.sourceTarget.headRef
       ? input.sourceTarget.diffRootPath
       : input.sourceTarget.sourceRootPath;
+
   const counts = await resolveSoftwareMapDiffCounts({
     sourceRootPath: diffRootPath,
     baseRef: input.sourceTarget.baseRef,
@@ -1665,6 +1858,7 @@ async function buildSoftwareMapResolvedData(input: {
     codeElements: input.codeElements,
     coverageClaims: input.coverageClaims,
   });
+
   return {
     countsByElementPath: counts.countsByElementPath,
     unmappedByElementPath: counts.unmappedByElementPath,
@@ -1701,10 +1895,13 @@ export function resolveRequestDiffTarget(
   },
 ): ReviewRequestDiffTarget {
   const reviewDocumentPath = resolveReviewDocumentPath(url, input);
+
   if (!reviewDocumentPath) {
     throw new Error("Review document not found.");
   }
+
   const review = input.record ?? readReviewStoreRecord(input.rootPath);
+
   return {
     rootPath: resolveReviewRepoRootFromStore(input.rootPath, review),
     baseRef: review.baseCommit,

--- a/packages/progressive-review/src/server/review-api.ts
+++ b/packages/progressive-review/src/server/review-api.ts
@@ -213,6 +213,7 @@ interface ReviewApiOptions {
   reviewRootPath?: string;
   toolingRoot: string;
   stateReviewPath?: string;
+  threadsService?: () => ReviewThreadsService;
   telemetry?: ReviewTelemetryCapture;
   onSubmission?: (event: ReviewSubmissionEvent) => void | Promise<void>;
   onReviewDismiss?: () => void | Promise<void>;
@@ -292,6 +293,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   } = options;
   const agentRootPath = session.headRootPath ?? rootPath;
   const threadServices = new Map<string, ReviewThreadsService>();
+  const threadSubscriptions: Array<() => void> = [];
   const agentMirrors = new Map<string, NativeMessageMirror>();
   const launchedAgentMessageIds = new Set<string>();
   const canceledAgentMessageIds = new Set<string>();
@@ -332,12 +334,15 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   const threadsFor = (writableReviewPath: string): ReviewThreadsService => {
     let service = threadServices.get(writableReviewPath);
     if (!service) {
-      service = new ReviewThreadsService({
-        reviewPath: writableReviewPath,
-        author: process.env.USER ?? "Reviewer",
-        onCommit: onReviewThreadsCommit,
-      });
+      service =
+        options.threadsService?.() ??
+        new ReviewThreadsService({
+          reviewPath: writableReviewPath,
+          author: process.env.USER ?? "Reviewer",
+        });
       threadServices.set(writableReviewPath, service);
+      if (onReviewThreadsCommit)
+        threadSubscriptions.push(service.subscribe(onReviewThreadsCommit));
     }
     return service;
   };
@@ -1165,6 +1170,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       };
     },
     close: async () => {
+      for (const unsubscribe of threadSubscriptions) unsubscribe();
       await Promise.allSettled(
         [...agentMirrors.values()].map((mirror) => mirror.close()),
       );
@@ -1415,7 +1421,7 @@ Repo root: ${input.rootPath}
 Review document: ${input.reviewPath}
 Review app: ${input.appUrl ?? "unknown"}
 
-Read the review document, inspect the submitted comments, and make the requested code or review changes. Use \`review threads list\` (run in the repo root) as canonical thread state, and mark addressed threads with \`review threads resolve <threadId>\`. Do not edit the thread storage beside the review document by hand.
+Read the review document through \`review document get review.mdx --review <uuid>\` or the Review MCP tools, inspect the submitted comments, and make the requested code or review changes. Update Review source through \`review document write\` or MCP using the hash from the last read, never directly on disk. Use \`review threads list\` (run in the repo root) as canonical thread state, save each answer with \`review threads reply <threadId> --body <answer>\`, and mark addressed threads with \`review threads resolve <threadId>\`.
 
 You must close every open comment thread before you re-publish. Run \`review threads list\` again after you resolve the addressed threads. Do not run \`review publish\` while any comment thread is open.
 

--- a/packages/progressive-review/src/server/review-lifecycle.ts
+++ b/packages/progressive-review/src/server/review-lifecycle.ts
@@ -1,0 +1,403 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  changeIdentityForRevision,
+  resolveRevision,
+} from "@dev.fast/local-vcs";
+import type {
+  ReviewPublishReadyRequest,
+  ReviewView,
+} from "@dev.fast/review-protocol";
+import type { z } from "zod";
+
+import {
+  type SessionRef,
+  authoringSessionKey,
+  resolveAuthoringSessionRef,
+} from "../authoring-session";
+import {
+  type StoredReview,
+  findScopedReview,
+  parseAnyStoredReviewRecord,
+  sealReviewCandidate,
+  touchReviewAgentSession,
+} from "../review-home";
+import {
+  type ReviewPublicationEvent,
+  ReviewPublishRequestSchema,
+} from "../review-lifecycle-contracts";
+import type { MapPublishReporter } from "../review-map-publish";
+import {
+  assertReviewUnchanged,
+  withReviewMutationLock,
+} from "../review-mutation-lock";
+import {
+  ReviewPublicationValidationError,
+  prepareReviewSoftwareMapBundle,
+} from "../review-publication-preparation";
+import {
+  sealReviewDocumentPublication,
+  stageReviewDocumentPublication,
+} from "../review-publication-staging";
+import type { PublishReporter } from "../review-publish";
+import type { ReviewRebindJsonOutput, runReviewRebind } from "../review-rebind";
+import { prepareReviewRepair } from "../review-repair-preparation";
+import type {
+  ReviewRepairReadyRequest,
+  ReviewRepairReadyResponse,
+} from "../review-repair-state";
+import { repinReview } from "../review-scaffold";
+import { resolveReviewRoot } from "../runtime";
+import {
+  type ReviewSoftwareMapBundle,
+  readReviewSoftwareMapBundle,
+  sameReviewSoftwareMapBundle,
+  writeReviewSoftwareMapBundle,
+} from "../software-map-bundle";
+import { span } from "../startup-trace";
+import {
+  prepareReviewPublish,
+  resolvePublishReview,
+} from "./publish-preparation";
+import { materializePublishRevision } from "./publish-stage";
+
+// Caller identity is data, not an environment override or a storage location.
+export function agentEnvironment(
+  agent: SessionRef | undefined,
+): NodeJS.ProcessEnv {
+  return {
+    DEV_FAST_AGENT_SESSION: agent ? authoringSessionKey(agent) : undefined,
+  };
+}
+
+export async function repairReview(
+  request: { cwd: string; reviewUuid: string },
+  complete: (
+    request: ReviewRepairReadyRequest,
+  ) => Promise<ReviewRepairReadyResponse>,
+) {
+  const review = await findScopedReview(request.reviewUuid, {
+    worktreePath: request.cwd,
+    includeTerminal: true,
+    includeLegacySchema: true,
+  });
+  if (!review)
+    throw new Error(`Review not found in this checkout: ${request.reviewUuid}`);
+  const warnings: string[] = [];
+  const prepared = await prepareReviewRepair({
+    reviewDir: review.dir,
+    warning: (message) => warnings.push(message),
+  });
+  if (prepared.kind === "noop")
+    return {
+      ok: true as const,
+      noop: true,
+      reviewUuid: request.reviewUuid,
+      warnings,
+      status: prepared.review.status,
+      oldDocumentRevision: prepared.review.presentedDocumentRevision,
+      newDocumentRevision: prepared.review.presentedDocumentRevision,
+      oldMapRevision: prepared.review.presentedSoftwareMapRevision,
+      newMapRevision: prepared.review.presentedSoftwareMapRevision,
+    };
+  try {
+    return {
+      ...(await complete(prepared.request)),
+      noop: false,
+      reviewUuid: request.reviewUuid,
+      warnings,
+      sourceFallback: prepared.request.sourceFallback,
+    };
+  } finally {
+    await prepared.cleanup();
+  }
+}
+
+export async function publishReview(
+  request: z.infer<typeof ReviewPublishRequestSchema>,
+  complete: (
+    request: ReviewPublishReadyRequest,
+  ) => Promise<{ sessionId: string; focusWarning?: string }>,
+) {
+  const events: ReviewPublicationEvent[] = [];
+  const reporter: PublishReporter = {
+    stage: (name, status, details) =>
+      events.push({ event: "stage", name, status, ...details }),
+    warning: (stage, diagnostics) =>
+      events.push({ event: "warning", stage, diagnostics }),
+    error: (stage, diagnostics) =>
+      events.push({ event: "error", stage, diagnostics }),
+    validationErrors: (diagnostics) =>
+      events.push({ event: "diagnostics", diagnostics }),
+    published: (revision, sessionId, softwareMapRevision) =>
+      events.push({
+        event: "document-published",
+        revision,
+        sessionId,
+        softwareMapRevision,
+      }),
+  };
+  try {
+    const code = await publishReviewDocument(
+      {
+        ...request,
+        env: agentEnvironment(request.agent),
+        onReviewBound: (reviewUuid) => {
+          events.push({ event: "review-bound", reviewUuid });
+        },
+      },
+      reporter,
+      complete,
+    );
+    return { ok: code === 0, events };
+  } catch (error) {
+    reporter.error("publish", [
+      error instanceof Error ? error.message : String(error),
+    ]);
+    return { ok: false, events };
+  }
+}
+
+export async function publishReviewSoftwareMap(
+  request: z.infer<typeof ReviewPublishRequestSchema>,
+  complete: (request: ReviewPublishReadyRequest) => Promise<void>,
+) {
+  const events: ReviewPublicationEvent[] = [];
+  const code = await publishReviewMap(
+    { ...request, env: agentEnvironment(request.agent) },
+    {
+      stage: (name, status, details) =>
+        events.push({ event: "stage", name, status, ...details }),
+      error: (stage, diagnostics) =>
+        events.push({ event: "error", stage, diagnostics }),
+      published: (revision, documentRevision, unchanged) =>
+        events.push({
+          event: "map-published",
+          revision,
+          documentRevision,
+          unchanged,
+        }),
+    },
+    complete,
+  );
+  return { ok: code === 0, events };
+}
+
+export async function publishReviewDocument(
+  input: {
+    cwd: string;
+    reviewUuid?: string;
+    view?: ReviewView;
+    toolingRoot?: string;
+    env?: NodeJS.ProcessEnv;
+    onReviewBound?: (uuid: string) => void | Promise<void>;
+  },
+  reporter: PublishReporter,
+  complete: (
+    request: ReviewPublishReadyRequest,
+  ) => Promise<{ sessionId: string; focusWarning?: string }>,
+): Promise<number> {
+  const reviewRoot = await resolveReviewRoot(input.cwd);
+  const prepared = await span("publish: prepare", () =>
+    prepareReviewPublish({
+      cwd: reviewRoot,
+      reviewUuid: input.reviewUuid,
+      onReviewBound: input.onReviewBound,
+    }),
+  );
+  const review = prepared.review;
+  if (prepared.warnings?.length) {
+    reporter.warning("prepare", prepared.warnings);
+  }
+
+  reporter.stage("validate", "running");
+  let revision: string;
+  try {
+    const document = await span("publish: validate document", () =>
+      stageReviewDocumentPublication({ review }),
+    );
+    if (document.warnings.length > 0)
+      reporter.warning("validate", document.warnings);
+    reporter.stage("validate", "complete");
+    reporter.stage("revision", "running");
+    revision = await span("publish: seal revision", () =>
+      sealReviewDocumentPublication({ review, document }),
+    );
+  } catch (error) {
+    if (error instanceof ReviewPublicationValidationError) {
+      if (error.warnings.length > 0) {
+        reporter.warning("validate", error.warnings);
+      }
+      if (error.diagnostics) {
+        reporter.validationErrors(error.diagnostics);
+      } else {
+        reporter.error("validate", error.errors);
+      }
+    } else {
+      reporter.error("validate", [
+        error instanceof Error ? error.message : String(error),
+      ]);
+    }
+    return 1;
+  }
+  reporter.stage("revision", "complete", { revision });
+
+  reporter.stage("mount", "running");
+  const result = await complete({
+    reviewUuid: prepared.uuid,
+    revision,
+    view: input.view,
+    agent: resolveAuthoringSessionRef(input.env ?? process.env),
+  });
+  reporter.published(
+    revision,
+    result.sessionId,
+    review.review.presentedSoftwareMapRevision,
+  );
+  // The revision is promoted and on screen by now: a focus failure cannot
+  // make the publish a failure, so it reports as a warning with exit 0.
+  if (result.focusWarning) {
+    reporter.warning("mount", [result.focusWarning]);
+  }
+  reporter.stage("mount", "complete", { sessionId: result.sessionId });
+  return 0;
+}
+
+export async function publishReviewMap(
+  input: { cwd: string; reviewUuid?: string; env?: NodeJS.ProcessEnv },
+  report: MapPublishReporter,
+  complete: (request: ReviewPublishReadyRequest) => Promise<void>,
+): Promise<number> {
+  try {
+    const reviewRoot = await resolveReviewRoot(input.cwd);
+    const review = await resolvePublishReview(reviewRoot, input.reviewUuid);
+    const agent = resolveAuthoringSessionRef(input.env ?? process.env);
+    const documentRevision = review.review.presentedDocumentRevision;
+    if (!documentRevision) {
+      throw new Error(
+        "The Review document is not published. Run `review publish` first.",
+      );
+    }
+    const documentBuildDir = await materializePublishRevision({
+      review,
+      revision: documentRevision,
+    });
+    const presentedDocument = parseAnyStoredReviewRecord(
+      JSON.parse(
+        await readFile(path.join(documentBuildDir, "review.json"), "utf8"),
+      ),
+    );
+    if (!presentedDocument.sourceCommit) {
+      throw new Error(
+        "The published Review document has no pinned head commit.",
+      );
+    }
+
+    report.stage("validate", "running");
+    let bundle;
+    try {
+      bundle = await prepareReviewSoftwareMapBundle({
+        review,
+        baseCommit: presentedDocument.baseCommit,
+        headCommit: presentedDocument.sourceCommit,
+      });
+    } catch (error) {
+      if (error instanceof ReviewPublicationValidationError) {
+        report.error("validate", error.errors);
+        return 1;
+      }
+      throw error;
+    }
+    report.stage("validate", "complete");
+
+    const existingRevision = review.review.presentedSoftwareMapRevision;
+    if (existingRevision) {
+      const existingDir = await materializePublishRevision({
+        review,
+        revision: existingRevision,
+      });
+      const existing = await readReviewSoftwareMapBundle(existingDir);
+      if (existing && sameReviewSoftwareMapBundle(existing, bundle)) {
+        if (agent) {
+          await touchReviewAgentSession(
+            review,
+            authoringSessionKey(agent),
+            "publisher",
+          );
+        }
+        report.published(existingRevision, documentRevision, true);
+        return 0;
+      }
+    }
+
+    report.stage("revision", "running");
+    const revision = await sealReviewSoftwareMapPublication({
+      review,
+      bundle,
+    });
+    report.stage("revision", "complete", { revision });
+
+    report.stage("load", "running");
+    await complete({ reviewUuid: review.review.uuid, revision, agent });
+    report.stage("load", "complete");
+    report.published(revision, documentRevision, false);
+    return 0;
+  } catch (error) {
+    report.error("publish", [
+      error instanceof Error ? error.message : String(error),
+    ]);
+    return 1;
+  }
+}
+
+export async function sealReviewSoftwareMapPublication(input: {
+  review: StoredReview;
+  bundle: ReviewSoftwareMapBundle;
+}): Promise<string> {
+  return withReviewMutationLock(input.review.dir, async () => {
+    await assertReviewUnchanged(input.review.dir, input.review.review);
+    await writeReviewSoftwareMapBundle(input.review.dir, input.bundle);
+    return sealReviewCandidate(input.review.dir, "Publish Review software map");
+  });
+}
+export async function rebindReview(
+  input: Omit<Parameters<typeof runReviewRebind>[0], "stdout">,
+): Promise<ReviewRebindJsonOutput> {
+  const reviewRoot = await resolveReviewRoot(input.cwd);
+  const review = await resolvePublishReview(reviewRoot, input.reviewUuid);
+  const resolved = await resolveRevision(
+    review.review.worktreePath,
+    input.change,
+  );
+  if (!resolved) {
+    throw new Error(
+      `Change does not resolve in ${review.review.worktreePath}: ${input.change}`,
+    );
+  }
+  const sourceIdentity = await changeIdentityForRevision(
+    review.review.worktreePath,
+    input.change,
+  );
+  if (!sourceIdentity) {
+    throw new Error(`Change does not resolve to one identity: ${input.change}`);
+  }
+  const repinned = await repinReview(
+    review,
+    {
+      cwd: reviewRoot,
+      toolingRoot: input.toolingRoot,
+      progress: input.progress,
+      env: input.env,
+      createSourceAgentSession: input.createSourceAgentSession,
+    },
+    sourceIdentity,
+  );
+  const output: ReviewRebindJsonOutput = {
+    event: "rebound",
+    uuid: review.review.uuid,
+    change: input.change,
+  };
+  if (repinned.warnings) output.warnings = repinned.warnings;
+  return output;
+}

--- a/packages/progressive-review/src/server/review-lifecycle.ts
+++ b/packages/progressive-review/src/server/review-lifecycle.ts
@@ -78,7 +78,7 @@ export async function repairReview(
   ) => Promise<ReviewRepairReadyResponse>,
 ) {
   const review = await findScopedReview(request.reviewUuid, {
-    worktreePath: request.cwd,
+    worktreePath: await resolveReviewRoot(request.cwd),
     includeTerminal: true,
     includeLegacySchema: true,
   });

--- a/packages/progressive-review/src/server/review-lifecycle.ts
+++ b/packages/progressive-review/src/server/review-lifecycle.ts
@@ -82,13 +82,16 @@ export async function repairReview(
     includeTerminal: true,
     includeLegacySchema: true,
   });
+
   if (!review)
     throw new Error(`Review not found in this checkout: ${request.reviewUuid}`);
   const warnings: string[] = [];
+
   const prepared = await prepareReviewRepair({
     reviewDir: review.dir,
     warning: (message) => warnings.push(message),
   });
+
   if (prepared.kind === "noop")
     return {
       ok: true as const,
@@ -101,6 +104,7 @@ export async function repairReview(
       oldMapRevision: prepared.review.presentedSoftwareMapRevision,
       newMapRevision: prepared.review.presentedSoftwareMapRevision,
     };
+
   try {
     return {
       ...(await complete(prepared.request)),
@@ -121,6 +125,7 @@ export async function publishReview(
   ) => Promise<{ sessionId: string; focusWarning?: string }>,
 ) {
   const events: ReviewPublicationEvent[] = [];
+
   const reporter: PublishReporter = {
     stage: (name, status, details) =>
       events.push({ event: "stage", name, status, ...details }),
@@ -138,6 +143,7 @@ export async function publishReview(
         softwareMapRevision,
       }),
   };
+
   try {
     const code = await publishReviewDocument(
       {
@@ -150,11 +156,13 @@ export async function publishReview(
       reporter,
       complete,
     );
+
     return { ok: code === 0, events };
   } catch (error) {
     reporter.error("publish", [
       error instanceof Error ? error.message : String(error),
     ]);
+
     return { ok: false, events };
   }
 }
@@ -164,6 +172,7 @@ export async function publishReviewSoftwareMap(
   complete: (request: ReviewPublishReadyRequest) => Promise<void>,
 ) {
   const events: ReviewPublicationEvent[] = [];
+
   const code = await publishReviewMap(
     { ...request, env: agentEnvironment(request.agent) },
     {
@@ -181,6 +190,7 @@ export async function publishReviewSoftwareMap(
     },
     complete,
   );
+
   return { ok: code === 0, events };
 }
 
@@ -199,6 +209,7 @@ export async function publishReviewDocument(
   ) => Promise<{ sessionId: string; focusWarning?: string }>,
 ): Promise<number> {
   const reviewRoot = await resolveReviewRoot(input.cwd);
+
   const prepared = await span("publish: prepare", () =>
     prepareReviewPublish({
       cwd: reviewRoot,
@@ -206,17 +217,21 @@ export async function publishReviewDocument(
       onReviewBound: input.onReviewBound,
     }),
   );
+
   const review = prepared.review;
+
   if (prepared.warnings?.length) {
     reporter.warning("prepare", prepared.warnings);
   }
 
   reporter.stage("validate", "running");
   let revision: string;
+
   try {
     const document = await span("publish: validate document", () =>
       stageReviewDocumentPublication({ review }),
     );
+
     if (document.warnings.length > 0)
       reporter.warning("validate", document.warnings);
     reporter.stage("validate", "complete");
@@ -229,6 +244,7 @@ export async function publishReviewDocument(
       if (error.warnings.length > 0) {
         reporter.warning("validate", error.warnings);
       }
+
       if (error.diagnostics) {
         reporter.validationErrors(error.diagnostics);
       } else {
@@ -239,28 +255,35 @@ export async function publishReviewDocument(
         error instanceof Error ? error.message : String(error),
       ]);
     }
+
     return 1;
   }
+
   reporter.stage("revision", "complete", { revision });
 
   reporter.stage("mount", "running");
+
   const result = await complete({
     reviewUuid: prepared.uuid,
     revision,
     view: input.view,
     agent: resolveAuthoringSessionRef(input.env ?? process.env),
   });
+
   reporter.published(
     revision,
     result.sessionId,
     review.review.presentedSoftwareMapRevision,
   );
+
   // The revision is promoted and on screen by now: a focus failure cannot
   // make the publish a failure, so it reports as a warning with exit 0.
   if (result.focusWarning) {
     reporter.warning("mount", [result.focusWarning]);
   }
+
   reporter.stage("mount", "complete", { sessionId: result.sessionId });
+
   return 0;
 }
 
@@ -274,20 +297,24 @@ export async function publishReviewMap(
     const review = await resolvePublishReview(reviewRoot, input.reviewUuid);
     const agent = resolveAuthoringSessionRef(input.env ?? process.env);
     const documentRevision = review.review.presentedDocumentRevision;
+
     if (!documentRevision) {
       throw new Error(
         "The Review document is not published. Run `review publish` first.",
       );
     }
+
     const documentBuildDir = await materializePublishRevision({
       review,
       revision: documentRevision,
     });
+
     const presentedDocument = parseAnyStoredReviewRecord(
       JSON.parse(
         await readFile(path.join(documentBuildDir, "review.json"), "utf8"),
       ),
     );
+
     if (!presentedDocument.sourceCommit) {
       throw new Error(
         "The published Review document has no pinned head commit.",
@@ -296,6 +323,7 @@ export async function publishReviewMap(
 
     report.stage("validate", "running");
     let bundle;
+
     try {
       bundle = await prepareReviewSoftwareMapBundle({
         review,
@@ -305,19 +333,25 @@ export async function publishReviewMap(
     } catch (error) {
       if (error instanceof ReviewPublicationValidationError) {
         report.error("validate", error.errors);
+
         return 1;
       }
+
       throw error;
     }
+
     report.stage("validate", "complete");
 
     const existingRevision = review.review.presentedSoftwareMapRevision;
+
     if (existingRevision) {
       const existingDir = await materializePublishRevision({
         review,
         revision: existingRevision,
       });
+
       const existing = await readReviewSoftwareMapBundle(existingDir);
+
       if (existing && sameReviewSoftwareMapBundle(existing, bundle)) {
         if (agent) {
           await touchReviewAgentSession(
@@ -326,27 +360,33 @@ export async function publishReviewMap(
             "publisher",
           );
         }
+
         report.published(existingRevision, documentRevision, true);
+
         return 0;
       }
     }
 
     report.stage("revision", "running");
+
     const revision = await sealReviewSoftwareMapPublication({
       review,
       bundle,
     });
+
     report.stage("revision", "complete", { revision });
 
     report.stage("load", "running");
     await complete({ reviewUuid: review.review.uuid, revision, agent });
     report.stage("load", "complete");
     report.published(revision, documentRevision, false);
+
     return 0;
   } catch (error) {
     report.error("publish", [
       error instanceof Error ? error.message : String(error),
     ]);
+
     return 1;
   }
 }
@@ -358,30 +398,37 @@ export async function sealReviewSoftwareMapPublication(input: {
   return withReviewMutationLock(input.review.dir, async () => {
     await assertReviewUnchanged(input.review.dir, input.review.review);
     await writeReviewSoftwareMapBundle(input.review.dir, input.bundle);
+
     return sealReviewCandidate(input.review.dir, "Publish Review software map");
   });
 }
+
 export async function rebindReview(
   input: Omit<Parameters<typeof runReviewRebind>[0], "stdout">,
 ): Promise<ReviewRebindJsonOutput> {
   const reviewRoot = await resolveReviewRoot(input.cwd);
   const review = await resolvePublishReview(reviewRoot, input.reviewUuid);
+
   const resolved = await resolveRevision(
     review.review.worktreePath,
     input.change,
   );
+
   if (!resolved) {
     throw new Error(
       `Change does not resolve in ${review.review.worktreePath}: ${input.change}`,
     );
   }
+
   const sourceIdentity = await changeIdentityForRevision(
     review.review.worktreePath,
     input.change,
   );
+
   if (!sourceIdentity) {
     throw new Error(`Change does not resolve to one identity: ${input.change}`);
   }
+
   const repinned = await repinReview(
     review,
     {
@@ -393,11 +440,14 @@ export async function rebindReview(
     },
     sourceIdentity,
   );
+
   const output: ReviewRebindJsonOutput = {
     event: "rebound",
     uuid: review.review.uuid,
     change: input.change,
   };
+
   if (repinned.warnings) output.warnings = repinned.warnings;
+
   return output;
 }

--- a/packages/progressive-review/src/server/review-repair-promotion.ts
+++ b/packages/progressive-review/src/server/review-repair-promotion.ts
@@ -52,22 +52,28 @@ export async function validateRepairStagingRepository(
 ): Promise<void> {
   for (const root of [dir, stagingDir]) {
     const metadata = await lstat(path.join(root, ".git"));
+
     if (!metadata.isDirectory() || metadata.isSymbolicLink())
       throw new Error("Repair requires an isolated private Git directory.");
   }
+
   const compare = async (relative: string): Promise<void> => {
     const liveEntries = await readdir(path.join(dir, ".git", relative), {
       withFileTypes: true,
     });
+
     for (const entry of liveEntries) {
       const name = path.join(relative, entry.name);
+
       if (name === "index" || name === path.join("refs", "heads", "main"))
         continue;
       const staged = await lstat(path.join(stagingDir, ".git", name));
+
       if (entry.isSymbolicLink() || staged.isSymbolicLink())
         throw new Error(
           "Repair private Git metadata cannot contain symbolic links.",
         );
+
       if (entry.isDirectory()) {
         if (!staged.isDirectory())
           throw new Error("Prepared repair removed private history.");
@@ -83,19 +89,24 @@ export async function validateRepairStagingRepository(
         );
     }
   };
+
   await compare("");
+
   const inspectStaged = async (relative: string): Promise<void> => {
     for (const entry of await readdir(path.join(stagingDir, ".git", relative), {
       withFileTypes: true,
     })) {
       const name = path.join(relative, entry.name);
+
       if (entry.isSymbolicLink() || (!entry.isDirectory() && !entry.isFile()))
         throw new Error(
           "Repair private Git metadata cannot contain symbolic links or special files.",
         );
+
       const exists = await lstat(path.join(dir, ".git", name))
         .then(() => true)
         .catch(() => false);
+
       if (
         !exists &&
         name !== "index" &&
@@ -107,14 +118,18 @@ export async function validateRepairStagingRepository(
         throw new Error(
           "Prepared repair added unexpected private Git metadata.",
         );
+
       if (entry.isDirectory()) await inspectStaged(name);
     }
   };
+
   await inspectStaged("");
   const oldHistory = await reviewVcs.log(dir);
+
   const newHistory = new Set(
     (await reviewVcs.log(stagingDir)).map((entry) => entry.oid),
   );
+
   if (oldHistory.some((entry) => !newHistory.has(entry.oid)))
     throw new Error("Prepared repair must retain existing private history.");
 }
@@ -132,6 +147,7 @@ export async function assertReviewRepairInputsUnchanged(
       "Review changed while preparing repair; retry without changing its pinned commits or review status.",
     );
   assertNoActiveReviewAgentWrites(dir);
+
   if (
     request.expectedThreadDbFingerprint &&
     readReviewThreadDatabaseFingerprint(path.join(dir, "review.mdx")) !==
@@ -146,36 +162,45 @@ export async function readPreparedReviewRepairRecord(
   const previous = parseAnyStoredReviewRecord(
     parseJsonText(request.expectedRecord),
   );
+
   if (previous.uuid !== request.reviewUuid)
     throw new Error("Repair review UUID does not match its record.");
+
   if (!previous.presentedDocumentRevision)
     throw new Error("A draft without a presentation must use review publish.");
+
   if (!previous.presentedSoftwareMapRevision && request.newMapRevision)
     throw new Error("Repair cannot invent an absent software map.");
+
   const storedSchemaVersion =
     jsonNumber(
       jsonObject(parseJsonText(request.expectedRecord))?.schemaVersion,
     ) ?? REVIEW_SCHEMA_VERSION;
+
   if (
     previous.presentedSoftwareMapRevision &&
     !request.newMapRevision &&
     !allowsAbsentSoftwareMap({ schemaVersion: storedSchemaVersion })
   )
     throw new Error("Repair cannot discard a presented software map.");
+
   const next = {
     ...previous,
     presentedDocumentRevision: request.newDocumentRevision,
     presentedSoftwareMapRevision: request.newMapRevision,
   };
+
   const prepared = parseStoredReviewRecord(
     parseJsonText(
       await readFile(path.join(request.stagingDir, "review.json"), "utf8"),
     ),
   );
+
   if (!isDeepStrictEqual(prepared, next))
     throw new Error(
       "Prepared repair must preserve review status, pins, title, timestamps and attention metadata.",
     );
+
   return next;
 }
 
@@ -188,6 +213,7 @@ export async function applyPreparedReviewRepair(
   return withReviewMutationLock(dir, async () => {
     await assertReviewRepairInputsUnchanged(dir, request);
     const next = await readPreparedReviewRepairRecord(request);
+
     if (request.expectedThreadDbFingerprint)
       checkReviewThreadDbVersion(path.join(request.stagingDir, "review.mdx"));
     await promoteReviewArtifactFiles({
@@ -198,6 +224,7 @@ export async function applyPreparedReviewRepair(
     });
     importLegacyReview(dir);
     putReviewRecord(dir, next);
+
     return next;
   });
 }
@@ -248,6 +275,7 @@ export async function promoteReviewRepair<
   const stagingDir = await realpath(request.stagingDir);
   const liveDir = await realpath(review.dir);
   const relative = path.relative(liveDir, stagingDir);
+
   if (
     !relative ||
     (!relative.startsWith(`..${path.sep}`) &&
@@ -261,23 +289,29 @@ export async function promoteReviewRepair<
   await validateRepairStagingRepository(review.dir, stagingDir);
   const next = await readPreparedReviewRepairRecord(request);
   const stageFingerprint = await fingerprintReviewRepairInputs(stagingDir);
+
   const stagedThreadDbFingerprint = request.expectedThreadDbFingerprint
     ? readReviewThreadDatabaseFingerprint(path.join(stagingDir, "review.mdx"))
     : undefined;
+
   const createdBuilds: string[] = [];
   let successor: Session | undefined;
+
   try {
     const materialize = async (revision: string) => {
       const destination = path.join(review.dir, ".build", revision);
+
       if (!existsSync(destination)) {
         createdBuilds.push(destination);
       }
+
       return materializePublishRevision({
         review,
         revision,
         sourceDir: stagingDir,
       });
     };
+
     const materializedRecord = async (revision: string) =>
       materialize(revision)
         .then(async (root) =>
@@ -286,24 +320,30 @@ export async function promoteReviewRepair<
           ),
         )
         .catch(() => null);
+
     const documentDir = await materialize(request.newDocumentRevision);
+
     const mapDir = request.newMapRevision
       ? await materialize(request.newMapRevision)
       : undefined;
+
     if (!(await readReviewDocumentBundle(documentDir, "/")))
       throw new ReviewServerError(
         "Repaired document JSON is invalid.",
         422,
         "repair_document_invalid",
       );
+
     const presented = await reviewWithPresentedDocumentPins(
       { dir: review.dir, review: next },
       documentDir,
     );
+
     const expectedDocumentPins =
       (review.review.presentedDocumentRevision
         ? await materializedRecord(review.review.presentedDocumentRevision)
         : null) ?? review.review;
+
     if (
       presented.review.baseCommit !== expectedDocumentPins.baseCommit ||
       presented.review.sourceCommit !== expectedDocumentPins.sourceCommit ||
@@ -316,18 +356,22 @@ export async function promoteReviewRepair<
         422,
         "repair_document_pins",
       );
+
     if (mapDir) {
       const map = await readReviewSoftwareMapBundle(mapDir);
+
       if (!map)
         throw new ReviewServerError(
           "Repaired software map JSON is invalid.",
           422,
           "repair_map_invalid",
         );
+
       const expectedMapPins =
         (review.review.presentedSoftwareMapRevision
           ? await materializedRecord(review.review.presentedSoftwareMapRevision)
           : null) ?? presented.review;
+
       if (
         map.baseCommit !== expectedMapPins.baseCommit ||
         map.headCommit !== expectedMapPins.sourceCommit
@@ -338,6 +382,7 @@ export async function promoteReviewRepair<
           "repair_map_pins",
         );
     }
+
     successor = await input.registerSerialized({
       review: presented,
       canonicalRecord: review.review,
@@ -350,10 +395,12 @@ export async function promoteReviewRepair<
         ? path.join(stagingDir, "review.mdx")
         : undefined,
     });
+
     const validation = await input.dispatch(successor.descriptor.sessionId, {
       name: "validateCanvasMount",
       args: {},
     });
+
     if (!validation.ok)
       throw new ReviewServerError(
         `Repaired Review failed to mount: ${validation.error ?? "unknown error"}`,
@@ -367,6 +414,7 @@ export async function promoteReviewRepair<
         input.sessions.get(mounted.descriptor.sessionId) !== mounted
       )
         throw new Error("Repair validation session closed before promotion.");
+
       if (
         (await fingerprintReviewRepairInputs(stagingDir)) !==
           stageFingerprint ||
@@ -387,30 +435,39 @@ export async function promoteReviewRepair<
     });
     // Once promoted, UI refresh failures cannot turn a committed repair into a failed command.
     await input.startSessionTelemetry(mounted).catch(() => undefined);
+
     const descriptor = await reviewDescriptor(mounted.review, {
       threads: "read-only",
     }).catch(() => undefined);
+
     input.broadcast({
       event: "session-registered",
       session: mounted.descriptor,
       review: descriptor,
     });
+
+    const supersededSessions: Session[] = [];
+
+    for (const session of input.sessions.values()) {
+      if (
+        session !== mounted &&
+        session.promoted &&
+        session.review.review.uuid === request.reviewUuid
+      ) {
+        supersededSessions.push(session);
+      }
+    }
+
     await Promise.all(
-      [...input.sessions.values()]
-        .filter(
-          (session) =>
-            session !== mounted &&
-            session.promoted &&
-            session.review.review.uuid === request.reviewUuid,
-        )
-        .map((session) =>
-          input.closeSession(session, "replaced").catch(() => undefined),
-        ),
+      supersededSessions.map((session) =>
+        input.closeSession(session, "replaced").catch(() => undefined),
+      ),
     );
     void input.dispatch(mounted.descriptor.sessionId, {
       name: "focusCanvas",
       args: {},
     });
+
     return {
       ok: true,
       status: next.status,
@@ -425,6 +482,7 @@ export async function promoteReviewRepair<
     if (!successor?.promoted) {
       if (successor)
         await input.closeSession(successor, "closed").catch(() => undefined);
+
       for (const build of createdBuilds)
         await rm(build, { recursive: true, force: true });
     }

--- a/packages/progressive-review/src/server/review-repair-promotion.ts
+++ b/packages/progressive-review/src/server/review-repair-promotion.ts
@@ -31,6 +31,7 @@ import {
   assertNoActiveReviewAgentWrites,
   fingerprintReviewRepairInputs,
 } from "../review-repair-state";
+import { importLegacyReview, putReviewRecord } from "../review-state-db";
 import {
   checkReviewThreadDbVersion,
   readReviewThreadDatabaseFingerprint,
@@ -195,6 +196,8 @@ export async function applyPreparedReviewRepair(
       record: next,
       upgradeThreadDatabase: Boolean(request.expectedThreadDbFingerprint),
     });
+    importLegacyReview(dir);
+    putReviewRecord(dir, next);
     return next;
   });
 }
@@ -239,6 +242,7 @@ export async function promoteReviewRepair<
     reason: "closed" | "replaced",
   ) => Promise<void>;
   broadcast: (event: ReviewDesktopGlobalEvent) => void;
+  onPromoted?: () => void;
 }): Promise<ReviewRepairReadyResponse> {
   const { review, request } = input;
   const stagingDir = await realpath(request.stagingDir);
@@ -379,6 +383,7 @@ export async function promoteReviewRepair<
         review: await applyPreparedReviewRepair(review.dir, request),
       };
       mounted.promoted = true;
+      input.onPromoted?.();
     });
     // Once promoted, UI refresh failures cannot turn a committed repair into a failed command.
     await input.startSessionTelemetry(mounted).catch(() => undefined);

--- a/packages/progressive-review/src/server/review-threads-target.ts
+++ b/packages/progressive-review/src/server/review-threads-target.ts
@@ -13,6 +13,7 @@ export async function resolveThreadsReview(
   const candidates = (await reviewsForThreads(cwd, reviewUuid)).filter(
     (review) => review.review.status !== "rejected",
   );
+
   if (candidates.length === 0) {
     throw new Error(
       reviewUuid
@@ -20,9 +21,11 @@ export async function resolveThreadsReview(
         : "No review found for this worktree.",
     );
   }
+
   if (candidates.length > 1) {
     throw new Error("Multiple reviews require --review <uuid>.");
   }
+
   return candidates[0]!;
 }
 
@@ -31,27 +34,35 @@ async function reviewsForThreads(
   reviewUuid: string | undefined,
 ): Promise<StoredReview[]> {
   const managedReviewUuid = await reviewUuidForManagedCheckout(cwd);
+
   if (managedReviewUuid) {
     if (reviewUuid && reviewUuid !== managedReviewUuid) {
       throw new Error(
         `Managed checkout belongs to Review ${managedReviewUuid}, not ${reviewUuid}.`,
       );
     }
+
     const review = await findReview(managedReviewUuid);
+
     return review ? [review] : [];
   }
+
   if (reviewUuid) {
     const selected = await findScopedReview(reviewUuid, {
       worktreePath: cwd,
       includeTerminal: true,
     });
+
     return selected ? [selected] : [];
   }
+
   const listed = await listReviews({ worktreePath: cwd });
+
   if (listed.errors.length > 0) {
     throw new Error(
       `Could not read reviews:\n${listed.errors.map((error) => error.message).join("\n")}`,
     );
   }
+
   return listed.reviews;
 }

--- a/packages/progressive-review/src/server/review-threads-target.ts
+++ b/packages/progressive-review/src/server/review-threads-target.ts
@@ -1,0 +1,57 @@
+import { reviewUuidForManagedCheckout } from "../review-head-checkout";
+import {
+  type StoredReview,
+  findReview,
+  findScopedReview,
+  listReviews,
+} from "../review-home";
+
+export async function resolveThreadsReview(
+  cwd: string,
+  reviewUuid: string | undefined,
+): Promise<StoredReview> {
+  const candidates = (await reviewsForThreads(cwd, reviewUuid)).filter(
+    (review) => review.review.status !== "rejected",
+  );
+  if (candidates.length === 0) {
+    throw new Error(
+      reviewUuid
+        ? `Review not found: ${reviewUuid}`
+        : "No review found for this worktree.",
+    );
+  }
+  if (candidates.length > 1) {
+    throw new Error("Multiple reviews require --review <uuid>.");
+  }
+  return candidates[0]!;
+}
+
+async function reviewsForThreads(
+  cwd: string,
+  reviewUuid: string | undefined,
+): Promise<StoredReview[]> {
+  const managedReviewUuid = await reviewUuidForManagedCheckout(cwd);
+  if (managedReviewUuid) {
+    if (reviewUuid && reviewUuid !== managedReviewUuid) {
+      throw new Error(
+        `Managed checkout belongs to Review ${managedReviewUuid}, not ${reviewUuid}.`,
+      );
+    }
+    const review = await findReview(managedReviewUuid);
+    return review ? [review] : [];
+  }
+  if (reviewUuid) {
+    const selected = await findScopedReview(reviewUuid, {
+      worktreePath: cwd,
+      includeTerminal: true,
+    });
+    return selected ? [selected] : [];
+  }
+  const listed = await listReviews({ worktreePath: cwd });
+  if (listed.errors.length > 0) {
+    throw new Error(
+      `Could not read reviews:\n${listed.errors.map((error) => error.message).join("\n")}`,
+    );
+  }
+  return listed.reviews;
+}

--- a/packages/progressive-review/src/server/session-handler.threads.test.ts
+++ b/packages/progressive-review/src/server/session-handler.threads.test.ts
@@ -18,14 +18,17 @@ describe("createReviewSessionHandler", () => {
   it("shares external commits with every open session and unsubscribes closed sessions", async () => {
     const rootPath = await tempDir("review-shared-comments-");
     const reviewPath = path.join(rootPath, "review.mdx");
+
     const service = new ReviewThreadsService({
       reviewPath,
       author: "Reviewer",
     });
+
     const changes = [
       vi.fn<(commit: ReviewThreadsCommit) => void>(),
       vi.fn<(commit: ReviewThreadsCommit) => void>(),
     ];
+
     const handlers = await Promise.all(
       changes.map((onReviewThreadsCommit) =>
         createReviewSessionHandler({
@@ -47,6 +50,7 @@ describe("createReviewSessionHandler", () => {
         }),
       ),
     );
+
     try {
       for (const handler of handlers) {
         const response = await handler.handle(
@@ -54,8 +58,10 @@ describe("createReviewSessionHandler", () => {
             headers: { "x-review-token": "secret" },
           }),
         );
+
         expect(response.status).toBe(200);
       }
+
       const first = service.dispatch({
         command: "comment.create",
         mutationId: "external-create",
@@ -66,22 +72,27 @@ describe("createReviewSessionHandler", () => {
           body: "Shared question",
         },
       });
+
       for (const changed of changes)
         expect(changed).toHaveBeenCalledExactlyOnceWith(first);
       await handlers[0]!.close();
+
       const second = service.dispatch({
         command: "comment.update",
         mutationId: "external-resolve",
         threadId: "shared",
         update: { status: "resolved" },
       });
+
       expect(changes[0]).toHaveBeenCalledTimes(1);
       expect(changes[1]).toHaveBeenLastCalledWith(second);
+
       const snapshot = await handlers[1]!.handle(
         new Request("http://localhost/__progressive-review/comments", {
           headers: { "x-review-token": "secret" },
         }),
       );
+
       expect(await snapshot.json()).toMatchObject({
         ok: true,
         snapshot: {
@@ -98,8 +109,10 @@ describe("createReviewSessionHandler", () => {
     const reviewPath = path.join(rootPath, "review.mdx");
     const sessionUrl = "http://127.0.0.1:5570/sessions/test-session";
     const token = "session-secret";
+
     const onReviewThreadsCommit =
       vi.fn<(commit: ReviewThreadsCommit) => void>();
+
     const handler = await createReviewSessionHandler({
       ...unusedAgentServices,
       rootPath,
@@ -124,10 +137,12 @@ describe("createReviewSessionHandler", () => {
     ) => {
       const headers = new Headers({ "x-review-token": token });
       const init: RequestInit = { method, headers };
+
       if (body) {
         headers.set("content-type", "application/json");
         init.body = JSON.stringify(body);
       }
+
       return handler.handle(
         new Request(new URL(`/__progressive-review${path}`, sessionUrl), init),
       );
@@ -154,6 +169,7 @@ describe("createReviewSessionHandler", () => {
         },
         body: "A fresh external comment",
       });
+
       expect(comment.status).toBe(200);
       await expect(comment.json()).resolves.toMatchObject({
         ok: true,
@@ -175,12 +191,15 @@ describe("createReviewSessionHandler", () => {
     const token = "session-secret";
     let enterMutation!: () => void;
     let releaseMutation!: () => void;
+
     const mutationEntered = new Promise<void>((resolve) => {
       enterMutation = resolve;
     });
+
     const mutationReleased = new Promise<void>((resolve) => {
       releaseMutation = resolve;
     });
+
     const handler = await createReviewSessionHandler({
       ...unusedAgentServices,
       rootPath,
@@ -191,6 +210,7 @@ describe("createReviewSessionHandler", () => {
       runReviewThreadMutation: async (operation) => {
         enterMutation();
         await mutationReleased;
+
         return operation();
       },
       session: {
@@ -239,6 +259,7 @@ describe("createReviewSessionHandler", () => {
           },
         ),
       );
+
       await mutationEntered;
       expect(readReviewComments(reviewPath)).toEqual({});
 

--- a/packages/progressive-review/src/server/session-handler.threads.test.ts
+++ b/packages/progressive-review/src/server/session-handler.threads.test.ts
@@ -8,12 +8,91 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { readReviewComments } from "../review-state-store";
 import { cleanupTempDirs, tempDir } from "../review-test-utils";
+import { ReviewThreadsService } from "../review-threads-service";
 import { createReviewSessionHandler } from "./session-handler";
 import { unusedAgentServices } from "./session-handler-test-utils";
 
 afterEach(cleanupTempDirs);
 
 describe("createReviewSessionHandler", () => {
+  it("shares external commits with every open session and unsubscribes closed sessions", async () => {
+    const rootPath = await tempDir("review-shared-comments-");
+    const reviewPath = path.join(rootPath, "review.mdx");
+    const service = new ReviewThreadsService({
+      reviewPath,
+      author: "Reviewer",
+    });
+    const changes = [
+      vi.fn<(commit: ReviewThreadsCommit) => void>(),
+      vi.fn<(commit: ReviewThreadsCommit) => void>(),
+    ];
+    const handlers = await Promise.all(
+      changes.map((onReviewThreadsCommit) =>
+        createReviewSessionHandler({
+          ...unusedAgentServices,
+          rootPath,
+          toolingRoot: rootPath,
+          reviewPath,
+          routePath: "/",
+          token: "secret",
+          session: {
+            rootPath,
+            baseRef: "HEAD",
+            reviewPath,
+            appUrl: "http://localhost",
+            startedAt: Date.now(),
+          },
+          threadsService: () => service,
+          onReviewThreadsCommit,
+        }),
+      ),
+    );
+    try {
+      for (const handler of handlers) {
+        const response = await handler.handle(
+          new Request("http://localhost/__progressive-review/comments", {
+            headers: { "x-review-token": "secret" },
+          }),
+        );
+        expect(response.status).toBe(200);
+      }
+      const first = service.dispatch({
+        command: "comment.create",
+        mutationId: "external-create",
+        input: {
+          threadId: "shared",
+          messageId: "question",
+          target: { kind: "document" },
+          body: "Shared question",
+        },
+      });
+      for (const changed of changes)
+        expect(changed).toHaveBeenCalledExactlyOnceWith(first);
+      await handlers[0]!.close();
+      const second = service.dispatch({
+        command: "comment.update",
+        mutationId: "external-resolve",
+        threadId: "shared",
+        update: { status: "resolved" },
+      });
+      expect(changes[0]).toHaveBeenCalledTimes(1);
+      expect(changes[1]).toHaveBeenLastCalledWith(second);
+      const snapshot = await handlers[1]!.handle(
+        new Request("http://localhost/__progressive-review/comments", {
+          headers: { "x-review-token": "secret" },
+        }),
+      );
+      expect(await snapshot.json()).toMatchObject({
+        ok: true,
+        snapshot: {
+          revision: second!.revision,
+          comments: { shared: { status: "resolved" } },
+        },
+      });
+    } finally {
+      await Promise.all(handlers.map((handler) => handler.close()));
+    }
+  });
   it("returns committed state and announces only applied changes", async () => {
     const rootPath = await tempDir("review-session-handler-");
     const reviewPath = path.join(rootPath, "review.mdx");

--- a/packages/progressive-review/src/server/session-handler.ts
+++ b/packages/progressive-review/src/server/session-handler.ts
@@ -50,12 +50,17 @@ import {
 } from "./review-session-mode";
 
 const API_PREFIX = "/__progressive-review";
+
 const DOCUMENT_PATH_PREFIX = `${API_PREFIX}/documents/`;
+
 const MAP_PATH_PREFIX = `${API_PREFIX}/software-maps/`;
+
 const NEEDS_REPUBLISH_ERROR =
   "This review was published by an earlier version of Review and its document must be regenerated.";
+
 const NEEDS_REPUBLISH_MAP_ERROR =
   "This review's software map must be regenerated.";
+
 const HISTORICAL_UNAVAILABLE_ERROR =
   "This older revision is unavailable in this version of Review";
 
@@ -128,11 +133,14 @@ export async function createReviewSessionHandler(
   const mode = input.mode ?? LIVE_REVIEW_SESSION_MODE;
   const artifacts = input.artifacts ?? {};
   const renderDir = path.dirname(input.reviewPath);
+
   const storageDir =
     session.storageDir ??
     path.dirname(input.stateReviewPath ?? input.reviewPath);
+
   const reviewRootPath = input.reviewRootPath ?? storageDir;
   await mkdir(storageDir, { recursive: true, mode: 0o700 });
+
   if (!artifacts.document)
     await mkdir(renderDir, { recursive: true, mode: 0o700 });
   const token = input.token ?? crypto.randomBytes(32).toString("base64url");
@@ -140,14 +148,19 @@ export async function createReviewSessionHandler(
   const documentsDir = path.join(renderDir, ".review-documents");
   let currentBundle: ReviewDocumentBundle | null = null;
   let bundlePromise: Promise<ReviewDocumentBundle | null> | null = null;
+
   let softwareMapBundlePromise: Promise<ReviewSoftwareMapBundle | null> | null =
     null;
+
   const eventClients = new Set<ReviewEventClient>();
+
   const telemetryContext: ProgressiveReviewTelemetryContext = {
     reviewUuid: input.reviewUuid,
     presentationSessionId: input.sessionId,
   };
+
   let reviewPresented = false;
+
   const sessionTelemetry = input.telemetry
     ? {
         captureTabViewed: (
@@ -173,8 +186,10 @@ export async function createReviewSessionHandler(
                 appSessionId: jsonString(properties.app_session_id),
               },
             );
+
             return;
           }
+
           await input.telemetry!.captureUiEvent(
             event,
             properties,
@@ -187,8 +202,10 @@ export async function createReviewSessionHandler(
   const getBundle = async (): Promise<ReviewDocumentBundle | null> => {
     if (currentBundle) return currentBundle;
     bundlePromise ??= readReviewDocumentBundle(renderDir, input.routePath);
+
     try {
       currentBundle = await bundlePromise;
+
       return currentBundle;
     } finally {
       bundlePromise = null;
@@ -200,11 +217,13 @@ export async function createReviewSessionHandler(
     softwareMapBundlePromise ??= readReviewSoftwareMapBundle(
       input.softwareMapRootPath,
     );
+
     return softwareMapBundlePromise;
   };
 
   const broadcast = (event: ReviewServerEvent) => {
     const frame = `data: ${JSON.stringify(event)}\n\n`;
+
     for (const client of eventClients) client.write(frame);
   };
 
@@ -212,6 +231,7 @@ export async function createReviewSessionHandler(
     if (!input.reviewUuid) {
       throw new Error("A review UUID is required to report needs_republish.");
     }
+
     return input.reviewUuid;
   };
 
@@ -229,6 +249,7 @@ export async function createReviewSessionHandler(
     message: string,
   ): Promise<Response> => {
     const reviewUuid = needsRepublishReviewUuid();
+
     const detail: ReviewErrorDetail =
       mode.kind === "historical"
         ? { code: "historical_revision_unavailable", reviewUuid }
@@ -237,6 +258,7 @@ export async function createReviewSessionHandler(
             reviewUuid,
             mapStale: kind === "document" ? await mapIsStale() : true,
           };
+
     return jsonResponse(
       {
         ok: false,
@@ -270,15 +292,19 @@ export async function createReviewSessionHandler(
       context.req.path === `${API_PREFIX}/session`
     ) {
       await next();
+
       return;
     }
+
     if (!isAuthorizedRequest(context.req.raw, token)) {
       return jsonResponse({ ok: false, error: "Unauthorized" }, 401);
     }
+
     await next();
   });
   app.get(`${API_PREFIX}/session`, async () => {
     const presentedRecord = reviewSessionModeRecord(mode);
+
     const resolvedBaseRef = presentedRecord
       ? artifacts.source
         ? null
@@ -289,13 +315,16 @@ export async function createReviewSessionHandler(
         )({
           reviewRootPath,
         });
+
     const sessionPayload: ReturnType<typeof reviewSessionPayload> & {
       resolvedBaseRef: typeof resolvedBaseRef;
       reviewStatus?: ReviewRecord["status"];
     } = { ...reviewSessionPayload(), resolvedBaseRef };
+
     if (input.getReviewStatus) {
       sessionPayload.reviewStatus = input.getReviewStatus();
     }
+
     return jsonResponse({ ok: true, session: sessionPayload, token }, 200);
   });
   app.get(`${API_PREFIX}/revisions`, async () => {
@@ -305,6 +334,7 @@ export async function createReviewSessionHandler(
         404,
       );
     }
+
     return jsonResponse(
       { ok: true, versions: await input.listDocumentVersions() },
       200,
@@ -314,8 +344,10 @@ export async function createReviewSessionHandler(
     if (artifacts.document)
       return artifactUnavailable("document", artifacts.document);
     const bundle = await getBundle();
+
     if (!bundle)
       return artifactUnavailable("document", staleArtifactMessage("document"));
+
     return jsonResponse(
       {
         ok: true,
@@ -327,6 +359,7 @@ export async function createReviewSessionHandler(
   });
   app.get(`${DOCUMENT_PATH_PREFIX}:documentName`, async (context) => {
     const bundle = await getBundle();
+
     if (
       !bundle ||
       context.req.param("documentName") !== `${bundle.contentHash}.json`
@@ -336,6 +369,7 @@ export async function createReviewSessionHandler(
         404,
       );
     }
+
     return new Response(bundle.json, {
       status: 200,
       headers: {
@@ -347,14 +381,17 @@ export async function createReviewSessionHandler(
   app.get(`${API_PREFIX}/software-map`, async () => {
     if (artifacts.map) return artifactUnavailable("map", artifacts.map);
     const bundle = await getSoftwareMapBundle();
+
     if (!bundle) {
       if (input.softwareMapRootPath)
         return artifactUnavailable("map", staleArtifactMessage("map"));
+
       return jsonResponse(
         { ok: false, error: "Software map is not published" },
         404,
       );
     }
+
     return jsonResponse(
       {
         ok: true,
@@ -368,15 +405,18 @@ export async function createReviewSessionHandler(
   app.get(`${MAP_PATH_PREFIX}:mapName`, async (context) => {
     const bundle = await getSoftwareMapBundle();
     const mapName = context.req.param("mapName");
+
     const json =
       mapName === `head-${bundle?.contentHash}.json`
         ? bundle?.headJson
         : mapName === `base-${bundle?.contentHash}.json`
           ? bundle?.baseJson
           : undefined;
+
     if (!json) {
       return jsonResponse({ ok: false, error: "Software map not found" }, 404);
     }
+
     return new Response(json, {
       status: 200,
       headers: {
@@ -387,14 +427,18 @@ export async function createReviewSessionHandler(
   });
   app.get(`${API_PREFIX}/events`, (context) => {
     context.header("cache-control", "no-cache, no-transform");
+
     const response = streamSSE(context, async (stream) => {
       let finish!: () => void;
+
       const disconnected = new Promise<void>((resolve) => {
         finish = resolve;
       });
+
       let pending: Promise<void> = stream
         .write(": connected\n\n")
         .then(() => undefined);
+
       const client: ReviewEventClient = {
         write(frame) {
           pending = pending.then(async () => {
@@ -406,13 +450,17 @@ export async function createReviewSessionHandler(
           void stream.close();
         },
       };
+
       stream.onAbort(finish);
       eventClients.add(client);
+
       const heartbeat = setInterval(
         () => client.write(": heartbeat\n\n"),
         15_000,
       );
+
       heartbeat.unref?.();
+
       try {
         await disconnected;
         await pending;
@@ -421,9 +469,12 @@ export async function createReviewSessionHandler(
         eventClients.delete(client);
       }
     });
+
     response.headers.set("content-type", "text/event-stream; charset=utf-8");
+
     return response;
   });
+
   const reviewApi = createReviewApi({
     mode,
     readOnlyThreadsPath: input.readOnlyThreadsPath,
@@ -460,6 +511,7 @@ export async function createReviewSessionHandler(
     submitHook: input.submitHook,
     session,
   });
+
   app.route(API_PREFIX, reviewApi.app);
   app.all(`${API_PREFIX}/*`, () =>
     jsonResponse({ ok: false, error: "not found" }, 404, {
@@ -471,6 +523,7 @@ export async function createReviewSessionHandler(
   app.onError((error) => {
     if (error instanceof ReviewBusyError)
       return jsonResponse(reviewBusyResponse(error), 409);
+
     return jsonResponse(
       {
         ok: false,
@@ -513,6 +566,7 @@ export async function createReviewSessionHandler(
     },
     close: async () => {
       await reviewApi.close();
+
       for (const client of eventClients) client.close();
       eventClients.clear();
     },

--- a/packages/progressive-review/src/server/session-handler.ts
+++ b/packages/progressive-review/src/server/session-handler.ts
@@ -23,6 +23,7 @@ import {
   readReviewDocumentBundle,
 } from "../review-bundle";
 import { ReviewBusyError, reviewBusyResponse } from "../review-mutation-lock";
+import type { ReviewThreadsService } from "../review-threads-service";
 import { resolveReviewSessionBaseCommit } from "../review-worktree-target";
 import {
   type ReviewSoftwareMapBundle,
@@ -70,6 +71,7 @@ export interface ReviewSessionHandlerInput {
   reviewPath: string;
   softwareMapRootPath?: string;
   stateReviewPath?: string;
+  threadsService?: () => ReviewThreadsService;
   routePath: string;
   token?: string;
   sessionId?: string;
@@ -432,6 +434,7 @@ export async function createReviewSessionHandler(
     reviewRootPath,
     toolingRoot: input.toolingRoot,
     stateReviewPath: input.stateReviewPath,
+    threadsService: input.threadsService,
     telemetry: sessionTelemetry,
     onSubmission: async (event) => {
       broadcast({

--- a/packages/progressive-review/src/server/tutorial-service.ts
+++ b/packages/progressive-review/src/server/tutorial-service.ts
@@ -34,6 +34,7 @@ import {
   createReviewUuid,
   findReview,
   listReviews,
+  persistStoredReviewRecord,
   reviewTitleFromDocument,
   sealReviewCandidate,
 } from "../review-home";
@@ -41,6 +42,7 @@ import {
   pinReviewSourceHeadRef,
   reviewSourceHeadRef,
 } from "../review-source-ref";
+import { deleteReviewState } from "../review-state-db";
 import { devReviewHome } from "../review-storage";
 import { writePrivateJsonAtomic } from "./desktop-paths";
 
@@ -140,6 +142,7 @@ export function createTutorialService(input: {
     for (const review of listed.reviews) {
       if (await isManagedTutorialPath(review.review.worktreePath, sampleRoot)) {
         await input.deleteReview(review);
+        deleteReviewState(review.dir);
       }
     }
     await rm(tutorialRoot, { recursive: true, force: true });
@@ -224,10 +227,7 @@ export function createTutorialService(input: {
           lastPublishedAt: publishedAt,
         },
       };
-      await writePrivateJsonAtomic(
-        path.join(candidate.dir, "review.json"),
-        candidate.review,
-      );
+      await persistStoredReviewRecord(candidate.dir, candidate.review);
       const runtimeManifest = await readTutorialRuntimeManifest(assetsRoot);
       await Promise.all([
         ...runtimeManifest.reviewFiles.map((entry) =>
@@ -253,10 +253,7 @@ export function createTutorialService(input: {
           presentedSoftwareMapRevision: revision,
         },
       };
-      await writePrivateJsonAtomic(
-        path.join(review.dir, "review.json"),
-        review.review,
-      );
+      await persistStoredReviewRecord(review.dir, review.review);
       await writePrivateJsonAtomic(stampPath, {
         version: TUTORIAL_STAMP_VERSION,
         reviewUuid: review.review.uuid,

--- a/packages/progressive-review/src/server/tutorial-service.ts
+++ b/packages/progressive-review/src/server/tutorial-service.ts
@@ -47,7 +47,9 @@ import { devReviewHome } from "../review-storage";
 import { writePrivateJsonAtomic } from "./desktop-paths";
 
 const execFilePromise = promisify(execFile);
+
 const TUTORIAL_STATUS_VERSION = 1;
+
 /* Version 9 adds the interactive trace quote chapter. Older records are
    re-materialized on first open to pick up the updated document. */
 const TUTORIAL_STAMP_VERSION = 9;
@@ -91,6 +93,7 @@ export function createTutorialService(input: {
     uuid: string,
   ): Promise<StoredReview | null> => {
     const loaded = await findReview(uuid);
+
     return loaded?.review.visibility === "system" ? loaded : null;
   };
 
@@ -101,18 +104,22 @@ export function createTutorialService(input: {
     review: StoredReview;
   } | null> => {
     const stamp = await readTutorialStamp(stampPath);
+
     if (!stamp) return null;
     const review = await findTutorialReview(stamp.reviewUuid).catch(() => null);
+
     if (
       !review ||
       !(await isValidTutorialReview(review, sampleRoot, expectedHarness))
     ) {
       return null;
     }
+
     // An app update ships new bundles pinned to a new commit. A record
     // bound to the old commit is stale: re-materialize instead of serving
     // new bundles against the old repository.
     const manifest = await readShippedMapManifest(assetsRoot).catch(() => null);
+
     if (
       !manifest ||
       manifest.headCommit !== review.review.sourceCommit ||
@@ -120,6 +127,7 @@ export function createTutorialService(input: {
     ) {
       return null;
     }
+
     // Copy-only edits leave the sample repository's commits unchanged.
     // Refresh the saved tutorial when its compiled document has changed too.
     const documentMatches = await Promise.all([
@@ -133,24 +141,29 @@ export function createTutorialService(input: {
           shipped.contentHash === saved.contentHash,
       )
       .catch(() => false);
+
     if (!documentMatches) return null;
+
     return { stamp, review };
   };
 
   const cleanup = async (): Promise<void> => {
     const listed = await listReviews({ includeSystem: true });
+
     for (const review of listed.reviews) {
       if (await isManagedTutorialPath(review.review.worktreePath, sampleRoot)) {
         await input.deleteReview(review);
         deleteReviewState(review.dir);
       }
     }
+
     await rm(tutorialRoot, { recursive: true, force: true });
   };
 
   return {
     async status() {
       const state = await readValidState();
+
       return {
         version: TUTORIAL_STATUS_VERSION,
         reviewUuid: state?.stamp.reviewUuid ?? null,
@@ -159,8 +172,10 @@ export function createTutorialService(input: {
 
     async referencesReview(reviewUuid) {
       const stamp = await readTutorialStamp(stampPath);
+
       if (stamp?.reviewUuid === reviewUuid) return true;
       const review = await findTutorialReview(reviewUuid).catch(() => null);
+
       return review
         ? isManagedTutorialPath(review.review.worktreePath, sampleRoot)
         : false;
@@ -168,11 +183,13 @@ export function createTutorialService(input: {
 
     async find() {
       const state = await readValidState();
+
       return state?.review ?? null;
     },
 
     async prepare(agent, options) {
       const current = await readValidState(agent);
+
       if (current) return current.review;
 
       await options?.beforeReset();
@@ -185,10 +202,13 @@ export function createTutorialService(input: {
       });
 
       const head = await resolveRevision(sampleRoot, "main");
+
       if (!head) {
         throw new Error("Tutorial repository has no main commit.");
       }
+
       const manifest = await readShippedMapManifest(assetsRoot);
+
       if (manifest.headCommit !== head.commit) {
         throw new Error(
           `Tutorial assets are inconsistent: repository HEAD ${head.commit} does not match the shipped bundle commit ${manifest.headCommit}.`,
@@ -202,6 +222,7 @@ export function createTutorialService(input: {
         head.commit,
       );
       const sourceSession = freshSourceSessionKey(agent);
+
       const created = await createReviewDir({
         uuid,
         visibility: "system",
@@ -215,10 +236,12 @@ export function createTutorialService(input: {
           path.join(assetsRoot, "review.mdx"),
         ),
       });
+
       // Store the shipped source and precompiled bundles as a genuine Review
       // revision. Opening can then use the same materialization and session
       // path as any published Review.
       const publishedAt = new Date().toISOString();
+
       const candidate: StoredReview = {
         ...created,
         review: {
@@ -227,6 +250,7 @@ export function createTutorialService(input: {
           lastPublishedAt: publishedAt,
         },
       };
+
       await persistStoredReviewRecord(candidate.dir, candidate.review);
       const runtimeManifest = await readTutorialRuntimeManifest(assetsRoot);
       await Promise.all([
@@ -241,10 +265,12 @@ export function createTutorialService(input: {
           },
         ),
       ]);
+
       const revision = await sealReviewCandidate(
         candidate.dir,
         "Materialize bundled tutorial Review",
       );
+
       const review: StoredReview = {
         ...candidate,
         review: {
@@ -253,11 +279,13 @@ export function createTutorialService(input: {
           presentedSoftwareMapRevision: revision,
         },
       };
+
       await persistStoredReviewRecord(review.dir, review.review);
       await writePrivateJsonAtomic(stampPath, {
         version: TUTORIAL_STAMP_VERSION,
         reviewUuid: review.review.uuid,
       } satisfies TutorialStamp);
+
       return review;
     },
 
@@ -274,10 +302,12 @@ async function materializeSampleRepository(input: {
   sampleRoot: string;
 }): Promise<void> {
   await mkdir(input.tutorialRoot, { recursive: true, mode: 0o700 });
+
   const temporaryRoot = path.join(
     input.tutorialRoot,
     `.sample-service-${crypto.randomUUID()}`,
   );
+
   try {
     await cp(path.join(input.assetsRoot, "sample-service"), temporaryRoot, {
       recursive: true,
@@ -307,15 +337,20 @@ async function readShippedMapManifest(
     "software-map",
     "manifest.json",
   );
+
   const value = parseJsonText(await readFile(manifestPath, "utf8"));
   const manifest = isJsonObject(value) ? value : undefined;
+
   const headCommit =
     manifest && jsonString(jsonProperty(manifest, "headCommit"));
+
   const baseCommit =
     manifest && jsonString(jsonProperty(manifest, "baseCommit"));
+
   if (headCommit === undefined || baseCommit === undefined) {
     throw new Error("Tutorial software-map manifest is invalid.");
   }
+
   return { headCommit, baseCommit };
 }
 
@@ -327,6 +362,7 @@ async function isValidTutorialReview(
   if (!(await isManagedTutorialPath(review.review.worktreePath, sampleRoot))) {
     return false;
   }
+
   if (
     review.review.visibility !== "system" ||
     !(
@@ -338,17 +374,22 @@ async function isValidTutorialReview(
   ) {
     return false;
   }
+
   const storedHarness =
     parseAuthoringSessionKey(review.review.sourceSession)?.harness ??
     parseFreshSourceSessionHarness(review.review.sourceSession);
+
   if (expectedHarness && storedHarness !== expectedHarness) return false;
   const sourceCommit = review.review.sourceCommit;
+
   if (!sourceCommit || review.review.baseCommit === sourceCommit) return false;
+
   const [head, base, count] = await Promise.all([
     resolveRevision(sampleRoot, "HEAD").catch(() => null),
     resolveRevision(sampleRoot, "HEAD^").catch(() => null),
     runGit(sampleRoot, ["rev-list", "--count", "HEAD"]).catch(() => ""),
   ]);
+
   return (
     head?.commit === sourceCommit &&
     base?.commit === review.review.baseCommit &&
@@ -361,8 +402,10 @@ async function readTutorialStamp(
 ): Promise<TutorialStamp | null> {
   try {
     const value = parseJsonText(await readFile(stampPath, "utf8"));
+
     if (!isJsonObject(value)) return null;
     const reviewUuid = jsonString(jsonProperty(value, "reviewUuid"));
+
     return jsonProperty(value, "version") === TUTORIAL_STAMP_VERSION &&
       reviewUuid !== undefined
       ? { version: TUTORIAL_STAMP_VERSION, reviewUuid }
@@ -375,7 +418,9 @@ async function readTutorialStamp(
 async function requireTutorialAssets(assetsRoot: string): Promise<void> {
   const { requiredPaths: required } =
     await readTutorialRuntimeManifest(assetsRoot);
+
   const missing: string[] = [];
+
   for (const entry of required) {
     try {
       await stat(path.join(assetsRoot, entry));
@@ -383,6 +428,7 @@ async function requireTutorialAssets(assetsRoot: string): Promise<void> {
       missing.push(entry);
     }
   }
+
   if (missing.length > 0) {
     throw new Error(
       `Tutorial runtime assets are missing: ${missing.join(", ")}.`,
@@ -402,9 +448,11 @@ async function readTutorialRuntimeManifest(
   const value = parseJsonText(
     await readFile(path.join(assetsRoot, "runtime-manifest.json"), "utf8"),
   );
+
   const manifest = isJsonObject(value) ? value : undefined;
   const reviewFiles = manifest && jsonProperty(manifest, "reviewFiles");
   const requiredPaths = manifest && jsonProperty(manifest, "requiredPaths");
+
   if (
     !manifest ||
     jsonProperty(manifest, "version") !== 1 ||
@@ -414,6 +462,7 @@ async function readTutorialRuntimeManifest(
   ) {
     throw new Error("Tutorial runtime manifest is invalid.");
   }
+
   return {
     version: 1,
     reviewFiles: [...new Set(reviewFiles)],
@@ -429,6 +478,7 @@ function isRelativePathList(
     entries.length > 0 &&
     entries.every((entry) => {
       const relativePath = jsonString(entry);
+
       return (
         relativePath !== undefined &&
         relativePath.length > 0 &&
@@ -447,7 +497,9 @@ async function isManagedTutorialPath(
     realpath(candidate).catch(() => path.resolve(candidate)),
     realpath(root).catch(() => path.resolve(root)),
   ]);
+
   const relative = path.relative(canonicalRoot, canonicalCandidate);
+
   return (
     relative === "" ||
     (!relative.startsWith("..") && !path.isAbsolute(relative))
@@ -459,5 +511,6 @@ async function runGit(cwd: string, args: string[]): Promise<string> {
     cwd,
     encoding: "utf8",
   });
+
   return stdout;
 }

--- a/packages/progressive-review/src/stored-review-migration-force.test.ts
+++ b/packages/progressive-review/src/stored-review-migration-force.test.ts
@@ -18,6 +18,7 @@ import {
 } from "./stored-review-migration";
 
 const roots: string[] = [];
+
 afterEach(async () => {
   closeAllReviewThreadStores();
   await Promise.all(
@@ -31,26 +32,32 @@ it.each([4, 5])(
     const { reviewHome, reviewDir, dbPath } = await fixture(schemaVersion);
     const before = databaseRows(dbPath);
     const onDrop = vi.fn<() => void>();
+
     const blocked = await migrateStoredReview({
       reviewDir,
       onDropLegacyCodeRecord: onDrop,
     });
+
     expect(blocked.threadDbError).toBeTruthy();
     expect(blocked.upgradedThreadDb).toBe(false);
     expect(onDrop).not.toHaveBeenCalled();
     expect(databaseRows(dbPath)).toEqual(before);
+
     const recordBeforeForce = await readFile(
       path.join(reviewDir, "review.json"),
       "utf8",
     );
+
     const log: string[] = [];
     const blockers: string[] = [];
+
     const forced = await migrateStoredReviewData({
       reviewHome,
       force: true,
       log: (message) => log.push(message),
       onBlocker: (message) => blockers.push(message),
     });
+
     expect(forced).toMatchObject({
       documents: 1,
       upgradedThreadDatabases: 1,
@@ -103,12 +110,14 @@ it("does not report rolled-back drops as committed losses", async () => {
   const before = databaseRows(dbPath);
   const log: string[] = [];
   const blockers: string[] = [];
+
   const result = await migrateStoredReviewData({
     reviewHome,
     force: true,
     log: (message) => log.push(message),
     onBlocker: (message) => blockers.push(message),
   });
+
   expect(blockers.join("\n")).toContain("injected commit failure");
   expect(result).toMatchObject({
     upgradedThreadDatabases: 0,
@@ -122,6 +131,7 @@ it("does not report rolled-back drops as committed losses", async () => {
 
 function databaseRows(dbPath: string) {
   const db = new DatabaseSync(dbPath, { readOnly: true });
+
   try {
     return {
       version: db
@@ -144,11 +154,14 @@ async function fixture(schemaVersion: number) {
   const reviewHome = await mkdtemp(
     path.join(os.tmpdir(), "review-migration-force-"),
   );
+
   roots.push(reviewHome);
   const source = path.join(reviewHome, "source");
   await mkdir(source);
+
   const git = (args: string[]) =>
     execFileSync("git", ["-C", source, ...args], { encoding: "utf8" }).trim();
+
   git(["init", "-q", "-b", "main"]);
   git(["config", "user.email", "fixture@example.test"]);
   git(["config", "user.name", "Fixture"]);
@@ -156,6 +169,7 @@ async function fixture(schemaVersion: number) {
   git(["add", "."]);
   git(["commit", "-qm", "source"]);
   const commit = git(["rev-parse", "HEAD"]);
+
   const created = await createReviewDir({
     reviewsHomePath: reviewHome,
     worktreePath: source,
@@ -165,6 +179,7 @@ async function fixture(schemaVersion: number) {
     sourceIdentity: { kind: "git-branch", name: "main" },
     sourceSession: "disabled:review",
   });
+
   await writeFile(
     path.join(created.dir, "review.json"),
     JSON.stringify({ ...created.review, schemaVersion }),
@@ -176,6 +191,7 @@ async function fixture(schemaVersion: number) {
   db.exec(
     "UPDATE meta SET value = '2' WHERE key = 'schema_version'; CREATE TABLE questions (question_id TEXT PRIMARY KEY, record_json TEXT NOT NULL);",
   );
+
   const thread = {
     target: {
       kind: "code",
@@ -186,6 +202,7 @@ async function fixture(schemaVersion: number) {
     },
     messages: [{ body: "private prose" }],
   };
+
   db.prepare("INSERT INTO comments VALUES (?, ?)").run(
     "bad-comment",
     JSON.stringify(thread),
@@ -203,5 +220,6 @@ async function fixture(schemaVersion: number) {
     '{"body":"private prose"}',
   );
   db.close();
+
   return { reviewHome, reviewDir: created.dir, dbPath };
 }

--- a/packages/progressive-review/src/stored-review-migration-force.test.ts
+++ b/packages/progressive-review/src/stored-review-migration-force.test.ts
@@ -10,7 +10,7 @@ import { createReviewDir } from "./review-home";
 import {
   REVIEW_THREAD_DB_SCHEMA_VERSION,
   closeAllReviewThreadStores,
-  createReviewThreadDb,
+  createLegacyReviewThreadDb,
 } from "./review-thread-store-backend";
 import {
   migrateStoredReview,
@@ -169,7 +169,7 @@ async function fixture(schemaVersion: number) {
     path.join(created.dir, "review.json"),
     JSON.stringify({ ...created.review, schemaVersion }),
   );
-  createReviewThreadDb(created.dir);
+  createLegacyReviewThreadDb(created.dir);
   closeAllReviewThreadStores();
   const dbPath = path.join(created.dir, "review.db");
   const db = new DatabaseSync(dbPath);

--- a/packages/progressive-review/src/stored-review-migration.ts
+++ b/packages/progressive-review/src/stored-review-migration.ts
@@ -108,19 +108,24 @@ async function migrateStoredReviewLocked(
   input: StoredReviewMigrationInput,
 ): Promise<StoredReviewMigrationOutcome> {
   const reviewPath = path.join(input.reviewDir, "review.mdx");
+
   const value = jsonObject(
     parseJsonText(
       await readFile(path.join(input.reviewDir, "review.json"), "utf8"),
     ),
   );
+
   const schemaVersion = value?.schemaVersion;
+
   if (
     !value ||
     ![2, 3, 4, REVIEW_SCHEMA_VERSION].includes(Number(schemaVersion))
   ) {
     throw new Error("Unsupported Review schema; the record was preserved.");
   }
+
   const validatedRecord = parseAnyStoredReviewRecord(value);
+
   const migratedRecord =
     schemaVersion === 3 || schemaVersion === 2
       ? parseStoredReviewRecord({
@@ -128,8 +133,10 @@ async function migrateStoredReviewLocked(
           sourceSession: DISABLED_REVIEW_SOURCE_SESSION,
         })
       : validatedRecord;
+
   if (migratedRecord.uuid !== path.basename(input.reviewDir))
     throw new Error("review.json UUID does not match its directory");
+
   const migrated =
     schemaVersion !== REVIEW_SCHEMA_VERSION &&
     (await regeneratePresentedArtifacts({
@@ -142,6 +149,7 @@ async function migrateStoredReviewLocked(
       log: input.log,
       finalizeSource: async (record) => {
         if (schemaVersion !== 2 && schemaVersion !== 3) return record;
+
         const migrated = await migratePendingReviewSourceSession({
           reviewDir: input.reviewDir,
           value,
@@ -149,6 +157,7 @@ async function migrateStoredReviewLocked(
             input.createSourceSession ?? createReviewSourceAgentSession,
           onWarning: input.log,
         });
+
         return {
           ...record,
           sourceSession: migrated.sourceSession,
@@ -156,6 +165,7 @@ async function migrateStoredReviewLocked(
         };
       },
     }));
+
   if (schemaVersion === 2 || schemaVersion === 3) {
     try {
       await rm(sourceMigrationStatePath(input.reviewDir), { force: true });
@@ -165,21 +175,25 @@ async function migrateStoredReviewLocked(
       );
     }
   }
+
   const record = parseStoredReviewRecord(
     parseJsonText(
       await readFile(path.join(input.reviewDir, "review.json"), "utf8"),
     ),
   );
+
   const dropped: Array<
     Parameters<
       NonNullable<ReviewThreadDbMigrationOptions["onDropLegacyCodeRecord"]>
     >[0]
   > = [];
+
   const threadDbMigration: ReviewThreadDbMigrationOptions = {
     force: input.force ?? false,
     preserveLegacyQuestions: true,
     onDropLegacyCodeRecord: (record) => dropped.push(record),
   };
+
   if (record.sourceCommit) {
     threadDbMigration.migrateLegacyCodeRecord = createLegacyCodeRecordMigrator({
       rootPath: record.worktreePath,
@@ -187,8 +201,10 @@ async function migrateStoredReviewLocked(
       headCommit: record.sourceCommit,
     });
   }
+
   let upgradedThreadDb = false;
   let threadDbError: string | undefined;
+
   try {
     upgradedThreadDb =
       (await migrateReviewThreadDb(reviewPath, threadDbMigration)) ===
@@ -197,9 +213,11 @@ async function migrateStoredReviewLocked(
   } catch (error) {
     threadDbError = errorMessage(error);
   }
+
   if (upgradedThreadDb)
     for (const record of dropped) input.onDropLegacyCodeRecord?.(record);
   putReviewRecord(input.reviewDir, record);
+
   return { record, migrated, upgradedThreadDb, threadDbError };
 }
 
@@ -213,6 +231,7 @@ export async function migrateStoredReviewData(input: {
     recursive: true,
     force: true,
   });
+
   const total: StoredReviewMigrationResult = {
     failedReviewUuids: [],
     documents: 0,
@@ -223,18 +242,22 @@ export async function migrateStoredReviewData(input: {
     legacyCheckoutsRemoved: 0,
     upgradedThreadDatabases: 0,
   };
+
   const reviewsRoot = path.join(input.reviewHome, "reviews");
   const cleanedLegacyRoots = new Set<string>();
   let entries: import("node:fs").Dirent[];
+
   try {
     entries = await readdir(reviewsRoot, { withFileTypes: true });
   } catch (error) {
     if (isMissingFileError(error)) return total;
     throw error;
   }
+
   for (const entry of entries) {
     if (!entry.isDirectory() || !UUID_PATTERN.test(entry.name)) continue;
     const reviewDir = path.join(reviewsRoot, entry.name);
+
     try {
       const outcome = await migrateStoredReview({
         reviewDir,
@@ -247,7 +270,9 @@ export async function migrateStoredReviewData(input: {
           );
         },
       });
+
       const worktreePath = outcome.record.worktreePath;
+
       if (!cleanedLegacyRoots.has(worktreePath)) {
         cleanedLegacyRoots.add(worktreePath);
         total.legacyCheckoutsRemoved += await removeLegacyReviewCheckouts({
@@ -255,12 +280,14 @@ export async function migrateStoredReviewData(input: {
           onBlocker: input.onBlocker,
         });
       }
+
       if (outcome.upgradedThreadDb) {
         total.upgradedThreadDatabases += 1;
         input.log?.(
           `Upgraded Review database ${entry.name} to the current schema.`,
         );
       }
+
       if (outcome.threadDbError)
         input.onBlocker?.(
           `Review ${entry.name} database migration failed: ${outcome.threadDbError}`,
@@ -273,6 +300,7 @@ export async function migrateStoredReviewData(input: {
       input.log?.(message);
     }
   }
+
   return total;
 }
 
@@ -324,8 +352,10 @@ async function migratePendingReviewSourceSession(input: {
       ]),
     )
     .digest("hex");
+
   const statePath = sourceMigrationStatePath(input.reviewDir);
   let pending: z.infer<typeof sourceMigrationStateSchema> | undefined;
+
   try {
     pending = sourceMigrationStateSchema.parse(
       parseJsonText(await readFile(statePath, "utf8")),
@@ -337,16 +367,19 @@ async function migratePendingReviewSourceSession(input: {
         { cause: error },
       );
   }
+
   if (pending && pending.key !== key) {
     throw new Error(
       `Source migration binding ${statePath} belongs to different Review pins. Inspect and reconcile the pending binding before retrying; no new native fork was created.`,
     );
   }
+
   if (pending?.state === "started") {
     throw new Error(
       `Source migration binding ${statePath} was interrupted after starting a native fork. Inspect the native session and recover the pending binding before retrying; no new native fork was created.`,
     );
   }
+
   if (!pending) {
     await writePrivateJsonAtomic(statePath, {
       version: 1,
@@ -363,8 +396,10 @@ async function migratePendingReviewSourceSession(input: {
     };
     await writePrivateJsonAtomic(statePath, pending);
   }
+
   const { agentSession: _agentSession, ...record } = input.value;
   const priorAgentSessions = jsonObject(record.agentSessions) ?? {};
+
   return parseAnyStoredReviewRecord({
     ...record,
     sourceSession: pending.sourceSession,
@@ -392,12 +427,15 @@ async function migrateReviewSourceSession(input: {
   const worktreePath = jsonString(input.value.worktreePath) ?? null;
   const sourceCommit = jsonString(input.value.sourceCommit) ?? null;
   const { agentSession: _agentSession, ...record } = input.value;
+
   if (!source || !uuid || !worktreePath || !sourceCommit) {
     input.onWarning?.(
       `Review ${uuid ?? "with unknown UUID"} has no usable authoring session. Ask Agent is disabled, but the Review was preserved.`,
     );
+
     return { ...record, sourceSession: "disabled:review" };
   }
+
   try {
     const checkout = await ensureReviewPinnedCheckout({
       rootPath: worktreePath,
@@ -405,17 +443,21 @@ async function migrateReviewSourceSession(input: {
       reviewUuid: uuid,
       role: "head",
     });
+
     if (!checkout) {
       throw new Error("the pinned head checkout is unavailable");
     }
+
     const frozen = await input.createSourceSession({
       agent: source,
       reviewUuid: uuid,
       rootPath: checkout,
     });
+
     const sourceSession = authoringSessionKey(frozen);
     const now = new Date().toISOString();
     const priorAgentSessions = jsonObject(record.agentSessions) ?? {};
+
     return {
       ...record,
       agentSessions: {
@@ -433,6 +475,7 @@ async function migrateReviewSourceSession(input: {
       `Review ${uuid} source session migration failed: ${errorMessage(error)}. Ask Agent is disabled, but the Review was preserved.`,
     );
   }
+
   return {
     ...record,
     sourceSession: "disabled:review",
@@ -450,18 +493,23 @@ async function regeneratePresentedArtifacts(input: {
   const staging = await mkdtemp(
     path.join(tmpdir(), "review-artifact-migration-"),
   );
+
   const documentDir = path.join(staging, "document");
   const mapDir = path.join(staging, "map");
+
   try {
     let documentBundle: ReturnType<typeof bundleReviewDocument> | null = null;
+
     let evaluatedDocument:
       | Awaited<ReturnType<typeof evaluateSealedReviewDocument>>
       | undefined;
+
     let documentRecord: StoredReviewRecord | undefined;
     let mapRecord: StoredReviewRecord | undefined;
     let mapBundle: ReviewSoftwareMapBundle | null = null;
     let mapRevision = input.review.presentedSoftwareMapRevision;
     const documentRevision = input.review.presentedDocumentRevision;
+
     if (documentRevision) {
       await materializeReviewRevision(
         input.reviewDir,
@@ -473,6 +521,7 @@ async function regeneratePresentedArtifacts(input: {
           await readFile(path.join(documentDir, "review.json"), "utf8"),
         ),
       );
+
       if (!(await readReviewDocumentBundle(documentDir, "/"))) {
         evaluatedDocument = await evaluateSealedReviewDocument(
           documentDir,
@@ -481,22 +530,28 @@ async function regeneratePresentedArtifacts(input: {
         documentBundle = bundleReviewDocument(evaluatedDocument.document);
       }
     }
+
     if (mapRevision) {
       await materializeReviewRevision(input.reviewDir, mapRevision, mapDir);
       mapRecord = parseAnyStoredReviewRecord(
         parseJsonText(await readFile(path.join(mapDir, "review.json"), "utf8")),
       );
+
       if (!(await readReviewSoftwareMapBundle(mapDir))) {
         mapBundle = await legacySoftwareMapBundle(mapDir);
+
         if (!mapBundle) {
           if (!input.allowAbsentMap)
             throw new Error("The presented software map is missing.");
+
           const evaluated =
             mapRevision === documentRevision && evaluatedDocument
               ? evaluatedDocument
               : await evaluateSealedReviewDocument(mapDir, input.log);
+
           if (evaluated.legacySoftwareMap) {
             const sealed = mapRecord;
+
             if (!sealed.sourceCommit)
               throw new Error(
                 "The embedded software map has no sealed source commit.",
@@ -512,10 +567,12 @@ async function regeneratePresentedArtifacts(input: {
         }
       }
     }
+
     // Source migration and schema normalization must not race a lifecycle or pin change.
     return await withReviewMutationLock(input.reviewDir, async () => {
       const recordPath = path.join(input.reviewDir, "review.json");
       const currentText = await readFile(recordPath, "utf8");
+
       if (
         JSON.stringify(parseJsonText(currentText)) !==
         JSON.stringify(input.original)
@@ -524,6 +581,7 @@ async function regeneratePresentedArtifacts(input: {
           "Review changed while preparing migration; rerun review migrate apply.",
         );
       }
+
       if (!documentBundle && !mapBundle) {
         if (
           input.original.schemaVersion !== REVIEW_SCHEMA_VERSION ||
@@ -537,10 +595,13 @@ async function regeneratePresentedArtifacts(input: {
             }),
           );
           input.log?.("Migrated Review " + input.review.uuid + " to schema 5.");
+
           return true;
         }
+
         return false;
       }
+
       const candidateDir = path.join(staging, "candidate");
       await cp(
         path.join(input.reviewDir, ".git"),
@@ -554,11 +615,13 @@ async function regeneratePresentedArtifacts(input: {
         path.join(candidateDir, ".bundle"),
         { recursive: true },
       );
+
       if (!mapBundle) {
         await rm(path.join(candidateDir, ".bundle/software-map"), {
           recursive: true,
           force: true,
         });
+
         if (mapRevision) {
           await cp(
             path.join(mapDir, ".bundle/software-map"),
@@ -567,9 +630,11 @@ async function regeneratePresentedArtifacts(input: {
           );
         }
       }
+
       const candidateRecordPath = path.join(candidateDir, "review.json");
       let completed = false;
       const newRevisions: string[] = [];
+
       try {
         if (documentBundle) {
           await rm(path.join(candidateDir, ".bundle/document"), {
@@ -584,6 +649,7 @@ async function regeneratePresentedArtifacts(input: {
           });
           await writeReviewDocumentBundle(candidateDir, documentBundle);
         }
+
         if (mapBundle) {
           await rm(path.join(candidateDir, ".bundle/software-map"), {
             recursive: true,
@@ -591,10 +657,12 @@ async function regeneratePresentedArtifacts(input: {
           });
           await writeReviewSoftwareMapBundle(candidateDir, mapBundle);
         }
+
         let next = {
           ...input.review,
           presentedSoftwareMapRevision: mapRevision,
         };
+
         if (mapBundle) {
           await replaceCandidateSources(candidateDir, mapDir);
           await writePrivateJsonAtomic(candidateRecordPath, {
@@ -608,19 +676,23 @@ async function regeneratePresentedArtifacts(input: {
           newRevisions.push(mapRevision);
           next = { ...next, presentedSoftwareMapRevision: mapRevision };
         }
+
         if (documentBundle) {
           await replaceCandidateSources(candidateDir, documentDir);
           await writePrivateJsonAtomic(candidateRecordPath, {
             ...next,
             ...reviewSourcePins(documentRecord!),
           });
+
           const revision = await sealReviewCandidate(
             candidateDir,
             "Migrate current Review document to JSON",
           );
+
           newRevisions.push(revision);
           next = { ...next, presentedDocumentRevision: revision };
         }
+
         for (const revision of newRevisions) {
           await materializeReviewRevision(
             candidateDir,
@@ -628,6 +700,7 @@ async function regeneratePresentedArtifacts(input: {
             path.join(input.reviewDir, ".build", revision),
           );
         }
+
         next = await input.finalizeSource(next);
         await promoteReviewArtifactFiles({
           reviewDir: input.reviewDir,
@@ -640,6 +713,7 @@ async function regeneratePresentedArtifacts(input: {
             input.review.uuid +
             " to JSON.",
         );
+
         return true;
       } finally {
         if (!completed) {
@@ -665,6 +739,7 @@ async function replaceCandidateSources(
       await rm(path.join(candidateDir, name), { recursive: true, force: true });
     }
   }
+
   await cp(sourceDir, candidateDir, {
     recursive: true,
     filter: (source) =>
@@ -679,6 +754,7 @@ export async function legacySoftwareMapBundle(
 ): Promise<ReviewSoftwareMapBundle | null> {
   const mapDir = path.join(legacyBuildDir, ".bundle", "software-map");
   let manifestValue: JsonObject | undefined;
+
   try {
     manifestValue = jsonObject(
       parseJsonText(await readFile(path.join(mapDir, "manifest.json"), "utf8")),
@@ -691,12 +767,16 @@ export async function legacySoftwareMapBundle(
         if (isMissingFileError(directoryError)) return null;
         throw directoryError;
       }
+
       throw new Error("The presented software map has no manifest.");
     }
+
     throw error;
   }
+
   const headCommit = jsonString(manifestValue?.headCommit);
   const baseCommit = jsonString(manifestValue?.baseCommit);
+
   if (
     manifestValue?.version !== 1 ||
     !headCommit ||
@@ -708,27 +788,33 @@ export async function legacySoftwareMapBundle(
       "The presented software-map manifest is invalid or unsupported.",
     );
   }
+
   const load = async (
     file: string,
   ): Promise<NormalizedSoftwareModel | null> => {
     const url = pathToFileURL(path.join(mapDir, file));
     url.searchParams.set("t", `${Date.now()}-${Math.random()}`);
+
     try {
       // SAFETY: an imported legacy map module has no static TypeScript shape;
       // isNormalizedSoftwareModel validates its default export before use.
       const module = (await import(url.href)) as { default?: unknown };
+
       return isNormalizedSoftwareModel(module.default) ? module.default : null;
     } catch {
       return null;
     }
   };
+
   const [head, base] = await Promise.all([
     load("head-map.js"),
     load("base-map.js"),
   ]);
+
   if (!head || !base)
     throw new Error(
       "The presented software map could not be converted; its sealed head or base bundle is invalid.",
     );
+
   return bundleReviewSoftwareMap({ head, base, headCommit, baseCommit });
 }

--- a/packages/progressive-review/src/stored-review-migration.ts
+++ b/packages/progressive-review/src/stored-review-migration.ts
@@ -44,6 +44,7 @@ import { withReviewMutationLock } from "./review-mutation-lock";
 import { evaluateSealedReviewDocument } from "./review-sealed-document";
 import { createReviewSourceAgentSession } from "./review-source-agent-session";
 import { reviewSourcePins } from "./review-source-pins";
+import { importLegacyReview, putReviewRecord } from "./review-state-db";
 import {
   type ReviewThreadDbMigrationOptions,
   migrateReviewThreadDb,
@@ -192,11 +193,13 @@ async function migrateStoredReviewLocked(
     upgradedThreadDb =
       (await migrateReviewThreadDb(reviewPath, threadDbMigration)) ===
       "upgraded";
+    importLegacyReview(input.reviewDir);
   } catch (error) {
     threadDbError = errorMessage(error);
   }
   if (upgradedThreadDb)
     for (const record of dropped) input.onDropLegacyCodeRecord?.(record);
+  putReviewRecord(input.reviewDir, record);
   return { record, migrated, upgradedThreadDb, threadDbError };
 }
 

--- a/packages/progressive-review/src/stored-review-source-migration.test.ts
+++ b/packages/progressive-review/src/stored-review-source-migration.test.ts
@@ -19,6 +19,7 @@ import {
   sealReviewCandidate,
 } from "./review-home";
 import type { createReviewSourceAgentSession } from "./review-source-agent-session";
+import { deleteReviewState } from "./review-state-db";
 import { closeAllReviewThreadStores } from "./review-thread-store-backend";
 import { reviewVcs } from "./review-vcs";
 import { migrateStoredReview } from "./stored-review-migration";
@@ -282,6 +283,7 @@ async function fixture(broken = false) {
     presentedDocumentRevision: revision,
   });
   await writeFile(path.join(review.dir, "review.json"), original);
+  deleteReviewState(review.dir);
   return { review, original };
 }
 

--- a/packages/progressive-review/src/stored-review-source-migration.test.ts
+++ b/packages/progressive-review/src/stored-review-source-migration.test.ts
@@ -25,6 +25,7 @@ import { reviewVcs } from "./review-vcs";
 import { migrateStoredReview } from "./stored-review-migration";
 
 const roots: string[] = [];
+
 afterEach(async () => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
@@ -38,18 +39,21 @@ it.each(["document", "seal"])(
   "does not fork before %s validation succeeds",
   async (failure) => {
     const { review, original } = await fixture(failure === "document");
+
     const createSourceSession = vi.fn<typeof createReviewSourceAgentSession>(
       async () => ({
         harness: "codex" as const,
         sessionId: "frozen",
       }),
     );
+
     const failedSeal =
       failure === "seal"
         ? vi
             .spyOn(reviewVcs, "seal")
             .mockRejectedValue(new Error("candidate seal failed"))
         : undefined;
+
     for (const attempt of [1, 2]) {
       await expect(
         migrateStoredReview({ reviewDir: review.dir, createSourceSession }),
@@ -58,21 +62,25 @@ it.each(["document", "seal"])(
         failure === "document" ? "broken document" : "candidate seal failed",
       );
     }
+
     expect(createSourceSession).not.toHaveBeenCalled();
     expect(await readFile(path.join(review.dir, "review.json"), "utf8")).toBe(
       original,
     );
     expect(existsSync(`${review.dir}.source-migration.json`)).toBe(false);
     failedSeal?.mockRestore();
+
     if (failure === "document") {
       await writeFile(
         path.join(review.dir, ".bundle/document/review-document.js"),
         legacyDocument,
       );
+
       const revision = await sealReviewCandidate(
         review.dir,
         "Repaired fixture",
       );
+
       await writeFile(
         path.join(review.dir, "review.json"),
         JSON.stringify({
@@ -81,10 +89,12 @@ it.each(["document", "seal"])(
         }),
       );
     }
+
     const migrated = await migrateStoredReview({
       reviewDir: review.dir,
       createSourceSession,
     });
+
     expect(migrated.record.sourceSession).toBe("codex:frozen");
     expect(createSourceSession).toHaveBeenCalledTimes(1);
   },
@@ -93,15 +103,18 @@ it.each(["document", "seal"])(
 it("reuses a durable fork after record promotion fails", async () => {
   const { review, original } = await fixture();
   const displaced = `${review.dir}.displaced`;
+
   const createSourceSession = vi.fn<typeof createReviewSourceAgentSession>(
     async () => {
       await rename(review.dir, displaced);
+
       return {
         harness: "codex" as const,
         sessionId: "frozen",
       };
     },
   );
+
   try {
     await expect(
       migrateStoredReview({ reviewDir: review.dir, createSourceSession }),
@@ -109,6 +122,7 @@ it("reuses a durable fork after record promotion fails", async () => {
   } finally {
     await rename(displaced, review.dir);
   }
+
   expect(createSourceSession).toHaveBeenCalledTimes(1);
   expect(await readFile(path.join(review.dir, "review.json"), "utf8")).toBe(
     original,
@@ -116,10 +130,12 @@ it("reuses a durable fork after record promotion fails", async () => {
   expect(
     JSON.parse(await readFile(`${review.dir}.source-migration.json`, "utf8")),
   ).toMatchObject({ state: "ready", sourceSession: "codex:frozen" });
+
   const migrated = await migrateStoredReview({
     reviewDir: review.dir,
     createSourceSession,
   });
+
   expect(migrated.record.sourceSession).toBe("codex:frozen");
   expect(createSourceSession).toHaveBeenCalledTimes(1);
   expect(existsSync(`${review.dir}.source-migration.json`)).toBe(false);
@@ -129,22 +145,28 @@ it("serializes concurrent direct migration and loader before creating a fork", a
   const { review } = await fixture();
   const entered = Promise.withResolvers<void>();
   const release = Promise.withResolvers<void>();
+
   const createSourceSession = vi.fn<typeof createReviewSourceAgentSession>(
     async () => {
       entered.resolve();
       await release.promise;
+
       return { harness: "codex" as const, sessionId: "frozen" };
     },
   );
+
   const first = migrateStoredReview({
     reviewDir: review.dir,
     createSourceSession,
   });
+
   await entered.promise;
+
   const second = migrateStoredReview({
     reviewDir: review.dir,
     createSourceSession,
   });
+
   const loaded = readStoredReview(review.dir);
   release.resolve();
   const results = await Promise.all([first, second, loaded]);
@@ -161,15 +183,18 @@ it.each(["started", "different pins"])(
   async (state) => {
     const { review } = await fixture();
     const displaced = `${review.dir}.displaced`;
+
     const createSourceSession = vi.fn<typeof createReviewSourceAgentSession>(
       async () => {
         await rename(review.dir, displaced);
+
         return {
           harness: "codex" as const,
           sessionId: "frozen",
         };
       },
     );
+
     try {
       await expect(
         migrateStoredReview({ reviewDir: review.dir, createSourceSession }),
@@ -177,6 +202,7 @@ it.each(["started", "different pins"])(
     } finally {
       await rename(displaced, review.dir);
     }
+
     const statePath = `${review.dir}.source-migration.json`;
     const pending = JSON.parse(await readFile(statePath, "utf8"));
     await writeFile(
@@ -198,17 +224,21 @@ it.each(["started", "different pins"])(
 
 it("preserves disabled-source behavior for a native provider failure", async () => {
   const { review } = await fixture();
+
   const createSourceSession = vi.fn<typeof createReviewSourceAgentSession>(
     async () => {
       throw new Error("provider unavailable");
     },
   );
+
   const log = vi.fn<(message: string) => void>();
+
   const migrated = await migrateStoredReview({
     reviewDir: review.dir,
     createSourceSession,
     log,
   });
+
   expect(migrated.record.sourceSession).toBe("disabled:review");
   expect(log.mock.calls.flat().join(" ")).toContain("provider unavailable");
   await migrateStoredReview({ reviewDir: review.dir, createSourceSession });
@@ -218,6 +248,7 @@ it("preserves disabled-source behavior for a native provider failure", async () 
 it("does not turn a binding persistence failure into disabled success or another fork", async () => {
   const { review, original } = await fixture();
   const statePath = `${review.dir}.source-migration.json`;
+
   const createSourceSession = vi.fn<typeof createReviewSourceAgentSession>(
     async () => {
       expect(JSON.parse(await readFile(statePath, "utf8"))).toMatchObject({
@@ -225,9 +256,11 @@ it("does not turn a binding persistence failure into disabled success or another
       });
       await rm(statePath);
       await mkdir(statePath);
+
       return { harness: "codex", sessionId: "frozen" };
     },
   );
+
   await expect(
     migrateStoredReview({ reviewDir: review.dir, createSourceSession }),
   ).rejects.toThrow(/EISDIR|EEXIST/);
@@ -246,8 +279,10 @@ async function fixture(broken = false) {
   vi.stubEnv("DEV_REVIEW_HOME", home);
   const source = path.join(home, "source");
   await mkdir(source);
+
   const git = (args: string[]) =>
     execFileSync("git", ["-C", source, ...args], { encoding: "utf8" }).trim();
+
   git(["init", "-q", "-b", "main"]);
   git(["config", "user.email", "review@example.test"]);
   git(["config", "user.name", "Review Test"]);
@@ -255,6 +290,7 @@ async function fixture(broken = false) {
   git(["add", "."]);
   git(["commit", "-qm", "source"]);
   const commit = git(["rev-parse", "HEAD"]);
+
   const review = await createReviewDir({
     worktreePath: source,
     baseRef: "main",
@@ -262,6 +298,7 @@ async function fixture(broken = false) {
     sourceCommit: commit,
     sourceIdentity: { kind: "git-branch", name: "main" },
   });
+
   const bundle = path.join(review.dir, ".bundle/document");
   await mkdir(bundle, { recursive: true });
   await writeFile(
@@ -275,6 +312,7 @@ async function fixture(broken = false) {
       : legacyDocument,
   );
   const revision = await sealReviewCandidate(review.dir, "Legacy document");
+
   const original = JSON.stringify({
     ...review.review,
     schemaVersion: 3,
@@ -282,8 +320,10 @@ async function fixture(broken = false) {
     sourceSession: undefined,
     presentedDocumentRevision: revision,
   });
+
   await writeFile(path.join(review.dir, "review.json"), original);
   deleteReviewState(review.dir);
+
   return { review, original };
 }
 

--- a/packages/progressive-review/src/threads-cli.test.ts
+++ b/packages/progressive-review/src/threads-cli.test.ts
@@ -11,6 +11,7 @@ import { promisify } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { type StoredReview, createReviewDir } from "./review-home";
+import { startLifecycleTestServer } from "./review-lifecycle-test-utils";
 import { requireCompletedAgentResponsesForRepublish } from "./review-publish-thread-gate";
 import { appendReviewComment } from "./review-state-store";
 import { cleanupTempDirs, gitRepository } from "./review-test-utils";
@@ -28,8 +29,11 @@ import {
 const execFilePromise = promisify(execFile);
 
 const cleanups: string[] = [];
+let server: Awaited<ReturnType<typeof startLifecycleTestServer>> | undefined;
 
 afterEach(async () => {
+  await server?.close();
+  server = undefined;
   vi.unstubAllEnvs();
   closeAllReviewThreadStores();
   for (const dir of cleanups.splice(0)) {
@@ -195,6 +199,7 @@ async function makeReview(): Promise<{
   const home = await mkdtemp(path.join(os.tmpdir(), "review-threads-home-"));
   cleanups.push(home);
   vi.stubEnv("DEV_REVIEW_HOME", home);
+  server = await startLifecycleTestServer();
   const review = await createReviewDir({
     worktreePath: root,
     baseRef: "main",

--- a/packages/progressive-review/src/threads-cli.test.ts
+++ b/packages/progressive-review/src/threads-cli.test.ts
@@ -29,6 +29,7 @@ import {
 const execFilePromise = promisify(execFile);
 
 const cleanups: string[] = [];
+
 let server: Awaited<ReturnType<typeof startLifecycleTestServer>> | undefined;
 
 afterEach(async () => {
@@ -36,9 +37,11 @@ afterEach(async () => {
   server = undefined;
   vi.unstubAllEnvs();
   closeAllReviewThreadStores();
+
   for (const dir of cleanups.splice(0)) {
     await rm(dir, { recursive: true, force: true });
   }
+
   await cleanupTempDirs();
 });
 
@@ -54,6 +57,7 @@ describe("review threads CLI", () => {
         messages: [],
       },
     };
+
     let destination: string | undefined;
     let request = "";
     const proxy = createServer();
@@ -62,6 +66,7 @@ describe("review threads CLI", () => {
       socket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
       socket.on("data", (chunk) => {
         request += chunk.toString();
+
         if (!request.includes("\r\n\r\n")) return;
         const body = JSON.stringify(payload);
         socket.end(
@@ -70,9 +75,11 @@ describe("review threads CLI", () => {
       });
     });
     await new Promise<void>((resolve) => proxy.listen(0, "127.0.0.1", resolve));
+
     try {
       // listen above binds a TCP port and has completed successfully.
       const address = proxy.address() as AddressInfo;
+
       const output = await captureOutput((stdout) =>
         runReviewThreadsGet({
           cwd: process.cwd(),
@@ -87,6 +94,7 @@ describe("review threads CLI", () => {
           },
         }),
       );
+
       expect(JSON.parse(output)).toEqual(payload);
       expect(destination).toBe("review.invalid:12345");
       expect(request).toContain("GET /agent-threads/thread-proxy HTTP/1.1");
@@ -108,11 +116,13 @@ describe("review threads CLI", () => {
       body: "Please fix.",
       author: "Reviewer",
     });
+
     const listed = JSON.parse(
       await captureOutput((stdout) =>
         runReviewThreadsList({ cwd: root, stdout }),
       ),
     );
+
     expect(listed).toMatchObject({
       review: review.review.uuid,
       comments: {
@@ -130,6 +140,7 @@ describe("review threads CLI", () => {
         }),
       ),
     );
+
     expect(replied).toMatchObject({ event: "replied", threadId: "thread-1" });
 
     const resolved = JSON.parse(
@@ -137,6 +148,7 @@ describe("review threads CLI", () => {
         runReviewThreadsResolve({ cwd: root, threadId: "thread-1", stdout }),
       ),
     );
+
     expect(resolved).toMatchObject({
       event: "resolved",
       threadId: "thread-1",
@@ -147,6 +159,7 @@ describe("review threads CLI", () => {
         runReviewThreadsList({ cwd: root, stdout }),
       ),
     );
+
     expect(after.comments["thread-1"]).toMatchObject({
       status: "resolved",
       messages: [
@@ -200,12 +213,15 @@ async function makeReview(): Promise<{
   cleanups.push(home);
   vi.stubEnv("DEV_REVIEW_HOME", home);
   server = await startLifecycleTestServer();
+
   const review = await createReviewDir({
     worktreePath: root,
     baseRef: "main",
     baseCommit: await git(root, ["rev-parse", "HEAD"]),
   });
+
   const document = path.join(review.dir, "review.mdx");
+
   return { root, review, document };
 }
 
@@ -213,6 +229,7 @@ async function git(root: string, args: string[]): Promise<string> {
   const { stdout } = await execFilePromise("git", ["-C", root, ...args], {
     encoding: "utf8",
   });
+
   return stdout.trim();
 }
 
@@ -223,6 +240,7 @@ async function captureOutput(
   let output = "";
   stream.on("data", (chunk) => (output += String(chunk)));
   await expect(run(stream)).resolves.toBe(0);
+
   return output;
 }
 

--- a/packages/progressive-review/src/threads-cli.ts
+++ b/packages/progressive-review/src/threads-cli.ts
@@ -28,10 +28,12 @@ export async function runReviewThreadsList(
   input: ReviewThreadsTarget & { json?: boolean; stdout: Writable },
 ): Promise<number> {
   const review = await resolveThreadsReview(input.cwd, input.reviewUuid);
+
   const payload = {
     review: review.review.uuid,
     comments: (await readThreadsClient(review.review.uuid)).comments,
   };
+
   // Indented output is easier for a human to read, but it breaks any reader
   // that takes one event per line. --json picks the line-oriented form.
   input.stdout.write(
@@ -39,6 +41,7 @@ export async function runReviewThreadsList(
       ? `${JSON.stringify(payload)}\n`
       : `${JSON.stringify(payload, null, 2)}\n`,
   );
+
   return 0;
 }
 
@@ -51,6 +54,7 @@ export async function runReviewThreadsGet(
 ): Promise<number> {
   const thread = await readAttachedReviewThread(input);
   input.stdout.write(`${JSON.stringify(thread, null, 2)}\n`);
+
   return 0;
 }
 
@@ -66,11 +70,13 @@ async function readAttachedReviewThread(input: {
   const env = input.env ?? process.env;
   const baseUrl = env[REVIEW_AGENT_THREAD_URL_ENV]?.trim();
   const token = env[REVIEW_AGENT_THREAD_TOKEN_ENV]?.trim();
+
   if (!baseUrl || !token) {
     throw new Error(
       "review threads get requires an attached Review Desktop server.",
     );
   }
+
   // Node fetch does not automatically use the proxy supplied by Codex's
   // network sandbox. Keep this dispatcher local to the attached-thread read.
   const dispatcher = new EnvHttpProxyAgent({
@@ -78,9 +84,12 @@ async function readAttachedReviewThread(input: {
     httpsProxy: env.https_proxy ?? env.HTTPS_PROXY,
     noProxy: env.no_proxy ?? env.NO_PROXY,
   });
+
   const requestOptions = { dispatcher };
+
   try {
     let response: Response;
+
     try {
       response = await fetch(
         `${baseUrl.replace(/\/$/u, "")}/${encodeURIComponent(input.threadId)}`,
@@ -91,28 +100,36 @@ async function readAttachedReviewThread(input: {
         cause: error,
       });
     }
+
     if (response.status === 404) {
       await response.body?.cancel();
       throw new Error(`Comment thread not found: ${input.threadId}`);
     }
+
     if (!response.ok) {
       await response.body?.cancel();
       throw new Error(
         `Review Desktop could not read the thread (${response.status}).`,
       );
     }
+
     const record: unknown = await response.json();
+
     if (!isJsonObject(record)) {
       throw new Error("Review Desktop returned an invalid thread response.");
     }
+
     const review = jsonString(record.review);
     const state = record.state;
+
     if (review === undefined || (state !== "draft" && state !== "submitted")) {
       throw new Error("Review Desktop returned an invalid thread response.");
     }
+
     if (input.reviewUuid && input.reviewUuid !== review) {
       throw new Error(`Review not found: ${input.reviewUuid}`);
     }
+
     return {
       review,
       state,
@@ -143,6 +160,7 @@ export async function runReviewThreadsResolve(
       threadId: input.threadId,
     })}\n`,
   );
+
   return 0;
 }
 
@@ -155,6 +173,7 @@ export async function runReviewThreadsReply(
   },
 ): Promise<number> {
   const body = input.body.trim();
+
   if (!body) throw new Error("Reply body is required.");
   const review = await resolveThreadsReview(input.cwd, input.reviewUuid);
   const messageId = randomUUID();
@@ -178,5 +197,6 @@ export async function runReviewThreadsReply(
       messageId,
     })}\n`,
   );
+
   return 0;
 }

--- a/packages/progressive-review/src/threads-cli.ts
+++ b/packages/progressive-review/src/threads-cli.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import path from "node:path";
 import type { Writable } from "node:stream";
 
 import {
@@ -13,21 +12,12 @@ import {
   REVIEW_AGENT_THREAD_TOKEN_ENV,
   REVIEW_AGENT_THREAD_URL_ENV,
 } from "./native-agent/terminal-command";
-import { reviewUuidForManagedCheckout } from "./review-head-checkout";
 import {
-  type StoredReview,
-  findReview,
-  findScopedReview,
-  listReviews,
-} from "./review-home";
-import {
-  appendReviewAgentMessage,
-  readReviewComments,
-  updateReviewComment,
-} from "./review-state-store";
-
-// `review threads get` reads its attached Review server. Other commands can
-// still operate after that server closes, so they use review.db.
+  commandThreadsClient,
+  readThreadsClient,
+  replyThreadClient,
+  resolveThreadsReviewClient as resolveThreadsReview,
+} from "./review-lifecycle-client";
 
 export interface ReviewThreadsTarget {
   cwd: string;
@@ -38,10 +28,9 @@ export async function runReviewThreadsList(
   input: ReviewThreadsTarget & { json?: boolean; stdout: Writable },
 ): Promise<number> {
   const review = await resolveThreadsReview(input.cwd, input.reviewUuid);
-  const document = reviewDocumentPath(review);
   const payload = {
     review: review.review.uuid,
-    comments: readReviewComments(document),
+    comments: (await readThreadsClient(review.review.uuid)).comments,
   };
   // Indented output is easier for a human to read, but it breaks any reader
   // that takes one event per line. --json picks the line-oriented form.
@@ -141,10 +130,12 @@ export async function runReviewThreadsResolve(
   },
 ): Promise<number> {
   const review = await resolveThreadsReview(input.cwd, input.reviewUuid);
-  const document = reviewDocumentPath(review);
-  if (!updateReviewComment(document, input.threadId, { status: "resolved" })) {
-    throw new Error(`Comment thread not found: ${input.threadId}`);
-  }
+  await commandThreadsClient(review.review.uuid, {
+    command: "comment.update",
+    mutationId: randomUUID(),
+    threadId: input.threadId,
+    update: { status: "resolved" },
+  });
   input.stdout.write(
     `${JSON.stringify({
       event: "resolved",
@@ -166,21 +157,17 @@ export async function runReviewThreadsReply(
   const body = input.body.trim();
   if (!body) throw new Error("Reply body is required.");
   const review = await resolveThreadsReview(input.cwd, input.reviewUuid);
-  const document = reviewDocumentPath(review);
-  const thread = readReviewComments(document)[input.threadId];
-  if (!thread) {
-    throw new Error(`Comment thread not found: ${input.threadId}`);
-  }
   const messageId = randomUUID();
   // The republish gate requires a completed model response with role "agent"
   // on every current-round thread, so a CLI reply must not read as another
   // reviewer message.
-  appendReviewAgentMessage(document, input.threadId, {
-    id: messageId,
-    by: input.author?.trim() || "Agent",
-    at: new Date().toISOString(),
+  await replyThreadClient({
+    reviewUuid: review.review.uuid,
+    mutationId: randomUUID(),
+    threadId: input.threadId,
+    messageId,
+    author: input.author?.trim() || "Agent",
     body,
-    role: "agent",
     format: "plain",
   });
   input.stdout.write(
@@ -192,58 +179,4 @@ export async function runReviewThreadsReply(
     })}\n`,
   );
   return 0;
-}
-
-function reviewDocumentPath(review: StoredReview): string {
-  return path.join(review.dir, "review.mdx");
-}
-
-async function resolveThreadsReview(
-  cwd: string,
-  reviewUuid: string | undefined,
-): Promise<StoredReview> {
-  const candidates = (await reviewsForThreads(cwd, reviewUuid)).filter(
-    (review) => review.review.status !== "rejected",
-  );
-  if (candidates.length === 0) {
-    throw new Error(
-      reviewUuid
-        ? `Review not found: ${reviewUuid}`
-        : "No review found for this worktree.",
-    );
-  }
-  if (candidates.length > 1) {
-    throw new Error("Multiple reviews require --review <uuid>.");
-  }
-  return candidates[0]!;
-}
-
-async function reviewsForThreads(
-  cwd: string,
-  reviewUuid: string | undefined,
-): Promise<StoredReview[]> {
-  const managedReviewUuid = await reviewUuidForManagedCheckout(cwd);
-  if (managedReviewUuid) {
-    if (reviewUuid && reviewUuid !== managedReviewUuid) {
-      throw new Error(
-        `Managed checkout belongs to Review ${managedReviewUuid}, not ${reviewUuid}.`,
-      );
-    }
-    const review = await findReview(managedReviewUuid);
-    return review ? [review] : [];
-  }
-  if (reviewUuid) {
-    const selected = await findScopedReview(reviewUuid, {
-      worktreePath: cwd,
-      includeTerminal: true,
-    });
-    return selected ? [selected] : [];
-  }
-  const listed = await listReviews({ worktreePath: cwd });
-  if (listed.errors.length > 0) {
-    throw new Error(
-      `Could not read reviews:\n${listed.errors.map((error) => error.message).join("\n")}`,
-    );
-  }
-  return listed.reviews;
 }

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -17,6 +17,7 @@ export const byCommitSchema = z.object({
   indexed_by: z.enum(["hook", "ci"]),
   ts: z.string(),
 });
+
 export type ByCommitEntry = z.infer<typeof byCommitSchema>;
 
 export const sessionMetaSchema = z.object({
@@ -28,30 +29,37 @@ export const sessionMetaSchema = z.object({
   author: z.string().nullable(),
   ts: z.string(),
 });
+
 export type SessionMeta = z.infer<typeof sessionMetaSchema>;
 
 // Version 3: `review publish` owns validation, bundling, and sealing; the
 // desktop serves prebuilt revisions and exposes /publish-ready instead of the
 // removed /publish route. (Version 2 added the bundled-CLI discovery fields.)
 export const REVIEW_DESKTOP_DISCOVERY_VERSION = 3;
+
 // Version 5: document and software-map bundles are JSON.
 export const REVIEW_SCHEMA_VERSION = 5;
 
 const requiredString = z
   .string({ error: "must be a string" })
   .refine((value) => value.trim().length > 0, "must be a string");
+
 const stringAllowEmpty = z.string({ error: "must be a string" });
+
 const positiveInteger = z
   .number({ error: "must be a positive integer" })
   .int("must be a positive integer")
   .positive("must be a positive integer");
+
 const nonNegativeInteger = z
   .number({ error: "must be a non-negative integer" })
   .int("must be a non-negative integer")
   .nonnegative("must be a non-negative integer");
+
 const reviewDiffSideSchema = z.enum(["base", "head"], {
   error: "must be base or head",
 });
+
 export const reviewViewSchema = z.enum([
   "review",
   "commits",
@@ -59,7 +67,9 @@ export const reviewViewSchema = z.enum([
   "map",
   "trace",
 ]);
+
 export type ReviewView = z.infer<typeof reviewViewSchema>;
+
 const reviewThemeSchema = z.enum(["light", "dark"], {
   error: "must be light or dark",
 });
@@ -70,6 +80,7 @@ function urlSchema(
 ) {
   return requiredString.transform((value, context) => {
     let url: URL;
+
     try {
       url = new URL(value);
     } catch {
@@ -77,23 +88,30 @@ function urlSchema(
         code: "custom",
         message: "must be an absolute URL",
       });
+
       return z.NEVER;
     }
+
     const error = constraint?.(url);
+
     if (error) {
       context.addIssue({ code: "custom", message: error });
+
       return z.NEVER;
     }
+
     return output === "origin" ? url.origin : url.href;
   });
 }
 
 const absoluteUrlSchema = urlSchema("href");
+
 const loopbackUrlSchema = urlSchema("href", (url) =>
   url.protocol === "http:" && url.hostname === "127.0.0.1" && url.port
     ? null
     : "must use http://127.0.0.1:<port>",
 ).transform((value) => value.replace(/\/$/, ""));
+
 const loopbackOriginSchema = urlSchema("origin", (url) =>
   url.protocol === "http:" && url.hostname === "127.0.0.1" && url.port
     ? null
@@ -103,8 +121,10 @@ const loopbackOriginSchema = urlSchema("origin", (url) =>
 export function normalizeReviewRoutePath(pathname: string): string {
   const pathnameOnly = String(pathname || "/").split(/[?#]/)[0] || "/";
   let end = pathnameOnly.length;
+
   while (end > 1 && pathnameOnly.charCodeAt(end - 1) === 47) end--;
   const trimmed = pathnameOnly.slice(0, end) || "/";
+
   return trimmed === "/"
     ? "/"
     : trimmed.startsWith("/")
@@ -125,12 +145,18 @@ export const ReviewRuntimeConfigSchema = z.strictObject({
   theme: reviewThemeSchema,
   host: z.literal("desktop"),
 });
+
 export type ReviewRuntimeConfig = z.infer<typeof ReviewRuntimeConfigSchema>;
+
 export type ReviewHost = ReviewRuntimeConfig["host"];
+
 export type ReviewTheme = ReviewRuntimeConfig["theme"];
+
 export type ReviewDiffSide = z.infer<typeof reviewDiffSideSchema>;
+
 /** How embedded diffs lay out: base and head side by side, or one column. */
 export const REVIEW_DIFF_LAYOUTS = ["split", "unified"] as const;
+
 export type ReviewDiffLayout = (typeof REVIEW_DIFF_LAYOUTS)[number];
 
 export interface ReviewDisposable {
@@ -140,10 +166,12 @@ export interface ReviewDisposable {
 const threadTargetNonEmptyStringSchema = z
   .string({ error: "must be a non-empty string" })
   .min(1, "must be a non-empty string");
+
 const threadTargetNonNegativeIntegerSchema = z.coerce
   .number({ error: "must be a non-negative integer" })
   .int("must be a non-negative integer")
   .nonnegative("must be a non-negative integer");
+
 const threadTargetPositiveIntegerSchema = z.coerce
   .number({ error: "must be a positive integer" })
   .int("must be a positive integer")
@@ -155,6 +183,7 @@ const ThreadSelectionSchema = z.strictObject({
   hash: threadTargetNonEmptyStringSchema,
   quote: threadTargetNonEmptyStringSchema,
 });
+
 export type ThreadSelection = z.infer<typeof ThreadSelectionSchema>;
 
 const TextSurfaceSchema = z.discriminatedUnion(
@@ -189,10 +218,12 @@ const TextSurfaceSchema = z.discriminatedUnion(
   ],
   "must be document, block, table-cell, or anchor",
 );
+
 export type TextSurface = z.infer<typeof TextSurfaceSchema>;
 
 const gitLabPositionNullableString = (maxLength: number) =>
   z.string().max(maxLength).nullable().optional();
+
 const gitLabPositionNullableInteger = z.number().int().nullable().optional();
 
 export const GitLabDiffLinePositionSchema = z.strictObject({
@@ -203,6 +234,7 @@ export const GitLabDiffLinePositionSchema = z.strictObject({
   old_line: gitLabPositionNullableInteger,
   new_line: gitLabPositionNullableInteger,
 });
+
 export type GitLabDiffLinePosition = z.infer<
   typeof GitLabDiffLinePositionSchema
 >;
@@ -244,6 +276,7 @@ export const GitLabDiffPositionSchema = z.strictObject({
     .optional(),
   ignore_whitespace_change: z.boolean().nullable().optional(),
 });
+
 export type GitLabDiffPosition = z.infer<typeof GitLabDiffPositionSchema>;
 
 export interface GitLabTextDiffRow {
@@ -268,10 +301,12 @@ export function createGitLabTextDiffPosition(
   input: CreateGitLabTextDiffPositionInput,
 ): GitLabDiffPosition {
   const path = input.new_path ?? input.old_path;
+
   if (!path) throw new Error("A GitLab diff position must have a file path.");
   const filePathHash = input.file_path_hash ?? gitLabLineCodePathHash(path);
   const start = gitLabDiffLinePosition(filePathHash, input.start);
   const end = gitLabDiffLinePosition(filePathHash, input.end);
+
   return {
     base_sha: input.base_sha,
     start_sha: input.start_sha,
@@ -304,10 +339,12 @@ export function gitLabLineCodePathHash(value: string): string {
   let h3 = 0x10325476;
   let h4 = 0xc3d2e1f0;
   const words = new Uint32Array(80);
+
   for (let offset = 0; offset < length; offset += 64) {
     for (let index = 0; index < 16; index += 1) {
       words[index] = view.getUint32(offset + index * 4, false);
     }
+
     for (let index = 16; index < 80; index += 1) {
       words[index] = rotateLeft(
         words[index - 3]! ^
@@ -317,19 +354,23 @@ export function gitLabLineCodePathHash(value: string): string {
         1,
       );
     }
+
     let a = h0;
     let b = h1;
     let c = h2;
     let d = h3;
     let e = h4;
+
     for (let index = 0; index < 80; index += 1) {
       const group = Math.floor(index / 20);
+
       const f =
         group === 0
           ? (b & c) | (~b & d)
           : group === 2
             ? (b & c) | (b & d) | (c & d)
             : b ^ c ^ d;
+
       const k = [0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xca62c1d6][group]!;
       const next = (rotateLeft(a, 5) + f + e + k + words[index]!) >>> 0;
       e = d;
@@ -338,12 +379,14 @@ export function gitLabLineCodePathHash(value: string): string {
       b = a;
       a = next;
     }
+
     h0 = (h0 + a) >>> 0;
     h1 = (h1 + b) >>> 0;
     h2 = (h2 + c) >>> 0;
     h3 = (h3 + d) >>> 0;
     h4 = (h4 + e) >>> 0;
   }
+
   return [h0, h1, h2, h3, h4]
     .map((word) => word.toString(16).padStart(8, "0"))
     .join("");
@@ -359,6 +402,7 @@ export function gitLabDiffPositionRows(
   position: GitLabDiffPosition,
 ): { start: GitLabTextDiffRow; end: GitLabTextDiffRow } | null {
   if (position.position_type !== "text") return null;
+
   if (position.line_range) {
     return {
       start: {
@@ -371,10 +415,12 @@ export function gitLabDiffPositionRows(
       },
     };
   }
+
   const row = {
     old_line: position.old_line ?? null,
     new_line: position.new_line ?? null,
   };
+
   return row.old_line === null && row.new_line === null
     ? null
     : { start: row, end: row };
@@ -387,6 +433,7 @@ function gitLabDiffLinePosition(
   if (row.old_line === null && row.new_line === null) {
     throw new Error("A GitLab text diff row must have an old or new line.");
   }
+
   return {
     line_code: `${filePathHash}_${row.old_line ?? 0}_${row.new_line ?? 0}`,
     type:
@@ -421,6 +468,7 @@ export const CodeThreadTargetSchema = z
         });
       }
     }
+
     if (
       target.change_position &&
       !isCompleteReviewCodePosition(target.change_position)
@@ -432,6 +480,7 @@ export const CodeThreadTargetSchema = z
       });
     }
   });
+
 export type CodeThreadTarget = z.infer<typeof CodeThreadTargetSchema>;
 
 export const ThreadTargetSchema = z.discriminatedUnion(
@@ -462,6 +511,7 @@ export const ThreadTargetSchema = z.discriminatedUnion(
   ],
   "must be document, code, text, or graph",
 );
+
 export type ThreadTarget = z.infer<typeof ThreadTargetSchema>;
 
 export const CreateReviewCommentInputSchema = z.strictObject({
@@ -471,6 +521,7 @@ export const CreateReviewCommentInputSchema = z.strictObject({
   body: threadTargetNonEmptyStringSchema,
   agentInput: z.boolean().optional(),
 });
+
 export type CreateReviewCommentInput = z.infer<
   typeof CreateReviewCommentInputSchema
 >;
@@ -479,6 +530,7 @@ export const ReviewCommentAgentSessionSchema = z.strictObject({
   harness: z.enum(["codex", "claude-code", "opencode", "pi"]),
   sessionId: threadTargetNonEmptyStringSchema,
 });
+
 export type ReviewCommentAgentSession = z.infer<
   typeof ReviewCommentAgentSessionSchema
 >;
@@ -500,9 +552,11 @@ export const ReviewCommentThreadRecordSchema = z.strictObject({
     }),
   ),
 });
+
 export type ReviewCommentThreadRecord = z.infer<
   typeof ReviewCommentThreadRecordSchema
 >;
+
 export type ReviewCommentMessage =
   ReviewCommentThreadRecord["messages"][number];
 
@@ -533,6 +587,7 @@ export const ReviewCommentThreadMapSchema = z
       }
     }
   });
+
 export type ReviewCommentThreadMap = z.infer<
   typeof ReviewCommentThreadMapSchema
 >;
@@ -541,6 +596,7 @@ export const ReviewCommentDraftThreadSchema = z.strictObject({
   thread: ReviewCommentThreadRecordSchema,
   inputs: z.array(CreateReviewCommentInputSchema).min(1),
 });
+
 export type ReviewCommentDraftThread = z.infer<
   typeof ReviewCommentDraftThreadSchema
 >;
@@ -556,6 +612,7 @@ export const ReviewCommentDraftThreadMapSchema = z
           message: "must match the storage key",
         });
       }
+
       for (const [index, input] of draft.inputs.entries()) {
         if (input.threadId !== threadId) {
           context.addIssue({
@@ -567,6 +624,7 @@ export const ReviewCommentDraftThreadMapSchema = z
       }
     }
   });
+
 export type ReviewCommentDraftThreadMap = z.infer<
   typeof ReviewCommentDraftThreadMapSchema
 >;
@@ -582,12 +640,15 @@ export function parseReviewCommentThreadMap(
 ): ReviewCommentThreadMap {
   if (!isJsonObject(value)) return {};
   const comments: ReviewCommentThreadMap = {};
+
   for (const [threadId, candidate] of Object.entries(value)) {
     const parsed = ReviewCommentThreadRecordSchema.safeParse(candidate);
+
     if (parsed.success && parsed.data.threadId === threadId) {
       comments[threadId] = parsed.data;
     }
   }
+
   return comments;
 }
 
@@ -598,6 +659,7 @@ export const ReviewThreadsSnapshotSchema = z.strictObject({
   comments: ReviewCommentThreadMapSchema,
   drafts: ReviewCommentDraftThreadMapSchema,
 });
+
 export type ReviewThreadsSnapshot = z.infer<typeof ReviewThreadsSnapshotSchema>;
 
 export const ReviewThreadsCommitSchema = z.strictObject({
@@ -613,6 +675,7 @@ export const ReviewThreadsCommitSchema = z.strictObject({
   ),
   deletedDraftThreadIds: z.array(threadTargetNonEmptyStringSchema),
 });
+
 export type ReviewThreadsCommit = z.infer<typeof ReviewThreadsCommitSchema>;
 
 const ReviewCommentUpdateSchema = z.strictObject({
@@ -667,6 +730,7 @@ export const ReviewThreadsCommandSchema = z.discriminatedUnion("command", [
     messageId: threadTargetNonEmptyStringSchema,
   }),
 ]);
+
 export type ReviewThreadsCommand = z.infer<typeof ReviewThreadsCommandSchema>;
 
 export interface ReviewLocalCommentThread {
@@ -913,9 +977,11 @@ export interface ReviewCanvasOnboarding {
 // Both lists mirror the workbench side (`reviewThemeChoice.ts` and
 // `REVIEW_KEYMAPS` in `reviewConfigurationDefaults.ts`).
 export const REVIEW_THEME_CHOICES = ["dark", "light", "system"] as const;
+
 export type ReviewThemeChoice = (typeof REVIEW_THEME_CHOICES)[number];
 
 export const REVIEW_KEYMAP_CHOICES = ["none", "vim", "emacs"] as const;
+
 export type ReviewKeymapChoice = (typeof REVIEW_KEYMAP_CHOICES)[number];
 
 export const REVIEW_TUTORIAL_STEP_IDS = [
@@ -932,7 +998,9 @@ export const REVIEW_TUTORIAL_STEP_IDS = [
   "chooseKeymap",
   "openTraceQuote",
 ] as const;
+
 export type TutorialStepId = (typeof REVIEW_TUTORIAL_STEP_IDS)[number];
+
 export const REVIEW_TUTORIAL_PROGRESS_STORAGE_KEY =
   "review.tutorial.progress.v1";
 
@@ -1127,6 +1195,7 @@ export const ReviewDesktopDiscoverySchema = z.object({
   // PATH.
   cliRuntimePath: requiredString.optional(),
 });
+
 export type ReviewDesktopDiscovery = z.infer<
   typeof ReviewDesktopDiscoverySchema
 >;
@@ -1139,9 +1208,11 @@ export const ReviewRepositoryIdentitySchema = z.strictObject({
   repositoryPath: requiredString,
   worktreeRoot: requiredString,
 });
+
 export type ReviewRepositoryIdentity = z.infer<
   typeof ReviewRepositoryIdentitySchema
 >;
+
 export type ReviewRepositoryKind = ReviewRepositoryIdentity["kind"];
 
 export const ReviewStatusSchema = z.enum([
@@ -1156,6 +1227,7 @@ export const ReviewSourceIdentitySchema = z.strictObject({
   kind: z.enum(["git-branch", "git-commit", "jj-bookmark", "jj-change"]),
   name: requiredString,
 });
+
 export type ReviewSourceIdentity = z.infer<typeof ReviewSourceIdentitySchema>;
 
 export const ReviewAgentSessionRoleSchema = z.enum([
@@ -1165,6 +1237,7 @@ export const ReviewAgentSessionRoleSchema = z.enum([
   "updater",
   "question",
 ]);
+
 export type ReviewAgentSessionRole = z.infer<
   typeof ReviewAgentSessionRoleSchema
 >;
@@ -1174,6 +1247,7 @@ export const ReviewAgentSessionAttributionSchema = z.strictObject({
   firstSeenAt: requiredString,
   lastSeenAt: requiredString,
 });
+
 export type ReviewAgentSessionAttribution = z.infer<
   typeof ReviewAgentSessionAttributionSchema
 >;
@@ -1210,6 +1284,7 @@ export const ReviewRecordSchema = z.strictObject({
   viewedAt: requiredString.nullable().optional(),
   dismissedAt: requiredString.nullable().optional(),
 });
+
 export type ReviewRecord = z.infer<typeof ReviewRecordSchema>;
 
 export const ReviewCommitSummarySchema = z.strictObject({
@@ -1226,6 +1301,7 @@ export const ReviewCommitSummarySchema = z.strictObject({
   additions: z.number().int().nonnegative(),
   deletions: z.number().int().nonnegative(),
 });
+
 export type ReviewCommitSummary = z.infer<typeof ReviewCommitSummarySchema>;
 
 export const ReviewDescriptorSchema = z.strictObject({
@@ -1267,6 +1343,7 @@ export const ReviewDescriptorSchema = z.strictObject({
      setting. Null when retention is off or the review is not dismissed. */
   reapsAt: requiredString.nullable().optional(),
 });
+
 export type ReviewDescriptor = z.infer<typeof ReviewDescriptorSchema>;
 
 export const ReviewSessionDescriptorSchema = z.strictObject({
@@ -1281,6 +1358,7 @@ export const ReviewSessionDescriptorSchema = z.strictObject({
     .regex(/^[0-9a-f]{40}$/)
     .optional(),
 });
+
 export type ReviewSessionDescriptor = z.infer<
   typeof ReviewSessionDescriptorSchema
 >;
@@ -1291,6 +1369,7 @@ export const ReviewDocumentVersionSchema = z.strictObject({
   sealedAt: positiveInteger,
   isCurrent: z.boolean(),
 });
+
 export type ReviewDocumentVersionWire = z.infer<
   typeof ReviewDocumentVersionSchema
 >;
@@ -1300,6 +1379,7 @@ export const AuthoringAgentSessionSchema = z.strictObject({
   harness: z.enum(["claude-code", "codex", "opencode", "pi"]),
   sessionId: requiredString,
 });
+
 export type AuthoringAgentSessionWire = z.infer<
   typeof AuthoringAgentSessionSchema
 >;
@@ -1317,6 +1397,7 @@ export const ReviewErrorDetailSchema = z.discriminatedUnion("code", [
     reviewUuid: z.uuid({ error: "must be a UUID" }),
   }),
 ]);
+
 export type ReviewErrorDetail = z.infer<typeof ReviewErrorDetailSchema>;
 
 export const ReviewErrorResponseSchema = z
@@ -1332,6 +1413,7 @@ export const ReviewErrorResponseSchema = z
     path: ["detail"],
     message: "An error reports either a bare code or a structured detail",
   });
+
 export type ReviewErrorResponse = z.infer<typeof ReviewErrorResponseSchema>;
 
 export const ReviewThreadsSnapshotResponseSchema = z.discriminatedUnion("ok", [
@@ -1341,6 +1423,7 @@ export const ReviewThreadsSnapshotResponseSchema = z.discriminatedUnion("ok", [
   }),
   ReviewErrorResponseSchema,
 ]);
+
 export type ReviewThreadsSnapshotResponse = z.infer<
   typeof ReviewThreadsSnapshotResponseSchema
 >;
@@ -1352,6 +1435,7 @@ export const ReviewThreadsCommandResponseSchema = z.discriminatedUnion("ok", [
   }),
   ReviewErrorResponseSchema,
 ]);
+
 export type ReviewThreadsCommandResponse = z.infer<
   typeof ReviewThreadsCommandResponseSchema
 >;
@@ -1362,6 +1446,7 @@ export const ReviewOpenResponseSchema = z.strictObject({
   session: ReviewSessionDescriptorSchema,
   review: ReviewDescriptorSchema,
 });
+
 export type ReviewOpenResponse = z.infer<typeof ReviewOpenResponseSchema>;
 
 /* The tutorial Review is not in the review store, so `GET /reviews` never
@@ -1374,6 +1459,7 @@ export const ReviewTutorialOpenResponseSchema = z.strictObject({
   review: ReviewDescriptorSchema,
   session: ReviewSessionDescriptorSchema,
 });
+
 export type ReviewTutorialOpenResponse = z.infer<
   typeof ReviewTutorialOpenResponseSchema
 >;
@@ -1392,7 +1478,9 @@ export const ReviewListResponseSchema = z.strictObject({
     }),
   ),
 });
+
 export type ReviewListResponse = z.infer<typeof ReviewListResponseSchema>;
+
 export type ReviewListError = ReviewListResponse["errors"][number];
 
 export const ReviewStackLayerSchema = z.strictObject({
@@ -1403,17 +1491,20 @@ export const ReviewStackLayerSchema = z.strictObject({
   reviewTitle: stringAllowEmpty.nullable(),
   relation: z.enum(["earlier", "current", "later"]),
 });
+
 export type ReviewStackLayer = z.infer<typeof ReviewStackLayerSchema>;
 
 export const ReviewStackResponseSchema = z.strictObject({
   layers: z.array(ReviewStackLayerSchema),
 });
+
 export type ReviewStackResponse = z.infer<typeof ReviewStackResponseSchema>;
 
 export const ReviewCliInstallTargetSchema = z.enum(
   ["claude", "codex", "cursor", "opencode", "pi"],
   { error: "must be claude, codex, cursor, opencode, or pi" },
 );
+
 export type ReviewCliInstallTarget = z.infer<
   typeof ReviewCliInstallTargetSchema
 >;
@@ -1421,6 +1512,7 @@ export type ReviewCliInstallTarget = z.infer<
 export const ReviewFffInstallTargetSchema = z.enum(["claude", "codex", "pi"], {
   error: "must be claude, codex, or pi",
 });
+
 export type ReviewFffInstallTarget = z.infer<
   typeof ReviewFffInstallTargetSchema
 >;
@@ -1430,6 +1522,7 @@ export const ReviewFffManagedRegistrationSchema = z.strictObject({
   command: requiredString,
   args: z.array(requiredString),
 });
+
 export type ReviewFffManagedRegistration = z.infer<
   typeof ReviewFffManagedRegistrationSchema
 >;
@@ -1445,6 +1538,7 @@ export const ReviewCliInstallStampSchema = z.strictObject({
   traceManaged: z.boolean().optional(),
   updatedAt: requiredString,
 });
+
 export type ReviewCliInstallStamp = z.infer<typeof ReviewCliInstallStampSchema>;
 
 export const ReviewCliInstallStatusSchema = z.strictObject({
@@ -1507,6 +1601,7 @@ export const ReviewCliInstallStatusSchema = z.strictObject({
     .strictObject({ path: requiredString, version: requiredString })
     .nullable(),
 });
+
 export type ReviewCliInstallStatus = z.infer<
   typeof ReviewCliInstallStatusSchema
 >;
@@ -1542,6 +1637,7 @@ export const ReviewCliInstallApplyRequestSchema = z
       request.trace !== undefined,
     { message: "must install skills, the command, FFF, or trace capture" },
   );
+
 export type ReviewCliInstallApplyRequest = z.infer<
   typeof ReviewCliInstallApplyRequestSchema
 >;
@@ -1551,6 +1647,7 @@ export const ReviewCliInstallApplyResponseSchema = z.strictObject({
   output: stringAllowEmpty,
   shimPath: requiredString.optional(),
 });
+
 export type ReviewCliInstallApplyResponse = z.infer<
   typeof ReviewCliInstallApplyResponseSchema
 >;
@@ -1565,6 +1662,7 @@ export const ReviewPublishReadyRequestSchema = z.strictObject({
   agent: AuthoringAgentSessionSchema.optional(),
   view: reviewViewSchema.optional(),
 });
+
 export type ReviewPublishReadyRequest = z.infer<
   typeof ReviewPublishReadyRequestSchema
 >;
@@ -1585,6 +1683,7 @@ export const ReviewSubmissionWireSchema = z.strictObject({
   comments: z.array(z.unknown()),
   prompt: stringAllowEmpty,
 });
+
 export type ReviewSubmissionWire = z.infer<typeof ReviewSubmissionWireSchema>;
 
 export const ReviewSessionLifecycleEventSchema = z.discriminatedUnion("event", [
@@ -1605,6 +1704,7 @@ export const ReviewSessionLifecycleEventSchema = z.discriminatedUnion("event", [
     error: requiredString,
   }),
 ]);
+
 export type ReviewSessionLifecycleEvent = z.infer<
   typeof ReviewSessionLifecycleEventSchema
 >;
@@ -1682,6 +1782,7 @@ export const ReviewDesktopGlobalEventSchema = z.discriminatedUnion("event", [
     }),
   }),
 ]);
+
 export type ReviewDesktopGlobalEvent = z.infer<
   typeof ReviewDesktopGlobalEventSchema
 >;
@@ -1714,6 +1815,7 @@ export const ReviewSessionSchema = z.strictObject({
     .optional(),
   startedAt: positiveInteger,
 });
+
 export type ReviewSessionWire = z.infer<typeof ReviewSessionSchema>;
 
 export const ReviewDiffFileSchema = z.strictObject({
@@ -1724,6 +1826,7 @@ export const ReviewDiffFileSchema = z.strictObject({
   deletions: nonNegativeInteger,
   patch: requiredString.optional(),
 });
+
 export type ReviewDiffFileWire = z.infer<typeof ReviewDiffFileSchema>;
 
 export interface ReviewDiffStats {
@@ -1756,6 +1859,7 @@ export const ReviewDiffFilesRequestSchema = z.strictObject({
     .regex(/^[0-9a-f]{40}$/i, "must be a 40-hex revision")
     .optional(),
 });
+
 export type ReviewDiffFilesRequest = z.infer<
   typeof ReviewDiffFilesRequestSchema
 >;
@@ -1769,6 +1873,7 @@ export const ReviewDiffFilesResponseSchema = z.discriminatedUnion("ok", [
   }),
   ReviewErrorResponseSchema,
 ]);
+
 export type ReviewDiffFilesResponse = z.infer<
   typeof ReviewDiffFilesResponseSchema
 >;
@@ -1781,6 +1886,7 @@ export const ReviewFileContentRequestSchema = z.strictObject({
     .regex(/^[0-9a-f]{40}$/i, "must be a 40-hex revision")
     .optional(),
 });
+
 export type ReviewFileContentRequest = z.infer<
   typeof ReviewFileContentRequestSchema
 >;
@@ -1795,6 +1901,7 @@ export const ReviewFileContentResponseSchema = z.union([
   z.strictObject({ ok: z.literal(true), binary: z.literal(true) }),
   ReviewErrorResponseSchema,
 ]);
+
 export type ReviewFileContentResponse = z.infer<
   typeof ReviewFileContentResponseSchema
 >;
@@ -1807,6 +1914,7 @@ export const ReviewSessionResponseSchema = z.discriminatedUnion("ok", [
   }),
   ReviewErrorResponseSchema,
 ]);
+
 export type ReviewSessionResponse = z.infer<typeof ReviewSessionResponseSchema>;
 
 export const ReviewDocumentResponseSchema = z.discriminatedUnion("ok", [
@@ -1817,6 +1925,7 @@ export const ReviewDocumentResponseSchema = z.discriminatedUnion("ok", [
   }),
   ReviewErrorResponseSchema,
 ]);
+
 export type ReviewDocumentResponse = z.infer<
   typeof ReviewDocumentResponseSchema
 >;
@@ -1830,6 +1939,7 @@ export const ReviewSoftwareMapResponseSchema = z.discriminatedUnion("ok", [
   }),
   ReviewErrorResponseSchema,
 ]);
+
 export type ReviewSoftwareMapResponse = z.infer<
   typeof ReviewSoftwareMapResponseSchema
 >;
@@ -1849,6 +1959,7 @@ export const ReviewServerEventSchema = z.discriminatedUnion("event", [
     commit: ReviewThreadsCommitSchema,
   }),
 ]);
+
 export type ReviewServerEvent = z.infer<typeof ReviewServerEventSchema>;
 
 export const ReviewRangeSchema = z
@@ -1865,12 +1976,14 @@ export const ReviewRangeSchema = z
       });
     }
   });
+
 export type ReviewRangeWire = z.infer<typeof ReviewRangeSchema>;
 
 export const ReviewOpenEditorSchema = z.strictObject({
   path: requiredString,
   scheme: requiredString,
 });
+
 export type ReviewOpenEditorWire = z.infer<typeof ReviewOpenEditorSchema>;
 
 export const ReviewEditorSelectionSchema = z.strictObject({
@@ -1880,6 +1993,7 @@ export const ReviewEditorSelectionSchema = z.strictObject({
   endLine: positiveInteger,
   endColumn: positiveInteger,
 });
+
 export type ReviewEditorSelectionWire = z.infer<
   typeof ReviewEditorSelectionSchema
 >;
@@ -1889,6 +2003,7 @@ export const ReviewDesktopStateSchema = z.strictObject({
   activeEditor: ReviewOpenEditorSchema.nullable(),
   selection: ReviewEditorSelectionSchema.nullable(),
 });
+
 export type ReviewDesktopState = z.infer<typeof ReviewDesktopStateSchema>;
 
 const reviewThreadDecorationKindSchema = z.enum([
@@ -1896,6 +2011,7 @@ const reviewThreadDecorationKindSchema = z.enum([
   "draft",
   "resolved",
 ]);
+
 export type ReviewThreadDecorationKind = z.infer<
   typeof reviewThreadDecorationKindSchema
 >;
@@ -1916,6 +2032,7 @@ export const ReviewThreadAnchorSchema = z
       });
     }
   });
+
 export type ReviewThreadAnchorWire = z.infer<typeof ReviewThreadAnchorSchema>;
 
 const openFileArgsSchema = z
@@ -1945,6 +2062,7 @@ const openFileArgsSchema = z
       });
     }
   });
+
 const revealArgsSchema = z
   .strictObject({
     path: requiredString,
@@ -2052,12 +2170,14 @@ export const ReviewVerbRequestSchema = z.discriminatedUnion("name", [
   }),
   z.strictObject({ name: z.literal("state"), args: z.strictObject({}) }),
 ]);
+
 export type ReviewVerbRequest = z.infer<typeof ReviewVerbRequestSchema>;
 
 export const ReviewVerbResponseSchema = z.discriminatedUnion("ok", [
   z.strictObject({ ok: z.literal(true), result: z.unknown().optional() }),
   ReviewErrorResponseSchema,
 ]);
+
 export type ReviewVerbResponse = z.infer<typeof ReviewVerbResponseSchema>;
 
 export const ReviewDesktopVerbFrameSchema = z.strictObject({
@@ -2066,6 +2186,7 @@ export const ReviewDesktopVerbFrameSchema = z.strictObject({
   sessionId: requiredString,
   request: ReviewVerbRequestSchema,
 });
+
 export type ReviewDesktopVerbFrame = z.infer<
   typeof ReviewDesktopVerbFrameSchema
 >;
@@ -2075,6 +2196,7 @@ export const ReviewDesktopVerbResultSchema = z.strictObject({
   sessionId: requiredString,
   response: ReviewVerbResponseSchema,
 });
+
 export type ReviewDesktopVerbResult = z.infer<
   typeof ReviewDesktopVerbResultSchema
 >;
@@ -2112,6 +2234,7 @@ export const ReviewSurfaceEventSchema = z.discriminatedUnion("event", [
     view: reviewViewSchema,
   }),
 ]);
+
 export type ReviewSurfaceEvent = z.infer<typeof ReviewSurfaceEventSchema>;
 
 // --- Agent trace view & trace quotes ----------------------------------------
@@ -2147,6 +2270,7 @@ export const ReviewAgentTraceEventSchema = z.discriminatedUnion("kind", [
     label: requiredString,
   }),
 ]);
+
 export type ReviewAgentTraceEvent = z.infer<typeof ReviewAgentTraceEventSchema>;
 
 export const ReviewAgentTraceSessionSchema = z.strictObject({
@@ -2160,6 +2284,7 @@ export const ReviewAgentTraceSessionSchema = z.strictObject({
     z.strictObject({ sha: requiredString, subject: stringAllowEmpty }),
   ),
 });
+
 export type ReviewAgentTraceSession = z.infer<
   typeof ReviewAgentTraceSessionSchema
 >;
@@ -2172,6 +2297,7 @@ export const ReviewAgentTraceListResponseSchema = z.discriminatedUnion("ok", [
   }),
   ReviewErrorResponseSchema,
 ]);
+
 export type ReviewAgentTraceListResponse = z.infer<
   typeof ReviewAgentTraceListResponseSchema
 >;
@@ -2193,6 +2319,7 @@ export const ReviewAgentTraceResponseSchema = z.discriminatedUnion("ok", [
   }),
   ReviewErrorResponseSchema,
 ]);
+
 export type ReviewAgentTraceResponse = z.infer<
   typeof ReviewAgentTraceResponseSchema
 >;

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1195,6 +1195,7 @@ export const ReviewRecordSchema = z.strictObject({
   pullRequestUrl: absoluteUrlSchema.nullable().optional(),
   title: stringAllowEmpty,
   sourceSession: requiredString,
+  titleOverride: z.string().optional(),
   agentSessions: z
     .record(requiredString, ReviewAgentSessionAttributionSchema)
     .optional(),
@@ -1609,6 +1610,11 @@ export type ReviewSessionLifecycleEvent = z.infer<
 >;
 
 export const ReviewDesktopGlobalEventSchema = z.discriminatedUnion("event", [
+  z.strictObject({
+    event: z.literal("review-metadata-changed"),
+    uuid: z.uuid(),
+    title: z.string(),
+  }),
   z.strictObject({
     event: z.literal("session-registered"),
     session: ReviewSessionDescriptorSchema,


### PR DESCRIPTION
Moves Review lifecycle and storage into the Desktop server. Metadata and comments share one desktop-owned database with per-Review isolation, supported legacy import/recovery, and one comment service for CLI/MCP requests and open canvases.

Scaffold, rebind, publication, repair, lookup, and comment operations use the Desktop API. The stdio MCP bridge and document-source commands use hashes to reject concurrent overwrites, preserve explicit titles, and reuse #187's native validation, sealing, and mount pipeline. Existing Ask now, Request changes, and agent-answer publication behavior remain covered.

Builds on #187, now based on main after #161 merged. #190 adds live document authoring on top.

The anti-slop cleanup normalizes install targets in one pass and selects all superseded sessions before starting their closes, preserving repair ordering. Remaining source changes are statement spacing.

Validation:
- All 120 configured source files changed by the full stack pass lint with `--deny-warnings` (zero warnings/errors) and formatting. The final stack passes package typecheck and 145 tests across 10 focused dependent files. Independent token comparison across the final stack found only only the intended collection rewrites beyond whitespace before the inherited heartbeat-test repair. No rule configuration or suppressions changed.
- After the final stack replay: package typecheck and 115 focused tests passed across lifecycle, publication, source edits, session behavior, cache retries/limits, and legacy migration failures.
- Earlier implementation validation included the full package suite, Desktop/native checks, and a Desktop smoke test exercising API scaffold, MCP authoring, publication, custom titles, comments, replies, and resolution.
- [Current-head CI passed](https://github.com/devdotfast/review/actions/runs/34555047733): Desktop build, tutorial validation, lint, formatting, typechecks, and workspace tests. The refresh preserves main's dependency security updates.
