### PR TITLE
Promote a published preview build to a stable release

### DIFF
--- a/.github/workflows/review-desktop-preview.yml
+++ b/.github/workflows/review-desktop-preview.yml
@@ -448,9 +448,8 @@ jobs:
           TAG: v${{ needs.version.outputs.version }}
           COMMIT: ${{ needs.version.outputs.commit }}
         run: |
-          # Promotion requires the preview commit to be main's tip, so a preview
-          # off any other line of development can never be promoted. Tagging one
-          # would only litter the namespace with dead handles.
+          # Tag previews on main's history, including older commits that can
+          # still be promoted after main advances.
           STATUS=$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...${COMMIT}" --jq .status)
           case "$STATUS" in
             identical | behind) ;;

--- a/.github/workflows/review-desktop-preview.yml
+++ b/.github/workflows/review-desktop-preview.yml
@@ -58,6 +58,31 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
 
+      # A re-run reuses GITHUB_RUN_NUMBER, so it recomputes the same version
+      # string while re-resolving the mutable ref, which may have moved on. Left
+      # to the tag push at the end, that collision would surface only after
+      # signing, notarization, and an R2 upload that already overwrote the keys
+      # for this version.
+      - name: Check the preview tag is free
+        shell: bash
+        env:
+          TAG: v${{ steps.version.outputs.version }}
+          COMMIT: ${{ steps.version.outputs.commit }}
+        run: |
+          # Prefer the peeled line so an annotated tag resolves to its commit.
+          EXISTING=$(git ls-remote origin "refs/tags/${TAG}" "refs/tags/${TAG}^{}" \
+            | awk '{ if (index($2, "^{}")) peeled = $1; else plain = $1 }
+                   END { print (peeled != "" ? peeled : plain) }')
+
+          if [ -z "$EXISTING" ]; then
+            echo "${TAG} is free."
+          elif [ "$EXISTING" = "$COMMIT" ]; then
+            echo "${TAG} already points at ${COMMIT}; this run republishes it."
+          else
+            echo "::error::${TAG} already exists on origin at ${EXISTING}, but this run builds ${COMMIT}. Delete the tag, or start a fresh run so a new run number produces a new version."
+            exit 1
+          fi
+
   compile:
     name: Compile Darwin payload on Linux
     needs: version
@@ -401,3 +426,54 @@ jobs:
         run: |
           security delete-keychain "$RUNNER_TEMP/buildagent.keychain" || true
           rm -f "$RUNNER_TEMP/notary-key.p8"
+
+  # The one job here that can write to the repository, and it holds no signing
+  # or R2 credentials. `needs: version` carries the review-release environment
+  # gate transitively, and `needs: build` means a tag only ever names a preview
+  # that uploaded, answered its update feed, and served its installer.
+  tag-preview:
+    name: Tag published preview
+    needs: [version, build]
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # A promotion handle: review-desktop-release.yml resolves this tag back to
+      # the commit the preview was built from.
+      - name: Push the preview tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: v${{ needs.version.outputs.version }}
+          COMMIT: ${{ needs.version.outputs.commit }}
+        run: |
+          # Promotion requires the preview commit to be main's tip, so a preview
+          # off any other line of development can never be promoted. Tagging one
+          # would only litter the namespace with dead handles.
+          STATUS=$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...${COMMIT}" --jq .status)
+          case "$STATUS" in
+            identical | behind) ;;
+            *)
+              echo "${COMMIT} is not on main (${STATUS}); a preview off main is not promotable, so it stays untagged."
+              exit 0
+              ;;
+          esac
+
+          SHA=""
+          TYPE=""
+          if RESPONSE=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" 2>/dev/null); then
+            SHA=$(printf '%s' "$RESPONSE" | jq -r .object.sha)
+            TYPE=$(printf '%s' "$RESPONSE" | jq -r .object.type)
+          fi
+
+          if [ -z "$SHA" ]; then
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f "ref=refs/tags/${TAG}" -f "sha=${COMMIT}" >/dev/null
+            echo "Tagged ${COMMIT} as ${TAG}."
+          elif [ "$TYPE" = "commit" ] && [ "$SHA" = "$COMMIT" ]; then
+            echo "${TAG} already points at ${COMMIT}; nothing to do."
+          else
+            echo "::error::${TAG} exists on origin as ${TYPE} ${SHA}, but this run built ${COMMIT}. Delete the tag before re-running, or start a fresh run so a new run number produces a new version."
+            exit 1
+          fi

--- a/.github/workflows/review-desktop-release.yml
+++ b/.github/workflows/review-desktop-release.yml
@@ -49,6 +49,9 @@ jobs:
       version: ${{ steps.bump.outputs.version || steps.dryrun.outputs.version }}
       tag: ${{ steps.bump.outputs.tag }}
       commit: ${{ steps.bump.outputs.commit || steps.dryrun.outputs.commit }}
+      # A promotion builds the commit the preview was built from, which is
+      # normally behind main by then. A release from main builds its tip.
+      ref: ${{ steps.bump.outputs.tag || steps.resolve.outputs.preview_commit || github.sha }}
     steps:
       # The `main` ruleset requires a pull request and the "Review Desktop"
       # check, and lists DeployKey as its only non-admin bypass actor. Checking
@@ -69,6 +72,7 @@ jobs:
           RELEASE_SOURCE: ${{ inputs.release_source }}
           PREVIEW_TAG_INPUT: ${{ inputs.preview_tag }}
           DRY_RUN: ${{ inputs.dry_run }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           # A dispatch form field left with stale text arrives as a non-empty
           # string, so trim before testing for emptiness.
@@ -127,11 +131,19 @@ jobs:
             git fetch --no-tags origin "+refs/tags/${PREVIEW_TAG}:refs/tags/${PREVIEW_TAG}"
             PREVIEW_COMMIT=$(git rev-parse "refs/tags/${PREVIEW_TAG}^{commit}")
 
-            HEAD_SHA=$(git rev-parse HEAD)
-            if [ "$PREVIEW_COMMIT" != "$HEAD_SHA" ]; then
-              echo "::error::${PREVIEW_TAG} was built from ${PREVIEW_COMMIT}, but ${GITHUB_REF_NAME} is at ${HEAD_SHA}. Only the preview built from the current tip can be promoted: run review-desktop-preview.yml against ${GITHUB_REF_NAME} and promote the tag it pushes."
-              exit 1
-            fi
+            # Whatever merged since the preview published stays out of this
+            # release: promotion ships the commit that was actually tested. It
+            # must still be on ${GITHUB_REF_NAME}, so a branch that never landed
+            # cannot be released. Asked over the API because this checkout is
+            # shallow and has no history to walk.
+            STATUS=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${GITHUB_REF_NAME}...${PREVIEW_COMMIT}" --jq .status)
+            case "$STATUS" in
+              identical | behind) ;;
+              *)
+                echo "::error::${PREVIEW_TAG} was built from ${PREVIEW_COMMIT}, which is not on ${GITHUB_REF_NAME} (${STATUS}). Only a preview built from a commit that landed can be promoted."
+                exit 1
+                ;;
+            esac
             # Load-bearing: a preview computes its version from the package.json
             # it was built against, so this is what catches a preview that
             # straddled another release and now targets a version already cut.
@@ -163,6 +175,7 @@ jobs:
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "preview_commit=$PREVIEW_COMMIT" >> "$GITHUB_OUTPUT"
 
       - name: Bump version and create tag
         if: ${{ !inputs.dry_run }}
@@ -171,6 +184,7 @@ jobs:
         env:
           VERSION: ${{ steps.resolve.outputs.version }}
           TAG: ${{ steps.resolve.outputs.tag }}
+          PREVIEW_COMMIT: ${{ steps.resolve.outputs.preview_commit }}
         run: |
           # product.json carries the same number to the running app, which shows
           # it in the About panel, alongside the stable channel identity.
@@ -183,14 +197,21 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add apps/review-desktop/package.json apps/review-desktop/code-oss/product.json
           git commit -m "chore(review-desktop): bump version to ${VERSION} [skip ci]"
-          git tag "$TAG"
+
+          # The tag marks what shipped, which for a promotion is the commit the
+          # preview was built from rather than this bump. The build jobs stamp
+          # the version onto that tree, the way the preview run stamped its own.
+          # The bump still lands on ${GITHUB_REF_NAME} because the next release
+          # derives its version from there.
+          TARGET="${PREVIEW_COMMIT:-$(git rev-parse HEAD)}"
+          git tag "$TAG" "$TARGET"
           # Atomic: the previous release left an orphan tag on origin because
           # the branch push was rejected after the tag push had already landed.
           git push --atomic origin "HEAD:${GITHUB_REF_NAME}" "$TAG"
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "commit=$TARGET" >> "$GITHUB_OUTPUT"
 
       - name: Dry-run version
         if: ${{ inputs.dry_run }}
@@ -199,6 +220,7 @@ jobs:
         env:
           RELEASE_SOURCE: ${{ inputs.release_source }}
           RESOLVED_VERSION: ${{ steps.resolve.outputs.version }}
+          PREVIEW_COMMIT: ${{ steps.resolve.outputs.preview_commit }}
         run: |
           if [ "$RELEASE_SOURCE" = "preview" ]; then
             # The build jobs stamp the promoted version into this same commit,
@@ -210,7 +232,7 @@ jobs:
             VERSION=$(node -p "require('./apps/review-desktop/package.json').version")
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "commit=${PREVIEW_COMMIT:-$(git rev-parse HEAD)}" >> "$GITHUB_OUTPUT"
 
       - name: Create draft GitHub Release
         if: ${{ !inputs.dry_run }}
@@ -232,13 +254,14 @@ jobs:
       - name: Checkout release tag
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ needs.tag.outputs.tag || github.sha }}
+          ref: ${{ needs.tag.outputs.ref }}
 
-      # A promotion dry run checks out the preview commit, whose tree still
-      # carries the version released before it. Stamp the version the promotion
-      # would ship so the packaged artifacts and the feed manifest carry it too.
-      - name: Stamp the promoted version for a dry run
-        if: ${{ inputs.dry_run && inputs.release_source == 'preview' }}
+      # A promotion checks out the commit the preview was built from, whose tree
+      # still carries the version released before it. Stamp the promoted version
+      # so the packaged artifacts and the feed manifest carry it, the way the
+      # preview run stamped its own version onto this same tree.
+      - name: Stamp the promoted version
+        if: ${{ inputs.release_source == 'preview' }}
         run: |
           node apps/review-desktop/scripts/stamp-release-channel.mjs \
             --version "${{ needs.tag.outputs.version }}" \
@@ -348,13 +371,14 @@ jobs:
       - name: Checkout release tag
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ needs.tag.outputs.tag || github.sha }}
+          ref: ${{ needs.tag.outputs.ref }}
 
-      # A promotion dry run checks out the preview commit, whose tree still
-      # carries the version released before it. Stamp the version the promotion
-      # would ship so the packaged artifacts and the feed manifest carry it too.
-      - name: Stamp the promoted version for a dry run
-        if: ${{ inputs.dry_run && inputs.release_source == 'preview' }}
+      # A promotion checks out the commit the preview was built from, whose tree
+      # still carries the version released before it. Stamp the promoted version
+      # so the packaged artifacts and the feed manifest carry it, the way the
+      # preview run stamped its own version onto this same tree.
+      - name: Stamp the promoted version
+        if: ${{ inputs.release_source == 'preview' }}
         run: |
           node apps/review-desktop/scripts/stamp-release-channel.mjs \
             --version "${{ needs.tag.outputs.version }}" \

--- a/.github/workflows/review-desktop-release.yml
+++ b/.github/workflows/review-desktop-release.yml
@@ -12,6 +12,19 @@ on:
           - minor
           - major
         default: patch
+      release_source:
+        description: "Release main's tip, or promote a published preview tag."
+        required: true
+        type: choice
+        options:
+          - main
+          - preview
+        default: main
+      preview_tag:
+        description: "Preview tag to promote, e.g. v0.0.32-preview.20260907.7. Required when release_source is preview."
+        required: false
+        type: string
+        default: ""
       dry_run:
         description: "Build and validate only. Do not tag, upload, or publish."
         required: false
@@ -46,60 +59,125 @@ jobs:
         with:
           ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
-      - name: Bump version and create tag
-        if: ${{ !inputs.dry_run }}
-        id: bump
+      # Every read-only gate lives here so a dry run rehearses the same checks a
+      # real run must pass, and so the write step below re-derives nothing.
+      - name: Resolve release version
+        id: resolve
         shell: bash
+        env:
+          BUMP: ${{ inputs.bump }}
+          RELEASE_SOURCE: ${{ inputs.release_source }}
+          PREVIEW_TAG_INPUT: ${{ inputs.preview_tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          BUMP="${{ inputs.bump }}"
+          # A dispatch form field left with stale text arrives as a non-empty
+          # string, so trim before testing for emptiness.
+          PREVIEW_TAG="$(printf '%s' "$PREVIEW_TAG_INPUT" | tr -d '[:space:]')"
+
+          if [ "$RELEASE_SOURCE" != "preview" ] && [ -n "$PREVIEW_TAG" ]; then
+            echo "::error::preview_tag only applies when release_source is 'preview'. Clear the field, or set release_source to 'preview'."
+            exit 1
+          fi
+
           CURRENT=$(node -p "require('./apps/review-desktop/package.json').version")
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+          # The pattern must stay an unquoted variable: bash matches a quoted
+          # right-hand side as a literal string, not as a regex.
+          version_re='^([0-9]+)\.([0-9]+)\.([0-9]+)$'
+          if [[ ! $CURRENT =~ $version_re ]]; then
+            echo "::error::apps/review-desktop/package.json is at '${CURRENT}', which is not X.Y.Z. ${GITHUB_REF_NAME} must never carry a prerelease version."
+            exit 1
+          fi
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+          PATCH="${BASH_REMATCH[3]}"
 
           case "$BUMP" in
             major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
             minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
             patch) PATCH=$((PATCH + 1)) ;;
+            *) echo "::error::unknown bump type '${BUMP}'"; exit 1 ;;
           esac
 
           VERSION="${MAJOR}.${MINOR}.${PATCH}"
           TAG="v${VERSION}"
-          echo "Releasing Review Desktop v${VERSION} (tag: $TAG)"
 
-          # Both checks below run before anything is written, so a doomed run
-          # stops without leaving a tag or a commit behind.
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "::error::${TAG} already exists on origin. Delete it before re-running."
-            exit 1
+          if [ "$RELEASE_SOURCE" = "preview" ]; then
+            if [ -z "$PREVIEW_TAG" ]; then
+              echo "::error::release_source 'preview' requires preview_tag, e.g. v${VERSION}-preview.$(date -u +%Y%m%d).1 — take it from the preview run that published the build you are promoting."
+              exit 1
+            fi
+            if [ "$BUMP" != "patch" ]; then
+              echo "::error::a preview always targets the next patch, so promoting one requires bump 'patch' (got '${BUMP}'). Release from ${GITHUB_REF_NAME} for a minor or major."
+              exit 1
+            fi
+
+            preview_re='^v([0-9]+\.[0-9]+\.[0-9]+)-preview\.[0-9]{8}\.[0-9]+$'
+            if [[ ! $PREVIEW_TAG =~ $preview_re ]]; then
+              echo "::error::preview_tag '${PREVIEW_TAG}' is not a preview tag. Expected vX.Y.Z-preview.YYYYMMDD.N, as pushed by review-desktop-preview.yml."
+              exit 1
+            fi
+            PREVIEW_VERSION="${BASH_REMATCH[1]}"
+
+            if ! git ls-remote --exit-code --tags origin "refs/tags/${PREVIEW_TAG}" >/dev/null 2>&1; then
+              echo "::error::${PREVIEW_TAG} does not exist on origin. Only a preview that finished publishing from ${GITHUB_REF_NAME} is tagged."
+              exit 1
+            fi
+            # `+` so a tag already in this checkout cannot block the fetch, and
+            # `^{commit}` peels a lightweight and an annotated tag alike.
+            git fetch --no-tags origin "+refs/tags/${PREVIEW_TAG}:refs/tags/${PREVIEW_TAG}"
+            PREVIEW_COMMIT=$(git rev-parse "refs/tags/${PREVIEW_TAG}^{commit}")
+
+            HEAD_SHA=$(git rev-parse HEAD)
+            if [ "$PREVIEW_COMMIT" != "$HEAD_SHA" ]; then
+              echo "::error::${PREVIEW_TAG} was built from ${PREVIEW_COMMIT}, but ${GITHUB_REF_NAME} is at ${HEAD_SHA}. Only the preview built from the current tip can be promoted: run review-desktop-preview.yml against ${GITHUB_REF_NAME} and promote the tag it pushes."
+              exit 1
+            fi
+            # Load-bearing: a preview computes its version from the package.json
+            # it was built against, so this is what catches a preview that
+            # straddled another release and now targets a version already cut.
+            if [ "$PREVIEW_VERSION" != "$VERSION" ]; then
+              echo "::error::${PREVIEW_TAG} targets ${PREVIEW_VERSION}, but the next patch from ${CURRENT} is ${VERSION}. That preview predates a release; publish a new one."
+              exit 1
+            fi
+
+            echo "Promoting ${PREVIEW_TAG} (${PREVIEW_COMMIT}) to Review Desktop ${TAG}."
+          else
+            echo "Releasing Review Desktop ${TAG} from ${GITHUB_REF_NAME}."
           fi
 
-          git fetch origin "${GITHUB_REF_NAME}"
-          if [ "$(git rev-parse HEAD)" != "$(git rev-parse FETCH_HEAD)" ]; then
-            echo "::error::${GITHUB_REF_NAME} moved since this run started. Re-run the workflow."
-            exit 1
+          # Remote write-state, checked only where a push actually follows. Both
+          # run before anything is written, so a doomed run stops without
+          # leaving a tag or a commit behind.
+          if [ "$DRY_RUN" != "true" ]; then
+            if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+              echo "::error::${TAG} already exists on origin. Delete it before re-running."
+              exit 1
+            fi
+
+            git fetch origin "${GITHUB_REF_NAME}"
+            if [ "$(git rev-parse HEAD)" != "$(git rev-parse FETCH_HEAD)" ]; then
+              echo "::error::${GITHUB_REF_NAME} moved since this run started. Re-run the workflow."
+              exit 1
+            fi
           fi
 
-          cd apps/review-desktop
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version and create tag
+        if: ${{ !inputs.dry_run }}
+        id: bump
+        shell: bash
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
           # product.json carries the same number to the running app, which shows
-          # it in the About panel. `scripts/product-hardening.test.mjs` fails if
-          # these two drift apart.
-          VERSION="$VERSION" node --input-type=module -e '
-            import fs from "node:fs";
-            const pkg = JSON.parse(fs.readFileSync("./package.json", "utf8"));
-            pkg.version = process.env.VERSION;
-            fs.writeFileSync("./package.json", `${JSON.stringify(pkg, null, 2)}\n`);
-
-            const productPath = "./code-oss/product.json";
-            const product = fs.readFileSync(productPath, "utf8");
-            const updated = product.replace(
-              /("reviewVersion":\s*")[^"]*(")/,
-              `$1${process.env.VERSION}$2`,
-            );
-            if (updated === product) {
-              throw new Error(`reviewVersion not found in ${productPath}`);
-            }
-            fs.writeFileSync(productPath, updated);
-          '
-          cd ../..
+          # it in the About panel, alongside the stable channel identity.
+          # `scripts/product-hardening.test.mjs` fails if these drift apart.
+          node apps/review-desktop/scripts/stamp-release-channel.mjs \
+            --version "$VERSION" \
+            --quality stable
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -117,8 +195,20 @@ jobs:
       - name: Dry-run version
         if: ${{ inputs.dry_run }}
         id: dryrun
+        shell: bash
+        env:
+          RELEASE_SOURCE: ${{ inputs.release_source }}
+          RESOLVED_VERSION: ${{ steps.resolve.outputs.version }}
         run: |
-          VERSION=$(node -p "require('./apps/review-desktop/package.json').version")
+          if [ "$RELEASE_SOURCE" = "preview" ]; then
+            # The build jobs stamp the promoted version into this same commit,
+            # so the artifacts a promotion dry run validates carry it too.
+            VERSION="$RESOLVED_VERSION"
+          else
+            # Nothing stamps a release-from-main dry run, so the artifacts carry
+            # the version already committed here.
+            VERSION=$(node -p "require('./apps/review-desktop/package.json').version")
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
@@ -143,6 +233,16 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.tag.outputs.tag || github.sha }}
+
+      # A promotion dry run checks out the preview commit, whose tree still
+      # carries the version released before it. Stamp the version the promotion
+      # would ship so the packaged artifacts and the feed manifest carry it too.
+      - name: Stamp the promoted version for a dry run
+        if: ${{ inputs.dry_run && inputs.release_source == 'preview' }}
+        run: |
+          node apps/review-desktop/scripts/stamp-release-channel.mjs \
+            --version "${{ needs.tag.outputs.version }}" \
+            --quality stable
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
@@ -249,6 +349,16 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.tag.outputs.tag || github.sha }}
+
+      # A promotion dry run checks out the preview commit, whose tree still
+      # carries the version released before it. Stamp the version the promotion
+      # would ship so the packaged artifacts and the feed manifest carry it too.
+      - name: Stamp the promoted version for a dry run
+        if: ${{ inputs.dry_run && inputs.release_source == 'preview' }}
+        run: |
+          node apps/review-desktop/scripts/stamp-release-channel.mjs \
+            --version "${{ needs.tag.outputs.version }}" \
+            --quality stable
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6

--- a/.github/workflows/review-desktop-release.yml
+++ b/.github/workflows/review-desktop-release.yml
@@ -49,9 +49,6 @@ jobs:
       version: ${{ steps.bump.outputs.version || steps.dryrun.outputs.version }}
       tag: ${{ steps.bump.outputs.tag }}
       commit: ${{ steps.bump.outputs.commit || steps.dryrun.outputs.commit }}
-      # A promotion builds the commit the preview was built from, which is
-      # normally behind main by then. A release from main builds its tip.
-      ref: ${{ steps.bump.outputs.tag || steps.resolve.outputs.preview_commit || github.sha }}
     steps:
       # The `main` ruleset requires a pull request and the "Review Desktop"
       # check, and lists DeployKey as its only non-admin bypass actor. Checking
@@ -251,10 +248,10 @@ jobs:
     runs-on: review_big_boy
     timeout-minutes: 45
     steps:
-      - name: Checkout release tag
+      - name: Checkout resolved release commit
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ needs.tag.outputs.ref }}
+          ref: ${{ needs.tag.outputs.commit }}
 
       # A promotion checks out the commit the preview was built from, whose tree
       # still carries the version released before it. Stamp the promoted version
@@ -368,10 +365,10 @@ jobs:
       RELEASE_COMMIT: ${{ needs.tag.outputs.commit }}
       RELEASE_TAG: ${{ needs.tag.outputs.tag }}
     steps:
-      - name: Checkout release tag
+      - name: Checkout resolved release commit
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ needs.tag.outputs.ref }}
+          ref: ${{ needs.tag.outputs.commit }}
 
       # A promotion checks out the commit the preview was built from, whose tree
       # still carries the version released before it. Stamp the promoted version

--- a/apps/review-desktop/README.md
+++ b/apps/review-desktop/README.md
@@ -135,6 +135,36 @@ patch/minor/major bump. The workflow:
 6. curls the live feed to confirm the new release is served, attaches the dmg
    to the GitHub release, and publishes it.
 
+### Promoting a preview to stable
+
+A preview that has been running well can be released as the stable build
+instead of cutting a fresh one from whatever `main` now holds:
+
+```sh
+gh workflow run review-desktop-preview.yml -f ref=main
+# ...then, with the tag that run pushed:
+gh workflow run review-desktop-release.yml \
+  -f bump=patch -f release_source=preview \
+  -f preview_tag=v0.0.32-preview.20260907.7
+```
+
+`release_source: preview` requires `preview_tag`, accepts only a `patch` bump,
+and requires the tag to point at the **exact commit `main` is on**. Anything
+merged in between invalidates the tag, so promote before you merge, or publish
+a new preview. The stable version is derived from the tag (`v0.0.32` above) and
+must be the next patch, which is what rejects a preview that straddled another
+release.
+
+Promotion rebuilds from source. Preview and stable are different applications —
+separate bundle identifier, application name, data folders, URL scheme, and
+update feed — so the stable run stamps stable identity onto that commit and
+takes the same build, sign, notarize, upload, and publish path as any release.
+No preview binary is relabelled.
+
+A dry run makes no remote change: it stamps the promoted version onto the
+preview commit and builds it, so the artifacts and the feed manifest carry the
+version the real promotion would ship.
+
 ### Preview builds
 
 Run the **Review Desktop Preview** workflow from `main`, and pass the branch,
@@ -144,9 +174,13 @@ tag, or commit to build as its `ref` input:
 gh workflow run review-desktop-preview.yml -f ref=<branch>
 ```
 
-The workflow makes no commit, tag, or GitHub release. It stamps the working
+The workflow makes no commit and no GitHub release. It stamps the working
 tree with the next patch version plus
 `-preview.<yyyymmdd>.<run-number>`, then publishes only to preview R2 keys.
+Once the upload, the update feed, and the installer landing all check out, it
+pushes a lightweight `v<version>` tag at the commit it built — but only when
+that commit is on `main`, since nothing else can be promoted. That tag is what
+"Promoting a preview to stable" above takes as its `preview_tag`.
 The ref must include the preview tooling, so branch it from a `main` that
 already contains this workflow and its scripts. Updates are keyed by commit;
 publishing an older commit intentionally rolls preview installations back to

--- a/apps/review-desktop/README.md
+++ b/apps/review-desktop/README.md
@@ -148,12 +148,20 @@ gh workflow run review-desktop-release.yml \
   -f preview_tag=v0.0.32-preview.20260907.7
 ```
 
-`release_source: preview` requires `preview_tag`, accepts only a `patch` bump,
-and requires the tag to point at the **exact commit `main` is on**. Anything
-merged in between invalidates the tag, so promote before you merge, or publish
-a new preview. The stable version is derived from the tag (`v0.0.32` above) and
-must be the next patch, which is what rejects a preview that straddled another
-release.
+`release_source: preview` requires `preview_tag` and accepts only a `patch`
+bump. The tag needs to be on `main`, but **not** at its tip: whatever merged
+after the preview published stays out of the release, because a promotion ships
+the commit that was actually tested. The stable version comes from the tag
+(`v0.0.32` above) and must be the next patch, which is what rejects a preview
+that predates another release — publish a new one in that case.
+
+So `vX.Y.Z` marks the commit that shipped, which for a promotion is behind
+`main` by however much landed in the meantime. `main` still gets its
+`chore(review-desktop): bump version` commit, because the next release derives
+its version from there; that commit is bookkeeping, not the released tree.
+Checking out `vX.Y.Z` therefore gives you the released source with the previous
+version still in `package.json` — the build stamps the release version in, the
+same way a preview build stamps its own.
 
 Promotion rebuilds from source. Preview and stable are different applications —
 separate bundle identifier, application name, data folders, URL scheme, and
@@ -161,9 +169,8 @@ update feed — so the stable run stamps stable identity onto that commit and
 takes the same build, sign, notarize, upload, and publish path as any release.
 No preview binary is relabelled.
 
-A dry run makes no remote change: it stamps the promoted version onto the
-preview commit and builds it, so the artifacts and the feed manifest carry the
-version the real promotion would ship.
+A dry run makes no remote change, and builds the same commit under the same
+stamp a real promotion would.
 
 ### Preview builds
 
@@ -179,8 +186,9 @@ tree with the next patch version plus
 `-preview.<yyyymmdd>.<run-number>`, then publishes only to preview R2 keys.
 Once the upload, the update feed, and the installer landing all check out, it
 pushes a lightweight `v<version>` tag at the commit it built — but only when
-that commit is on `main`, since nothing else can be promoted. That tag is what
-"Promoting a preview to stable" above takes as its `preview_tag`.
+that commit is on `main`, since a branch that never landed cannot be promoted.
+That tag is what "Promoting a preview to stable" above takes as its
+`preview_tag`, and it stays promotable as `main` moves on.
 The ref must include the preview tooling, so branch it from a `main` that
 already contains this workflow and its scripts. Updates are keyed by commit;
 publishing an older commit intentionally rolls preview installations back to


### PR DESCRIPTION
## Why

A preview run leaves no permanent marker, so there is no way today to say *"the preview we have been running all week is good — ship exactly that."* The only stable path is a fresh bump off whatever `main` has become. `tasks/review-desktop-preview-promotion-plan.md` specified the fix; this implements it.

## What

**`review-desktop-preview.yml`**
- A new `tag-preview` job pushes a lightweight `v<version>` tag at the commit it built. It runs on `ubuntu-latest` with `contents: write`, no secrets and no checkout, so the job holding the Apple signing cert, keychain password, notary key, and R2 keys keeps `contents: read`. The `review-release` environment gate still applies transitively through `needs: version`.
- `needs: build` means a tag only ever names a preview that uploaded, answered its update feed, and served its installer.
- Only commits on `main` get tagged — a preview off any other branch could never be promoted, and logs a soft skip rather than failing.
- A tag-free precheck in the `version` job. A re-run reuses `GITHUB_RUN_NUMBER`, so it recomputes the same version string while re-resolving the mutable `ref`, which may have moved. Left to the tag push, that collision would surface only after signing, notarization, and an R2 upload that already overwrote the keys for that version.

**`review-desktop-release.yml`**
- New `release_source` (`main` | `preview`, default `main`) and `preview_tag` inputs.
- A read-only `resolve` step holds every gate: input combinations, the tag format, that the tag exists on origin, that its commit is **on `main`** (not necessarily at the tip), that the derived version is the next patch, and that the stable tag is free.
- A promotion builds the commit the preview was built from, so whatever merged since stays out of the release. `vX.Y.Z` marks that commit; the build stamps the release version onto its tree the way a preview build stamps its own. `main` still gets its bump commit, because the next release derives its version from there.
- The bump step now calls `stamp-release-channel.mjs --quality stable` instead of inlining its own JSON surgery. Byte-identical output, and it restamps stable identity rather than shipping whatever the tree carries.
- A dry run makes no remote change and builds the same commit under the same stamp a real promotion would.

Releasing from `main` is unchanged and remains the default, including every dry run of it.

## Verification

- 38/38 of the affected tests pass, including `preview-release-workflow.test.mjs`, whose `job("build")` slice runs to EOF and so covers the appended job.
- `actionlint` reports only `SC2129` and `SC2046`, both pre-existing; the rewrite removes the baseline's `SC2016`. `pnpm lint` and `pnpm format:check` clean.
- The stamp swap is provably a no-op: the old inline script and the new one were run on identical copies — `diff -r` byte-identical, and against the committed tree exactly 2 files / 2 lines.
- All 13 guard cases were rehearsed against a scratch local origin using GitHub's exact shell flags (`-eo pipefail`, no `-u`): blank tag, tag with `release_source=main`, malformed tag, bare stable tag, `bump=minor`, absent tag, tag behind main, the straddled-release version mismatch, an existing stable tag, a non-`X.Y.Z` `package.json`, and main-moved. Re-run under `/bin/bash` 3.2.57, the macOS runner shell.
- Annotated and lightweight tags both peel to the same commit through the `ls-remote` snippet and the `fetch +`/`^{commit}` path. Tag push is a no-op at the same sha and rejected at a different one without `--force`.
- The promotability call classifies correctly against this repo: main tip `identical`, older main commit `behind`, feature branch `diverged`.

No hosted dispatch and no real release were run.

## Merging

No preview built before this merges is promotable — tagging is what this adds, so earlier runs have no tag. The first promotable build is the first preview run after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
