### PR TITLE
Fix FFF MCP installer after repository rename

### DIFF
--- a/packages/progressive-review/README.md
+++ b/packages/progressive-review/README.md
@@ -122,7 +122,7 @@ when you need to manage the current repository manually.
 For a missing registration, setup runs the equivalent commands:
 
 ```sh
-curl -L https://dmtrkovalenko.dev/install-fff-mcp.sh | bash
+curl -fsSL --retry 3 --retry-all-errors https://raw.githubusercontent.com/dmtrKovalenko/fff/main/install-mcp.sh | bash
 claude mcp add -s user fff -- "$HOME/.local/bin/fff-mcp" "$HOME/.dev/trace-search"
 codex mcp add fff -- "$HOME/.local/bin/fff-mcp" "$HOME/.dev/trace-search"
 pi install npm:@ff-labs/pi-fff

--- a/packages/progressive-review/src/agent-fff.ts
+++ b/packages/progressive-review/src/agent-fff.ts
@@ -20,7 +20,8 @@ import { isFile } from "./fs-utils";
 import { devReviewHome } from "./review-storage";
 
 export const FFF_SERVER_NAME = "fff";
-export const FFF_INSTALL_URL = "https://dmtrkovalenko.dev/install-fff-mcp.sh";
+export const FFF_INSTALL_URL =
+  "https://raw.githubusercontent.com/dmtrKovalenko/fff/main/install-mcp.sh";
 export const FFF_TARGETS: ReviewFffInstallTarget[] = ["claude", "codex", "pi"];
 export const PI_FFF_PACKAGE = "npm:@ff-labs/pi-fff";
 
@@ -74,7 +75,10 @@ export async function installFffForTargets(input: {
     input.write("Installing FFF MCP…\n");
     const installer = await runCommand(
       "/bin/bash",
-      ["-c", `set -o pipefail; curl -fL ${FFF_INSTALL_URL} | bash`],
+      [
+        "-c",
+        `set -o pipefail; curl -fsSL --retry 3 --retry-all-errors ${FFF_INSTALL_URL} | bash`,
+      ],
       input.homeDir,
       input.env,
     );


### PR DESCRIPTION
Update the FFF MCP installer to the renamed repository script and retry transient download failures. Replaces #130, which GitHub marked merged into its former stack base during reordering; this PR contains only the installer fix against main.