### PR TITLE
Add native MDX live authoring through the desktop API

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
@@ -224,6 +224,9 @@ export class ReviewCanvasEditorPane extends EditorPane {
 	private readonly modelSubscription = this._register(
 		new MutableDisposable(),
 	);
+	private readonly documentSubscription = this._register(
+		new MutableDisposable(),
+	);
 	private readonly inlineEditors: ReviewInlineEditorService;
 	private readonly diffViews: ReviewDiffViewService;
 
@@ -428,6 +431,7 @@ export class ReviewCanvasEditorPane extends EditorPane {
 			this.inlineEditors.reset();
 			this.diffViews.reset();
 			this.modelSubscription.clear();
+			this.documentSubscription.clear();
 			// Not the full session reset the other branches run: the Source tab
 			// exists to browse the active review's worktree beside the tabs the
 			// tree opened. `verbs.resetSession()` would close those tabs, and
@@ -474,6 +478,7 @@ export class ReviewCanvasEditorPane extends EditorPane {
 			return;
 		}
 		this.modelSubscription.clear();
+		this.documentSubscription.clear();
 		if (input.target.kind === "home") {
 			this.renderedInput = input;
 			this.renderedModel = null;
@@ -1201,7 +1206,7 @@ export class ReviewCanvasEditorPane extends EditorPane {
 			if (generation !== this.loadGeneration) {
 				return new Error("Review canvas load was superseded.");
 			}
-			const document = model.resolveDocument(loadReviewDocumentData);
+			let document = model.resolveDocument(loadReviewDocumentData);
 			const softwareMapEnabled = this.currentSoftwareMapEnabled();
 			const softwareMap = softwareMapEnabled
 				? model.resolveSoftwareMap(loadReviewSoftwareMaps)
@@ -1223,7 +1228,7 @@ export class ReviewCanvasEditorPane extends EditorPane {
 				assets.clearReviewViewState(bridge.config);
 			}
 			let tutorial: ReviewCanvasTutorialBridge | undefined;
-			const renderSession = () =>
+			const renderSession = (renderGeneration = generation) =>
 				this.render(
 					{
 					kind: "session",
@@ -1242,7 +1247,7 @@ export class ReviewCanvasEditorPane extends EditorPane {
 					},
 					...(tutorial ? { tutorial } : {}),
 					},
-					generation,
+					renderGeneration,
 					assets,
 				);
 			if (input.target.kind === "review") {
@@ -1264,6 +1269,15 @@ export class ReviewCanvasEditorPane extends EditorPane {
 					closeTutorial,
 				);
 			}
+			this.documentSubscription.value = model.onDidChangeDocument(() => {
+				if (this.renderedInput !== input || this.renderedModel !== model) {
+					return;
+				}
+				document = model.resolveDocument(loadReviewDocumentData);
+				void renderSession(this.loadGeneration).catch((error) =>
+					this.logService.error(error),
+				);
+			});
 			await renderSession();
 			loadTimeout = setTimeout(
 				() =>

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewModuleCache.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewModuleCache.test.ts
@@ -57,3 +57,18 @@ test("clear forces the next load to run the loader again", async () => {
 	cache.clear();
 	assert.equal(await cache.load("a", loader), 2);
 });
+
+test("invalidating a live document leaves the map cached and ignores an older rejection", async () => {
+	const cache = new ReviewModuleCache();
+	let rejectOld!: (error: Error) => void;
+	const old = cache.load("document", () => new Promise<string>((_resolve, reject) => {
+		rejectOld = reject;
+	}));
+	assert.equal(await cache.load("map", async () => "original map"), "original map");
+	cache.delete("document");
+	assert.equal(await cache.load("document", async () => "new document"), "new document");
+	rejectOld(new Error("superseded"));
+	await assert.rejects(old, /superseded/);
+	assert.equal(await cache.load("document", async () => "wrong"), "new document");
+	assert.equal(await cache.load("map", async () => "wrong"), "original map");
+});

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewModuleCache.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewModuleCache.ts
@@ -33,4 +33,8 @@ export class ReviewModuleCache {
 	clear(): void {
 		this.entries.clear();
 	}
+
+	delete(key: string): void {
+		this.entries.delete(key);
+	}
 }

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionModelService.ts
@@ -76,6 +76,8 @@ class ReviewSessionUnavailableError extends Error {}
 export class ReviewSessionModel extends Disposable {
 	private readonly _onDidChange = this._register(new Emitter<void>());
 	readonly onDidChange = this._onDidChange.event;
+	private readonly _onDidChangeDocument = this._register(new Emitter<void>());
+	readonly onDidChangeDocument = this._onDidChangeDocument.event;
 
 	private _session: ReviewDesktopSession;
 	get session(): ReviewDesktopSession {
@@ -130,6 +132,14 @@ export class ReviewSessionModel extends Disposable {
 		this._register(
 			onDidChangeReviewData((event) => {
 				if (event.uuid !== this.reviewUuid || this._state !== "active") {
+					return;
+				}
+				if (event.documentChanged) {
+					if (event.sessionId !== this._session.session.sessionId) {
+						return;
+					}
+					this.modules.delete("document");
+					this._onDidChangeDocument.fire();
 					return;
 				}
 				this._onDidChange.fire();

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -62,6 +62,40 @@ validates and presents the result. Do not read or edit Review source directly
 on disk. Source repository inspection and software-map scratch files remain
 separate from Review document storage.
 
+#### Live canvas edits
+
+`review_get_live_document({ reviewUuid })` returns `mode`, `revision`,
+`sourceHash`, and ordered `{ id, source }` nodes. `source` is an MDX fragment,
+not a second component format: all native Review components are supported.
+Use `data.*` for exports from `data.ts`; edit that file through the document API.
+
+`review_mutate_document` takes `reviewUuid`, a fresh UUID `mutationId`, the
+last read `expectedSourceHash`, and one `operation`:
+
+- `{ type: "replace", nodes }` explicitly starts live authoring, replacing the old document.
+- `{ type: "insert", node, afterId }` inserts a new stable node.
+- `{ type: "update", node }` replaces the source of an existing node.
+- `{ type: "move", id, afterId }` reorders a node without changing its identity.
+- `{ type: "delete", id }` removes a node.
+
+`afterId: null` means the beginning. IDs start with a letter and contain only
+letters, digits, `_`, or `-` (at most 80 characters). Keep IDs stable across
+updates. Each accepted edit returns the next snapshot. Retrying the most recent
+request with the same mutation ID and payload returns that snapshot; a stale
+source hash or a reused ID with different content is a conflict.
+
+The desktop compiles each candidate before changing the MDX source. Invalid
+edits leave the document unchanged. The open current canvas receives validated
+updates without remounting its sibling components. Activity particles have an
+in-flow gutter and honor reduced-motion preferences.
+
+Live editing does not seal a publication, bypass the comment-response gate,
+or change historical versions. Use `review_publish` to initially open a new
+Review and to seal completed work. The shared database caches native previews;
+the MDX document retains the stable nodes and can rebuild that cache after a
+restart. Raw document-file writes remain explicit whole-file replacements;
+use node operations to preserve the live document structure.
+
 `review_list_comments`, `review_comment_command`, and `review_reply_comment`
 use the same comment service as the canvas. Replies are stored as agent
 messages, not reviewer messages. The existing `review threads` commands use

--- a/packages/progressive-review/app/src/App.tsx
+++ b/packages/progressive-review/app/src/App.tsx
@@ -697,7 +697,6 @@ function ReviewLayoutContent({
                   <ReviewToc />
                   <ReviewDocumentSelectionSurface articleRef={articleRef}>
                     <ReviewDocumentBoundary
-                      key={documentRevision}
                       session={session}
                       revision={documentRevision}
                       onError={(_revision, error) =>

--- a/packages/progressive-review/app/src/App.tsx
+++ b/packages/progressive-review/app/src/App.tsx
@@ -108,10 +108,15 @@ import { captureClientError, captureUiEvent } from "./ui-telemetry";
 import { useReviewTabTelemetry } from "./use-review-tab-telemetry";
 
 const DEFAULT_SIDE_PEEK_WIDTH = 560;
+
 const MIN_SIDE_PEEK_WIDTH = 360;
+
 const MAX_SIDE_PEEK_WIDTH = 920;
+
 const MIN_DOCUMENT_WIDTH = 560;
+
 const EMPTY_ANCHORS = new Map<string, AnchorRef>();
+
 const EMPTY_ANCHOR_CONTENTS = new Map<string, string>();
 
 export function App({
@@ -131,6 +136,7 @@ export function App({
 }): ReactElement {
   useWindowErrorTelemetry();
   const resolved = useResolvedReviewDocument(documentState);
+
   return (
     <ReviewDiffFilesProvider documentKey={resolved.diffDocumentKey}>
       <ReviewLayout
@@ -192,11 +198,14 @@ function useResolvedReviewDocument(
   documentState: ReviewDocumentAppState,
 ): ResolvedReviewDocument {
   const session = useReviewSession();
+
   return useMemo(() => {
     const document =
       documentState.state === "ready" ? documentState.document : null;
+
     const routePath = document?.routePath ?? session.config.routePath ?? "/";
     const filePath = document?.filePath ?? routePath;
+
     return {
       document,
       routePath,
@@ -213,7 +222,9 @@ function useWindowErrorTelemetry(): void {
     const handleError = (event: ErrorEvent) => {
       captureClientError(session, "window", event.error);
     };
+
     window.addEventListener("error", handleError);
+
     return () => window.removeEventListener("error", handleError);
   }, [session]);
 }
@@ -240,19 +251,24 @@ function ReviewLayout({
     routePath: documentRoute,
     revision: documentRevision,
   } = resolved;
+
   const softwareMap =
     softwareMapState.state === "ready" ? softwareMapState.softwareMap : null;
+
   const articleRef = useRef<HTMLElement | null>(null);
   const appRef = useRef<HTMLDivElement | null>(null);
   const shellRef = useRef<HTMLElement | null>(null);
   const scrollRegionRef = useRef<HTMLElement | null>(null);
+
   const [traceSelection, setTraceSelection] = useState<
     TraceSelection | undefined
   >(undefined);
+
   const roots = useMemo(
     () => ({ appRef, shellRef, scrollRegionRef, articleRef }),
     [],
   );
+
   return (
     <ReviewRootsProvider roots={roots}>
       <ReviewFindProvider
@@ -346,14 +362,18 @@ function ReviewLayoutContent({
   useSuppressPanelMotionOnCanvasResume(appRef);
   const activePanel = useReviewPanel((state) => state.active);
   const panelMotion = useReviewPanel((state) => state.motion);
+
   const closeForDocumentChange = useReviewPanel(
     (state) => state.closeForDocumentChange,
   );
+
   const closeForAgentTerminal = useReviewPanel(
     (state) => state.closeForAgentTerminal,
   );
+
   const openThreads = useReviewPanel((state) => state.openThreads);
   const debugSettings = useReviewDebugSettings();
+
   const sidePeekResize = useRightPanelResize({
     stateKey: "side-peek-width",
     defaultWidth: DEFAULT_SIDE_PEEK_WIDTH,
@@ -364,8 +384,10 @@ function ReviewLayoutContent({
     label: "Resize side peek",
     containerRef: appRef,
   });
+
   const viewStateSync = useReviewViewStateSync({ scrollRegionRef, panelStore });
   const hasChangeRange = range.baseCommit !== range.headCommit;
+
   const [activeView, setActiveView] = useState<ReviewView>(() =>
     normalizeReviewView(
       viewStateSync.initialActiveView ?? "review",
@@ -373,6 +395,7 @@ function ReviewLayoutContent({
       hasChangeRange,
     ),
   );
+
   const [diffScope, setDiffScope] = useState<ReviewCommitSummary | null>(null);
   const reviewFind = useReviewFindRegistration();
   useEffect(() => {
@@ -387,44 +410,55 @@ function ReviewLayoutContent({
       .then(async (res) => {
         if (!res.ok) return;
         const data: JsonValue = await res.json();
+
         const sessions =
           isJsonObject(data) && data.ok === true
             ? jsonArray(data.sessions)
             : undefined;
+
         if (sessions !== undefined && sessions.length > 0) {
           setHasTraceSessions(true);
         }
       })
       .catch(() => {});
+
     return () => controller.abort();
   }, [session]);
   const diffFiles = useReviewDiffFiles();
+
   const filesTabFileCount = diffScope
     ? diffScope.fileCount
     : diffFiles.status === "loaded"
       ? diffFiles.files.length
       : (initialDiffStats?.files?.length ?? null);
+
   const reviewViews: readonly ReviewView[] = [
     "review",
     ...(hasChangeRange ? (["commits", "diff"] as const) : []),
     ...(softwareMapEnabled ? (["map"] as const) : []),
     ...(hasTraceSessions ? (["trace"] as const) : []),
   ];
+
   const reviewViewsRef = useRef(reviewViews);
   reviewViewsRef.current = reviewViews;
+
   const applyReviewView = (view: ReviewView) => {
     const normalizedView = normalizeReviewView(
       view,
       softwareMapEnabled,
       hasChangeRange,
     );
+
     if (normalizedView !== "diff") setDiffScope(null);
+
     if (shouldCloseSidePeekForReviewView(normalizedView)) {
       closeForDocumentChange();
     }
+
     setActiveView(normalizedView);
     viewStateSync.persistActiveView(normalizedView);
   };
+
   useEffect(() => {
     if (
       normalizeReviewView(activeView, softwareMapEnabled, hasChangeRange) !==
@@ -435,14 +469,18 @@ function ReviewLayoutContent({
   }, [activeView, hasChangeRange, softwareMapEnabled]);
   useReviewTabTelemetry(activeView);
   const threadCount = review.allCommentThreads().length;
+
   const askPanelOpen =
     activePanel?.kind === "threads" && activePanel.page.kind === "new-ask";
+
   /* An open review batch means the next thing you write most likely joins it,
      so every entry point says "Comment" rather than "Ask". */
   const askOrCommentLabel =
     review.pendingCommentCount > 0 ? "New comment" : "New ask";
+
   const threadsPanelOpen =
     activePanel?.kind === "threads" && activePanel.page.kind !== "new-ask";
+
   useEffect(
     () =>
       session.surface.subscribe((event) => {
@@ -479,6 +517,7 @@ function ReviewLayoutContent({
       }
     });
   }, [session.surface]);
+
   const activeSoftwareMapSource = useMemo(
     () =>
       selectActiveSoftwareMapModel({
@@ -487,6 +526,7 @@ function ReviewLayoutContent({
       }),
     [review.softwareMapFocusRequest?.elementPath, softwareModels],
   );
+
   const activeSoftwareMap = useMemo(
     () =>
       applySoftwareMapTopologyStatuses(
@@ -495,8 +535,10 @@ function ReviewLayoutContent({
       ),
     [activeSoftwareMapSource, softwareMapTopologyDiff],
   );
+
   const rightPanelOpen = activePanel !== null;
   const mapOverlayOpen = useMapOverlayOpen(appRef);
+
   // SAFETY: `--side-peek-width` is a CSS custom property, which React forwards
   // to style.setProperty; the CSSProperties typings only omit custom names.
   const appStyle = rightPanelOpen
@@ -504,6 +546,7 @@ function ReviewLayoutContent({
         "--side-peek-width": `${sidePeekResize.width}px`,
       } as CSSProperties)
     : undefined;
+
   const appClassName = [
     "review-app",
     `review-app--theme-${debugSettings.theme}`,
@@ -894,6 +937,7 @@ function OpenCurrentReview({
   reviewUuid: string;
 }): ReactElement {
   const session = useReviewSession();
+
   return (
     <button
       type="button"
@@ -940,12 +984,14 @@ function ReviewBatonChip({
   outcome: ReviewSubmissionOutcome | null;
 }): ReactElement | null {
   if (!outcome) return null;
+
   const label =
     outcome === "changes-requested"
       ? "agent is updating"
       : outcome === "approved"
         ? "approved"
         : "dismissed";
+
   return (
     <span className={`review-baton-chip review-baton-chip--${outcome}`}>
       {outcome === "changes-requested" && (
@@ -983,25 +1029,33 @@ function useMapOverlayOpen(appRef: RefObject<HTMLDivElement | null>): boolean {
   const [open, setOpen] = useState(false);
   useEffect(() => {
     const app = appRef.current;
+
     if (!app) return;
+
     const update = () =>
       setOpen(Boolean(app.querySelector(".software-map-overlay")));
+
     update();
     const observer = new MutationObserver(update);
     observer.observe(app, { childList: true, subtree: true });
+
     return () => observer.disconnect();
   }, [appRef]);
+
   return open;
 }
 
 function FloatingDraftHost(): ReactElement | null {
   const review = useReview();
+
   const draftTarget = commentDraftTargetForSurface(
     review.draftTarget,
     "document",
   );
+
   if (!draftTarget) return null;
   const draftQuote = draftTarget.title ?? targetQuote(draftTarget.target);
+
   const submitDraft = (askAgent: boolean, body: string) => {
     const {
       draftSurface: _draftSurface,
@@ -1011,6 +1065,7 @@ function FloatingDraftHost(): ReactElement | null {
       messageId: _messageId,
       ...input
     } = draftTarget;
+
     if (askAgent) {
       void review.askAgent({
         ...input,
@@ -1018,8 +1073,10 @@ function FloatingDraftHost(): ReactElement | null {
         body,
       });
       review.closeCommentDraft();
+
       return;
     }
+
     void review
       .saveComment({
         ...input,
@@ -1030,6 +1087,7 @@ function FloatingDraftHost(): ReactElement | null {
         review.closeCommentDraft();
       });
   };
+
   return (
     <div className="review-floating-draft">
       <ThreadDraftCard
@@ -1058,22 +1116,28 @@ function MapSettingsControl(): ReactElement {
     nodeTint,
     setNodeTint,
   } = useReviewDebugSettings();
+
   const controlRef = useRef<HTMLDivElement | null>(null);
   const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
     if (!isOpen) return;
+
     const closeOnOutsidePointerDown = (event: PointerEvent) => {
       const target = event.target;
+
       if (target instanceof Node && controlRef.current?.contains(target))
         return;
       setIsOpen(false);
     };
+
     const closeOnEscape = (event: KeyboardEvent) => {
       if (event.key === "Escape") setIsOpen(false);
     };
+
     document.addEventListener("pointerdown", closeOnOutsidePointerDown, true);
     document.addEventListener("keydown", closeOnEscape);
+
     return () => {
       document.removeEventListener(
         "pointerdown",
@@ -1170,6 +1234,7 @@ function DebugSwitch({
 
 function nodeTintLabel(tint: ReviewNodeTint) {
   if (tint === "none") return "None";
+
   return tint === "slate" ? "Slate" : "Mineral";
 }
 
@@ -1178,12 +1243,15 @@ export function applySoftwareMapTopologyStatuses(
   diff: SoftwareMapTopologyDiff | null,
 ): NormalizedSoftwareModel | undefined {
   if (!model || !diff) return model;
+
   const elements = model.elements.map((element): NormalizedSoftwareElement => {
     const topologyStatus = diff.elementStatusByPath[element.path];
+
     return topologyStatus
       ? { ...element, changeStatus: topologyStatus }
       : element;
   });
+
   return {
     ...model,
     elements,
@@ -1199,7 +1267,9 @@ function SelectionCommentButton({
   clearTarget: () => void;
 }) {
   const review = useReview();
+
   if (!target || review.historicalRevision) return null;
+
   return (
     <div
       className="selection-action-buttons selection-action-buttons--anchored"
@@ -1235,11 +1305,15 @@ function ReviewDocumentSelectionSurface({
 }) {
   const [selectionTarget, setSelectionTarget] =
     useState<SelectionTarget | null>(null);
+
   useEffect(() => {
     const article = articleRef.current;
+
     if (!article) return;
+
     return observeDocumentSelection(article, setSelectionTarget);
   }, [articleRef]);
+
   return (
     <article ref={articleRef} className="review-document">
       {children}

--- a/packages/progressive-review/app/src/desktop-entry.test.tsx
+++ b/packages/progressive-review/app/src/desktop-entry.test.tsx
@@ -10,6 +10,7 @@ import { parseJsonText } from "@dev.fast/review-protocol";
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { ReviewNode } from "../../src/review-document-data";
 import { bundleReviewSoftwareMap } from "../../src/software-map-bundle";
 import { mountReviewCanvas } from "./desktop-entry";
 import { testReviewBridge } from "./review-session-test-utils";
@@ -771,6 +772,126 @@ describe("publication validation mounts", () => {
       await act(async () => handle?.dispose());
     }
   });
+});
+
+it("keeps keyed rich components mounted while a live revision loads, inserts, and reorders nodes", async () => {
+  const bridge = testReviewBridge(
+    { sessionId: "live-nodes" },
+    {
+      request: requestStub,
+      diffView: { create: createDiffView },
+    },
+  );
+  const section: ReviewNode = {
+    type: "element",
+    tag: "section",
+    props: { id: "review-node-orders", className: "review-live-orders" },
+    children: [
+      {
+        type: "component",
+        name: "ReviewSection",
+        props: { title: "Orders" },
+        children: [
+          {
+            type: "element",
+            tag: "h2",
+            props: {},
+            children: [{ type: "text", value: "Orders" }],
+          },
+          {
+            type: "element",
+            tag: "p",
+            props: {},
+            children: [{ type: "text", value: "Keep this state" }],
+          },
+        ],
+      },
+    ],
+  };
+  const intro: ReviewNode = {
+    type: "element",
+    tag: "section",
+    props: { id: "review-node-intro", className: "review-live-intro" },
+    children: [
+      {
+        type: "element",
+        tag: "p",
+        props: {},
+        children: [{ type: "text", value: "Inserted first" }],
+      },
+    ],
+  };
+  const load = (
+    contentHash: string,
+    body: ReviewNode[],
+  ): ReviewDocumentLoad => ({
+    state: "ready",
+    contentHash,
+    data: parseJsonText(
+      JSON.stringify({
+        format: "review-document/1",
+        title: "Live",
+        routePath: "/",
+        sourcePath: "review.mdx",
+        anchors: {},
+        anchorContents: {},
+        softwareModels: [],
+        body,
+      }),
+    ),
+  });
+  const container = document.createElement("div");
+  document.body.append(container);
+  const softwareMap = Promise.resolve(null);
+  let handle: ReturnType<typeof mountReviewCanvas> | undefined;
+  try {
+    await act(async () => {
+      handle = mountReviewCanvas(
+        container,
+        sessionContent(bridge, {
+          document: Promise.resolve(load("one", [section])),
+          softwareMap,
+        }),
+      );
+    });
+    const original = container.querySelector("#review-node-orders");
+    const body = container.querySelector<HTMLElement>(".review-section-body")!;
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(
+          'button[aria-label="Collapse Orders"]',
+        )!
+        .click(),
+    );
+    expect(body.hidden).toBe(true);
+    const pending = Promise.withResolvers<ReviewDocumentLoad>();
+    await act(async () =>
+      handle?.update(
+        sessionContent(bridge, { document: pending.promise, softwareMap }),
+      ),
+    );
+    expect(container.querySelector("#review-node-orders")).toBe(original);
+    await act(async () =>
+      pending.resolve(load("two", [intro, structuredClone(section)])),
+    );
+    expect(container.textContent).toContain("Inserted first");
+    expect(container.querySelector("#review-node-orders")).toBe(original);
+    expect(body.hidden).toBe(true);
+    await act(async () =>
+      handle?.update(
+        sessionContent(bridge, {
+          document: Promise.resolve(
+            load("three", [structuredClone(section), intro]),
+          ),
+          softwareMap,
+        }),
+      ),
+    );
+    expect(container.querySelector("#review-node-orders")).toBe(original);
+    expect(body.hidden).toBe(true);
+  } finally {
+    await act(async () => handle?.dispose());
+  }
 });
 
 function sessionContent(

--- a/packages/progressive-review/app/src/desktop-entry.test.tsx
+++ b/packages/progressive-review/app/src/desktop-entry.test.tsx
@@ -670,6 +670,51 @@ describe("desktop review document load states", () => {
 });
 
 describe("publication validation mounts", () => {
+  it("waits for a replacement validation bundle before reporting readiness", async () => {
+    const order: string[] = [];
+    const bridge = testReviewBridge(
+      { sessionId: "validation-replacement" },
+      {
+        request: requestStub,
+        ready: () => order.push("ready"),
+        reportDiagnostic: (diagnostic) => {
+          if (diagnostic.level === "error") order.push("error");
+        },
+        diffView: { create: createDiffView },
+      },
+    );
+    const softwareMap = Promise.resolve(null);
+    const content = (document: Promise<ReviewDocumentLoad>) => ({
+      ...sessionContent(bridge, { document, softwareMap }),
+      purpose: "validation" as const,
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    let handle: ReturnType<typeof mountReviewCanvas> | undefined;
+    try {
+      await act(async () => {
+        handle = mountReviewCanvas(
+          container,
+          content(Promise.resolve(codePeekDocument("first"))),
+        );
+      });
+      expect(order).toEqual(["ready"]);
+      order.length = 0;
+      const replacement = Promise.withResolvers<ReviewDocumentLoad>();
+      await act(async () => handle?.update(content(replacement.promise)));
+      expect(order).toEqual([]);
+      await act(async () =>
+        replacement.resolve({
+          state: "unavailable",
+          message: "Replacement failed",
+        }),
+      );
+      expect(order).toEqual(["error"]);
+    } finally {
+      await act(async () => handle?.dispose());
+    }
+  });
+
   it.each([
     "document-unavailable",
     "document-republish",

--- a/packages/progressive-review/app/src/desktop-entry.test.tsx
+++ b/packages/progressive-review/app/src/desktop-entry.test.tsx
@@ -70,9 +70,11 @@ describe("desktop review document load states", () => {
       });
     });
     expect(container.querySelector(".review-home-attention")).toBeNull();
+
     const entry = container.querySelector<HTMLButtonElement>(
       ".review-home-unavailable-entries button",
     );
+
     expect(entry?.textContent).toContain("Old review");
     expect(container.querySelector('[aria-label="Copy prompt"]')).toBeNull();
     await act(async () => entry?.click());
@@ -88,6 +90,7 @@ describe("desktop review document load states", () => {
       { sessionId: "migration-banner-order" },
       { request: requestStub, diffView: { create: createDiffView } },
     );
+
     const content = sessionContent(bridge, {
       document: Promise.resolve({
         state: "needs-republish",
@@ -96,6 +99,7 @@ describe("desktop review document load states", () => {
       }),
       softwareMap: Promise.resolve(null),
     });
+
     content.reviewErrors = [
       {
         code: "MIGRATION_REQUIRED",
@@ -124,6 +128,7 @@ describe("desktop review document load states", () => {
   it("keeps a valid document visible and offers repair only inside a stale map", async () => {
     const reportDiagnostic =
       vi.fn<(diagnostic: ReviewCanvasDiagnostic) => void>();
+
     const bridge = testReviewBridge(
       { sessionId: "map-only-repair" },
       {
@@ -132,6 +137,7 @@ describe("desktop review document load states", () => {
         diffView: { create: createDiffView },
       },
     );
+
     const container = document.createElement("div");
     document.body.append(container);
     let handle: ReturnType<typeof mountReviewCanvas> | undefined;
@@ -189,8 +195,10 @@ describe("desktop review document load states", () => {
   });
   it("opens the current review from expected historical unavailability without diagnostics", async () => {
     const post = vi.fn<() => Promise<{ ok: true }>>(async () => ({ ok: true }));
+
     const reportDiagnostic =
       vi.fn<(diagnostic: ReviewCanvasDiagnostic) => void>();
+
     const bridge = testReviewBridge(
       { sessionId: "old-history" },
       {
@@ -200,6 +208,7 @@ describe("desktop review document load states", () => {
         diffView: { create: createDiffView },
       },
     );
+
     const reviewUuid = "11111111-1111-4111-8111-111111111111";
     const container = document.createElement("div");
     document.body.append(container);
@@ -223,9 +232,11 @@ describe("desktop review document load states", () => {
     );
     expect(container.textContent).not.toContain("review publish");
     expect(container.textContent).not.toContain("review repair");
+
     const button = [...container.querySelectorAll("button")].find(
       (node) => node.textContent === "Open current review",
     );
+
     await act(async () => button!.click());
     expect(post).toHaveBeenCalledWith({
       name: "openReview",
@@ -239,6 +250,7 @@ describe("desktop review document load states", () => {
       { sessionId: "rendered-data-behavior" },
       { request: requestStub, diffView: { create: createDiffView } },
     );
+
     const content = sessionContent(bridge, {
       document: Promise.resolve({
         state: "ready",
@@ -291,9 +303,11 @@ describe("desktop review document load states", () => {
       }),
       softwareMap: Promise.resolve(null),
     });
+
     const container = document.createElement("div");
     document.body.append(container);
     let handle: ReturnType<typeof mountReviewCanvas> | undefined;
+
     try {
       await act(async () => {
         handle = mountReviewCanvas(container, content);
@@ -307,9 +321,11 @@ describe("desktop review document load states", () => {
       const heading = container.querySelector(".review-section-heading > h2");
       expect(heading?.id).toBe("authored-heading");
       expect(container.querySelectorAll("#authored-heading")).toHaveLength(1);
+
       const body = container.querySelector<HTMLElement>(
         ".review-section-body",
       )!;
+
       expect(body.querySelector("h2")).toBeNull();
       expect(body.hidden).toBe(false);
       await act(async () => {
@@ -328,15 +344,18 @@ describe("desktop review document load states", () => {
 
   it("keeps the app shell and valid map after document failure, settling ready before diagnostics", async () => {
     const order: string[] = [];
+
     const model = defineSoftwareModel({
       systems: { orders: { label: "Orders map" } },
     });
+
     const mapBundle = bundleReviewSoftwareMap({
       head: model,
       base: model,
       headCommit: "a".repeat(40),
       baseCommit: "b".repeat(40),
     });
+
     const bridge = testReviewBridge(
       { sessionId: "unavailable-document" },
       {
@@ -346,6 +365,7 @@ describe("desktop review document load states", () => {
         diffView: { create: createDiffView },
       },
     );
+
     const content = sessionContent(bridge, {
       document: Promise.resolve({
         state: "unavailable",
@@ -358,6 +378,7 @@ describe("desktop review document load states", () => {
         base: parseJsonText(mapBundle.baseJson),
       }),
     });
+
     const container = document.createElement("div");
     document.body.append(container);
 
@@ -390,8 +411,10 @@ describe("desktop review document load states", () => {
 
   it("waits for replacement bundles before publishing ready or diagnostics", async () => {
     const ready = vi.fn<() => void>();
+
     const reportDiagnostic =
       vi.fn<(diagnostic: ReviewCanvasDiagnostic) => void>();
+
     const bridge = testReviewBridge(
       { sessionId: "replacement-bundles" },
       {
@@ -401,6 +424,7 @@ describe("desktop review document load states", () => {
         diffView: { create: createDiffView },
       },
     );
+
     const container = document.createElement("div");
     document.body.append(container);
     let handle: ReturnType<typeof mountReviewCanvas> | undefined;
@@ -420,6 +444,7 @@ describe("desktop review document load states", () => {
     expect(reportDiagnostic).toHaveBeenCalledTimes(1);
     ready.mockClear();
     reportDiagnostic.mockClear();
+
     const replacementBridge = testReviewBridge(
       { sessionId: "replacement-bundles" },
       {
@@ -431,8 +456,10 @@ describe("desktop review document load states", () => {
     );
 
     const replacementDocument = Promise.withResolvers<ReviewDocumentLoad>();
+
     const replacementSoftwareMap =
       Promise.withResolvers<ReviewSoftwareMapLoad | null>();
+
     await act(async () => {
       handle?.update(
         sessionContent(replacementBridge, {
@@ -465,10 +492,12 @@ describe("desktop review document load states", () => {
   it("does not prepare a late obsolete document after replacement", async () => {
     const oldDocument = Promise.withResolvers<ReviewDocumentLoad>();
     const request = vi.fn<typeof requestStub>(requestStub);
+
     const bridge = testReviewBridge(
       { sessionId: "late-replacement" },
       { request, diffView: { create: createDiffView } },
     );
+
     const container = document.createElement("div");
     document.body.append(container);
     let handle: ReturnType<typeof mountReviewCanvas> | undefined;
@@ -502,10 +531,12 @@ describe("desktop review document load states", () => {
   it("does not prepare a late document after disposal", async () => {
     const documentBundle = Promise.withResolvers<ReviewDocumentLoad>();
     const request = vi.fn<typeof requestStub>(requestStub);
+
     const bridge = testReviewBridge(
       { sessionId: "late-disposal" },
       { request, diffView: { create: createDiffView } },
     );
+
     const container = document.createElement("div");
     document.body.append(container);
     let handle: ReturnType<typeof mountReviewCanvas> | undefined;
@@ -528,6 +559,7 @@ describe("desktop review document load states", () => {
   it("does not report an unchanged peer failure after one bundle is replaced", async () => {
     const reportDiagnostic =
       vi.fn<(diagnostic: ReviewCanvasDiagnostic) => void>();
+
     const bridge = testReviewBridge(
       { sessionId: "single-replacement" },
       {
@@ -536,10 +568,12 @@ describe("desktop review document load states", () => {
         diffView: { create: createDiffView },
       },
     );
+
     const documentBundle = Promise.resolve<ReviewDocumentLoad>({
       state: "unavailable",
       message: "Document fetch failed",
     });
+
     const container = document.createElement("div");
     document.body.append(container);
     let handle: ReturnType<typeof mountReviewCanvas> | undefined;
@@ -556,6 +590,7 @@ describe("desktop review document load states", () => {
 
     const replacementSoftwareMap =
       Promise.withResolvers<ReviewSoftwareMapLoad | null>();
+
     await act(async () => {
       handle?.update(
         sessionContent(bridge, {
@@ -575,8 +610,10 @@ describe("desktop review document load states", () => {
     "signals ready for needs-republish without reporting an error (mapStale=%s)",
     async (mapStale) => {
       const ready = vi.fn<() => void>();
+
       const reportDiagnostic =
         vi.fn<(diagnostic: ReviewCanvasDiagnostic) => void>();
+
       const bridge = testReviewBridge(
         { sessionId: `needs-republish-${mapStale}` },
         {
@@ -586,6 +623,7 @@ describe("desktop review document load states", () => {
           diffView: { create: createDiffView },
         },
       );
+
       const content = sessionContent(bridge, {
         document: Promise.resolve({
           state: "needs-republish",
@@ -601,6 +639,7 @@ describe("desktop review document load states", () => {
             : null,
         ),
       });
+
       const container = document.createElement("div");
       document.body.append(container);
 
@@ -647,6 +686,7 @@ describe("desktop review document load states", () => {
       expect(
         container.querySelector('button[aria-label="Copy prompt"]'),
       ).toBeNull();
+
       if (mapStale) {
         await act(async () =>
           container
@@ -656,6 +696,7 @@ describe("desktop review document load states", () => {
             .click(),
         );
       }
+
       expect(
         container
           .querySelector(".review-map-view")
@@ -672,6 +713,7 @@ describe("desktop review document load states", () => {
 describe("publication validation mounts", () => {
   it("waits for a replacement validation bundle before reporting readiness", async () => {
     const order: string[] = [];
+
     const bridge = testReviewBridge(
       { sessionId: "validation-replacement" },
       {
@@ -683,14 +725,18 @@ describe("publication validation mounts", () => {
         diffView: { create: createDiffView },
       },
     );
+
     const softwareMap = Promise.resolve(null);
+
     const content = (document: Promise<ReviewDocumentLoad>) => ({
       ...sessionContent(bridge, { document, softwareMap }),
       purpose: "validation" as const,
     });
+
     const container = document.createElement("div");
     document.body.append(container);
     let handle: ReturnType<typeof mountReviewCanvas> | undefined;
+
     try {
       await act(async () => {
         handle = mountReviewCanvas(
@@ -728,6 +774,7 @@ describe("publication validation mounts", () => {
     "absent-map",
   ] as const)("settles %s before publication", async (scenario) => {
     const order: string[] = [];
+
     const bridge = testReviewBridge(
       { sessionId: `validation-${scenario}` },
       {
@@ -747,11 +794,14 @@ describe("publication validation mounts", () => {
         diffView: { create: createDiffView },
       },
     );
+
     let documentLoad: ReviewDocumentLoad = codePeekDocument(
       "validation-document",
     );
+
     let mapLoad: ReviewSoftwareMapLoad | null = null;
     const reviewUuid = "11111111-1111-4111-8111-111111111111";
+
     if (
       scenario === "document-unavailable" ||
       scenario === "historical-unavailable"
@@ -760,21 +810,28 @@ describe("publication validation mounts", () => {
         state: "unavailable",
         message: "Unavailable",
       };
+
     if (
       scenario === "historical-unavailable" &&
       documentLoad.state === "unavailable"
     )
       documentLoad.currentReviewUuid = reviewUuid;
+
     if (scenario === "document-republish")
       documentLoad = { state: "needs-republish", reviewUuid, mapStale: false };
+
     if (scenario === "malformed-document")
       documentLoad = { state: "ready", contentHash: "invalid", data: {} };
+
     if (scenario === "map-unavailable")
       mapLoad = { state: "unavailable", message: "Unavailable map" };
+
     if (scenario === "map-republish")
       mapLoad = { state: "needs-republish", reviewUuid };
+
     if (scenario === "malformed-map")
       mapLoad = { state: "ready", contentHash: "invalid", head: {}, base: {} };
+
     if (scenario === "render-failure") {
       documentLoad = {
         state: "ready",
@@ -798,9 +855,11 @@ describe("publication validation mounts", () => {
         },
       };
     }
+
     const container = document.createElement("div");
     document.body.append(container);
     let handle: ReturnType<typeof mountReviewCanvas> | undefined;
+
     try {
       await act(async () => {
         handle = mountReviewCanvas(container, {
@@ -827,6 +886,7 @@ it("keeps keyed rich components mounted while a live revision loads, inserts, an
       diffView: { create: createDiffView },
     },
   );
+
   const section: ReviewNode = {
     type: "element",
     tag: "section",
@@ -853,6 +913,7 @@ it("keeps keyed rich components mounted while a live revision loads, inserts, an
       },
     ],
   };
+
   const intro: ReviewNode = {
     type: "element",
     tag: "section",
@@ -866,6 +927,7 @@ it("keeps keyed rich components mounted while a live revision loads, inserts, an
       },
     ],
   };
+
   const load = (
     contentHash: string,
     body: ReviewNode[],
@@ -885,10 +947,12 @@ it("keeps keyed rich components mounted while a live revision loads, inserts, an
       }),
     ),
   });
+
   const container = document.createElement("div");
   document.body.append(container);
   const softwareMap = Promise.resolve(null);
   let handle: ReturnType<typeof mountReviewCanvas> | undefined;
+
   try {
     await act(async () => {
       handle = mountReviewCanvas(
@@ -984,6 +1048,7 @@ function codePeekDocument(contentHash: string): ReviewDocumentLoad {
       resolution: null,
     },
   };
+
   return {
     state: "ready",
     contentHash,
@@ -1025,12 +1090,15 @@ async function requestStub(input: string): Promise<Response> {
       }),
     );
   }
+
   if (input.includes("/agent-traces")) {
     return new Response(JSON.stringify({ ok: true, sessions: [] }));
   }
+
   if (input.includes("/session")) {
     return new Response(JSON.stringify({ session: {} }));
   }
+
   return new Response(JSON.stringify({}));
 }
 

--- a/packages/progressive-review/app/src/desktop-entry.tsx
+++ b/packages/progressive-review/app/src/desktop-entry.tsx
@@ -58,11 +58,13 @@ function DesktopReviewApp({
   findHost: ReviewFindHost;
 }) {
   const session = useReviewSession();
+
   // Render boundaries report during commit, before our readiness effect.
   // Keep their failure authoritative for this pair of validation artifacts.
   const settlementSession = useMemo(() => {
     if (purpose === "display") return session;
     let failed = false;
+
     return {
       ...session,
       signalReady: () => {
@@ -74,19 +76,24 @@ function DesktopReviewApp({
       },
     };
   }, [session, purpose, documentBundle, softwareMapBundle]);
+
   const sessionRef = useRef(session);
   sessionRef.current = session;
   const container = useReviewContainer();
+
   const reportedDocumentBundle = useRef<Promise<ReviewDocumentLoad> | null>(
     null,
   );
+
   const reportedSoftwareMapBundle =
     useRef<Promise<ReviewSoftwareMapLoad | null> | null>(null);
+
   const documentState = useSettledLoad(
     documentBundle,
     async (load): Promise<ReviewDocumentAppState> => {
       if (load.state !== "ready") return load;
       const document = await prepareReviewDocument(load, sessionRef.current);
+
       if (purpose === "validation") {
         for (const anchor of document.anchors.values()) {
           if (anchor.peek && !anchor.peek.resolution)
@@ -95,16 +102,20 @@ function DesktopReviewApp({
             );
         }
       }
+
       return { state: "ready", document };
     },
     session,
     purpose === "display",
   );
+
   const softwareMapState = useSettledLoad(
     softwareMapBundle,
     (load): ReviewSoftwareMapAppState => {
       if (load === null) return { state: "absent" };
+
       if (load.state !== "ready") return load;
+
       return {
         state: "ready",
         softwareMap: hydratePublishedSoftwareMap(load),
@@ -121,15 +132,18 @@ function DesktopReviewApp({
     ) {
       return;
     }
+
     // The display host opens a usable recovery shell before diagnostics.
     // Validation instead reports every unusable artifact before success.
     if (purpose === "display") settlementSession.signalReady();
+
     if (
       reportedDocumentBundle.current !== documentBundle &&
       reportLoadFailure(settlementSession, "document", documentState, purpose)
     ) {
       reportedDocumentBundle.current = documentBundle;
     }
+
     if (
       reportedSoftwareMapBundle.current !== softwareMapBundle &&
       reportLoadFailure(
@@ -141,6 +155,7 @@ function DesktopReviewApp({
     ) {
       reportedSoftwareMapBundle.current = softwareMapBundle;
     }
+
     if (
       purpose === "validation" &&
       documentState.state === "ready" &&
@@ -161,6 +176,7 @@ function DesktopReviewApp({
   useEffect(() => {
     if (!container) return;
     const { authoredCodePeekRequestCount } = codePeekDiagnostics;
+
     if (authoredCodePeekRequestCount === 0) return;
     container.dataset.reviewAuthoredCodePeekRequestCount = String(
       authoredCodePeekRequestCount,
@@ -204,18 +220,22 @@ function useSettledLoad<TLoad, TState>(
 ): TState | ReviewLoadFallback {
   const settleRef = useRef(settle);
   settleRef.current = settle;
+
   const [settledLoad, setSettledLoad] = useState<{
     bundle: Promise<TLoad>;
     session: ReviewSession;
     value: TState | ReviewLoadFallback;
   }>(() => ({ bundle, session, value: reviewLoadLoading }));
+
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       try {
         const load = await bundle;
+
         if (cancelled) return;
         const settled = await settleRef.current(load);
+
         if (!cancelled) setSettledLoad({ bundle, session, value: settled });
       } catch (error) {
         if (cancelled) return;
@@ -227,10 +247,12 @@ function useSettledLoad<TLoad, TState>(
         });
       }
     })();
+
     return () => {
       cancelled = true;
     };
   }, [bundle, session]);
+
   // Keep the visible editor mounted during live updates. Validation must
   // settle the requested bundle before its previous state can imply readiness.
   return settledLoad.session === session &&
@@ -258,18 +280,23 @@ function reportLoadFailure(
           ? state.message
           : `The ${source} needs repair before publication.`,
     });
+
     return true;
   }
+
   if (state.state !== "unavailable" || state.currentReviewUuid) return false;
   const cause = state.cause ?? new Error(state.message);
   captureClientError(session, source, cause);
+
   const diagnostic: ReviewCanvasDiagnostic = {
     level: "error",
     source: "loader",
     message: cause.message,
   };
+
   if (cause.stack) diagnostic.stack = cause.stack;
   session.reportDiagnostic(diagnostic);
+
   return true;
 }
 
@@ -295,7 +322,9 @@ function ReviewCanvas({
       />
     );
   }
+
   if (content.kind === "home") return <Home content={content} />;
+
   if (content.kind === "source") {
     if (content.error) {
       return (
@@ -305,6 +334,7 @@ function ReviewCanvas({
         </div>
       );
     }
+
     return (
       <div className="review-source-empty">
         <p>Select a file in the source tree</p>
@@ -312,6 +342,7 @@ function ReviewCanvas({
       </div>
     );
   }
+
   if (content.kind === "welcome") {
     return (
       <WelcomePage
@@ -322,9 +353,11 @@ function ReviewCanvas({
       />
     );
   }
+
   if (content.kind === "settings") {
     return <SettingsPage settings={content.settings} />;
   }
+
   if (content.kind === "completed") {
     return (
       <CanvasShell title="Review completed">
@@ -341,6 +374,7 @@ function ReviewCanvas({
       </CanvasShell>
     );
   }
+
   if (content.kind === "error") {
     return (
       <CanvasShell title="Review unavailable">
@@ -348,6 +382,7 @@ function ReviewCanvas({
       </CanvasShell>
     );
   }
+
   return <ReviewCanvasLoading page />;
 }
 
@@ -360,6 +395,7 @@ function Home({
   const dismissReview = content.dismissReview;
   const restoreReview = content.restoreReview;
   const openSourceTree = content.openSourceTree;
+
   return (
     <ReviewHome
       reviews={content.reviews}
@@ -405,7 +441,9 @@ function CanvasShell({
 // own theme bridge) the workbench root is the theme authority.
 function workbenchColorTheme(container: HTMLElement): "dark" | "light" {
   const workbench = container.ownerDocument.querySelector(".monaco-workbench");
+
   if (!workbench) return "dark";
+
   return workbench.classList.contains("vs-dark") ||
     workbench.classList.contains("hc-black")
     ? "dark"
@@ -440,25 +478,31 @@ export function mountReviewCanvas(
   const render = () => {
     themeSubscription?.dispose();
     themeSubscription = null;
+
     if (content.kind === "session") {
       resetSessionDiagnostics(container);
+
       if (session?.bridge !== content.bridge) {
         session = createReviewSession(content.bridge);
       }
     } else {
       session = null;
     }
+
     if (content.kind === "session") {
       applyTheme(content.bridge.currentTheme());
       themeSubscription = content.bridge.onDidChangeTheme(applyTheme);
     } else {
       applyTheme(workbenchColorTheme(container));
+
       const workbench =
         container.ownerDocument.querySelector(".monaco-workbench");
+
       if (workbench) {
         const observer = new MutationObserver(() => {
           applyTheme(workbenchColorTheme(container));
         });
+
         observer.observe(workbench, {
           attributes: true,
           attributeFilter: ["class"],
@@ -466,6 +510,7 @@ export function mountReviewCanvas(
         themeSubscription = { dispose: () => observer.disconnect() };
       }
     }
+
     root.render(
       <ReviewContainerProvider container={container}>
         {session ? (
@@ -478,6 +523,7 @@ export function mountReviewCanvas(
       </ReviewContainerProvider>,
     );
   };
+
   render();
 
   return {

--- a/packages/progressive-review/app/src/desktop-entry.tsx
+++ b/packages/progressive-review/app/src/desktop-entry.tsx
@@ -98,6 +98,7 @@ function DesktopReviewApp({
       return { state: "ready", document };
     },
     session,
+    purpose === "display",
   );
   const softwareMapState = useSettledLoad(
     softwareMapBundle,
@@ -110,6 +111,7 @@ function DesktopReviewApp({
       };
     },
     session,
+    purpose === "display",
   );
 
   useEffect(() => {
@@ -198,6 +200,7 @@ function useSettledLoad<TLoad, TState>(
   bundle: Promise<TLoad>,
   settle: (load: TLoad) => TState | Promise<TState>,
   session: ReviewSession,
+  preservePrevious: boolean,
 ): TState | ReviewLoadFallback {
   const settleRef = useRef(settle);
   settleRef.current = settle;
@@ -228,9 +231,10 @@ function useSettledLoad<TLoad, TState>(
       cancelled = true;
     };
   }, [bundle, session]);
-  // DesktopReviewApp is keyed by session ID. Keep this session's mounted
-  // document while its next validated live revision is being hydrated.
-  return settledLoad.session === session
+  // Keep the visible editor mounted during live updates. Validation must
+  // settle the requested bundle before its previous state can imply readiness.
+  return settledLoad.session === session &&
+    (preservePrevious || settledLoad.bundle === bundle)
     ? settledLoad.value
     : reviewLoadLoading;
 }

--- a/packages/progressive-review/app/src/desktop-entry.tsx
+++ b/packages/progressive-review/app/src/desktop-entry.tsx
@@ -97,6 +97,7 @@ function DesktopReviewApp({
       }
       return { state: "ready", document };
     },
+    session,
   );
   const softwareMapState = useSettledLoad(
     softwareMapBundle,
@@ -108,6 +109,7 @@ function DesktopReviewApp({
         softwareMap: hydratePublishedSoftwareMap(load),
       };
     },
+    session,
   );
 
   useEffect(() => {
@@ -195,13 +197,15 @@ const reviewLoadLoading: ReviewLoadFallback = { state: "loading" };
 function useSettledLoad<TLoad, TState>(
   bundle: Promise<TLoad>,
   settle: (load: TLoad) => TState | Promise<TState>,
+  session: ReviewSession,
 ): TState | ReviewLoadFallback {
   const settleRef = useRef(settle);
   settleRef.current = settle;
   const [settledLoad, setSettledLoad] = useState<{
     bundle: Promise<TLoad>;
+    session: ReviewSession;
     value: TState | ReviewLoadFallback;
-  }>(() => ({ bundle, value: reviewLoadLoading }));
+  }>(() => ({ bundle, session, value: reviewLoadLoading }));
   useEffect(() => {
     let cancelled = false;
     void (async () => {
@@ -209,12 +213,13 @@ function useSettledLoad<TLoad, TState>(
         const load = await bundle;
         if (cancelled) return;
         const settled = await settleRef.current(load);
-        if (!cancelled) setSettledLoad({ bundle, value: settled });
+        if (!cancelled) setSettledLoad({ bundle, session, value: settled });
       } catch (error) {
         if (cancelled) return;
         const cause = error instanceof Error ? error : new Error(String(error));
         setSettledLoad({
           bundle,
+          session,
           value: { state: "unavailable", message: cause.message, cause },
         });
       }
@@ -222,8 +227,12 @@ function useSettledLoad<TLoad, TState>(
     return () => {
       cancelled = true;
     };
-  }, [bundle]);
-  return settledLoad.bundle === bundle ? settledLoad.value : reviewLoadLoading;
+  }, [bundle, session]);
+  // DesktopReviewApp is keyed by session ID. Keep this session's mounted
+  // document while its next validated live revision is being hydrated.
+  return settledLoad.session === session
+    ? settledLoad.value
+    : reviewLoadLoading;
 }
 
 function reportLoadFailure(

--- a/packages/progressive-review/app/src/review-document-boundary.test.tsx
+++ b/packages/progressive-review/app/src/review-document-boundary.test.tsx
@@ -62,7 +62,6 @@ describe("ReviewDocumentBoundary", () => {
         <StrictMode>
           <div data-testid="shell">Files Map Threads</div>
           <ReviewDocumentBoundary
-            key="bad-1"
             revision="bad-1"
             onError={onError}
             session={session}
@@ -100,7 +99,6 @@ describe("ReviewDocumentBoundary", () => {
         <StrictMode>
           <div data-testid="shell">Files Map Threads</div>
           <ReviewDocumentBoundary
-            key="good-2"
             revision="good-2"
             onError={onError}
             session={session}

--- a/packages/progressive-review/app/src/review-document-boundary.test.tsx
+++ b/packages/progressive-review/app/src/review-document-boundary.test.tsx
@@ -23,6 +23,7 @@ import { ReviewDocumentBoundary } from "./review-document-boundary";
 import { testReviewSession } from "./review-session-test-utils";
 
 let request: Mock<(url: string, init?: RequestInit) => Promise<Response>>;
+
 let session: ReviewSession;
 
 const roots: Array<ReturnType<typeof createRoot>> = [];
@@ -158,9 +159,11 @@ function clientErrorReports(): JsonObject[] {
     .filter(([url]) => url.includes("/telemetry/event"))
     .map(([, init]) => {
       const body = parseJsonText(String(init?.body));
+
       if (!isJsonObject(body)) {
         throw new Error("Telemetry event body is not an object");
       }
+
       return body;
     });
 }

--- a/packages/progressive-review/app/src/review-document-boundary.tsx
+++ b/packages/progressive-review/app/src/review-document-boundary.tsx
@@ -13,22 +13,38 @@ interface ReviewDocumentBoundaryProps {
 
 interface ReviewDocumentBoundaryState {
   hasError: boolean;
+  revision: string;
 }
 
 export class ReviewDocumentBoundary extends Component<
   ReviewDocumentBoundaryProps,
   ReviewDocumentBoundaryState
 > {
-  state: ReviewDocumentBoundaryState = { hasError: false };
-  private reported = false;
+  state: ReviewDocumentBoundaryState = {
+    hasError: false,
+    revision: this.props.revision,
+  };
+  private reportedRevision: string | null = null;
 
-  static getDerivedStateFromError(): ReviewDocumentBoundaryState {
+  static getDerivedStateFromProps(
+    props: ReviewDocumentBoundaryProps,
+    state: ReviewDocumentBoundaryState,
+  ): ReviewDocumentBoundaryState | null {
+    return props.revision !== state.revision
+      ? { revision: props.revision, hasError: false }
+      : null;
+  }
+
+  static getDerivedStateFromError(): Pick<
+    ReviewDocumentBoundaryState,
+    "hasError"
+  > {
     return { hasError: true };
   }
 
   componentDidCatch(error: Error, _info: ErrorInfo): void {
-    if (this.reported) return;
-    this.reported = true;
+    if (this.reportedRevision === this.props.revision) return;
+    this.reportedRevision = this.props.revision;
     captureClientError(this.props.session, "render", error);
     this.props.onError(this.props.revision, error);
   }

--- a/packages/progressive-review/app/src/review-document-boundary.tsx
+++ b/packages/progressive-review/app/src/review-document-boundary.tsx
@@ -63,6 +63,7 @@ export class ReviewDocumentBoundary extends Component<
         />
       );
     }
+
     return this.props.children;
   }
 }

--- a/packages/progressive-review/app/src/review-document-prepare.test.ts
+++ b/packages/progressive-review/app/src/review-document-prepare.test.ts
@@ -178,6 +178,35 @@ it("keeps available peeks visible and retries incomplete preparation on a later 
   expect(resolveCodePeek).toHaveBeenCalledTimes(3);
 });
 
+it("bounds live revision hydration while retaining the newest revision for retry", async () => {
+  const session = testReviewSession();
+  const first = await prepareReviewDocument(load, session, { resolveCodePeek });
+  for (let revision = 1; revision < 16; revision++) {
+    await prepareReviewDocument(
+      { ...load, contentHash: `live-${revision}` },
+      session,
+      { resolveCodePeek },
+    );
+  }
+  const newest = { ...load, contentHash: "live-16" };
+  resolveCodePeek.mockRejectedValueOnce(new Error("peek unavailable"));
+  const partial = await prepareReviewDocument(newest, session, {
+    resolveCodePeek,
+  });
+  expect(partial.anchors.get("create-order")?.peek?.resolution).toBeNull();
+  expect(
+    await prepareReviewDocument(newest, session, { resolveCodePeek }),
+  ).toBe(partial);
+  expect(partial.anchors.get("create-order")?.peek?.resolution).toEqual({
+    snapshot: { roots: [], resolved: {} },
+  });
+  expect(resolveCodePeek).toHaveBeenCalledTimes(18);
+  expect(
+    await prepareReviewDocument(load, session, { resolveCodePeek }),
+  ).not.toBe(first);
+  expect(resolveCodePeek).toHaveBeenCalledTimes(19);
+});
+
 it("evicts rejected hydration without caching invalid document data", async () => {
   const session = testReviewSession();
   const invalid = { ...documentData(), anchors: {} };

--- a/packages/progressive-review/app/src/review-document-prepare.test.ts
+++ b/packages/progressive-review/app/src/review-document-prepare.test.ts
@@ -181,6 +181,7 @@ it("keeps available peeks visible and retries incomplete preparation on a later 
 it("bounds live revision hydration while retaining the newest revision for retry", async () => {
   const session = testReviewSession();
   const first = await prepareReviewDocument(load, session, { resolveCodePeek });
+
   for (let revision = 1; revision < 16; revision++) {
     await prepareReviewDocument(
       { ...load, contentHash: `live-${revision}` },
@@ -188,11 +189,14 @@ it("bounds live revision hydration while retaining the newest revision for retry
       { resolveCodePeek },
     );
   }
+
   const newest = { ...load, contentHash: "live-16" };
   resolveCodePeek.mockRejectedValueOnce(new Error("peek unavailable"));
+
   const partial = await prepareReviewDocument(newest, session, {
     resolveCodePeek,
   });
+
   expect(partial.anchors.get("create-order")?.peek?.resolution).toBeNull();
   expect(
     await prepareReviewDocument(newest, session, { resolveCodePeek }),

--- a/packages/progressive-review/app/src/review-document-prepare.ts
+++ b/packages/progressive-review/app/src/review-document-prepare.ts
@@ -66,6 +66,7 @@ export function prepareReviewDocument(
     }
 
     session.documents.set(load.contentHash, cached);
+
     // A live authoring session can produce thousands of native revisions.
     if (session.documents.size > 16)
       session.documents.delete(session.documents.keys().next().value!);

--- a/packages/progressive-review/app/src/review-document-prepare.ts
+++ b/packages/progressive-review/app/src/review-document-prepare.ts
@@ -46,10 +46,9 @@ export async function resolveReviewDocumentPeeks(
 }
 
 /**
- * One hydration per content hash for the life of a session: the canvas
- * remounts the document on every view change, and peek resolution must not
- * re-run for a document the session already prepared. Failed peeks retry on
- * the same hydrated document, preserving successful resolutions and refs.
+ * Reuse hydration across remounts while a content hash remains in the
+ * session's bounded cache. Failed peeks retry on the same hydrated document,
+ * preserving successful resolutions and refs.
  */
 export function prepareReviewDocument(
   load: ReadyReviewDocumentLoad,
@@ -67,6 +66,9 @@ export function prepareReviewDocument(
     }
 
     session.documents.set(load.contentHash, cached);
+    // A live authoring session can produce thousands of native revisions.
+    if (session.documents.size > 16)
+      session.documents.delete(session.documents.keys().next().value!);
   }
 
   if (cached.preparation) return cached.preparation;

--- a/packages/progressive-review/app/src/review-document-renderer.tsx
+++ b/packages/progressive-review/app/src/review-document-renderer.tsx
@@ -1,3 +1,4 @@
+import { jsonString } from "@dev.fast/review-protocol";
 import {
   Fragment,
   type FunctionComponent,
@@ -15,6 +16,7 @@ import type {
   HydratedReviewComponentProps,
   HydratedReviewNode,
 } from "./review-document-hydrate";
+import { ReviewLiveNode } from "./review-live-node";
 
 /** A prose override renders the same validated props as its intrinsic tag. */
 export type ProseElementComponent = FunctionComponent<
@@ -50,6 +52,23 @@ function renderNode(
     return createElement(
       components.components[node.name],
       node.props,
+      ...children,
+    );
+  }
+  const liveId = jsonString(node.props.id);
+  const liveRevision = jsonString(node.props.className);
+  if (
+    node.tag === "section" &&
+    liveId?.startsWith("review-node-") &&
+    liveRevision?.startsWith("review-live-")
+  ) {
+    return createElement(
+      ReviewLiveNode,
+      {
+        key: liveId,
+        id: liveId,
+        revision: liveRevision,
+      },
       ...children,
     );
   }

--- a/packages/progressive-review/app/src/review-document-renderer.tsx
+++ b/packages/progressive-review/app/src/review-document-renderer.tsx
@@ -48,6 +48,7 @@ function renderNode(
 ): ReactNode {
   if (node.type === "text") return node.value;
   const children = node.children.map((child) => renderNode(child, components));
+
   if (node.type === "component") {
     return createElement(
       components.components[node.name],
@@ -55,8 +56,10 @@ function renderNode(
       ...children,
     );
   }
+
   const liveId = jsonString(node.props.id);
   const liveRevision = jsonString(node.props.className);
+
   if (
     node.tag === "section" &&
     liveId?.startsWith("review-node-") &&
@@ -72,12 +75,15 @@ function renderNode(
       ...children,
     );
   }
+
   const override = components.elementOverrides[node.tag];
+
   if (override) return createElement(override, node.props, ...children);
   // Alignment is the one saved style the renderer restores: the publish
   // schema validates it, and the inline style keeps the document's table CSS
   // from overriding an authored column alignment.
   const align = tableAlignSchema.safeParse(node.props.align);
+
   if (align.success) {
     return createElement(
       node.tag,
@@ -85,5 +91,6 @@ function renderNode(
       ...children,
     );
   }
+
   return createElement(node.tag, node.props, ...children);
 }

--- a/packages/progressive-review/app/src/review-live-node.tsx
+++ b/packages/progressive-review/app/src/review-live-node.tsx
@@ -15,21 +15,26 @@ export function ReviewLiveNode({
   useLayoutEffect(() => {
     setActive(true);
     const element = content.current;
+
     const reduced = element?.ownerDocument.defaultView?.matchMedia?.(
       "(prefers-reduced-motion: reduce)",
     ).matches;
+
     const animation = reduced
       ? undefined
       : element?.animate?.([{ opacity: 0.35 }, { opacity: 1 }], {
           duration: 320,
           easing: "ease-out",
         });
+
     const timer = setTimeout(() => setActive(false), 1400);
+
     return () => {
       clearTimeout(timer);
       animation?.cancel();
     };
   }, [revision]);
+
   return (
     <section
       id={id}

--- a/packages/progressive-review/app/src/review-live-node.tsx
+++ b/packages/progressive-review/app/src/review-live-node.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { type ReactNode, useLayoutEffect, useRef, useState } from "react";
 
 /** The activity gutter participates in layout, including for one-line nodes. */
 export function ReviewLiveNode({
@@ -12,7 +12,7 @@ export function ReviewLiveNode({
 }) {
   const content = useRef<HTMLDivElement>(null);
   const [active, setActive] = useState(false);
-  useEffect(() => {
+  useLayoutEffect(() => {
     setActive(true);
     const element = content.current;
     const reduced = element?.ownerDocument.defaultView?.matchMedia?.(

--- a/packages/progressive-review/app/src/review-live-node.tsx
+++ b/packages/progressive-review/app/src/review-live-node.tsx
@@ -1,0 +1,49 @@
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+/** The activity gutter participates in layout, including for one-line nodes. */
+export function ReviewLiveNode({
+  id,
+  revision,
+  children,
+}: {
+  id: string;
+  revision: string;
+  children?: ReactNode;
+}) {
+  const content = useRef<HTMLDivElement>(null);
+  const [active, setActive] = useState(false);
+  useEffect(() => {
+    setActive(true);
+    const element = content.current;
+    const reduced = element?.ownerDocument.defaultView?.matchMedia?.(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    const animation = reduced
+      ? undefined
+      : element?.animate?.([{ opacity: 0.35 }, { opacity: 1 }], {
+          duration: 320,
+          easing: "ease-out",
+        });
+    const timer = setTimeout(() => setActive(false), 1400);
+    return () => {
+      clearTimeout(timer);
+      animation?.cancel();
+    };
+  }, [revision]);
+  return (
+    <section
+      id={id}
+      className="review-live-node"
+      data-authoring={active || undefined}
+    >
+      <span className="review-live-node__activity" aria-hidden="true">
+        {Array.from({ length: 9 }, (_, index) => (
+          <i key={index} />
+        ))}
+      </span>
+      <div ref={content} className="review-live-node__content">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -10584,3 +10584,62 @@ button.review-stack-row:disabled .review-stack-relation {
 .review-trace-peek-open-full:hover {
   background: var(--accent-wash);
 }
+/* Live activity has its own in-flow gutter. No translated/scaled content,
+ * outward outlines, or negative-positioned particles can cover a sibling. */
+.review-live-node {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  column-gap: 12px;
+  align-items: start;
+}
+
+.review-live-node__content {
+  min-width: 0;
+  display: flow-root;
+}
+
+.review-live-node__activity {
+  display: grid;
+  grid-template-columns: repeat(3, 4px);
+  gap: 4px;
+  padding-block: 8px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.review-live-node[data-authoring] > .review-live-node__activity {
+  opacity: 1;
+}
+
+.review-live-node__activity i {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: review-live-sparkle 1100ms ease-in-out infinite;
+}
+
+.review-live-node__activity i:nth-child(3n) {
+  animation-delay: -370ms;
+}
+.review-live-node__activity i:nth-child(3n + 1) {
+  animation-delay: -730ms;
+}
+
+@keyframes review-live-sparkle {
+  0%,
+  100% {
+    opacity: 0.2;
+    transform: scale(0.65);
+  }
+  45% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .review-live-node__activity i {
+    animation: none;
+  }
+}

--- a/packages/progressive-review/src/review-lifecycle.test.ts
+++ b/packages/progressive-review/src/review-lifecycle.test.ts
@@ -57,12 +57,14 @@ async function fixture() {
 it("authors rich live nodes through the desktop API and rejects competing edits", async () => {
   const review = await fixture();
   const reviewUuid = review.review.uuid;
+
   const initial = ReviewDocumentFileResponseSchema.parse(
     await requestReviewLifecycle("/lifecycle/document/read", {
       reviewUuid,
       name: "review.mdx",
     }),
   );
+
   const request = {
     reviewUuid,
     mutationId: randomUUID(),
@@ -72,10 +74,12 @@ it("authors rich live nodes through the desktop API and rejects competing edits"
       nodes: [{ id: "title", source: "# API authored" }],
     },
   };
+
   const accepted = await requestReviewLifecycle(
     "/lifecycle/document/mutate",
     request,
   );
+
   expect(accepted).toMatchObject({ revision: 1, mode: "incremental" });
   expect(
     await requestReviewLifecycle("/lifecycle/document/mutate", request),

--- a/packages/progressive-review/src/review-lifecycle.test.ts
+++ b/packages/progressive-review/src/review-lifecycle.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { readFile, rm, symlink } from "node:fs/promises";
 import path from "node:path";
@@ -35,16 +36,65 @@ async function fixture() {
   await reviewHome();
   const worktreePath = await gitRepository();
 
+  const commit = execFileSync(
+    "git",
+    ["-C", worktreePath, "rev-parse", "HEAD"],
+    { encoding: "utf8" },
+  ).trim();
+
   const review = await createReviewDir({
     worktreePath,
     baseRef: "main",
-    baseCommit: "a".repeat(40),
+    baseCommit: commit,
+    sourceCommit: commit,
   });
 
   server = await startLifecycleTestServer();
 
   return review;
 }
+
+it("authors rich live nodes through the desktop API and rejects competing edits", async () => {
+  const review = await fixture();
+  const reviewUuid = review.review.uuid;
+  const initial = ReviewDocumentFileResponseSchema.parse(
+    await requestReviewLifecycle("/lifecycle/document/read", {
+      reviewUuid,
+      name: "review.mdx",
+    }),
+  );
+  const request = {
+    reviewUuid,
+    mutationId: randomUUID(),
+    expectedSourceHash: initial.sourceHash,
+    operation: {
+      type: "replace",
+      nodes: [{ id: "title", source: "# API authored" }],
+    },
+  };
+  const accepted = await requestReviewLifecycle(
+    "/lifecycle/document/mutate",
+    request,
+  );
+  expect(accepted).toMatchObject({ revision: 1, mode: "incremental" });
+  expect(
+    await requestReviewLifecycle("/lifecycle/document/mutate", request),
+  ).toEqual(accepted);
+  await expect(
+    requestReviewLifecycle("/lifecycle/document/mutate", {
+      ...request,
+      mutationId: randomUUID(),
+    }),
+  ).rejects.toThrow("source changed");
+  expect(
+    await requestReviewLifecycle("/lifecycle/document/live", { reviewUuid }),
+  ).toEqual(accepted);
+  await server!.close();
+  server = await startLifecycleTestServer();
+  expect(
+    await requestReviewLifecycle("/lifecycle/document/live", { reviewUuid }),
+  ).toEqual(accepted);
+});
 
 it("serializes source edits, rejects stale writes and symlinks, and preserves accepted content", async () => {
   const review = await fixture();

--- a/packages/progressive-review/src/review-live-document.test.ts
+++ b/packages/progressive-review/src/review-live-document.test.ts
@@ -1,0 +1,130 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { expect, it } from "vitest";
+
+import {
+  type ReviewLiveMutation,
+  ReviewLiveMutationSchema,
+  parseLiveDocument,
+  planLiveMutation,
+} from "./review-live-document";
+
+const reviewUuid = randomUUID();
+function edit(
+  source: string | null,
+  operation: ReviewLiveMutation["operation"],
+) {
+  const current = {
+    source,
+    sourceHash:
+      source === null
+        ? null
+        : createHash("sha256").update(source).digest("hex"),
+  };
+  const request = ReviewLiveMutationSchema.parse({
+    reviewUuid,
+    mutationId: randomUUID(),
+    expectedSourceHash: current.sourceHash,
+    operation,
+  });
+  return { current, request, source: planLiveMutation(current, request) };
+}
+
+it("preserves arbitrary rich MDX while inserting, updating, moving, and deleting stable nodes", () => {
+  const initial = edit("# Old document", {
+    type: "replace",
+    nodes: [
+      { id: "title", source: "# Live review" },
+      {
+        id: "diagram",
+        source:
+          "<SequenceDiagram {...data.sequence} />\n\n<section>Nested prose</section>",
+      },
+    ],
+  });
+  const inserted = edit(initial.source, {
+    type: "insert",
+    afterId: "title",
+    node: { id: "intro", source: "Hello" },
+  });
+  const updated = edit(inserted.source, {
+    type: "update",
+    node: { id: "intro", source: "New prose" },
+  });
+  const moved = edit(updated.source, {
+    type: "move",
+    id: "diagram",
+    afterId: null,
+  });
+  const deleted = edit(moved.source, { type: "delete", id: "title" });
+  expect(parseLiveDocument(deleted.source)).toMatchObject({
+    revision: 5,
+    nodes: [
+      {
+        id: "diagram",
+        source:
+          "<SequenceDiagram {...data.sequence} />\n\n<section>Nested prose</section>",
+      },
+      { id: "intro", source: "New prose" },
+    ],
+  });
+  expect(
+    planLiveMutation(
+      { source: initial.source, sourceHash: "new-hash" },
+      initial.request,
+    ),
+  ).toBe(initial.source);
+  expect(() =>
+    planLiveMutation(
+      { source: initial.source, sourceHash: "new-hash" },
+      { ...initial.request, operation: { type: "replace", nodes: [] } },
+    ),
+  ).toThrow("already used");
+  expect(() =>
+    planLiveMutation(
+      { source: deleted.source, sourceHash: "latest" },
+      updated.request,
+    ),
+  ).toThrow("source changed");
+});
+
+it("requires explicit conversion, validates identifiers, and refuses ambiguous node boundaries", () => {
+  expect(() =>
+    edit("# Old", {
+      type: "insert",
+      afterId: null,
+      node: { id: "new", source: "Hello" },
+    }),
+  ).toThrow("explicitly start");
+  expect(() =>
+    edit(null, { type: "replace", nodes: [{ id: "bad/id", source: "Hello" }] }),
+  ).toThrow("Invalid string");
+  expect(() =>
+    edit(null, {
+      type: "replace",
+      nodes: [{ id: "ok", source: "{/* review-live/end */}" }],
+    }),
+  ).toThrow("reserved");
+  const live = edit(null, {
+    type: "replace",
+    nodes: [{ id: "one", source: "Hello" }],
+  }).source;
+  expect(() => parseLiveDocument(live + "extra")).toThrow("structure changed");
+  expect(() =>
+    edit(live, {
+      type: "insert",
+      afterId: "missing",
+      node: { id: "two", source: "Hi" },
+    }),
+  ).toThrow("Unknown");
+  expect(() => edit(live, { type: "move", id: "one", afterId: "one" })).toThrow(
+    "itself",
+  );
+  expect(() =>
+    edit(live, {
+      type: "insert",
+      afterId: null,
+      node: { id: "one", source: "Hi" },
+    }),
+  ).toThrow("already exists");
+});

--- a/packages/progressive-review/src/review-live-document.test.ts
+++ b/packages/progressive-review/src/review-live-document.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./review-live-document";
 
 const reviewUuid = randomUUID();
+
 function edit(
   source: string | null,
   operation: ReviewLiveMutation["operation"],
@@ -21,12 +22,14 @@ function edit(
         ? null
         : createHash("sha256").update(source).digest("hex"),
   };
+
   const request = ReviewLiveMutationSchema.parse({
     reviewUuid,
     mutationId: randomUUID(),
     expectedSourceHash: current.sourceHash,
     operation,
   });
+
   return { current, request, source: planLiveMutation(current, request) };
 }
 
@@ -42,20 +45,24 @@ it("preserves arbitrary rich MDX while inserting, updating, moving, and deleting
       },
     ],
   });
+
   const inserted = edit(initial.source, {
     type: "insert",
     afterId: "title",
     node: { id: "intro", source: "Hello" },
   });
+
   const updated = edit(inserted.source, {
     type: "update",
     node: { id: "intro", source: "New prose" },
   });
+
   const moved = edit(updated.source, {
     type: "move",
     id: "diagram",
     afterId: null,
   });
+
   const deleted = edit(moved.source, { type: "delete", id: "title" });
   expect(parseLiveDocument(deleted.source)).toMatchObject({
     revision: 5,
@@ -105,10 +112,12 @@ it("requires explicit conversion, validates identifiers, and refuses ambiguous n
       nodes: [{ id: "ok", source: "{/* review-live/end */}" }],
     }),
   ).toThrow("reserved");
+
   const live = edit(null, {
     type: "replace",
     nodes: [{ id: "one", source: "Hello" }],
   }).source;
+
   expect(() => parseLiveDocument(live + "extra")).toThrow("structure changed");
   expect(() =>
     edit(live, {

--- a/packages/progressive-review/src/review-live-document.ts
+++ b/packages/progressive-review/src/review-live-document.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { ReviewServerError } from "./server/http-json";
 
 const marker = "review-live/";
+
 const nodeSchema = z.strictObject({
   id: z.string().regex(/^[a-zA-Z][a-zA-Z0-9_-]{0,79}$/),
   source: z
@@ -15,6 +16,7 @@ const nodeSchema = z.strictObject({
       message: "MDX fragments cannot contain reserved review-live markers.",
     }),
 });
+
 const nodesSchema = z
   .array(nodeSchema)
   .max(1000)
@@ -22,6 +24,7 @@ const nodesSchema = z
     (nodes) => new Set(nodes.map((node) => node.id)).size === nodes.length,
     { message: "Node IDs must be unique." },
   );
+
 const headerSchema = z.strictObject({
   revision: z.number().int().positive(),
   mutationId: z.uuid(),
@@ -53,7 +56,9 @@ export const ReviewLiveMutationSchema = z.strictObject({
 });
 
 export type ReviewLiveMutation = z.infer<typeof ReviewLiveMutationSchema>;
+
 type LiveNode = z.infer<typeof nodeSchema>;
+
 interface LiveDocument extends z.infer<typeof headerSchema> {
   nodes: LiveNode[];
 }
@@ -61,6 +66,7 @@ interface LiveDocument extends z.infer<typeof headerSchema> {
 /** Ordinary MDX, compiled by the same native compiler as a sealed document. */
 export function serializeLiveDocument(document: LiveDocument): string {
   const { nodes, ...header } = document;
+
   return [
     `{/* review-live/1 ${JSON.stringify(header)} */}`,
     'import * as data from "./data.ts";',
@@ -75,18 +81,23 @@ export function serializeLiveDocument(document: LiveDocument): string {
 export function parseLiveDocument(source: string | null): LiveDocument | null {
   if (!source?.startsWith("{/* review-live/1 ")) return null;
   const header = /^\{\/\* review-live\/1 (.+) \*\/\}/.exec(source);
+
   if (!header) throw conflict("Invalid live document header.");
   const metadata = headerSchema.parse(parseJsonText(header[1]!));
+
   const nodes = [
     ...source.matchAll(
       /\{\/\* review-live\/node ([\w-]+) \*\/\}\n<section id="review-node-\1" className="review-live-[a-f0-9]+">\n\n([\s\S]*?)\n\n<\/section>\n\{\/\* review-live\/end \*\/\}/g,
     ),
   ].map((match) => ({ id: match[1]!, source: match[2]! }));
+
   const document = { ...metadata, nodes: nodesSchema.parse(nodes) };
+
   if (serializeLiveDocument(document) !== source)
     throw conflict(
       "Live document structure changed outside the node API. Replace the document explicitly to recover.",
     );
+
   return document;
 }
 
@@ -97,35 +108,45 @@ export function planLiveMutation(
 ): string {
   // An explicit replacement can also recover a manually damaged live document.
   let document: LiveDocument | null;
+
   try {
     document = parseLiveDocument(current.source);
   } catch (error) {
     if (request.operation.type !== "replace") throw error;
     document = null;
   }
+
   const requestHash = createHash("sha256")
     .update(JSON.stringify(request))
     .digest("hex");
+
   if (document?.mutationId === request.mutationId) {
     if (document.requestHash !== requestHash)
       throw conflict("Mutation ID was already used for a different edit.");
+
     return current.source!;
   }
+
   if (current.sourceHash !== request.expectedSourceHash)
     throw conflict(
       "Document source changed. Read the live document before retrying.",
     );
   const operation = request.operation;
+
   if (!document && operation.type !== "replace")
     throw conflict(
       "Use replace to explicitly start live authoring of this document.",
     );
   const nodes = [...(document?.nodes ?? [])];
+
   const indexOf = (id: string) => {
     const index = nodes.findIndex((node) => node.id === id);
+
     if (index < 0) throw conflict(`Unknown live node: ${id}`);
+
     return index;
   };
+
   switch (operation.type) {
     case "replace":
       nodes.splice(0, nodes.length, ...operation.nodes);
@@ -157,6 +178,7 @@ export function planLiveMutation(
       break;
     }
   }
+
   return serializeLiveDocument({
     revision: (document?.revision ?? 0) + 1,
     mutationId: request.mutationId,

--- a/packages/progressive-review/src/review-live-document.ts
+++ b/packages/progressive-review/src/review-live-document.ts
@@ -1,0 +1,170 @@
+import { createHash } from "node:crypto";
+
+import { parseJsonText } from "@dev.fast/review-protocol";
+import { z } from "zod";
+
+import { ReviewServerError } from "./server/http-json";
+
+const marker = "review-live/";
+const nodeSchema = z.strictObject({
+  id: z.string().regex(/^[a-zA-Z][a-zA-Z0-9_-]{0,79}$/),
+  source: z
+    .string()
+    .min(1)
+    .refine((source) => !source.includes(marker), {
+      message: "MDX fragments cannot contain reserved review-live markers.",
+    }),
+});
+const nodesSchema = z
+  .array(nodeSchema)
+  .max(1000)
+  .refine(
+    (nodes) => new Set(nodes.map((node) => node.id)).size === nodes.length,
+    { message: "Node IDs must be unique." },
+  );
+const headerSchema = z.strictObject({
+  revision: z.number().int().positive(),
+  mutationId: z.uuid(),
+  requestHash: z.string(),
+});
+
+export const ReviewLiveMutationSchema = z.strictObject({
+  reviewUuid: z.uuid(),
+  mutationId: z.uuid(),
+  expectedSourceHash: z.string().nullable(),
+  operation: z.discriminatedUnion("type", [
+    z.strictObject({ type: z.literal("replace"), nodes: nodesSchema }),
+    z.strictObject({
+      type: z.literal("insert"),
+      node: nodeSchema,
+      afterId: nodeSchema.shape.id.nullable(),
+    }),
+    z.strictObject({
+      type: z.literal("update"),
+      node: nodeSchema,
+    }),
+    z.strictObject({ type: z.literal("delete"), id: nodeSchema.shape.id }),
+    z.strictObject({
+      type: z.literal("move"),
+      id: nodeSchema.shape.id,
+      afterId: nodeSchema.shape.id.nullable(),
+    }),
+  ]),
+});
+
+export type ReviewLiveMutation = z.infer<typeof ReviewLiveMutationSchema>;
+type LiveNode = z.infer<typeof nodeSchema>;
+interface LiveDocument extends z.infer<typeof headerSchema> {
+  nodes: LiveNode[];
+}
+
+/** Ordinary MDX, compiled by the same native compiler as a sealed document. */
+export function serializeLiveDocument(document: LiveDocument): string {
+  const { nodes, ...header } = document;
+  return [
+    `{/* review-live/1 ${JSON.stringify(header)} */}`,
+    'import * as data from "./data.ts";',
+    ...nodes.map(
+      ({ id, source }) =>
+        `{/* review-live/node ${id} */}\n<section id="review-node-${id}" className="review-live-${createHash("sha256").update(source).digest("hex")}">\n\n${source}\n\n</section>\n{/* review-live/end */}`,
+    ),
+    "",
+  ].join("\n\n");
+}
+
+export function parseLiveDocument(source: string | null): LiveDocument | null {
+  if (!source?.startsWith("{/* review-live/1 ")) return null;
+  const header = /^\{\/\* review-live\/1 (.+) \*\/\}/.exec(source);
+  if (!header) throw conflict("Invalid live document header.");
+  const metadata = headerSchema.parse(parseJsonText(header[1]!));
+  const nodes = [
+    ...source.matchAll(
+      /\{\/\* review-live\/node ([\w-]+) \*\/\}\n<section id="review-node-\1" className="review-live-[a-f0-9]+">\n\n([\s\S]*?)\n\n<\/section>\n\{\/\* review-live\/end \*\/\}/g,
+    ),
+  ].map((match) => ({ id: match[1]!, source: match[2]! }));
+  const document = { ...metadata, nodes: nodesSchema.parse(nodes) };
+  if (serializeLiveDocument(document) !== source)
+    throw conflict(
+      "Live document structure changed outside the node API. Replace the document explicitly to recover.",
+    );
+  return document;
+}
+
+/** Pure edit planning: no source is changed until the native compiler accepts it. */
+export function planLiveMutation(
+  current: { source: string | null; sourceHash: string | null },
+  request: ReviewLiveMutation,
+): string {
+  // An explicit replacement can also recover a manually damaged live document.
+  let document: LiveDocument | null;
+  try {
+    document = parseLiveDocument(current.source);
+  } catch (error) {
+    if (request.operation.type !== "replace") throw error;
+    document = null;
+  }
+  const requestHash = createHash("sha256")
+    .update(JSON.stringify(request))
+    .digest("hex");
+  if (document?.mutationId === request.mutationId) {
+    if (document.requestHash !== requestHash)
+      throw conflict("Mutation ID was already used for a different edit.");
+    return current.source!;
+  }
+  if (current.sourceHash !== request.expectedSourceHash)
+    throw conflict(
+      "Document source changed. Read the live document before retrying.",
+    );
+  const operation = request.operation;
+  if (!document && operation.type !== "replace")
+    throw conflict(
+      "Use replace to explicitly start live authoring of this document.",
+    );
+  const nodes = [...(document?.nodes ?? [])];
+  const indexOf = (id: string) => {
+    const index = nodes.findIndex((node) => node.id === id);
+    if (index < 0) throw conflict(`Unknown live node: ${id}`);
+    return index;
+  };
+  switch (operation.type) {
+    case "replace":
+      nodes.splice(0, nodes.length, ...operation.nodes);
+      break;
+    case "update":
+      nodes[indexOf(operation.node.id)] = operation.node;
+      break;
+    case "delete":
+      nodes.splice(indexOf(operation.id), 1);
+      break;
+    case "insert":
+      if (nodes.some((node) => node.id === operation.node.id))
+        throw conflict(`Live node already exists: ${operation.node.id}`);
+      nodes.splice(
+        operation.afterId === null ? 0 : indexOf(operation.afterId) + 1,
+        0,
+        operation.node,
+      );
+      break;
+    case "move": {
+      if (operation.id === operation.afterId)
+        throw conflict("A node cannot be moved after itself.");
+      const [node] = nodes.splice(indexOf(operation.id), 1);
+      nodes.splice(
+        operation.afterId === null ? 0 : indexOf(operation.afterId) + 1,
+        0,
+        node!,
+      );
+      break;
+    }
+  }
+  return serializeLiveDocument({
+    revision: (document?.revision ?? 0) + 1,
+    mutationId: request.mutationId,
+    requestHash,
+    nodes: nodesSchema.parse(nodes),
+  });
+}
+
+function conflict(message: string): ReviewServerError {
+  return new ReviewServerError(message, 409);
+}

--- a/packages/progressive-review/src/review-mcp.ts
+++ b/packages/progressive-review/src/review-mcp.ts
@@ -22,10 +22,25 @@ import {
   ReviewRebindRequestSchema,
   ReviewScaffoldRequestSchema,
 } from "./review-lifecycle-contracts";
+import { ReviewLiveMutationSchema } from "./review-live-document";
 
 const reviewTarget = z.strictObject({ reviewUuid: z.uuid() });
 
 const tools = [
+  {
+    name: "review_get_live_document",
+    description:
+      "Read stable MDX nodes and the source hash for incremental authoring.",
+    path: "/lifecycle/document/live",
+    schema: reviewTarget,
+  },
+  {
+    name: "review_mutate_document",
+    description:
+      "Replace, insert, update, move, or delete stable MDX nodes. Each edit is compiled and shown live; rich Review components and data.ts expressions are supported. Use replace to start, then the returned source hash for each edit. afterId null inserts at the beginning. Publish separately to seal a revision.",
+    path: "/lifecycle/document/mutate",
+    schema: ReviewLiveMutationSchema,
+  },
   {
     name: "review_create",
     description: "Create or update a Review bound to a source checkout.",

--- a/packages/progressive-review/src/review-publication-staging.test.ts
+++ b/packages/progressive-review/src/review-publication-staging.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import {
   mkdir,
@@ -29,8 +30,64 @@ import {
 import { appendReviewComment, readReviewComments } from "./review-state-store";
 import { closeAllReviewThreadStores } from "./review-thread-store-backend";
 import { reviewVcs } from "./review-vcs";
+import {
+  mutateLiveDocument,
+  readLiveBundle,
+  readLiveSnapshot,
+} from "./server/review-live-authoring";
 
 const roots: string[] = [];
+
+it("compiles rich live MDX with native data, rejects invalid edits, and recovers its projection", async () => {
+  const { review } = await fixture();
+  const initial = await readLiveSnapshot(review);
+  const snapshot = await withReviewMutationLock(review.dir, () =>
+    mutateLiveDocument(review, {
+      reviewUuid: review.review.uuid,
+      mutationId: randomUUID(),
+      expectedSourceHash: initial.sourceHash,
+      operation: {
+        type: "replace",
+        nodes: [
+          { id: "title", source: "# Native live review\n\n{data.label}" },
+          {
+            id: "diagram",
+            source:
+              '<SequenceDiagram label="Flow" messages={[{from: {label: "Agent"}, to: {label: "Desktop"}, label: "Author", code: "api.edit()"}]} />',
+          },
+        ],
+      },
+    }),
+  );
+  expect(snapshot).toMatchObject({ mode: "incremental", revision: 1 });
+  const bundle = await readLiveBundle(review);
+  expect(bundle).not.toBeNull();
+  const document = reviewDocumentBundleData(bundle!);
+  expect(JSON.stringify(document)).toContain('"name":"SequenceDiagram"');
+  expect(JSON.stringify(document)).toContain('"id":"review-node-diagram"');
+  expect(JSON.stringify(document)).toContain("original");
+  expect(await readReviewDocumentBundle(review.dir, "/")).toBeNull();
+  await expect(
+    withReviewMutationLock(review.dir, () =>
+      mutateLiveDocument(review, {
+        reviewUuid: review.review.uuid,
+        mutationId: randomUUID(),
+        expectedSourceHash: snapshot.sourceHash,
+        operation: {
+          type: "update",
+          node: { id: "diagram", source: '<SequenceDiagram typo="broken" />' },
+        },
+      }),
+    ),
+  ).rejects.toThrow("Property 'typo' does not exist");
+  expect(await readLiveSnapshot(review)).toEqual(snapshot);
+  // A raw data.ts edit invalidates the cached native projection.
+  await writeFile(
+    path.join(review.dir, "data.ts"),
+    'export const label = "updated data";',
+  );
+  expect((await readLiveBundle(review))?.json).toContain("updated data");
+}, 30_000);
 afterEach(async () => {
   vi.unstubAllEnvs();
   closeAllReviewThreadStores();

--- a/packages/progressive-review/src/review-publication-staging.test.ts
+++ b/packages/progressive-review/src/review-publication-staging.test.ts
@@ -41,6 +41,7 @@ const roots: string[] = [];
 it("compiles rich live MDX with native data, rejects invalid edits, and recovers its projection", async () => {
   const { review } = await fixture();
   const initial = await readLiveSnapshot(review);
+
   const snapshot = await withReviewMutationLock(review.dir, () =>
     mutateLiveDocument(review, {
       reviewUuid: review.review.uuid,
@@ -59,6 +60,7 @@ it("compiles rich live MDX with native data, rejects invalid edits, and recovers
       },
     }),
   );
+
   expect(snapshot).toMatchObject({ mode: "incremental", revision: 1 });
   const bundle = await readLiveBundle(review);
   expect(bundle).not.toBeNull();
@@ -88,6 +90,7 @@ it("compiles rich live MDX with native data, rejects invalid edits, and recovers
   );
   expect((await readLiveBundle(review))?.json).toContain("updated data");
 }, 30_000);
+
 afterEach(async () => {
   vi.unstubAllEnvs();
   closeAllReviewThreadStores();
@@ -98,10 +101,12 @@ afterEach(async () => {
 
 it("prepares outside the live lock while preserving viewed and comment updates", async () => {
   const { review, home } = await fixture();
+
   const dependency = path.join(
     home,
     "reviews/node_modules/review-staging-dependency",
   );
+
   await mkdir(dependency, { recursive: true });
   await writeFile(
     path.join(dependency, "package.json"),
@@ -129,6 +134,7 @@ it("prepares outside the live lock while preserving viewed and comment updates",
   const updatesComplete = Promise.withResolvers<void>();
   const releaseHolder = Promise.withResolvers<void>();
   let holderReleased = false;
+
   const holder = withReviewMutationLock(review.dir, async () => {
     holderReady.resolve();
     await beginUpdates.promise;
@@ -144,9 +150,11 @@ it("prepares outside the live lock while preserving viewed and comment updates",
     await releaseHolder.promise;
     holderReleased = true;
   });
+
   let staging: ReturnType<typeof stageReviewDocumentPublication> | undefined;
   let document!: Awaited<ReturnType<typeof stageReviewDocumentPublication>>;
   let stagingDir!: string;
+
   try {
     await Promise.race([holderReady.promise, holder]);
     staging = stageReviewDocumentPublication({ review });
@@ -158,9 +166,11 @@ it("prepares outside the live lock while preserving viewed and comment updates",
   } finally {
     beginUpdates.resolve();
     releaseHolder.resolve();
+
     if (staging) await Promise.allSettled([staging]);
     await holder;
   }
+
   expect(existsSync(stagingDir)).toBe(false);
   expect(existsSync(path.join(review.dir, ".bundle"))).toBe(false);
   expect(JSON.stringify(reviewDocumentBundleData(document.bundle))).toContain(
@@ -178,6 +188,7 @@ it("prepares outside the live lock while preserving viewed and comment updates",
       .messages,
   ).toHaveLength(1);
   const materializedBundle = await readReviewDocumentBundle(materialized, "/");
+
   if (!materializedBundle) throw new Error("Missing materialized bundle");
   expect(reviewDocumentBundleData(materializedBundle)).toEqual(
     reviewDocumentBundleData(document.bundle),
@@ -189,24 +200,29 @@ async function waitForStagingCopy(reviewsDir: string): Promise<string> {
   for (let attempt = 0; attempt < 600; attempt++) {
     for (const name of await readdir(reviewsDir)) {
       const candidate = path.join(reviewsDir, name);
+
       if (
         name.startsWith(".review-publish-") &&
         existsSync(path.join(candidate, "review.mdx"))
       )
         return candidate;
     }
+
     await setTimeout(10);
   }
+
   throw new Error("Publication staging never copied the review.");
 }
 
 it("resolves Review-local pnpm dependencies without copying their symlinks", async () => {
   const { review } = await fixture();
   const modules = path.join(review.dir, "node_modules");
+
   const dependency = path.join(
     modules,
     ".pnpm/review-local@1.0.0/node_modules/review-local",
   );
+
   await mkdir(dependency, { recursive: true });
   await writeFile(
     path.join(dependency, "package.json"),
@@ -250,18 +266,23 @@ it("takes the mutation lock around document write and seal", async () => {
   const document = await stageReviewDocumentPublication({ review });
   const entered = Promise.withResolvers<void>();
   const release = Promise.withResolvers<void>();
+
   const holding = withReviewMutationLock(review.dir, async () => {
     entered.resolve();
     await release.promise;
   });
+
   await entered.promise;
   let finished = false;
+
   const sealing = sealReviewDocumentPublication({ review, document }).then(
     (revision) => {
       finished = true;
+
       return revision;
     },
   );
+
   for (let attempt = 0; attempt < 30; attempt++) await setImmediate();
   const bypassed = finished;
   release.resolve();
@@ -311,6 +332,7 @@ it.each([
 
 it("rechecks new open threads before sealing a prepared republication", async () => {
   const fixtureValue = await fixture();
+
   const review = {
     ...fixtureValue.review,
     review: {
@@ -318,6 +340,7 @@ it("rechecks new open threads before sealing a prepared republication", async ()
       presentedDocumentRevision: "a".repeat(40),
     },
   };
+
   await writeFile(
     path.join(review.dir, "review.json"),
     JSON.stringify(review.review),
@@ -357,12 +380,15 @@ async function fixture() {
   const home = await mkdtemp(
     path.join(tmpdir(), "review-publication-staging-"),
   );
+
   roots.push(home);
   vi.stubEnv("DEV_REVIEW_HOME", home);
   const root = path.join(home, "source");
   await mkdir(root);
+
   const git = (args: string[]) =>
     execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+
   git(["init", "-q", "-b", "main"]);
   git(["config", "user.email", "review@example.test"]);
   git(["config", "user.name", "Review Test"]);
@@ -370,6 +396,7 @@ async function fixture() {
   git(["add", "."]);
   git(["commit", "-qm", "source"]);
   const commit = git(["rev-parse", "HEAD"]);
+
   const review = await createReviewDir({
     worktreePath: root,
     baseRef: "main",
@@ -377,6 +404,7 @@ async function fixture() {
     sourceCommit: commit,
     sourceIdentity: { kind: "git-branch", name: "main" },
   });
+
   await writeFile(
     path.join(review.dir, "review.mdx"),
     'import { label } from "./data";\n\n# Staged document\n\n{label}\n',
@@ -385,5 +413,6 @@ async function fixture() {
     path.join(review.dir, "data.ts"),
     'export const label = "original";',
   );
+
   return { home, review };
 }

--- a/packages/progressive-review/src/review-publication-staging.ts
+++ b/packages/progressive-review/src/review-publication-staging.ts
@@ -31,10 +31,12 @@ interface StagedReviewDocument {
   bundle: ReviewDocumentBundle;
   warnings: string[];
   fingerprint: string;
+  sourceFingerprint: string;
 }
 
 export async function stageReviewDocumentPublication(input: {
   review: StoredReview;
+  source?: string;
 }): Promise<StagedReviewDocument> {
   const stagingDir = await mkdtemp(
     path.join(path.dirname(input.review.dir), ".review-publish-"),
@@ -43,6 +45,12 @@ export async function stageReviewDocumentPublication(input: {
     const fingerprint = await copyAuthoringTree(input.review.dir, stagingDir);
     if (fingerprint !== (await fingerprintAuthoring(input.review.dir)))
       throw authoringChanged();
+    if (input.source !== undefined)
+      await writeFile(path.join(stagingDir, "review.mdx"), input.source);
+    const sourceFingerprint =
+      input.source === undefined
+        ? fingerprint
+        : await fingerprintAuthoring(stagingDir);
     const dependencies = path.join(input.review.dir, "node_modules");
     let hasDependencies = true;
     try {
@@ -69,6 +77,7 @@ export async function stageReviewDocumentPublication(input: {
       bundle: prepared.bundle,
       warnings: prepared.warnings,
       fingerprint,
+      sourceFingerprint,
     };
   } catch (error) {
     if (error instanceof ReviewPublicationValidationError) {
@@ -120,7 +129,7 @@ const authoringTreeOptions = {
   symlink: "reject",
 } satisfies ReviewTreeOptions;
 
-async function fingerprintAuthoring(reviewDir: string): Promise<string> {
+export async function fingerprintAuthoring(reviewDir: string): Promise<string> {
   return fingerprintReviewTree(reviewDir, authoringTreeOptions);
 }
 

--- a/packages/progressive-review/src/review-publication-staging.ts
+++ b/packages/progressive-review/src/review-publication-staging.ts
@@ -41,24 +41,31 @@ export async function stageReviewDocumentPublication(input: {
   const stagingDir = await mkdtemp(
     path.join(path.dirname(input.review.dir), ".review-publish-"),
   );
+
   try {
     const fingerprint = await copyAuthoringTree(input.review.dir, stagingDir);
+
     if (fingerprint !== (await fingerprintAuthoring(input.review.dir)))
       throw authoringChanged();
+
     if (input.source !== undefined)
       await writeFile(path.join(stagingDir, "review.mdx"), input.source);
+
     const sourceFingerprint =
       input.source === undefined
         ? fingerprint
         : await fingerprintAuthoring(stagingDir);
+
     const dependencies = path.join(input.review.dir, "node_modules");
     let hasDependencies = true;
+
     try {
       await lstat(dependencies);
     } catch (error) {
       if (!isMissingFileError(error)) throw error;
       hasDependencies = false;
     }
+
     if (hasDependencies) {
       await symlink(
         dependencies,
@@ -66,13 +73,16 @@ export async function stageReviewDocumentPublication(input: {
         process.platform === "win32" ? "junction" : "dir",
       );
     }
+
     await writeFile(
       path.join(stagingDir, "review.json"),
       JSON.stringify(input.review.review),
     );
+
     const prepared = await prepareReviewDocumentBundle({
       review: { ...input.review, dir: stagingDir },
     });
+
     return {
       bundle: prepared.bundle,
       warnings: prepared.warnings,
@@ -90,6 +100,7 @@ export async function stageReviewDocumentPublication(input: {
         error.warnings,
       );
     }
+
     throw error;
   } finally {
     await rm(stagingDir, { recursive: true, force: true });
@@ -102,6 +113,7 @@ export async function sealReviewDocumentPublication(input: {
 }): Promise<string> {
   return withReviewMutationLock(input.review.dir, async () => {
     await assertReviewUnchanged(input.review.dir, input.review.review);
+
     if (
       input.document.fingerprint !==
       (await fingerprintAuthoring(input.review.dir))
@@ -110,6 +122,7 @@ export async function sealReviewDocumentPublication(input: {
     requireClosedThreadsForRepublish(input.review);
     requireCompletedAgentResponsesForRepublish(input.review);
     await writeReviewDocumentBundle(input.review.dir, input.document.bundle);
+
     return sealReviewCandidate(
       input.review.dir,
       REVIEW_PUBLISH_CANDIDATE_MESSAGE,

--- a/packages/progressive-review/src/review-publish-evaluate.test.ts
+++ b/packages/progressive-review/src/review-publish-evaluate.test.ts
@@ -23,6 +23,7 @@ describe("publish range evaluation", () => {
     const reviewDir = fixtureDir("review");
     const head = sourceFixture("head line");
     const base = sourceFixture("base line");
+
     const prepareEvidence = vi.fn<() => Promise<ReviewPublishEvidenceTargets>>(
       async () => ({
         head: { sourceRootPath: head },
@@ -69,11 +70,13 @@ describe("publish range evaluation", () => {
       }),
     ).rejects.toThrow("no runtime import");
     expect(fs.existsSync(path.join(reviewDir, ".build"))).toBe(false);
+
     const valid = await evaluateReviewDocumentBundleForPublish({
       reviewDir,
       bundleCode: bundleWithAnchors(""),
       prepareEvidence: async () => ({ head: { sourceRootPath: reviewDir } }),
     });
+
     expect(valid.errors).toEqual([]);
   });
 
@@ -101,6 +104,7 @@ describe("publish range evaluation", () => {
   it("does not prepare a worktree when the document has no peeks", async () => {
     const prepareEvidence =
       vi.fn<() => Promise<ReviewPublishEvidenceTargets>>();
+
     const result = await evaluateReviewDocumentBundleForPublish({
       reviewDir: fixtureDir("review"),
       bundleCode: bundleWithAnchors('summary: "Summary",'),
@@ -120,6 +124,7 @@ describe("publish range evaluation", () => {
         const anchors = session.defineAnchors({ shown: { title: "Shown", peek: { file: "x.ts", fromLine: 1, toLine: 1 } }, unused: { title: "Unused", peek: { file: "x.ts", fromLine: 2, toLine: 2 } } });
         export default createActiveReviewDocument({ title: "Legacy", routePath: "/", filePath: "review.mdx", modelNames: [], models: {}, Component: ({ components }) => jsx(components.AnchorLink, { anchor: anchors.shown, children: "Shown" }), isDefault: true });`,
     });
+
     expect(result.errors).toEqual([]);
     expect(Object.keys(result.document!.anchors).sort()).toEqual([
       "shown",
@@ -136,6 +141,7 @@ const base = defineSoftwareModel({ systems: { service: { label: "Base" } } });
 defineSoftwareModel({ systems: { inline: { label: "Inline" } } });
 export default createActiveReviewDocument({ title: "Legacy", routePath: "/", filePath: "review.mdx", modelNames: [], models: {}, repoSoftwareMap: head, baseSoftwareMap: base, Component: () => jsx("p", { children: "Legacy" }) });`,
     });
+
     expect(result.errors).toEqual([]);
     expect(result.legacySoftwareMap?.head.elements[0].label).toBe("Head");
     expect(result.legacySoftwareMap?.base.elements[0].label).toBe("Base");
@@ -159,6 +165,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
 const head = defineSoftwareModel({ systems: { service: { label: "Head" } } });
 export default createActiveReviewDocument({ title: "Legacy", routePath: "/", filePath: "review.mdx", modelNames: [], models: {}, repoSoftwareMap: ${head}, baseSoftwareMap: ${base}, Component: () => jsx("p", { children: "Legacy" }) });`,
       });
+
       expect(result.document).toBeNull();
       expect(result.legacySoftwareMap).toBeUndefined();
       expect(result.errors).toEqual([
@@ -170,6 +177,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
   it("materializes document metadata, nodes, anchors, and ordered software models", async () => {
     const reviewDir = fixtureDir("review");
     const head = sourceFixture("one line");
+
     const result = await evaluateReviewDocumentBundleForPublish({
       reviewDir,
       bundleCode: `
@@ -251,6 +259,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
         `React.createElement(components.CodePeek, {})`,
       ),
     });
+
     expect(auditFailure.errors.length).toBeGreaterThan(0);
     expect(auditFailure.document).toBeNull();
 
@@ -262,6 +271,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
         ),
       },
     );
+
     expect(documentLocalComponent.errors).toContain(
       "Document-local components are not supported; use the Review components.",
     );
@@ -271,6 +281,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
       reviewDir: fixtureDir("review"),
       bundleCode: bundleWithDocumentBody(`React.createElement("video")`),
     });
+
     expect(schemaFailure.errors.length).toBeGreaterThan(0);
     expect(schemaFailure.document).toBeNull();
   });
@@ -335,6 +346,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
 
     it("passes when quote text matches trace", async () => {
       const reviewDir = fixtureDir("review");
+
       const result = await evaluateReviewDocumentBundleForPublish({
         reviewDir,
         bundleCode: `
@@ -370,6 +382,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
 
     it("fails when quote text is not found in trace", async () => {
       const reviewDir = fixtureDir("review");
+
       const result = await evaluateReviewDocumentBundleForPublish({
         reviewDir,
         bundleCode: `
@@ -406,6 +419,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
 
     it("emits warning when event hint is stale", async () => {
       const reviewDir = fixtureDir("review");
+
       const result = await evaluateReviewDocumentBundleForPublish({
         reviewDir,
         bundleCode: `
@@ -446,6 +460,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
     const reviewDir = fixtureDir("review");
     const events: string[] = [];
     vi.stubGlobal("__reviewEvaluationEvents", events);
+
     const slow = `
       globalThis.__reviewEvaluationEvents.push("first:enter");
       ${bundleWithAnchors("")
@@ -456,11 +471,13 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
         )}
       globalThis.__reviewEvaluationEvents.push("first:exit");
     `;
+
     const fast = `
       globalThis.__reviewEvaluationEvents.push("second:enter");
       ${bundleWithAnchors("").replace('title: "Fixture"', 'title: "Second"')}
       globalThis.__reviewEvaluationEvents.push("second:exit");
     `;
+
     try {
       const [first, second] = await Promise.all([
         evaluateReviewDocumentBundleForPublish({
@@ -474,6 +491,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
           ranges: "skip",
         }),
       ]);
+
       const firstName = events[0]?.split(":")[0];
       const secondName = firstName === "first" ? "second" : "first";
       expect(events).toEqual([
@@ -495,11 +513,13 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
     const reviewDir = fixtureDir("review");
     const invalidReviewDir = path.join(reviewDir, "not-a-directory");
     fs.writeFileSync(invalidReviewDir, "occupied");
+
     const failed = evaluateReviewDocumentBundleForPublish({
       reviewDir: invalidReviewDir,
       bundleCode: bundleWithAnchors(""),
       ranges: "skip",
     });
+
     const next = evaluateReviewDocumentBundleForPublish({
       reviewDir,
       bundleCode: bundleWithAnchors(""),
@@ -517,6 +537,7 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
     const reviewDir = fixtureDir("review");
     const previous = { marker: "existing runtime" };
     vi.stubGlobal("__devFastReviewPublishRuntime", previous);
+
     try {
       const [failed, healthy] = await Promise.all([
         evaluateReviewDocumentBundleForPublish({
@@ -533,13 +554,16 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
           ),
         }),
       ]);
+
       expect(failed.errors.join(" ")).toContain("evaluation failed");
       expect(healthy.errors).toEqual([]);
       expect(healthy.document?.title).toBe("Healthy");
+
       // SAFETY: this test installs and restores the private runtime slot.
       const holder = globalThis as typeof globalThis & {
         __devFastReviewPublishRuntime?: typeof previous;
       };
+
       expect(holder.__devFastReviewPublishRuntime).toBe(previous);
       expect(fs.readdirSync(path.join(reviewDir, ".build"))).toEqual([]);
     } finally {
@@ -551,12 +575,14 @@ export default createActiveReviewDocument({ title: "Legacy", routePath: "/", fil
     const root = fixtureDir("source");
     fs.mkdirSync(path.join(root, "src"));
     fs.writeFileSync(path.join(root, "src", "example.ts"), source);
+
     return root;
   }
 
   function fixtureDir(label: string): string {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), `${label}-`));
     roots.push(root);
+
     return root;
   }
 });

--- a/packages/progressive-review/src/review-publish-evaluate.test.ts
+++ b/packages/progressive-review/src/review-publish-evaluate.test.ts
@@ -59,6 +59,24 @@ describe("publish range evaluation", () => {
     expect(prepareEvidence).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects a corrupt legacy module before writing temporary files and permits the next evaluation", async () => {
+    const reviewDir = fixtureDir("corrupt");
+    await expect(
+      evaluateReviewDocumentBundleForPublish({
+        reviewDir,
+        bundleCode: 'throw new Error("corrupt sealed document");',
+        prepareEvidence: async () => ({ head: { sourceRootPath: reviewDir } }),
+      }),
+    ).rejects.toThrow("no runtime import");
+    expect(fs.existsSync(path.join(reviewDir, ".build"))).toBe(false);
+    const valid = await evaluateReviewDocumentBundleForPublish({
+      reviewDir,
+      bundleCode: bundleWithAnchors(""),
+      prepareEvidence: async () => ({ head: { sourceRootPath: reviewDir } }),
+    });
+    expect(valid.errors).toEqual([]);
+  });
+
   it("reports a range outside the selected pinned file", async () => {
     const reviewDir = fixtureDir("review");
     const head = sourceFixture("one line");

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -1131,9 +1131,12 @@ export function createGlobalReviewServer(
     const request = z
       .strictObject({ reviewUuid: z.uuid() })
       .parse(await readBoundedRequestJson(context.req.raw));
+
     return withReviewLock(request.reviewUuid, async () => {
       const review = await findReview(request.reviewUuid);
+
       if (!review) throw new ReviewServerError("Review not found.", 404);
+
       return globalJson(200, await readLiveSnapshot(review));
     });
   });
@@ -1141,11 +1144,15 @@ export function createGlobalReviewServer(
     const request = ReviewLiveMutationSchema.parse(
       await readBoundedRequestJson(context.req.raw),
     );
+
     const snapshot = await withReviewLock(request.reviewUuid, async () => {
       const review = await findReview(request.reviewUuid);
+
       if (!review) throw new ReviewServerError("Review not found.", 404);
+
       return mutateLiveDocument(review, request);
     });
+
     for (const session of sessions.values()) {
       if (
         session.review.review.uuid !== request.reviewUuid ||
@@ -1160,6 +1167,7 @@ export function createGlobalReviewServer(
         documentChanged: true,
       });
     }
+
     return globalJson(200, snapshot);
   });
   app.post("/lifecycle/metadata", async (context) => {
@@ -2656,14 +2664,17 @@ export function createGlobalReviewServer(
         : async () => {
             // Candidate mount validation may run while publication owns the lock.
             if (!active.promoted) return null;
+
             return withReviewLock(registration.review.review.uuid, async () => {
               const latest = await findReview(registration.review.review.uuid);
+
               if (
                 latest?.review.baseCommit !== active.review.review.baseCommit ||
                 latest?.review.sourceCommit !==
                   active.review.review.sourceCommit
               )
                 return null;
+
               return latest ? readLiveBundle(latest) : null;
             });
           },

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -104,6 +104,7 @@ import {
   ReviewResolveRequestSchema,
   ReviewScaffoldRequestSchema,
 } from "../review-lifecycle-contracts";
+import { ReviewLiveMutationSchema } from "../review-live-document";
 import {
   ReviewBusyError,
   reviewBusyResponse,
@@ -173,6 +174,11 @@ import {
   rebindReview,
   repairReview,
 } from "./review-lifecycle";
+import {
+  mutateLiveDocument,
+  readLiveBundle,
+  readLiveSnapshot,
+} from "./review-live-authoring";
 import { promoteReviewRepair } from "./review-repair-promotion";
 import { resolveThreadsReview } from "./review-threads-target";
 import {
@@ -1120,6 +1126,41 @@ export function createGlobalReviewServer(
     if (!review) throw new ReviewServerError("Review not found.", 404);
 
     return globalJson(200, await readReviewDocumentFile(review, request.name));
+  });
+  app.post("/lifecycle/document/live", async (context) => {
+    const request = z
+      .strictObject({ reviewUuid: z.uuid() })
+      .parse(await readBoundedRequestJson(context.req.raw));
+    return withReviewLock(request.reviewUuid, async () => {
+      const review = await findReview(request.reviewUuid);
+      if (!review) throw new ReviewServerError("Review not found.", 404);
+      return globalJson(200, await readLiveSnapshot(review));
+    });
+  });
+  app.post("/lifecycle/document/mutate", async (context) => {
+    const request = ReviewLiveMutationSchema.parse(
+      await readBoundedRequestJson(context.req.raw),
+    );
+    const snapshot = await withReviewLock(request.reviewUuid, async () => {
+      const review = await findReview(request.reviewUuid);
+      if (!review) throw new ReviewServerError("Review not found.", 404);
+      return mutateLiveDocument(review, request);
+    });
+    for (const session of sessions.values()) {
+      if (
+        session.review.review.uuid !== request.reviewUuid ||
+        session.historicalRevision ||
+        !session.promoted
+      )
+        continue;
+      broadcastGlobal({
+        event: "review-data-changed",
+        uuid: request.reviewUuid,
+        sessionId: session.descriptor.sessionId,
+        documentChanged: true,
+      });
+    }
+    return globalJson(200, snapshot);
   });
   app.post("/lifecycle/metadata", async (context) => {
     const request = ReviewMetadataUpdateSchema.extend({
@@ -2610,6 +2651,22 @@ export function createGlobalReviewServer(
       reviewPath: registration.documentPath,
       softwareMapRootPath: registration.softwareMapRootPath,
       stateReviewPath: path.join(registration.review.dir, "review.mdx"),
+      getLiveBundle: registration.historicalRevision
+        ? undefined
+        : async () => {
+            // Candidate mount validation may run while publication owns the lock.
+            if (!active.promoted) return null;
+            return withReviewLock(registration.review.review.uuid, async () => {
+              const latest = await findReview(registration.review.review.uuid);
+              if (
+                latest?.review.baseCommit !== active.review.review.baseCommit ||
+                latest?.review.sourceCommit !==
+                  active.review.review.sourceCommit
+              )
+                return null;
+              return latest ? readLiveBundle(latest) : null;
+            });
+          },
       threadsService: registration.historicalRevision
         ? undefined
         : () => threadsFor(active.review),

--- a/packages/progressive-review/src/server/review-live-authoring.ts
+++ b/packages/progressive-review/src/server/review-live-authoring.ts
@@ -1,0 +1,128 @@
+import { parseJsonText } from "@dev.fast/review-protocol";
+import { z } from "zod";
+
+import { bundleReviewDocument } from "../review-bundle";
+import { reviewDocumentDataSchema } from "../review-document-data";
+import {
+  readReviewDocumentFile,
+  writeReviewDocumentFile,
+} from "../review-document-files";
+import type { StoredReview } from "../review-home";
+import {
+  type ReviewLiveMutation,
+  parseLiveDocument,
+  planLiveMutation,
+} from "../review-live-document";
+import {
+  assertReviewUnchanged,
+  reviewMutationFingerprint,
+} from "../review-mutation-lock";
+import {
+  fingerprintAuthoring,
+  stageReviewDocumentPublication,
+} from "../review-publication-staging";
+import {
+  ensureReviewRegistration,
+  openReviewStateDb,
+  reviewHomeForDir,
+} from "../review-state-db";
+import { ReviewServerError } from "./http-json";
+
+const projectionSchema = z.object({
+  fingerprint: z.string(),
+  recordFingerprint: z.string(),
+  document: reviewDocumentDataSchema,
+});
+
+export async function readLiveSnapshot(review: StoredReview) {
+  const current = await readReviewDocumentFile(review, "review.mdx");
+  const live = parseLiveDocument(current.source);
+  return {
+    reviewUuid: review.review.uuid,
+    mode: live ? "incremental" : "compiled",
+    sourceHash: current.sourceHash,
+    revision: live?.revision ?? 0,
+    nodes: live?.nodes ?? [],
+  };
+}
+
+/** Caller serializes mutations with the desktop's per-Review lock. */
+export async function mutateLiveDocument(
+  review: StoredReview,
+  request: ReviewLiveMutation,
+) {
+  const current = await readReviewDocumentFile(review, "review.mdx");
+  const source = planLiveMutation(current, request);
+  const staged = await stageReviewDocumentPublication({ review, source });
+  await assertReviewUnchanged(review.dir, review.review);
+  if (staged.fingerprint !== (await fingerprintAuthoring(review.dir)))
+    throw new ReviewServerError(
+      "Authoring inputs changed while compiling. Read the document and retry.",
+      409,
+    );
+  await writeReviewDocumentFile(review, {
+    name: "review.mdx",
+    source,
+    expectedSourceHash: current.sourceHash,
+  });
+  await saveProjection(review, staged.bundle.json, staged.sourceFingerprint);
+  return readLiveSnapshot(review);
+}
+
+/** Live projections never replace the sealed bundle or historical revisions. */
+export async function readLiveBundle(review: StoredReview) {
+  const source = await readReviewDocumentFile(review, "review.mdx");
+  if (!parseLiveDocument(source.source)) return null;
+  const db = openReviewStateDb(reviewHomeForDir(review.dir));
+  const row = db
+    .prepare(
+      "SELECT projection_json FROM documents WHERE review_id = ? AND route_path = '/'",
+    )
+    .get(review.review.uuid);
+  const cached = z.string().safeParse(row?.projection_json);
+  const projection = cached.success
+    ? projectionSchema.safeParse(parseJsonText(cached.data))
+    : null;
+  if (
+    projection?.success &&
+    projection.data.recordFingerprint ===
+      reviewMutationFingerprint(review.review) &&
+    projection.data.fingerprint === (await fingerprintAuthoring(review.dir))
+  )
+    return bundleReviewDocument(projection.data.document);
+  // Recover after a crash between the atomic MDX write and projection caching,
+  // or rebuild after data.ts changes. Never serve a projection for different pins.
+  const staged = await stageReviewDocumentPublication({ review });
+  await assertReviewUnchanged(review.dir, review.review);
+  if (staged.fingerprint !== (await fingerprintAuthoring(review.dir)))
+    throw new ReviewServerError(
+      "Authoring inputs changed while compiling the live document.",
+      409,
+    );
+  await saveProjection(review, staged.bundle.json, staged.fingerprint);
+  return staged.bundle;
+}
+
+async function saveProjection(
+  review: StoredReview,
+  json: string,
+  fingerprint: string,
+) {
+  const snapshot = await readLiveSnapshot(review);
+  ensureReviewRegistration(review.dir);
+  const db = openReviewStateDb(reviewHomeForDir(review.dir));
+  db.prepare(`INSERT INTO documents (review_id, route_path, mode, revision, source_hash, projection_json)
+    VALUES (?, '/', 'incremental', ?, ?, ?)
+    ON CONFLICT(review_id, route_path) DO UPDATE SET
+      mode = excluded.mode, revision = excluded.revision,
+      source_hash = excluded.source_hash, projection_json = excluded.projection_json`).run(
+    review.review.uuid,
+    snapshot.revision,
+    snapshot.sourceHash,
+    JSON.stringify({
+      fingerprint,
+      recordFingerprint: reviewMutationFingerprint(review.review),
+      document: parseJsonText(json),
+    }),
+  );
+}

--- a/packages/progressive-review/src/server/review-live-authoring.ts
+++ b/packages/progressive-review/src/server/review-live-authoring.ts
@@ -37,6 +37,7 @@ const projectionSchema = z.object({
 export async function readLiveSnapshot(review: StoredReview) {
   const current = await readReviewDocumentFile(review, "review.mdx");
   const live = parseLiveDocument(current.source);
+
   return {
     reviewUuid: review.review.uuid,
     mode: live ? "incremental" : "compiled",
@@ -55,6 +56,7 @@ export async function mutateLiveDocument(
   const source = planLiveMutation(current, request);
   const staged = await stageReviewDocumentPublication({ review, source });
   await assertReviewUnchanged(review.dir, review.review);
+
   if (staged.fingerprint !== (await fingerprintAuthoring(review.dir)))
     throw new ReviewServerError(
       "Authoring inputs changed while compiling. Read the document and retry.",
@@ -66,23 +68,29 @@ export async function mutateLiveDocument(
     expectedSourceHash: current.sourceHash,
   });
   await saveProjection(review, staged.bundle.json, staged.sourceFingerprint);
+
   return readLiveSnapshot(review);
 }
 
 /** Live projections never replace the sealed bundle or historical revisions. */
 export async function readLiveBundle(review: StoredReview) {
   const source = await readReviewDocumentFile(review, "review.mdx");
+
   if (!parseLiveDocument(source.source)) return null;
   const db = openReviewStateDb(reviewHomeForDir(review.dir));
+
   const row = db
     .prepare(
       "SELECT projection_json FROM documents WHERE review_id = ? AND route_path = '/'",
     )
     .get(review.review.uuid);
+
   const cached = z.string().safeParse(row?.projection_json);
+
   const projection = cached.success
     ? projectionSchema.safeParse(parseJsonText(cached.data))
     : null;
+
   if (
     projection?.success &&
     projection.data.recordFingerprint ===
@@ -94,12 +102,14 @@ export async function readLiveBundle(review: StoredReview) {
   // or rebuild after data.ts changes. Never serve a projection for different pins.
   const staged = await stageReviewDocumentPublication({ review });
   await assertReviewUnchanged(review.dir, review.review);
+
   if (staged.fingerprint !== (await fingerprintAuthoring(review.dir)))
     throw new ReviewServerError(
       "Authoring inputs changed while compiling the live document.",
       409,
     );
   await saveProjection(review, staged.bundle.json, staged.fingerprint);
+
   return staged.bundle;
 }
 

--- a/packages/progressive-review/src/server/session-handler.test.ts
+++ b/packages/progressive-review/src/server/session-handler.test.ts
@@ -31,6 +31,7 @@ import { unusedAgentServices } from "./session-handler-test-utils";
 it("serves live previews without changing sealed bundles and keeps in-flight hash URLs valid", async () => {
   const rootPath = await tempDir("review-live-session-");
   const reviewPath = path.join(rootPath, "review.mdx");
+
   const bundle = (title: string) =>
     bundleReviewDocument({
       format: "review-document/1",
@@ -42,9 +43,11 @@ it("serves live previews without changing sealed bundles and keeps in-flight has
       anchorContents: {},
       softwareModels: [],
     });
+
   const sealed = bundle("Sealed");
   await writeReviewDocumentBundle(rootPath, sealed);
   let live = bundle("First preview");
+
   const input = {
     ...unusedAgentServices,
     rootPath,
@@ -60,21 +63,26 @@ it("serves live previews without changing sealed bundles and keeps in-flight has
       startedAt: Date.now(),
     },
   };
+
   const handler = await createReviewSessionHandler({
     ...input,
     getLiveBundle: async () => live,
   });
+
   const historical = await createReviewSessionHandler(input);
+
   const get = (target: typeof handler, pathname: string) =>
     target.handle(
       new Request(`http://localhost${pathname}`, {
         headers: { "x-review-token": "secret" },
       }),
     );
+
   try {
     const first = ReviewDocumentResponseSchema.parse(
       await (await get(handler, "/__progressive-review/document")).json(),
     );
+
     expect(first).toMatchObject({ ok: true, contentHash: live.contentHash });
     const firstHash = live.contentHash;
     live = bundle("Second preview");
@@ -120,6 +128,7 @@ describe("createReviewSessionHandler", () => {
     const rootPath = await tempDir("review-missing-repair-");
     const reviewPath = path.join(rootPath, "review.mdx");
     const reviewUuid = "11111111-1111-4111-8111-111111111111";
+
     const handler = await createReviewSessionHandler({
       ...unusedAgentServices,
       rootPath,
@@ -140,6 +149,7 @@ describe("createReviewSessionHandler", () => {
         startedAt: Date.now(),
       },
     });
+
     try {
       for (const artifact of ["document", "software-map"]) {
         const response = await handler.handle(
@@ -148,6 +158,7 @@ describe("createReviewSessionHandler", () => {
             { headers: { "x-review-token": "secret" } },
           ),
         );
+
         expect(response.status).toBe(409);
         const payload = await response.json();
         expect(payload).toMatchObject({
@@ -174,6 +185,7 @@ describe("createReviewSessionHandler", () => {
       }),
     );
     let promoted = false;
+
     for (const mode of [
       {
         kind: "repairValidation",
@@ -200,6 +212,7 @@ describe("createReviewSessionHandler", () => {
           startedAt: Date.now(),
         },
       });
+
       const request = (route: string, method = "GET") =>
         handler.handle(
           new Request(`http://127.0.0.1:5570/__progressive-review/${route}`, {
@@ -207,6 +220,7 @@ describe("createReviewSessionHandler", () => {
             headers: { "x-review-token": "secret" },
           }),
         );
+
       try {
         const doc = await request("document");
         expect(doc.status).toBe(409);
@@ -228,6 +242,7 @@ describe("createReviewSessionHandler", () => {
             ReviewDocumentResponseSchema.safeParse(docPayload).success,
         ).toBe(true);
         expect((await request("software-map")).status).toBe(200);
+
         for (const route of [
           "code-peek/resolve",
           "software-map/resolved-data",
@@ -238,7 +253,9 @@ describe("createReviewSessionHandler", () => {
         ]) {
           expect((await request(route, "POST")).status).not.toBe(409);
         }
+
         expect((await request("telemetry/unknown", "POST")).status).toBe(404);
+
         for (const [route, method] of [
           ["thread-commands", "POST"],
           ["agent-runs", "POST"],
@@ -248,6 +265,7 @@ describe("createReviewSessionHandler", () => {
         ]) {
           expect((await request(route!, method)).status).toBe(409);
         }
+
         const dismissed = await request("dismiss", "POST");
         expect(dismissed.status).toBe(409);
         expect(await dismissed.json()).toMatchObject({
@@ -270,6 +288,7 @@ describe("createReviewSessionHandler", () => {
     const rootPath = await tempDir("review-historical-artifact-");
     const reviewPath = path.join(rootPath, "review.mdx");
     const reviewUuid = readOnlyRecord.uuid;
+
     const handler = await createReviewSessionHandler({
       ...unusedAgentServices,
       rootPath,
@@ -292,12 +311,14 @@ describe("createReviewSessionHandler", () => {
         startedAt: Date.now(),
       },
     });
+
     try {
       const response = await handler.handle(
         new Request("http://127.0.0.1:5570/__progressive-review/document", {
           headers: { "x-review-token": "secret" },
         }),
       );
+
       const payload = await response.json();
       expect(response.status).toBe(409);
       expect(ReviewDocumentResponseSchema.parse(payload)).toEqual({
@@ -317,18 +338,21 @@ describe("createReviewSessionHandler", () => {
     const sessionUrl = `http://127.0.0.1:5570/sessions/${sessionId}`;
     const token = "session-secret";
     const events: PostHogCaptureInput[] = [];
+
     const captureClient: ProgressiveReviewTelemetryCaptureClient = {
       enabled: true,
       capture: async (event) => {
         events.push(event);
       },
     };
+
     const telemetry = new ProgressiveReviewTelemetry({
       captureClient,
       env: {},
       installConfigPath: path.join(rootPath, "telemetry.json"),
       idFactory: () => "install-123",
     });
+
     const handler = await createReviewSessionHandler({
       ...unusedAgentServices,
       rootPath,
@@ -347,6 +371,7 @@ describe("createReviewSessionHandler", () => {
         startedAt: Date.now(),
       },
     });
+
     const capture = (name: string, properties?: JsonObject) =>
       handler.handle(
         new Request(
@@ -406,6 +431,7 @@ describe("createReviewSessionHandler", () => {
     const reviewPath = path.join(rootPath, "review.mdx");
     const sessionUrl = "http://127.0.0.1:5570/sessions/test-session";
     const token = "session-secret";
+
     const handler = await createReviewSessionHandler({
       ...unusedAgentServices,
       rootPath,
@@ -426,6 +452,7 @@ describe("createReviewSessionHandler", () => {
         startedAt: Date.now(),
       },
     });
+
     try {
       const write = await handler.handle(
         new Request(
@@ -440,16 +467,19 @@ describe("createReviewSessionHandler", () => {
           },
         ),
       );
+
       expect(write.status).toBe(409);
       await expect(write.json()).resolves.toMatchObject({
         ok: false,
         code: "historical_revision",
       });
+
       const read = await handler.handle(
         new Request(new URL("/__progressive-review/comments", sessionUrl), {
           headers: { "x-review-token": token },
         }),
       );
+
       expect(read.status).toBe(400);
       expect(await read.json()).toMatchObject({
         error: "The review thread database is unavailable.",
@@ -465,6 +495,7 @@ describe("createReviewSessionHandler", () => {
     const sessionUrl = "http://127.0.0.1:5570/sessions/test-session";
     const token = "session-secret";
     let reviewStatus: "awaiting-review" | "accepted" = "awaiting-review";
+
     const handler = await createReviewSessionHandler(
       {
         ...unusedAgentServices,
@@ -512,6 +543,7 @@ describe("createReviewSessionHandler", () => {
     const sessionUrl = "http://127.0.0.1:5570/sessions/test-session";
     const token = "session-secret";
     await writeFile(reviewPath, "# Test review\n");
+
     const handler = await createReviewSessionHandler({
       ...unusedAgentServices,
       rootPath,

--- a/packages/progressive-review/src/server/session-handler.test.ts
+++ b/packages/progressive-review/src/server/session-handler.test.ts
@@ -14,6 +14,10 @@ import {
   ProgressiveReviewTelemetry,
   type ProgressiveReviewTelemetryCaptureClient,
 } from "../progressive-review-telemetry";
+import {
+  bundleReviewDocument,
+  writeReviewDocumentBundle,
+} from "../review-bundle";
 import { cleanupTempDirs, tempDir } from "../review-test-utils";
 import {
   bundleReviewSoftwareMap,
@@ -23,6 +27,73 @@ import { defineSoftwareMap } from "../software-map-model";
 import type { ReviewSessionMode } from "./review-session-mode";
 import { createReviewSessionHandler } from "./session-handler";
 import { unusedAgentServices } from "./session-handler-test-utils";
+
+it("serves live previews without changing sealed bundles and keeps in-flight hash URLs valid", async () => {
+  const rootPath = await tempDir("review-live-session-");
+  const reviewPath = path.join(rootPath, "review.mdx");
+  const bundle = (title: string) =>
+    bundleReviewDocument({
+      format: "review-document/1",
+      title,
+      routePath: "/",
+      sourcePath: "review.mdx",
+      body: [{ type: "text", value: title }],
+      anchors: {},
+      anchorContents: {},
+      softwareModels: [],
+    });
+  const sealed = bundle("Sealed");
+  await writeReviewDocumentBundle(rootPath, sealed);
+  let live = bundle("First preview");
+  const input = {
+    ...unusedAgentServices,
+    rootPath,
+    toolingRoot: rootPath,
+    reviewPath,
+    routePath: "/",
+    token: "secret",
+    session: {
+      rootPath,
+      baseRef: "HEAD",
+      reviewPath,
+      appUrl: "http://localhost",
+      startedAt: Date.now(),
+    },
+  };
+  const handler = await createReviewSessionHandler({
+    ...input,
+    getLiveBundle: async () => live,
+  });
+  const historical = await createReviewSessionHandler(input);
+  const get = (target: typeof handler, pathname: string) =>
+    target.handle(
+      new Request(`http://localhost${pathname}`, {
+        headers: { "x-review-token": "secret" },
+      }),
+    );
+  try {
+    const first = ReviewDocumentResponseSchema.parse(
+      await (await get(handler, "/__progressive-review/document")).json(),
+    );
+    expect(first).toMatchObject({ ok: true, contentHash: live.contentHash });
+    const firstHash = live.contentHash;
+    live = bundle("Second preview");
+    expect(
+      await (await get(handler, "/__progressive-review/document")).json(),
+    ).toMatchObject({ contentHash: live.contentHash });
+    expect(
+      await (
+        await get(handler, `/__progressive-review/documents/${firstHash}.json`)
+      ).text(),
+    ).toBe(bundle("First preview").json);
+    expect(
+      await (await get(historical, "/__progressive-review/document")).json(),
+    ).toMatchObject({ contentHash: sealed.contentHash });
+  } finally {
+    await handler.close();
+    await historical.close();
+  }
+});
 
 const readOnlyRecord: ReviewRecord = {
   schemaVersion: REVIEW_SCHEMA_VERSION,

--- a/packages/progressive-review/src/server/session-handler.ts
+++ b/packages/progressive-review/src/server/session-handler.ts
@@ -76,6 +76,7 @@ export interface ReviewSessionHandlerInput {
   reviewPath: string;
   softwareMapRootPath?: string;
   stateReviewPath?: string;
+  getLiveBundle?: () => Promise<ReviewDocumentBundle | null>;
   threadsService?: () => ReviewThreadsService;
   routePath: string;
   token?: string;
@@ -199,7 +200,15 @@ export async function createReviewSessionHandler(
       }
     : undefined;
 
+  const liveBundles = new Map<string, ReviewDocumentBundle>();
   const getBundle = async (): Promise<ReviewDocumentBundle | null> => {
+    const live = await input.getLiveBundle?.();
+    if (live) {
+      liveBundles.set(`${live.contentHash}.json`, live);
+      if (liveBundles.size > 16)
+        liveBundles.delete(liveBundles.keys().next().value!);
+      return live;
+    }
     if (currentBundle) return currentBundle;
     bundlePromise ??= readReviewDocumentBundle(renderDir, input.routePath);
 
@@ -358,7 +367,8 @@ export async function createReviewSessionHandler(
     );
   });
   app.get(`${DOCUMENT_PATH_PREFIX}:documentName`, async (context) => {
-    const bundle = await getBundle();
+    const bundle =
+      liveBundles.get(context.req.param("documentName")) ?? (await getBundle());
 
     if (
       !bundle ||

--- a/packages/progressive-review/src/server/session-handler.ts
+++ b/packages/progressive-review/src/server/session-handler.ts
@@ -201,14 +201,19 @@ export async function createReviewSessionHandler(
     : undefined;
 
   const liveBundles = new Map<string, ReviewDocumentBundle>();
+
   const getBundle = async (): Promise<ReviewDocumentBundle | null> => {
     const live = await input.getLiveBundle?.();
+
     if (live) {
       liveBundles.set(`${live.contentHash}.json`, live);
+
       if (liveBundles.size > 16)
         liveBundles.delete(liveBundles.keys().next().value!);
+
       return live;
     }
+
     if (currentBundle) return currentBundle;
     bundlePromise ??= readReviewDocumentBundle(renderDir, input.routePath);
 

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1732,6 +1732,7 @@ export const ReviewDesktopGlobalEventSchema = z.discriminatedUnion("event", [
   }),
   z.strictObject({
     event: z.literal("review-data-changed"),
+    documentChanged: z.boolean().optional(),
     uuid: z.uuid({ error: "must be a UUID" }),
     sessionId: requiredString,
   }),


### PR DESCRIPTION
Adds native MDX live authoring through the Desktop API and MCP. Snapshot and replace/insert/update/move/delete operations preserve stable node identities, reject source-hash conflicts, and support safe retry of the last request.

The existing native compiler validates rich components and data.ts expressions. MDX remains canonical; validated native previews are cached in the shared database. Preview edits preserve sealed bundles, historical revisions, and the publication feedback gate. Canvas updates retain keyed sibling state, bound document caches, and show authoring activity without moving the content; reduced motion is respected.

Each edit validates the full document. Initial opening and final sealing still use review_publish. Durable question runs and feedback batches remain deferred.

Builds on #188, which builds on #187. The replay preserves the 16-revision cache limit while retaining hydrated documents and successful peeks during retries. The legacy-loader preflight now comes from #187 and prepares both modules before concurrent writes start.

The anti-slop cleanup on this layer adds statement spacing only; it inherits the validated cleanup from #187/#188.

Validation:
- All 120 configured source files changed by the full stack pass lint with `--deny-warnings` (zero warnings/errors) and formatting. The final stack passes package typecheck and 145 tests across 10 focused dependent files. Independent token comparison across the final stack found only only the intended collection rewrites beyond whitespace before the inherited heartbeat-test repair. No rule configuration or suppressions changed.
- At the final stack replay: package typecheck and 115 tests across 11 focused files passed, including rich editing, source conflicts/recovery, publication, cache eviction/retry, legacy preflight failures, and Desktop/server/session paths.
- Earlier implementation validation included the full package and Desktop suites, plus Desktop smoke tests for MCP/API edits, preserved collapsed sections, diagrams, and CodePeek rendering after restart.
- [Current-head CI passed](https://github.com/devdotfast/review/actions/runs/34555048638): Desktop build, tutorial validation, lint, formatting, typechecks, and workspace tests. The refresh preserves main's dependency security updates.
