### PR TITLE
Add an interactive agent traces section to onboarding

### DIFF
--- a/apps/review-desktop/README.md
+++ b/apps/review-desktop/README.md
@@ -352,7 +352,8 @@ Software Map defaults to off. Enable it to add the Map tab to reviews.
 Disable it to remove Map entry points. This preference persists in the
 application profile. The change does not require a reload.
 
-Trace capture defaults to off and is not part of onboarding. Enabling it
+Trace capture defaults to off. The tutorial includes an interactive sample
+quote and points to Settings for capture setup. Enabling capture
 takes S3/R2 credentials, installs the agent session hooks and the
 `trace-archaeology` skill for every installed agent, and lets reviews quote
 agent sessions. Disabling removes the hooks and skill again. The state lives

--- a/packages/progressive-review/app/src/trace-capture-section.tsx
+++ b/packages/progressive-review/app/src/trace-capture-section.tsx
@@ -11,8 +11,8 @@ type TraceCredentials = Exclude<InstallApplyRequest["trace"], true | undefined>;
 
 /**
  * Experimental trace capture controls. Lives under Settings ▸ Experimental
- * Features only: onboarding never mentions it, and nothing else in the app
- * depends on it being enabled.
+ * Features. The tutorial demonstrates a bundled trace without requiring
+ * capture to be enabled.
  *
  * The on/off state is the machine-level trace setting the review server owns,
  * read back through the install status. Enabling installs the agent hooks and

--- a/packages/progressive-review/app/src/tutorial-experience.test.tsx
+++ b/packages/progressive-review/app/src/tutorial-experience.test.tsx
@@ -25,6 +25,7 @@ const CHAPTER_TITLES = [
   "Commits and diffs",
   "Comments are threads",
   "Interactive Diagrams",
+  "Agent traces",
   "Get help",
 ];
 
@@ -452,7 +453,7 @@ describe("TutorialExperience", () => {
     expect(card()?.classList.contains("tutorial-guide--folded")).toBe(false);
   });
 
-  it("steps back to the previous chapter's last step and numbers sub-steps", () => {
+  it("steps back to the previous chapter's last step", () => {
     const tutorial = tutorialBridge([
       "chooseKeymap",
       "showHover",
@@ -461,9 +462,6 @@ describe("TutorialExperience", () => {
     ]);
     render(tutorial);
 
-    expect(card()?.querySelector("header span")?.textContent).toBe(
-      "Chapter 2.1 of 5",
-    );
     const back = [...canvasRoot.querySelectorAll("button")].find(
       (button) => button.textContent === "Back",
     );
@@ -570,6 +568,7 @@ describe("TutorialExperience", () => {
       "leaveComment",
       "openSequence",
       "openDatabase",
+      "openTraceQuote",
     ]);
     render(tutorial);
 

--- a/packages/progressive-review/app/src/tutorial-plan.ts
+++ b/packages/progressive-review/app/src/tutorial-plan.ts
@@ -5,6 +5,7 @@ export type TutorialChapterId =
   | "commits"
   | "comments"
   | "diagrams"
+  | "traces"
   | "finish";
 
 export type TutorialStepCompletion =
@@ -43,6 +44,7 @@ export const TUTORIAL_CHAPTERS: readonly TutorialChapterDefinition[] = [
   { id: "commits", title: "Commits and diffs" },
   { id: "comments", title: "Comments are threads" },
   { id: "diagrams", title: "Interactive Diagrams" },
+  { id: "traces", title: "Agent traces" },
   { id: "finish", title: "Get help" },
 ];
 
@@ -148,6 +150,15 @@ const tutorialSteps: readonly TutorialStepDefinition[] = [
     completion: "external",
     targetSelector:
       '[data-review-section="Interactive Diagrams"] .database-lens .diagram-tour-button',
+  },
+  {
+    id: "openTraceQuote",
+    chapter: "traces",
+    title: "Read the agent conversation",
+    instruction:
+      "Select the trace quote to read it in context. Enable capture for your own sessions in Settings → Experimental Features → Trace capture.",
+    completion: "click",
+    targetSelector: '[data-review-section="Agent traces"] .review-trace-quote',
   },
   {
     id: "getHelp",

--- a/packages/progressive-review/skills/dev-review/references/trace-quoting.md
+++ b/packages/progressive-review/skills/dev-review/references/trace-quoting.md
@@ -76,7 +76,7 @@ Use `trace_quote_props` from the response without reconstructing it. Every `Trac
 
 ## Quote density by section
 
-- Landing section: The 'why' of this section should almost entirely be composed from quotes of user prompts (or agent messages that were later approved by the user), save for some glue words connecting the quotes. Keep it concise; short quotes beat long ones here. The most important thing is to capture the user's intent, in their words, which led to the code change in the pinned diff.
+- Landing section: The 'summary' and 'why' sections should almost entirely be composed from quotes of user prompts (or agent messages that were later approved by the user), save for some glue words connecting the quotes. Keep it concise; short quotes beat long ones here. The most important thing is to capture the user's intent, in their words, which led to the code change in the pinned diff.
 - Requirements: at least one quote per bullet.
 - Design: a quote states each decision. An `AnchorLink` shows the decision in code.
 - Implementation: authored prose with `AnchorLink` evidence. Quotes are optional.

--- a/packages/progressive-review/src/review-agent-traces.ts
+++ b/packages/progressive-review/src/review-agent-traces.ts
@@ -44,6 +44,7 @@ import {
   isOpenCodeSessionId,
 } from "./opencode-trace-export";
 import { devReviewHome } from "./review-storage";
+import { TUTORIAL_TRACE_SESSION_ID, loadTutorialTrace } from "./tutorial-trace";
 
 /**
  * Resolves the agent sessions behind a review's change range, loads their
@@ -206,6 +207,9 @@ export async function loadReviewAgentTrace(input: {
   refresh?: boolean;
 }): Promise<LoadedReviewAgentTrace | null> {
   const { sessionId, trace } = input;
+  if (sessionId === TUTORIAL_TRACE_SESSION_ID) {
+    return !trace || trace === "main" ? loadTutorialTrace() : null;
+  }
   if (!sessionIdSchema.safeParse(sessionId).success) return null;
   const traceName = trace ?? "main";
   const traceKey =

--- a/packages/progressive-review/src/server/tutorial-service.test.ts
+++ b/packages/progressive-review/src/server/tutorial-service.test.ts
@@ -1,5 +1,12 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rename, rm } from "node:fs/promises";
+import {
+  appendFile,
+  cp,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -20,6 +27,46 @@ const execFilePromise = promisify(execFile);
 afterEach(() => vi.unstubAllEnvs());
 
 describe("tutorial service", () => {
+  it("refreshes the saved document after a tutorial edit without changing sample commits", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "review-tutorial-copy-"));
+    vi.stubEnv("DEV_REVIEW_HOME", home);
+    const assets = path.join(home, "package");
+    await cp(
+      path.join(packageRoot, "tutorial"),
+      path.join(assets, "tutorial"),
+      {
+        recursive: true,
+      },
+    );
+    const service = createTutorialService({
+      packageRoot: assets,
+      deleteReview: async (review) => {
+        await rm(review.dir, { recursive: true, force: true });
+      },
+    });
+    try {
+      const before = await service.prepare("claude-code");
+      const documentPath = path.join(
+        ".bundle",
+        "document",
+        "review-document.js",
+      );
+      await appendFile(
+        path.join(assets, "tutorial", documentPath),
+        "\n// Updated tutorial copy\n",
+      );
+      expect((await service.status()).reviewUuid).toBeNull();
+      const after = await service.prepare("claude-code");
+      expect(after.review.uuid).not.toBe(before.review.uuid);
+      expect(after.review.sourceCommit).toBe(before.review.sourceCommit);
+      expect(await readFile(path.join(after.dir, documentPath), "utf8")).toBe(
+        await readFile(path.join(assets, "tutorial", documentPath), "utf8"),
+      );
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
   it("materializes a hidden published Review with shipped bundles", async () => {
     const home = await mkdtemp(path.join(os.tmpdir(), "review-tutorial-"));
     vi.stubEnv("DEV_REVIEW_HOME", home);

--- a/packages/progressive-review/src/server/tutorial-service.ts
+++ b/packages/progressive-review/src/server/tutorial-service.ts
@@ -45,12 +45,12 @@ import { writePrivateJsonAtomic } from "./desktop-paths";
 
 const execFilePromise = promisify(execFile);
 const TUTORIAL_STATUS_VERSION = 1;
-/* Version 8 adds the representative authoring conversation and its lazy
-   source-session handoff. Older records are re-materialized on first open. */
-const TUTORIAL_STAMP_VERSION = 8;
+/* Version 9 adds the interactive trace quote chapter. Older records are
+   re-materialized on first open to pick up the updated document. */
+const TUTORIAL_STAMP_VERSION = 9;
 
 export interface TutorialStamp {
-  version: 8;
+  version: 9;
   reviewUuid: string;
 }
 
@@ -117,6 +117,16 @@ export function createTutorialService(input: {
     ) {
       return null;
     }
+    // Copy-only edits leave the sample repository's commits unchanged.
+    // Refresh the saved tutorial when its compiled document has changed too.
+    const documentPath = path.join(".bundle", "document", "review-document.js");
+    const documentMatches = await Promise.all([
+      readFile(path.join(assetsRoot, documentPath)),
+      readFile(path.join(review.dir, documentPath)),
+    ])
+      .then(([shipped, saved]) => shipped.equals(saved))
+      .catch(() => false);
+    if (!documentMatches) return null;
     return { stamp, review };
   };
 

--- a/packages/progressive-review/src/tutorial-trace.ts
+++ b/packages/progressive-review/src/tutorial-trace.ts
@@ -1,0 +1,46 @@
+import { AGENT_TRACE_PARSER_VERSION } from "./agent-trace-parser";
+import type { LoadedReviewAgentTrace } from "./review-agent-traces";
+
+// Reserved sample ID: the tutorial works offline without trace capture setup.
+export const TUTORIAL_TRACE_SESSION_ID = "review-tutorial-checkout";
+
+export function loadTutorialTrace(): LoadedReviewAgentTrace {
+  return {
+    parserVersion: AGENT_TRACE_PARSER_VERSION,
+    descriptor: {
+      sessionId: TUTORIAL_TRACE_SESSION_ID,
+      harness: "codex",
+      available: true,
+      source: null,
+      subagents: [],
+      commits: [],
+    },
+    traceName: null,
+    subagents: [],
+    trace: {
+      harness: "codex",
+      title: "Shared agent chat server — illustrative tutorial session",
+      startedAt: null,
+      endedAt: null,
+      activeMs: null,
+      userTurns: 1,
+      toolCalls: 0,
+      events: [
+        {
+          kind: "user",
+          text: "Right now, each Review window manages its own agent chats, so opening the same thread in another window can show stale messages or start a duplicate session. I think we want to have one shared server / source of truth for all agent chats. Can you move session ownership and message history into the server, and have each window subscribe to updates? Closing a window should not end the conversation. Keep the existing chat UI, and make sure reconnecting shows the messages that arrived while the window was closed.",
+        },
+        {
+          kind: "assistant",
+          markdown:
+            "I'll make the server own each thread's agent session and message history. Windows will read that history and subscribe to new messages, so opening a thread in two windows attaches both to the same conversation.",
+        },
+        {
+          kind: "assistant",
+          markdown:
+            "Closing a window will detach its subscription without stopping the agent session. On reconnect, the window will catch up from the server's stored history before displaying live updates. I'll also check that simultaneous requests to open the same thread cannot create duplicate sessions.",
+        },
+      ],
+    },
+  };
+}

--- a/packages/progressive-review/tutorial/review.mdx
+++ b/packages/progressive-review/tutorial/review.mdx
@@ -90,6 +90,19 @@ The database view groups writes by use case. Its operations open code too.
   <TutorialViewButton view="map">Open the software map</TutorialViewButton>
 </TutorialFeature>
 
+## Agent traces
+
+Trace quotes connect a Review to the agent conversation behind a change.
+Select this quote from an illustrative session to read it in context:
+
+<TraceQuote sessionId="review-tutorial-checkout" event={0}>we want to have one shared server / source of truth for all agent chats.</TraceQuote>
+
+To capture your own sessions, open **Preferences → Settings → Experimental
+Features → Trace capture**. Enter your S3/R2 bucket credentials and choose
+**Enable**. Have everyone on your team do this (with the same bucket credentials) to sync and review each other's traces.
+
+Trace capture is off by default; this sample works without setup.
+
 ## Get help
 
 To manage the Review skills installed for your agents, open **Preferences →

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -918,6 +918,7 @@ export const REVIEW_TUTORIAL_STEP_IDS = [
   "openDatabase",
   "getHelp",
   "chooseKeymap",
+  "openTraceQuote",
 ] as const;
 export type TutorialStepId = (typeof REVIEW_TUTORIAL_STEP_IDS)[number];
 export const REVIEW_TUTORIAL_PROGRESS_STORAGE_KEY =


### PR DESCRIPTION
Adds a brief Agent traces chapter to the tutorial, with a clickable quote that opens an illustrative conversation without trace capture setup. The chapter explains how to enable capture in Settings → Experimental Features → Trace capture using S3/R2 credentials.

Existing tutorial installs pick up the new chapter through a version update. Completed tours retain their completion state.

Validation: tutorial assets built successfully, tutorial validation passed, and all 23 targeted tutorial and trace-quote tests passed.