### PR TITLE
Add Discord community link and startup invitation

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/browser/reviewCommunity.contribution.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/reviewCommunity.contribution.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { onUnexpectedError } from '../../base/common/errors.js';
+import { IDialogService } from '../../platform/dialogs/common/dialogs.js';
+import { IOpenerService } from '../../platform/opener/common/opener.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../platform/storage/common/storage.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../workbench/common/contributions.js';
+import { REVIEW_DISCORD_URL } from '../common/reviewProtocol.js';
+
+const DISMISSED_KEY = 'review.community.dontShowAgain';
+
+class ReviewCommunityContribution implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.devfast.reviewCommunity';
+
+	constructor(
+		@IDialogService dialogService: IDialogService,
+		@IStorageService storageService: IStorageService,
+		@IOpenerService openerService: IOpenerService,
+	) {
+		if (storageService.getBoolean(DISMISSED_KEY, StorageScope.APPLICATION, false)) {
+			return;
+		}
+
+		void dialogService.confirm({
+			type: 'info',
+			message: 'Join the Review community',
+			detail: 'Meet the team, ask questions, and share feedback in the /dev/fast Discord. You can also join anytime using the Discord link next to Report a bug.',
+			primaryButton: 'Join Discord',
+			cancelButton: 'Not now',
+			checkbox: { label: "Don't show again" },
+		}).then(async result => {
+			if (result.checkboxChecked) {
+				storageService.store(DISMISSED_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+			}
+			if (result.confirmed) {
+				await openerService.open(REVIEW_DISCORD_URL, { openExternal: true });
+			}
+		}).catch(onUnexpectedError);
+	}
+}
+
+registerWorkbenchContribution2(ReviewCommunityContribution.ID, ReviewCommunityContribution, WorkbenchPhase.Restored);

--- a/apps/review-desktop/code-oss/src/vs/review/browser/reviewCommunity.contribution.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/reviewCommunity.contribution.ts
@@ -43,4 +43,4 @@ class ReviewCommunityContribution implements IWorkbenchContribution {
 	}
 }
 
-registerWorkbenchContribution2(ReviewCommunityContribution.ID, ReviewCommunityContribution, WorkbenchPhase.Restored);
+registerWorkbenchContribution2(ReviewCommunityContribution.ID, ReviewCommunityContribution, WorkbenchPhase.AfterRestored);

--- a/apps/review-desktop/code-oss/src/vs/review/browser/reviewCommunity.contribution.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/reviewCommunity.contribution.ts
@@ -33,7 +33,7 @@ class ReviewCommunityContribution implements IWorkbenchContribution {
 			cancelButton: 'Not now',
 			checkbox: { label: "Don't show again" },
 		}).then(async result => {
-			if (result.checkboxChecked) {
+			if (result.confirmed || result.checkboxChecked) {
 				storageService.store(DISMISSED_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
 			}
 			if (result.confirmed) {

--- a/apps/review-desktop/code-oss/src/vs/review/contrib/verbs/reviewVerbs.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/verbs/reviewVerbs.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IOpenerService } from "../../../platform/opener/common/opener.js";
 import { encodeBase64 } from "../../../base/common/buffer.js";
 import { Emitter, Event } from "../../../base/common/event.js";
 import { Disposable, DisposableStore } from "../../../base/common/lifecycle.js";
@@ -50,6 +51,7 @@ import {
   type ReviewVerbResponse,
   type ReviewView,
   parseReviewVerbRequest,
+  REVIEW_DISCORD_URL,
 } from "../../common/reviewProtocol.js";
 import {
   ReviewDecorationAnchors,
@@ -138,6 +140,7 @@ export class ReviewVerbsService
     @IReviewExplorerPartsService
     private readonly explorerParts: IReviewExplorerPartsService,
     @IHostService private readonly hostService: IHostService,
+    @IOpenerService private readonly openerService: IOpenerService,
   ) {
     super();
     for (const editor of codeEditorService.listCodeEditors())
@@ -164,6 +167,9 @@ export class ReviewVerbsService
     try {
       const request = parseReviewVerbRequest(value);
       switch (request.name) {
+        case "joinDiscord":
+          await this.openerService.open(REVIEW_DISCORD_URL, { openExternal: true });
+          break;
         case "openFile":
           await this.openFile(request.args);
           break;

--- a/apps/review-desktop/code-oss/src/vs/review/review.common.main.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/review.common.main.ts
@@ -271,6 +271,7 @@ registerSingleton(
 import "../workbench/contrib/logs/common/logs.contribution.js";
 import "./contrib/quickaccess/reviewQuickAccess.contribution.js";
 import "./browser/reviewTheme.contribution.js";
+import "./browser/reviewCommunity.contribution.js";
 import "./contrib/extensions/reviewCuratedExtensions.contribution.js";
 import "./contrib/install/reviewCliInstall.contribution.js";
 import "./contrib/telemetry/reviewLspTelemetry.contribution.js";

--- a/packages/progressive-review/app/src/App.tsx
+++ b/packages/progressive-review/app/src/App.tsx
@@ -542,6 +542,16 @@ function ReviewLayoutContent({
             </div>
             <div className="review-topbar-actions">
               <ReviewHistoryControl />
+              <button
+                type="button"
+                className="review-open-source-tree"
+                title="Join our Discord community"
+                onClick={() =>
+                  session.surface.post({ name: "joinDiscord", args: {} })
+                }
+              >
+                Discord ↗
+              </button>
               <BugReportControl />
               <ReviewBatonChip outcome={review.submissionOutcome} />
               <div

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1859,7 +1859,10 @@ const revealArgsSchema = z
     }
   });
 
+export const REVIEW_DISCORD_URL = "https://discord.gg/wYvd2cpMQg";
+
 export const ReviewVerbRequestSchema = z.discriminatedUnion("name", [
+  z.strictObject({ name: z.literal("joinDiscord"), args: z.strictObject({}) }),
   z.strictObject({ name: z.literal("openFile"), args: openFileArgsSchema }),
   z.strictObject({
     name: z.literal("showReviewView"),


### PR DESCRIPTION
Adds a Discord link beside Report a bug and a community invitation when Review starts. Both open the existing /dev/fast invite in the system browser.

The dialog offers Join Discord, Not now, and a Don't show again checkbox. Join Discord automatically suppresses future invitations. Not now dismisses it for the current window, or permanently across projects and launches when Don't show again is checked.

Validation:
- 100 protocol tests and 9 existing host/bug-report UI tests passed.
- Progressive Review typecheck and targeted lint passed.
- Git diff whitespace check passed.
- Desktop typecheck and fresh development build passed after installing checkout dependencies.

