### PR TITLE
Replace migration banner with a dismissible toast

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
@@ -511,6 +511,8 @@ export class ReviewCanvasEditorPane extends EditorPane {
 					return this.render(
 					{
 						kind: "home",
+						appVersion:
+							this.productService.reviewVersion ?? this.productService.version,
 						reviews: this.sessionService.reviews,
 						reviewErrors: this.sessionService.reviewErrors,
 						openReview: (uuid) => void openReview(uuid),
@@ -1338,6 +1340,8 @@ export class ReviewCanvasEditorPane extends EditorPane {
 		await this.render(
 			{
 				kind: "error",
+				appVersion:
+					this.productService.reviewVersion ?? this.productService.version,
 				message: error instanceof Error ? error.message : String(error),
 				reviewErrors: this.sessionService.reviewErrors,
 			},

--- a/packages/progressive-review/app/src/desktop-entry.tsx
+++ b/packages/progressive-review/app/src/desktop-entry.tsx
@@ -17,7 +17,8 @@ import { ReviewCanvasLoading } from "./review-canvas-loading";
 import { reviewDefinitionDiagnostics } from "./review-definition-runtime";
 import type { ReadyReviewDocumentEntry } from "./review-documents-runtime";
 import { type ReviewFindHost, createReviewFindHost } from "./review-find";
-import { ReviewHome, ReviewMigrationWarning } from "./review-home-view";
+import { ReviewHome } from "./review-home-view";
+import { ReviewMigrationToast } from "./review-migration-toast";
 import {
   ReviewContainerProvider,
   useReviewContainer,
@@ -140,7 +141,10 @@ function DesktopReviewApp({
   }
   return (
     <div className="review-session-content">
-      <ReviewMigrationWarning errors={reviewErrors} />
+      <ReviewMigrationToast
+        errors={reviewErrors}
+        appVersion={session.config.appVersion}
+      />
       <TutorialProvider tutorial={tutorial}>
         <App
           document={document}
@@ -226,7 +230,10 @@ function ReviewCanvas({
   if (content.kind === "error") {
     return (
       <CanvasShell title="Review unavailable">
-        <ReviewMigrationWarning errors={content.reviewErrors ?? []} />
+        <ReviewMigrationToast
+          errors={content.reviewErrors ?? []}
+          appVersion={content.appVersion}
+        />
         <p>{content.message}</p>
       </CanvasShell>
     );
@@ -245,6 +252,7 @@ function Home({
   const openSourceTree = content.openSourceTree;
   return (
     <ReviewHome
+      appVersion={content.appVersion}
       reviews={content.reviews}
       reviewErrors={content.reviewErrors}
       onOpen={(review) => content.openReview(review.uuid)}

--- a/packages/progressive-review/app/src/review-home-view.test.tsx
+++ b/packages/progressive-review/app/src/review-home-view.test.tsx
@@ -11,12 +11,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   REVIEW_HOME_VIEW_STORAGE_KEY,
-  REVIEW_MIGRATION_PROMPT,
   ReviewHome,
   formatRelativeTime,
   groupReviewsByWorktree,
   setupBannerMessage,
 } from "./review-home-view";
+import {
+  REVIEW_MIGRATION_DISMISSED_VERSION_KEY,
+  REVIEW_MIGRATION_PROMPT,
+  ReviewMigrationToast,
+} from "./review-migration-toast";
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -81,7 +85,9 @@ describe("ReviewHome", () => {
     ];
 
     await act(async () =>
-      root.render(<ReviewHome reviews={reviews} onOpen={onOpen} />),
+      root.render(
+        <ReviewHome appVersion="0.0.31" reviews={reviews} onOpen={onOpen} />,
+      ),
     );
     expect(container.querySelector(".review-home-topbar")).toBeNull();
     expect(container.querySelector(".review-home-card")).not.toBeNull();
@@ -123,7 +129,9 @@ describe("ReviewHome", () => {
     ];
 
     await act(async () =>
-      root.render(<ReviewHome reviews={reviews} onOpen={() => {}} />),
+      root.render(
+        <ReviewHome appVersion="0.0.31" reviews={reviews} onOpen={() => {}} />,
+      ),
     );
 
     expect(container.querySelectorAll(".review-home-workspace")).toHaveLength(
@@ -156,7 +164,9 @@ describe("ReviewHome", () => {
     ];
 
     await act(async () =>
-      root.render(<ReviewHome reviews={reviews} onOpen={() => {}} />),
+      root.render(
+        <ReviewHome appVersion="0.0.31" reviews={reviews} onOpen={() => {}} />,
+      ),
     );
 
     expect(
@@ -209,7 +219,9 @@ describe("ReviewHome", () => {
     ];
 
     await act(async () =>
-      root.render(<ReviewHome reviews={reviews} onOpen={() => {}} />),
+      root.render(
+        <ReviewHome appVersion="0.0.31" reviews={reviews} onOpen={() => {}} />,
+      ),
     );
 
     const visibleTitles = () =>
@@ -256,7 +268,12 @@ describe("ReviewHome", () => {
 
     await act(async () =>
       root.render(
-        <ReviewHome reviews={reviews} onOpen={onOpen} onDelete={onDelete} />,
+        <ReviewHome
+          appVersion="0.0.31"
+          reviews={reviews}
+          onOpen={onOpen}
+          onDelete={onDelete}
+        />,
       ),
     );
 
@@ -281,9 +298,142 @@ describe("ReviewHome", () => {
 
   it("hides the delete action when the host does not support deletion", async () => {
     await act(async () =>
-      root.render(<ReviewHome reviews={[descriptor()]} onOpen={() => {}} />),
+      root.render(
+        <ReviewHome
+          appVersion="0.0.31"
+          reviews={[descriptor()]}
+          onOpen={() => {}}
+        />,
+      ),
     );
     expect(container.querySelector(".review-home-delete")).toBeNull();
+  });
+
+  it("dismisses across canvases and remounts until the app version changes", async () => {
+    const errors: ReviewListError[] = [
+      {
+        reviewDir: "/tmp/reviews/legacy",
+        code: "MIGRATION_REQUIRED",
+        message: "Migration required",
+        reviewUuid: null,
+        title: "Legacy Review",
+        worktreePath: "/repo/old",
+        lastPublishedAt: null,
+      },
+    ];
+    const renderToasts = (appVersion: string) =>
+      act(async () =>
+        root.render(
+          <>
+            <ReviewHome
+              appVersion={appVersion}
+              reviews={[descriptor()]}
+              reviewErrors={errors}
+              onOpen={() => {}}
+            />
+            <ReviewMigrationToast appVersion={appVersion} errors={errors} />
+          </>,
+        ),
+      );
+    await renderToasts("0.0.31");
+    expect(container.querySelectorAll(".review-migration-toast")).toHaveLength(
+      2,
+    );
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(".review-migration-toast-dismiss")
+        ?.click(),
+    );
+    expect(container.querySelector(".review-migration-toast")).toBeNull();
+    expect(localStorage.getItem(REVIEW_MIGRATION_DISMISSED_VERSION_KEY)).toBe(
+      "0.0.31",
+    );
+    await act(async () => root.render(null));
+    errors.push({ ...errors[0]!, reviewDir: "/tmp/reviews/another" });
+    await renderToasts("0.0.31");
+    expect(container.querySelector(".review-migration-toast")).toBeNull();
+    await renderToasts("0.0.32");
+    expect(container.querySelectorAll(".review-migration-toast")).toHaveLength(
+      2,
+    );
+    expect(container.querySelector('[role="status"]')?.textContent).toBe(
+      "2 Reviews need migration.",
+    );
+    await act(async () =>
+      root.render(<ReviewMigrationToast appVersion="0.0.32" errors={[]} />),
+    );
+    expect(container.querySelector(".review-migration-toast")).toBeNull();
+  });
+
+  it("respects a persisted dismissal and changes from another window", async () => {
+    const errors: ReviewListError[] = [
+      {
+        reviewDir: "/tmp/legacy",
+        code: "MIGRATION_REQUIRED",
+        message: "Migration required",
+        reviewUuid: null,
+        title: "Legacy Review",
+        worktreePath: "/repo/old",
+        lastPublishedAt: null,
+      },
+    ];
+    localStorage.setItem(REVIEW_MIGRATION_DISMISSED_VERSION_KEY, "0.0.31");
+    await act(async () =>
+      root.render(<ReviewMigrationToast appVersion="0.0.31" errors={errors} />),
+    );
+    expect(container.querySelector(".review-migration-toast")).toBeNull();
+    await act(async () => {
+      localStorage.removeItem(REVIEW_MIGRATION_DISMISSED_VERSION_KEY);
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: REVIEW_MIGRATION_DISMISSED_VERSION_KEY,
+        }),
+      );
+    });
+    expect(container.querySelector(".review-migration-toast")).not.toBeNull();
+  });
+
+  it("can dismiss and navigate when storage is unavailable", async () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("Storage disabled");
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("Storage disabled");
+    });
+    const errors: ReviewListError[] = [
+      {
+        reviewDir: "/tmp/legacy",
+        code: "MIGRATION_REQUIRED",
+        message: "Migration required",
+        reviewUuid: null,
+        title: "Legacy Review",
+        worktreePath: "/repo/old",
+        lastPublishedAt: null,
+      },
+    ];
+    const renderToast = () =>
+      act(async () =>
+        root.render(
+          <ReviewMigrationToast
+            appVersion="storage-disabled-test"
+            errors={errors}
+          />,
+        ),
+      );
+    await renderToast();
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(".review-migration-toast-dismiss")
+        ?.click(),
+    );
+    expect(container.querySelector(".review-migration-toast")).toBeNull();
+    await act(async () => root.render(null));
+    await renderToast();
+    expect(container.querySelector(".review-migration-toast")).toBeNull();
+    vi.restoreAllMocks();
+    await act(async () =>
+      window.dispatchEvent(new StorageEvent("storage", { key: null })),
+    );
   });
 
   it("tells the user how to migrate incompatible reviews", async () => {
@@ -299,6 +449,7 @@ describe("ReviewHome", () => {
     await act(async () =>
       root.render(
         <ReviewHome
+          appVersion="0.0.31"
           reviews={[descriptor()]}
           reviewErrors={[error]}
           onOpen={() => {}}
@@ -307,11 +458,11 @@ describe("ReviewHome", () => {
     );
 
     expect(
-      container.querySelector(".review-migration-warning")?.textContent,
-    ).toBe("1 Review needs migration.Copy prompt");
+      container.querySelector(".review-migration-toast")?.textContent,
+    ).toBe("1 Review needs migration.Copy promptDismiss");
     expect(container.textContent).not.toContain("Review from schema 2");
     const copy = container.querySelector<HTMLButtonElement>(
-      '.review-migration-warning button[aria-label="Copy prompt"]',
+      '.review-migration-toast button[aria-label="Copy prompt"]',
     );
     expect(copy).not.toBeNull();
     const writeText = vi.fn<(text: string) => Promise<void>>(async () => {});
@@ -321,12 +472,20 @@ describe("ReviewHome", () => {
     });
     await act(async () => copy?.click());
     expect(writeText).toHaveBeenCalledWith(REVIEW_MIGRATION_PROMPT);
+    expect(copy?.textContent).toBe("Copied");
+    expect(container.querySelector(".review-migration-toast")).not.toBeNull();
   });
 
   it("restores list view from storage", async () => {
     localStorage.setItem(REVIEW_HOME_VIEW_STORAGE_KEY, "list");
     await act(async () =>
-      root.render(<ReviewHome reviews={[descriptor()]} onOpen={() => {}} />),
+      root.render(
+        <ReviewHome
+          appVersion="0.0.31"
+          reviews={[descriptor()]}
+          onOpen={() => {}}
+        />,
+      ),
     );
     expect(container.querySelector(".review-home-list-table")).not.toBeNull();
     expect(
@@ -346,7 +505,9 @@ describe("ReviewHome", () => {
     });
 
     await act(async () =>
-      root.render(<ReviewHome reviews={[review]} onOpen={() => {}} />),
+      root.render(
+        <ReviewHome appVersion="0.0.31" reviews={[review]} onOpen={() => {}} />,
+      ),
     );
     expect(container.textContent).toContain("updated 6 min ago");
     expect(container.textContent).not.toContain("updated not published");

--- a/packages/progressive-review/app/src/review-home-view.tsx
+++ b/packages/progressive-review/app/src/review-home-view.tsx
@@ -29,18 +29,16 @@ import {
 
 import { fuzzyMatches, fuzzySegments } from "../../src/fuzzy-match";
 import { TARGET_LABELS } from "./agent-setup-card";
-import { CopyPromptButton } from "./copy-prompt-button";
 import { ArchiveIcon } from "./review-corner-action";
+import { ReviewMigrationToast } from "./review-migration-toast";
 import { WelcomePage } from "./welcome-page";
 
 export type ReviewHomeView = "cards" | "list";
 
 export const REVIEW_HOME_VIEW_STORAGE_KEY = "dev.fast.review.homeView";
 
-export const REVIEW_MIGRATION_PROMPT =
-  "Use the local `review` CLI to migrate my Review data. Run `review migrate apply`. If a code comment position cannot be recovered, rerun `review migrate apply --force` to drop only the unrecoverable threads. Then restart Review and confirm that the Reviews and comments load.";
-
 interface ReviewHomeProps {
+  appVersion: string;
   reviews: readonly ReviewDescriptor[];
   reviewErrors?: readonly ReviewListError[];
   onOpen(review: ReviewDescriptor): void;
@@ -124,6 +122,7 @@ interface ReviewStatusDisplay {
 }
 
 export function ReviewHome({
+  appVersion,
   reviews,
   reviewErrors = [],
   onOpen,
@@ -188,7 +187,7 @@ export function ReviewHome({
         <div className="review-home-content">
           {setup ? <SetupBanner setup={setup} /> : null}
           {reviewErrors.length > 0 ? (
-            <ReviewScanWarning errors={reviewErrors} />
+            <ReviewScanWarning errors={reviewErrors} appVersion={appVersion} />
           ) : null}
           <div className="review-home-page-header">
             <h1>Reviews</h1>
@@ -231,33 +230,18 @@ export function ReviewHome({
   );
 }
 
-export function ReviewMigrationWarning({
+function ReviewScanWarning({
   errors,
+  appVersion,
 }: {
   errors: readonly ReviewListError[];
+  appVersion: string;
 }) {
-  const migrationCount = errors.filter(
-    (error) => error.code === "MIGRATION_REQUIRED",
-  ).length;
-  if (migrationCount === 0) return null;
-  return (
-    <section
-      className="review-migration-warning"
-      aria-label="Review migration required"
-    >
-      <span>
-        {`${migrationCount} ${migrationCount === 1 ? "Review needs" : "Reviews need"} migration.`}
-      </span>
-      <CopyPromptButton prompt={REVIEW_MIGRATION_PROMPT} />
-    </section>
-  );
-}
-
-function ReviewScanWarning({ errors }: { errors: readonly ReviewListError[] }) {
   const hasMigration = errors.some(
     (error) => error.code === "MIGRATION_REQUIRED",
   );
-  if (hasMigration) return <ReviewMigrationWarning errors={errors} />;
+  if (hasMigration)
+    return <ReviewMigrationToast errors={errors} appVersion={appVersion} />;
   return (
     <section className="review-scan-warning" aria-label="Review warnings">
       <span>{`${errors.length} ${errors.length === 1 ? "Review has" : "Reviews have"} issues.`}</span>

--- a/packages/progressive-review/app/src/review-migration-toast.tsx
+++ b/packages/progressive-review/app/src/review-migration-toast.tsx
@@ -1,0 +1,99 @@
+import type { ReviewListError } from "@dev.fast/review-protocol";
+import { useSyncExternalStore } from "react";
+
+import { CopyPromptButton } from "./copy-prompt-button";
+
+export const REVIEW_MIGRATION_PROMPT =
+  "Use the local `review` CLI to migrate my Review data. Run `review migrate apply`. If a code comment position cannot be recovered, rerun `review migrate apply --force` to drop only the unrecoverable threads. Then restart Review and confirm that the Reviews and comments load.";
+
+export const REVIEW_MIGRATION_DISMISSED_VERSION_KEY =
+  "dev.fast.review.migrationDismissedVersion.v1";
+const dismissalChanged = "review-migration-dismissal-changed";
+let fallbackDismissedVersion: string | null = null;
+
+function readDismissedVersion(): string | null {
+  if (fallbackDismissedVersion !== null) return fallbackDismissedVersion;
+  try {
+    return (
+      globalThis.localStorage?.getItem(
+        REVIEW_MIGRATION_DISMISSED_VERSION_KEY,
+      ) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+function subscribeToDismissal(onChange: () => void): () => void {
+  const onStorage = (event: StorageEvent) => {
+    if (
+      event.key === null ||
+      event.key === REVIEW_MIGRATION_DISMISSED_VERSION_KEY
+    ) {
+      fallbackDismissedVersion = null;
+      onChange();
+    }
+  };
+  // Canvases share a window; storage events only notify other windows.
+  window.addEventListener(dismissalChanged, onChange);
+  window.addEventListener("storage", onStorage);
+  return () => {
+    window.removeEventListener(dismissalChanged, onChange);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+function dismissForVersion(appVersion: string): void {
+  fallbackDismissedVersion = appVersion;
+  try {
+    if (globalThis.localStorage) {
+      globalThis.localStorage.setItem(
+        REVIEW_MIGRATION_DISMISSED_VERSION_KEY,
+        appVersion,
+      );
+      fallbackDismissedVersion = null;
+    }
+  } catch {
+    // Keep dismissal working across canvases when DOM storage is disabled.
+  }
+  window.dispatchEvent(new Event(dismissalChanged));
+}
+
+export function ReviewMigrationToast({
+  errors,
+  appVersion,
+}: {
+  errors: readonly ReviewListError[];
+  appVersion: string;
+}) {
+  const dismissedVersion = useSyncExternalStore(
+    subscribeToDismissal,
+    readDismissedVersion,
+  );
+  const migrationCount = errors.filter(
+    (error) => error.code === "MIGRATION_REQUIRED",
+  ).length;
+  if (migrationCount === 0 || dismissedVersion === appVersion) return null;
+  return (
+    <section
+      className="review-migration-toast"
+      aria-label="Review migration required"
+    >
+      <span role="status">
+        {`${migrationCount} ${migrationCount === 1 ? "Review needs" : "Reviews need"} migration.`}
+      </span>
+      <div className="review-migration-toast-actions">
+        <CopyPromptButton prompt={REVIEW_MIGRATION_PROMPT} />
+        <button
+          type="button"
+          className="review-migration-toast-dismiss"
+          aria-label="Dismiss migration reminder"
+          title="Hide until the next app update"
+          onClick={() => dismissForVersion(appVersion)}
+        >
+          Dismiss
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/packages/progressive-review/app/src/styles.css
+++ b/packages/progressive-review/app/src/styles.css
@@ -877,7 +877,6 @@ button {
   margin: 0 auto;
 }
 
-.review-migration-warning,
 .review-scan-warning {
   display: flex;
   gap: 12px;
@@ -893,36 +892,20 @@ button {
   color: var(--ink-soft);
 }
 
-.review-migration-warning .review-home-prompt-copy {
-  flex: 0 0 auto;
-}
-
-.review-migration-warning code,
 .review-scan-warning code {
   color: var(--ink);
 }
 
 .review-session-content {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
   height: 100%;
   min-height: 0;
   background: var(--bg);
 }
 
 .review-session-content > .review-app {
-  grid-row: 2;
   min-height: 0;
-}
-
-.review-session-content > .review-migration-warning {
-  align-self: auto;
-  width: auto;
-  margin: 8px 12px;
-}
-
-.review-canvas-shell > .review-migration-warning {
-  margin: 8px 0 16px;
 }
 
 .review-home-page-header {
@@ -10494,5 +10477,46 @@ button.review-stack-row:disabled .review-stack-relation {
 }
 
 .review-trace-peek-open-full:hover {
+  background: var(--accent-wash);
+}
+
+.review-migration-toast {
+  position: fixed;
+  z-index: 10000;
+  right: 18px;
+  bottom: 18px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  width: max-content;
+  max-width: min(440px, calc(100% - 36px));
+  padding: 10px 12px;
+  border: 1px solid var(--change-modified);
+  border-radius: 5px;
+  background: var(--bg-2);
+  box-shadow: 0 8px 28px var(--shadow-color);
+  color: var(--ink);
+  font: 12px/1.4 var(--font-mono);
+}
+
+.review-migration-toast-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.review-migration-toast-dismiss {
+  padding: 6px 8px;
+  border: 1px solid var(--chrome-border);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--ink);
+  font: inherit;
+  cursor: pointer;
+}
+
+.review-migration-toast-dismiss:hover {
   background: var(--accent-wash);
 }

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -987,6 +987,7 @@ export type ReviewCanvasContent =
   | { kind: "loading" }
   | {
       kind: "error";
+      appVersion: string;
       message: string;
       reviewErrors?: readonly ReviewListError[];
     }
@@ -997,6 +998,7 @@ export type ReviewCanvasContent =
   | { kind: "source"; error?: string }
   | {
       kind: "home";
+      appVersion: string;
       reviews: readonly ReviewDescriptor[];
       reviewErrors: readonly ReviewListError[];
       openReview(uuid: string): void;


### PR DESCRIPTION
The migration reminder currently takes a full-width row above every Review. Replace it with a compact bottom-right toast containing Copy prompt and Dismiss, restoring the full canvas height.

Dismissal is saved for the current app version and synchronized across canvases and windows. It survives navigation and restarts, and the reminder returns after an app update only if Reviews still need migration. Home and error content now receive the desktop version alongside sessions. Migration behavior is unchanged.

Validation: 16 focused UI tests and 2 canvas layout tests passed, plus progressive-review typecheck, targeted lint, formatting, and the production canvas build. Browser checks of the built canvas covered Home, session and error screens, narrow-window layout, keyboard dismissal, reload persistence, and version changes with no page errors.
