### PR TITLE
Show Ask loading pane immediately and fix comment UI

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/browser/media/review.css
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/media/review.css
@@ -1290,14 +1290,14 @@ body
   .form-actions
   .other-actions
   > .monaco-text-button:first-child
-  > span::after,
+  > span:not(.codicon)::after,
 .monaco-workbench.review-workbench
   .review-widget
   .form-actions
   .other-actions
   > .monaco-button-dropdown
   > .monaco-text-button:first-child
-  > span::after {
+  > span:not(.codicon)::after {
   content: "Ctrl↩";
   display: inline-grid;
   height: 15px;
@@ -1317,14 +1317,14 @@ body
   .form-actions
   .other-actions
   > .monaco-text-button:first-child
-  > span::after,
+  > span:not(.codicon)::after,
 .monaco-workbench.review-workbench.mac
   .review-widget
   .form-actions
   .other-actions
   > .monaco-button-dropdown
   > .monaco-text-button:first-child
-  > span::after {
+  > span:not(.codicon)::after {
   content: "⌘↩";
 }
 

--- a/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
@@ -159,6 +159,9 @@ const reviewCanvasPolicy = createTrustedTypesPolicy("reviewCanvas", {
 });
 
 const detachedScrollRestoreDeadlineMs = 30_000;
+// Canvas content loading is keyed by promise identity. Metadata-only refreshes
+// must not remount the document and its native diff when maps are disabled.
+const disabledSoftwareMap = Promise.resolve(null);
 
 // The tutorial step list as it first shipped. Stored progress payloads
 // without a `steps` field date from this era.
@@ -1216,7 +1219,7 @@ export class ReviewCanvasEditorPane extends EditorPane {
 								baseModuleUrl,
 							),
 					)
-				: Promise.resolve(null);
+				: disabledSoftwareMap;
 			const bridge = this.createBridge(model, assets, generation, {
 				ready: () => {
 					if (this.renderedInput === input && this.renderedModel === model) {

--- a/apps/review-desktop/code-oss/src/vs/review/contrib/verbs/reviewAskLoadingEditor.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/verbs/reviewAskLoadingEditor.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Dimension } from '../../../base/browser/dom.js';
+import { CancellationToken } from '../../../base/common/cancellation.js';
+import { Emitter } from '../../../base/common/event.js';
+import { MutableDisposable } from '../../../base/common/lifecycle.js';
+import { URI } from '../../../base/common/uri.js';
+import { IEditorOptions } from '../../../platform/editor/common/editor.js';
+import { SyncDescriptor } from '../../../platform/instantiation/common/descriptors.js';
+import { Registry } from '../../../platform/registry/common/platform.js';
+import { IStorageService } from '../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../platform/telemetry/common/telemetry.js';
+import { IThemeService } from '../../../platform/theme/common/themeService.js';
+import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../workbench/browser/editor.js';
+import { EditorPane } from '../../../workbench/browser/parts/editor/editorPane.js';
+import { EditorExtensions, EditorInputCapabilities, IEditorOpenContext } from '../../../workbench/common/editor.js';
+import { EditorInput } from '../../../workbench/common/editor/editorInput.js';
+import { IEditorGroup } from '../../../workbench/services/editor/common/editorGroupsService.js';
+
+/** Local UI for one Ask; never serialized or used as native session state. */
+export class ReviewAskLoadingInput extends EditorInput {
+  static readonly ID = 'review.askLoading';
+  readonly resource: URI;
+  private readonly changed = this._register(new Emitter<void>());
+  readonly onDidChangeStatus = this.changed.event;
+  status = 'Waiting for agent…';
+
+  constructor(messageId: string) {
+    super();
+    this.resource = URI.from({ scheme: 'review-ask', path: `/${messageId}` });
+  }
+
+  override get typeId(): string { return ReviewAskLoadingInput.ID; }
+  override get capabilities(): EditorInputCapabilities {
+    return EditorInputCapabilities.Readonly | EditorInputCapabilities.Singleton;
+  }
+  override getName(): string { return 'Ask'; }
+
+  fail(message: string): void {
+    this.status = `Unable to open agent: ${message}`;
+    this.changed.fire();
+  }
+}
+
+class ReviewAskLoadingPane extends EditorPane {
+  static readonly ID = 'review.askLoadingPane';
+  private container!: HTMLElement;
+  private readonly statusSubscription = this._register(new MutableDisposable());
+
+  constructor(
+    group: IEditorGroup,
+    @ITelemetryService telemetry: ITelemetryService,
+    @IThemeService theme: IThemeService,
+    @IStorageService storage: IStorageService,
+  ) { super(ReviewAskLoadingPane.ID, group, telemetry, theme, storage); }
+
+  protected override createEditor(parent: HTMLElement): void {
+    this.container = parent.ownerDocument.createElement('div');
+    this.container.style.cssText = 'box-sizing:border-box;height:100%;padding:24px;font-family:var(--monaco-monospace-font);color:var(--vscode-descriptionForeground)';
+    this.container.setAttribute('role', 'status');
+    this.container.tabIndex = 0;
+    parent.appendChild(this.container);
+  }
+
+  override async setInput(input: ReviewAskLoadingInput, options: IEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
+    await super.setInput(input, options, context, token);
+    const render = () => { this.container.textContent = input.status; };
+    this.statusSubscription.value = input.onDidChangeStatus(render);
+    render();
+  }
+
+  override clearInput(): void {
+    this.statusSubscription.clear();
+    this.container.textContent = '';
+    super.clearInput();
+  }
+  override layout(_dimension: Dimension): void {}
+  override focus(): void { this.container.focus(); }
+}
+
+Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(
+  EditorPaneDescriptor.create(ReviewAskLoadingPane, ReviewAskLoadingPane.ID, 'Ask'),
+  [new SyncDescriptor(ReviewAskLoadingInput)],
+);

--- a/apps/review-desktop/code-oss/src/vs/review/contrib/verbs/reviewVerbs.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/verbs/reviewVerbs.ts
@@ -3,10 +3,11 @@
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ReviewAskLoadingInput } from "./reviewAskLoadingEditor.js";
 import { IOpenerService } from "../../../platform/opener/common/opener.js";
 import { encodeBase64 } from "../../../base/common/buffer.js";
 import { Emitter, Event } from "../../../base/common/event.js";
-import { Disposable, DisposableStore } from "../../../base/common/lifecycle.js";
+import { Disposable, DisposableStore, MutableDisposable, toDisposable } from "../../../base/common/lifecycle.js";
 import {
   type ICodeEditor,
   MouseTargetType,
@@ -115,6 +116,12 @@ export class ReviewVerbsService
   private readonly decorationIdsByModel = new Map<string, string[]>();
   private readonly editorStores = new Map<string, DisposableStore>();
   private readonly agentSessionTerminals = new Map<string, ITerminalInstance>();
+  private readonly askPanes = new Map<string, {
+    input: ReviewAskLoadingInput;
+    startedAt: string;
+    opened: Promise<IEditorPane | undefined>;
+  }>();
+  private readonly commentSubscription = this._register(new MutableDisposable());
   private revealDecoration: IEditorDecorationsCollection | undefined;
 
   constructor(
@@ -143,6 +150,34 @@ export class ReviewVerbsService
     @IOpenerService private readonly openerService: IOpenerService,
   ) {
     super();
+    const watchAsks = () => {
+      const model = this.sessionModelService.activeModel;
+      this.commentSubscription.clear();
+      if (!model) return;
+      const comments = model.comments;
+      this.commentSubscription.value = toDisposable(comments.subscribe(() => {
+        for (const activity of comments.getSnapshot().agentActivities.values()) {
+          const pending = this.askPanes.get(activity.messageId);
+          if (activity.status === "failed") {
+            pending?.input.fail(activity.error);
+          } else if (activity.status === "running") {
+            this.askPanes.delete(activity.messageId);
+          } else if (activity.status === "starting" && pending?.startedAt !== activity.startedAt) {
+            pending?.input.dispose();
+            this._onDidEmitSurfaceEvent.fire({
+              event: "agentTerminalOpening",
+              sessionId: model.session.session.sessionId,
+            });
+            const input = new ReviewAskLoadingInput(activity.messageId);
+            const opened = this.editorService.openEditor(input, { pinned: true }, SIDE_GROUP);
+            this.askPanes.set(activity.messageId, { input, opened, startedAt: activity.startedAt });
+            void opened.catch(error => input.fail(String(error)));
+          }
+        }
+      }));
+    };
+    this._register(this.sessionModelService.onDidChangeActiveModel(watchAsks));
+    watchAsks();
     for (const editor of codeEditorService.listCodeEditors())
       this.trackEditor(editor);
     this._register(
@@ -275,15 +310,26 @@ export class ReviewVerbsService
       event: "agentTerminalOpening",
       sessionId: this.requireSession().session.sessionId,
     });
+    const pending = input.askMessageId === null ? undefined : this.askPanes.get(input.askMessageId);
+    const pane = pending ? await pending.opened : undefined;
+    // A closed loading tab is an explicit dismissal of this Ask's terminal.
+    if (pending?.input.isDisposed()) return;
+    const group = pane ? pane.group.id : SIDE_GROUP;
+    const finish = async () => {
+      if (!pending || !pane) return;
+      await pane.group.closeEditor(pending.input);
+      pending.input.dispose();
+    };
     const key = `native:${input.session.harness}:${input.session.sessionId}`;
     const existing = this.agentSessionTerminals.get(key);
     if (existing && this.terminalEditorService.instances.includes(existing)) {
       // The session already has a live terminal: bring it forward.
       await this.terminalEditorService.openEditor(existing, {
-        viewColumn: SIDE_GROUP,
+        viewColumn: group,
       });
       this.terminalService.setActiveInstance(existing);
       await existing.focusWhenReady(true);
+      await finish();
       return;
     }
     const instance = await this.terminalService.createTerminal({
@@ -304,7 +350,7 @@ export class ReviewVerbsService
         name: `${input.session.harness} · ${input.session.sessionId.slice(0, 8)}`,
         useShellEnvironment: true,
       },
-      location: { viewColumn: SIDE_GROUP },
+      location: { viewColumn: group },
     });
     this.agentSessionTerminals.set(key, instance);
     this._register(instance.onDisposed(() => {
@@ -313,10 +359,11 @@ export class ReviewVerbsService
       }
     }));
     await this.terminalEditorService.openEditor(instance, {
-      viewColumn: SIDE_GROUP,
+      viewColumn: group,
     });
     this.terminalService.setActiveInstance(instance);
     await instance.focusWhenReady(true);
+    await finish();
   }
 
   private async showThreads(): Promise<void> {

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewCanvasEditorTabsService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewCanvasEditorTabsService.ts
@@ -119,10 +119,16 @@ export class ReviewCanvasEditorTabsService
 			this.inputs.set(target.kind, input);
 		}
 		configure?.(input);
+		// A control command may arrive while an Ask's loading pane has focus.
+		// Reuse the review's group instead of mounting a second canvas there.
+		const existingGroup = this.editorGroupsService.groups.find(group => group.contains(input));
+		const targetGroup = existingGroup === undefined
+			? this.editorGroupsService.mainPart.activeGroup
+			: existingGroup;
 		await this.editorService.openEditor(
 			input,
 			{ pinned: true, inactive: !active, revealIfVisible: true },
-			this.editorGroupsService.mainPart.activeGroup,
+			targetGroup,
 		);
 		return input;
 	}
@@ -206,10 +212,16 @@ export class ReviewCanvasEditorTabsService
 		input: ReviewCanvasEditorInput,
 		active: boolean,
 	): Promise<void> {
+		// A control command may arrive while an Ask's loading pane has focus.
+		// Reuse the review's group instead of mounting a second canvas there.
+		const existingGroup = this.editorGroupsService.groups.find(group => group.contains(input));
+		const targetGroup = existingGroup === undefined
+			? this.editorGroupsService.mainPart.activeGroup
+			: existingGroup;
 		await this.editorService.openEditor(
 			input,
 			{ pinned: true, inactive: !active, revealIfVisible: true },
-			this.editorGroupsService.mainPart.activeGroup,
+			targetGroup,
 		);
 	}
 

--- a/packages/progressive-review/app/src/review-components.tsx
+++ b/packages/progressive-review/app/src/review-components.tsx
@@ -51,6 +51,7 @@ import {
   RefreshIcon,
   ResolveIcon,
   TerminalIcon,
+  TrashIcon,
 } from "./icons";
 import { newTabLinkProps } from "./link-props";
 import { createClientId, useReview, useReviewActions } from "./review-context";
@@ -1613,6 +1614,21 @@ function ThreadPanelInner({
               {thread.resolved ? <RefreshIcon /> : <ResolveIcon />}
               <span>{thread.resolved ? "Unresolve" : "Resolve"}</span>
             </button>
+            {thread.clientStatus === "draft" && (
+              <button
+                type="button"
+                className="icon-button"
+                aria-label="Delete thread"
+                title="Delete thread"
+                onClick={async () => {
+                  await review.deleteComment(thread.threadId);
+                  review.blurThread();
+                  setThreadsPage({ kind: "list" });
+                }}
+              >
+                <TrashIcon />
+              </button>
+            )}
             {thread.agentSession && (
               <button
                 type="button"

--- a/packages/progressive-review/app/src/thread-annotations.tsx
+++ b/packages/progressive-review/app/src/thread-annotations.tsx
@@ -170,8 +170,10 @@ export function ThreadAnnotations({
     clearThreadFocusRequest,
     askAgent: askAgentAction,
     saveComment,
+    deleteComment,
   } = useReviewActions();
   const {
+    historicalRevision,
     allCommentThreads,
     resolvedCommentThreads,
     draftTarget: contextDraftTarget,
@@ -446,7 +448,9 @@ export function ThreadAnnotations({
   useLayoutEffect(() => {
     if (gutter?.mode !== "cards") return;
     const entries = annotations
-      .filter((annotation) => annotation.anchorY !== null)
+      .filter(
+        (annotation) => annotation.anchorY !== null && !annotation.resolved,
+      )
       .sort((left, right) => (left.anchorY ?? 0) - (right.anchorY ?? 0));
     if (entries.length === 0) {
       setCardTops((current) => (current.size === 0 ? current : new Map()));
@@ -827,13 +831,32 @@ export function ThreadAnnotations({
                   thread={thread}
                   variant="margin"
                   compact
+                  onDelete={
+                    thread.clientStatus === "draft" && !historicalRevision
+                      ? async () => {
+                          await deleteComment(thread.threadId);
+                          if (isActive) blurThread();
+                        }
+                      : undefined
+                  }
                   onActivate={() => activate(annotation)}
                 />
               </div>
             );
           })}
           {draftTarget && (
-            <div style={{ top: Math.max(0, draftAnchorY ?? 0) }}>
+            <div
+              ref={(node) => {
+                const key = `draft:${draftTarget.threadId}`;
+                if (node) cardRefs.current.set(key, node);
+                else cardRefs.current.delete(key);
+              }}
+              style={{
+                top:
+                  cardTops.get(`draft:${draftTarget.threadId}`) ??
+                  Math.max(0, draftAnchorY ?? 0),
+              }}
+            >
               <ThreadDraftCard
                 quote={draftQuote}
                 variant="margin"

--- a/packages/progressive-review/src/server/review-api.ts
+++ b/packages/progressive-review/src/server/review-api.ts
@@ -645,7 +645,11 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       session: { resume: binding.sessionId },
       cwd: agentRootPath,
     });
-    await openNativeAgentTerminal({ session: binding, command });
+    await openNativeAgentTerminal({
+      session: binding,
+      command,
+      askMessageId: null,
+    });
     return reviewApiJsonResponse(200, { ok: true });
   }
 
@@ -1130,7 +1134,11 @@ export async function answerReviewComment(input: {
       cwd: input.rootPath,
       session: { resume: binding.sessionId },
     });
-    await input.openNativeAgentTerminal({ session: binding, command });
+    await input.openNativeAgentTerminal({
+      session: binding,
+      command,
+      askMessageId: input.comment.messageId,
+    });
     await input.onQuestionAgentSession?.(binding);
     return;
   }
@@ -1213,7 +1221,11 @@ export async function answerReviewComment(input: {
     .agentServer(launch.harness)
     .launch(launchInput);
   const binding: SessionRef = { harness: launch.harness, sessionId };
-  await input.openNativeAgentTerminal({ session: binding, command });
+  await input.openNativeAgentTerminal({
+    session: binding,
+    command,
+    askMessageId: input.comment.messageId,
+  });
   await input.onQuestionAgentSession?.(binding);
 }
 

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1945,6 +1945,8 @@ export const ReviewVerbRequestSchema = z.discriminatedUnion("name", [
     args: z.strictObject({
       /** The native session the terminal runs; the app keys terminals by it. */
       session: AuthoringAgentSessionSchema,
+      /** Null for a manual resume; otherwise replaces this Ask’s local loading pane. */
+      askMessageId: requiredString.nullable(),
       command: z.strictObject({
         cwd: requiredString,
         executable: requiredString,


### PR DESCRIPTION
Ask previously waited for draft persistence and native-session acceptance before opening a terminal pane. Open a local “Waiting for agent…” pane immediately, then replace it in the same editor group using the Ask message ID. Keep launch errors visible without adding persisted launch state. Reuse the review’s existing group so the terminal handoff cannot mount a second canvas over the waiting pane.

Also includes the related UI fixes from this branch: keep shortcut-badge styling off the loading icon, retain the canvas across metadata-only refreshes, include the draft composer in margin-card spacing, and expose draft deletion in the Threads panel.

Validation:
- Fully rebuilt local desktop app; a real Codex Ask showed the waiting pane and replaced it with the terminal in the same split.
- Desktop build, tutorial validation, lint, formatting, and typechecks passed locally.
- Full repository tests passed as part of `pnpm run ci`.
