### PR TITLE
Clear duplicate Ask text from the reply editor during launch

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/contrib/comments/reviewComments.contribution.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/comments/reviewComments.contribution.test.ts
@@ -82,6 +82,8 @@ test("keeps one stable comment projection per diff resource", async () => {
   let snapshotListener = (_change: { threadIds: ReadonlySet<string> }) => {};
   let currentSnapshot = snapshot;
   const savedComments: unknown[] = [];
+  let rejectAsk!: (error: Error) => void;
+  const pendingAsk = new Promise<void>((_resolve, reject) => { rejectAsk = reject; });
   let commentingRangeUpdates = 0;
   const commentService = {
     registerCommentController() {},
@@ -108,6 +110,9 @@ test("keeps one stable comment projection per diff resource", async () => {
     },
     async saveComment(input: unknown) {
       savedComments.push(input);
+    },
+    askAgent() {
+      return pendingAsk;
     },
   };
   const model = {
@@ -247,6 +252,20 @@ test("keeps one stable comment projection per diff resource", async () => {
   assert.equal(unified.threads[0].label, "L3\u20139 \u00b7 diff");
   assert.deepEqual(base.threads[0].range, new Range(267, 1, 270, Number.MAX_SAFE_INTEGER));
   assert.deepEqual(head.threads[0].range, new Range(320, 1, 322, Number.MAX_SAFE_INTEGER));
+  const replyThread = unified.threads[0];
+  replyThread.input = { uri: URI.parse("comment-input:/ask"), value: "Question" };
+  const inputChanges: string[] = [];
+  const inputListener = replyThread.onDidChangeInput(input => { if (input) inputChanges.push(input.value); });
+  const asking = controller.askNow({ thread: replyThread, text: "Question" });
+  // Clear before launch resolves, rather than displaying the question twice.
+  assert.equal(replyThread.input.value, "");
+  assert.deepEqual(inputChanges, [""]);
+  const rejected = assert.rejects(asking, /Could not save/);
+  rejectAsk(new Error("Could not save"));
+  await rejected;
+  assert.equal(replyThread.input.value, "Question");
+  assert.deepEqual(inputChanges, ["", "Question"]);
+  inputListener.dispose();
   currentSnapshot = {
     ...snapshot,
     agentActivities: new Map([

--- a/apps/review-desktop/code-oss/src/vs/review/contrib/comments/reviewComments.contribution.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/comments/reviewComments.contribution.ts
@@ -194,7 +194,8 @@ class ReviewCommentThread extends Disposable implements CommentThread<IRange> {
     readonly Comment[] | undefined
   >());
   readonly onDidChangeComments = this._onDidChangeComments.event;
-  readonly onDidChangeInput = Event.None;
+  private readonly _onDidChangeInput = this._register(new Emitter<CommentInput | undefined>());
+  readonly onDidChangeInput = this._onDidChangeInput.event;
   private readonly _onDidChangeLabel = this._register(new Emitter<string | undefined>());
   readonly onDidChangeLabel = this._onDidChangeLabel.event;
   private readonly _onDidChangeCollapsibleState = this._register(new Emitter<
@@ -215,6 +216,11 @@ class ReviewCommentThread extends Disposable implements CommentThread<IRange> {
   contextValue = REVIEW_COMMENT_THREAD_OPEN;
   readonly initialCollapsibleState = CommentThreadCollapsibleState.Expanded;
   input: CommentInput | undefined;
+  setInputValue(value: string): void {
+    if (!this.input) return;
+    this.input = { ...this.input, value };
+    this._onDidChangeInput.fire(this.input);
+  }
   label: string | undefined;
   comments: readonly Comment[] | undefined;
   private _collapsibleState = CommentThreadCollapsibleState.Expanded;
@@ -597,7 +603,7 @@ export class ReviewCommentController
     });
   }
 
-  askNow(context: ReviewCommentReplyContext): Promise<void> {
+  async askNow(context: ReviewCommentReplyContext): Promise<void> {
     const body = context.text.trim();
     if (!body) return Promise.resolve();
     const model = this.model;
@@ -605,12 +611,26 @@ export class ReviewCommentController
     if (!model || model.state !== "active" || !target) {
       throw new Error("The active review no longer owns this comment.");
     }
-    return model.comments.askAgent({
-      messageId: generateUuid(),
-      threadId: context.thread.threadId,
+    const thread = context.thread as ReviewCommentThread;
+    const messageId = generateUuid();
+    const submitted = model.comments.askAgent({
+      messageId,
+      threadId: thread.threadId,
       target,
       body,
     });
+    // The question is now in the thread; don't leave a second copy in the editor
+    // while waiting for the native terminal to open.
+    thread.setInputValue("");
+    try {
+      await submitted;
+    } catch (error) {
+      const saved = model.comments.getSnapshot().commentThreads.get(thread.threadId);
+      if (!saved?.messages.some((message) => message.id === messageId) && thread.input?.value === "") {
+        thread.setInputValue(context.text);
+      }
+      throw error;
+    }
   }
 
   editComment(context: ReviewCommentNodeContext): void {


### PR DESCRIPTION
Clicking Ask now added the question to the thread but left the same text in the reply editor until the native terminal opened. Clear the editor immediately through its input-change event, while preserving the existing loading state.

If submission fails before the question is saved, restore its text only while the editor is still empty. A saved question remains in the thread if agent startup fails.

Validation: formatting, lint, Desktop typecheck and the full Desktop test suite pass. Regression coverage holds launch pending to verify immediate clearing and restores the input on save failure. The local Desktop app was fully rebuilt for verification.
