### PR TITLE
Align review quotes and side-panel headers

### DIFF
--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -1,4 +1,5 @@
 .review-canvas-root {
+  --review-header-height: 35px;
   --font-serif: "Newsreader", Georgia, serif;
   --font-mono: "Geist Mono", ui-monospace, monospace;
   --font-display: var(--font-mono);
@@ -2412,7 +2413,7 @@ button {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  height: 35px;
+  height: var(--review-header-height);
   padding: 0 8px;
   border-bottom: 1px solid var(--chrome-border);
   background: var(--surface);
@@ -4121,7 +4122,7 @@ button {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  min-height: 44px;
+  min-height: var(--review-header-height);
   padding: 0 10px 0 16px;
   border-bottom: 1px solid var(--rule);
   background: var(--surface);
@@ -7282,6 +7283,7 @@ button.review-stack-row:disabled .review-stack-relation {
 .review-document > blockquote,
 .review-document > pre,
 .review-document > .code-peek,
+.review-document > .review-trace-quote-container,
 .review-section-header,
 .review-section-body > p,
 .review-section-body > h3,
@@ -7289,13 +7291,20 @@ button.review-stack-row:disabled .review-stack-relation {
 .review-section-body > ol,
 .review-section-body > blockquote,
 .review-section-body > pre,
-.review-section-body > .code-peek {
+.review-section-body > .code-peek,
+.review-section-body > .review-trace-quote-container {
   width: min(100%, var(--review-prose-max-width));
   max-width: calc(
     100cqi - var(--review-document-padding-inline) -
       var(--review-document-padding-inline)
   );
   margin-inline: auto;
+}
+
+/* Standalone quotes share the prose column; quotes inside prose stay inline. */
+.review-document > .review-trace-quote-container,
+.review-section-body > .review-trace-quote-container {
+  display: block;
 }
 
 /* Code peeks are sections, so unlike prose they have no browser block margin. */

--- a/packages/progressive-review/app/src/trace-quote.tsx
+++ b/packages/progressive-review/app/src/trace-quote.tsx
@@ -37,36 +37,42 @@ export function TraceQuote({
   const href = `#trace-${sessionId}${trace ? `-${trace}` : ""}${event !== undefined ? `-event-${event}` : ""}`;
 
   return (
-    <ProsePeekAnchor
-      href={href}
-      className="review-trace-quote"
-      isOpen={isOpen}
-      inertFallback={
-        <span className="review-trace-quote review-trace-quote--inert">
-          {children}
-        </span>
-      }
-      onOpen={() => {
-        openPeek?.({
-          kind: "peek",
-          content: {
-            kind: "trace-quote",
-            sessionId,
-            trace,
-            event,
-            quote,
-          },
-        });
-      }}
-      onAlreadyOpen={() => {
-        const targetTurn = document.getElementById("review-trace-target-event");
-        const quoteMark = targetTurn?.querySelector(".review-trace-quote-mark");
-        const el = quoteMark ?? targetTurn;
-        // jsdom has no scrollIntoView, so the call stays optional.
-        el?.scrollIntoView?.({ block: "center", behavior: "auto" });
-      }}
-    >
-      {children}
-    </ProsePeekAnchor>
+    <span className="review-trace-quote-container">
+      <ProsePeekAnchor
+        href={href}
+        className="review-trace-quote"
+        isOpen={isOpen}
+        inertFallback={
+          <span className="review-trace-quote review-trace-quote--inert">
+            {children}
+          </span>
+        }
+        onOpen={() => {
+          openPeek?.({
+            kind: "peek",
+            content: {
+              kind: "trace-quote",
+              sessionId,
+              trace,
+              event,
+              quote,
+            },
+          });
+        }}
+        onAlreadyOpen={() => {
+          const targetTurn = document.getElementById(
+            "review-trace-target-event",
+          );
+          const quoteMark = targetTurn?.querySelector(
+            ".review-trace-quote-mark",
+          );
+          const el = quoteMark ?? targetTurn;
+          // jsdom has no scrollIntoView, so the call stays optional.
+          el?.scrollIntoView?.({ block: "center", behavior: "auto" });
+        }}
+      >
+        {children}
+      </ProsePeekAnchor>
+    </span>
   );
 }


### PR DESCRIPTION
Standalone trace quotes now align with surrounding review prose, while their active highlight stays around the text. An outer container owns the prose-column layout so the quote link and faint quotation marks remain inline.

The review toolbar and shared side-panel header now use the same 35px height, aligning their bottom borders across trace, code-peek, tour, threads, and question panels.

Validation: Chrome layout checks at three window widths for quote alignment, text-sized highlights, inline quotes, and five panel variants; all four existing trace-quote tests passed; CSS formatting check passed.
