### PR TITLE
Automatically update generated skills by Review release version

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewCliInstall.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewCliInstall.test.ts
@@ -48,7 +48,7 @@ test('resyncs a CLI-only installation', () => {
 				updatedAt: '2026-09-02T00:00:00.000Z',
 			},
 		}),
-		{ targets: [], shim: true },
+		{ targets: [], shim: true, autoUpdate: true },
 	);
 });
 
@@ -62,7 +62,7 @@ test('falls back to installed skills for a legacy stamp without targets', () => 
 				updatedAt: '2026-09-02T00:00:00.000Z',
 			},
 		}),
-		{ targets: ['codex'], shim: false },
+		{ targets: ['codex'], shim: false, autoUpdate: true },
 	);
 });
 
@@ -76,7 +76,7 @@ test('preserves an explicit CLI opt-out while resyncing skills', () => {
 				updatedAt: '2026-09-02T00:00:00.000Z',
 			},
 		}),
-		{ targets: ['codex'], shim: false },
+		{ targets: ['codex'], shim: false, autoUpdate: true },
 	);
 });
 

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewCliInstall.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewCliInstall.ts
@@ -8,12 +8,14 @@ import type { ReviewCliInstallStatus, ReviewCliInstallTarget } from './reviewPro
 export interface ReviewCliInstallResyncRequest {
 	readonly targets: readonly ReviewCliInstallTarget[];
 	readonly shim: boolean;
+	readonly autoUpdate: true;
 }
 
 export function reviewCliInstallResyncRequest(status: ReviewCliInstallStatus): ReviewCliInstallResyncRequest | undefined {
+	if (status.stamp?.consent !== 'granted') return undefined;
 	const targets = status.stamp?.targets !== undefined
 		? status.stamp.targets
 		: status.agents.filter(agent => agent.installed).map(agent => agent.target);
 	const shim = Boolean(status.stamp?.shimPath);
-	return targets.length > 0 || shim ? { targets, shim } : undefined;
+	return targets.length > 0 || shim ? { targets, shim, autoUpdate: true } : undefined;
 }

--- a/apps/review-desktop/code-oss/src/vs/review/contrib/install/reviewCliInstall.contribution.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/contrib/install/reviewCliInstall.contribution.ts
@@ -244,7 +244,7 @@ registerAction2(UninstallReviewDesktopAction);
  * - no stamp: open no tab; empty Home renders the Welcome rail, and
  *   Preferences > Getting Started reaches the same pane when Home has
  *   reviews to list instead;
- * - granted + stale fingerprint: re-sync silently after an app update;
+ * - granted + stale CLI fingerprint or skill version: re-sync silently after an app update;
  * - declined or skipped: never open automatically (the menu action stays available).
  *
  * Dev sessions (`pnpm dev`, isBuilt false) never auto-open.
@@ -258,9 +258,9 @@ class ReviewCliInstallStartup implements IWorkbenchContribution {
 		if (!environmentService.isBuilt) {
 			return;
 		}
-		// Startup must never surface install errors; the Welcome rail reports
-		// them interactively instead.
-		void this.check().catch(() => undefined);
+		void this.check().catch(error => {
+			this.notificationService.warn(localize('review.cliInstall.updateFailed', "Review could not update its agent skills or CLI: {0}. Retry from Getting Started, or restart Review.", String(error)));
+		});
 	}
 
 	private async check(): Promise<void> {

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.test.ts
@@ -204,3 +204,15 @@ test("tutorial deletion suppresses auto-prepare across restarts until explicit o
 	assert.match(requests[2] ?? "", /POST .*\/tutorial\/prepare$/);
 	restoredService.dispose();
 });
+
+
+test("passes automatic skill updates to the server without enabling optional integrations", async (t) => {
+	const service = serviceWith();
+	let requestBody: unknown;
+	mockFetch(t, async (_url, init) => {
+		requestBody = JSON.parse(String(init?.body));
+		return Response.json({ ok: true, output: "updated" });
+	});
+	await service.applyCliInstall({ targets: ["codex"], shim: false, autoUpdate: true });
+	assert.deepEqual(requestBody, { targets: ["codex"], shim: false, autoUpdate: true });
+});

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewSessionService.ts
@@ -115,6 +115,7 @@ export interface IReviewSessionService {
 	deleteTutorial(): Promise<void>;
 	getCliInstallStatus(): Promise<ReviewCliInstallStatus>;
 	applyCliInstall(request: {
+		autoUpdate?: boolean;
 		targets: readonly ReviewCliInstallTarget[];
 		shim?: boolean;
 		fff?: boolean;
@@ -581,6 +582,7 @@ export class ReviewSessionService
 	}
 
 	async applyCliInstall(request: {
+		autoUpdate?: boolean;
 		targets: readonly ReviewCliInstallTarget[];
 		shim?: boolean;
 		fff?: boolean;
@@ -595,6 +597,7 @@ export class ReviewSessionService
 			},
 			body: JSON.stringify({
 				targets: request.targets,
+				...(request.autoUpdate ? { autoUpdate: true } : {}),
 				...(request.shim !== undefined ? { shim: request.shim } : {}),
 				...(request.fff ? { fff: true } : {}),
 				...(request.trace !== undefined ? { trace: request.trace } : {}),
@@ -602,6 +605,7 @@ export class ReviewSessionService
 			signal: AbortSignal.timeout(120_000),
 		});
 		const payload: JsonValue = await response.json().catch(() => ({}));
+		this.cliInstallStatus = undefined;
 		if (!response.ok) {
 			const detail = payload as { output?: unknown; error?: unknown };
 			throw new Error(
@@ -612,7 +616,6 @@ export class ReviewSessionService
 						: `Review install returned ${response.status}.`,
 			);
 		}
-		this.cliInstallStatus = undefined;
 		return parseReviewCliInstallApplyResponse(payload);
 	}
 

--- a/apps/review-desktop/scripts/skill-versions.test.mjs
+++ b/apps/review-desktop/scripts/skill-versions.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import {
+  cp,
+  link,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { stampReviewSkills } from "./stage-review-runtime.mjs";
+
+const appRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const sourceSkills = path.resolve(
+  appRoot,
+  "../../packages/progressive-review/skills",
+);
+
+test("stamps all packaged skills with the Desktop release, preserving source hardlinks", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "review-stamp-skills-"));
+  try {
+    const runtime = path.join(root, "runtime");
+    await cp(sourceSkills, path.join(runtime, "skills"), { recursive: true });
+    const source = path.join(root, "source.md");
+    const generated = path.join(runtime, "skills/dev-review/SKILL.md");
+    const original = await readFile(generated, "utf8");
+    await writeFile(source, original);
+    await rm(generated);
+    await link(source, generated);
+    await stampReviewSkills(runtime);
+    const { version } = JSON.parse(
+      await readFile(path.join(appRoot, "package.json"), "utf8"),
+    );
+    for (const name of ["dev-review", "dev-review-map", "trace-archaeology"]) {
+      const output = await readFile(
+        path.join(runtime, "skills", name, "SKILL.md"),
+        "utf8",
+      );
+      assert.ok(output.includes(`review-version: "${version}"`));
+      assert.ok(output.includes('review-managed-by: "Review Desktop"'));
+      assert.ok(output.includes("Do not edit."));
+    }
+    assert.equal(await readFile(source, "utf8"), original);
+    await stampReviewSkills(runtime, "2.0.0-preview.1");
+    assert.ok(
+      (await readFile(generated, "utf8")).includes(
+        'review-version: "2.0.0-preview.1"',
+      ),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("refuses invalid release versions and skills without generated metadata", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "review-invalid-skill-"));
+  try {
+    await assert.rejects(
+      stampReviewSkills(root, "not-a-version"),
+      /release version/,
+    );
+    const skill = path.join(root, "skills/dev-review");
+    await mkdir(skill, { recursive: true });
+    await writeFile(
+      path.join(skill, "SKILL.md"),
+      "---\nname: dev-review\ndescription: test\n---\n",
+    );
+    await assert.rejects(
+      stampReviewSkills(root, "1.0.0"),
+      /Missing generated skill metadata/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/apps/review-desktop/scripts/stage-review-runtime.mjs
+++ b/apps/review-desktop/scripts/stage-review-runtime.mjs
@@ -8,10 +8,13 @@ import {
   realpath,
   rm,
   stat,
+  writeFile,
 } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
+
+import { valid as validVersion } from "semver";
 
 const execFileAsync = promisify(execFile);
 
@@ -137,9 +140,43 @@ export async function stageReviewRuntime(packagedRoot) {
   );
 
   await stageReviewDocs(runtimeRoot);
+  await stampReviewSkills(runtimeRoot);
   await makeTreeOwnerWritable(path.join(runtimeRoot, "tutorial", "git-stub"));
   await assertRuntimeClosure(runtimeRoot);
   return runtimeRoot;
+}
+
+/** Stamp only deployed copies, before signing; source skills remain editable. */
+export async function stampReviewSkills(runtimeRoot, version) {
+  const releaseVersion =
+    version ??
+    JSON.parse(await readFile(path.join(appDirectory, "package.json"), "utf8"))
+      .version;
+  if (!validVersion(releaseVersion)) {
+    throw new Error(
+      "A Review Desktop release version is required to stamp skills.",
+    );
+  }
+  const skillsRoot = path.join(runtimeRoot, "skills");
+  for (const entry of await readdir(skillsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const skillPath = path.join(skillsRoot, entry.name, "SKILL.md");
+    const source = await readFile(skillPath, "utf8");
+    const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(source);
+    if (
+      !frontmatter ||
+      !/^  review-version: "[^"\n]+"$/m.test(frontmatter[1])
+    ) {
+      throw new Error(`Missing generated skill metadata: ${skillPath}`);
+    }
+    const stamped = frontmatter[0].replace(
+      /^  review-version: "[^"\n]+"$/m,
+      `  review-version: ${JSON.stringify(releaseVersion)}`,
+    );
+    // pnpm deploy may hardlink files from its store. Never modify that inode.
+    await rm(skillPath);
+    await writeFile(skillPath, stamped + source.slice(frontmatter[0].length));
+  }
 }
 
 export async function stageReviewDocs(
@@ -242,7 +279,9 @@ export async function assertRuntimeClosure(runtimeRoot) {
     try {
       await access(path.join(tutorialRoot, entry));
     } catch {
-      throw new Error(`The staged Review runtime is missing tutorial/${entry}.`);
+      throw new Error(
+        `The staged Review runtime is missing tutorial/${entry}.`,
+      );
     }
   }
   await assertNoCheckoutReferences(runtimeRoot);

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -25,7 +25,12 @@ same Review skills from `~/.agents/skills`.
 
 Review Desktop is the recommended installation path. On first launch it detects
 installed agents, asks which integrations to enable, and keeps their skills in
-sync with app updates. You can manage the integrations later from Review
+sync with app updates. Generated skills carry the Review Desktop release version in
+`SKILL.md` frontmatter. On the first launch after an update, Desktop replaces
+older skills for enabled integrations automatically, including local edits.
+Skills already at the bundled version are left alone. Start a new agent session
+to load refreshed skills. Reinstall from settings to repair same-version edits
+or missing supporting files; terminal-only installs are not automatically enrolled. You can manage the integrations later from Review
 settings.
 
 ## Installed skills

--- a/packages/progressive-review/app/src/agent-setup-card.tsx
+++ b/packages/progressive-review/app/src/agent-setup-card.tsx
@@ -59,6 +59,16 @@ export function AgentSetupCard({
       <ul className="review-agent-setup-agents">
         {status.agents.map((agent) => {
           const Logo = AGENT_LOGOS[agent.target];
+          const skills =
+            status.skills?.filter((skill) => skill.target === agent.target) ??
+            [];
+          const needsUpdate = skills.some((skill) => skill.stale);
+          const versions = skills
+            .map(
+              (skill) =>
+                `${skill.name}: installed ${skill.installedVersion ?? "unversioned"}; bundled ${skill.bundledVersion ?? "unversioned"}`,
+            )
+            .join("\n");
           const request: InstallRequest = { targets: [agent.target] };
           if (status.trace.enabled && supportsFff(agent.target)) {
             request.fff = true;
@@ -77,12 +87,15 @@ export function AgentSetupCard({
               <span
                 className="review-agent-setup-state"
                 data-installed={agent.installed}
+                title={versions || undefined}
               >
-                {agent.installed
-                  ? "installed"
-                  : agent.present
-                    ? "detected"
-                    : "not detected"}
+                {needsUpdate
+                  ? "update needed"
+                  : agent.installed
+                    ? "installed"
+                    : agent.present
+                      ? "detected"
+                      : "not detected"}
               </span>
               {agent.installed ? (
                 <button
@@ -119,9 +132,23 @@ export function AgentSetupCard({
       </ul>
       <p className="review-agent-setup-disclosure">
         Installing skills will also install <code>review</code> to your shell
-        PATH.
+        PATH. Review automatically replaces these generated skills after app
+        updates. Local edits are overwritten; start a new agent session to load
+        updated skills.
       </p>
-      {error ? <p className="review-agent-setup-error">{error}</p> : null}
+      {error || status.error ? (
+        <p className="review-agent-setup-error">{error ?? status.error}</p>
+      ) : null}
+      {status.skills
+        ?.filter((skill) => skill.error)
+        .map((skill) => (
+          <p
+            className="review-agent-setup-error"
+            key={`${skill.target}-${skill.name}`}
+          >
+            {skill.error}
+          </p>
+        ))}
     </section>
   );
 }

--- a/packages/progressive-review/skills/dev-review-map/SKILL.md
+++ b/packages/progressive-review/skills/dev-review-map/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: dev-review-map
 description: Author and save the pinned base and head software maps for a Review.
+metadata:
+  review-managed-by: "Review Desktop"
+  review-generated: "Do not edit. Review automatically replaces this skill directory on updates."
+  review-version: "development"
 ---
 
 # Review software-map worker

--- a/packages/progressive-review/skills/dev-review/SKILL.md
+++ b/packages/progressive-review/skills/dev-review/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: dev-review
 description: Answer product questions about Review Desktop, or author and publish a progressive Review for a branch, jj change, or pull request. Use for Review capabilities, setup, CLI, privacy, telemetry, troubleshooting, and code-change or architecture reviews.
+metadata:
+  review-managed-by: "Review Desktop"
+  review-generated: "Do not edit. Review automatically replaces this skill directory on updates."
+  review-version: "development"
 ---
 
 # dev.fast Review

--- a/packages/progressive-review/skills/trace-archaeology/SKILL.md
+++ b/packages/progressive-review/skills/trace-archaeology/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: trace-archaeology
 description: Find the agent sessions behind existing code and search past traces. Use when asked "why does this code exist", "what was the agent thinking here", "who/what wrote this", "has an agent solved X before", or when debugging agent-produced code where the original reasoning would help.
+metadata:
+  review-managed-by: "Review Desktop"
+  review-generated: "Do not edit. Review automatically replaces this skill directory on updates."
+  review-version: "development"
 ---
 
 # Trace archaeology

--- a/packages/progressive-review/src/install-directory.ts
+++ b/packages/progressive-review/src/install-directory.ts
@@ -1,0 +1,74 @@
+import { cp, lstat, mkdir, rename, rm } from "node:fs/promises";
+import path from "node:path";
+
+/** Callers hold the shared skill installer lock throughout the replacement. */
+export async function installDirectory(
+  src: string,
+  dest: string,
+  renameDirectory: typeof rename = rename,
+): Promise<void> {
+  await mkdir(path.dirname(dest), { recursive: true });
+  // The installer lock serializes these swaps. Temporary rollback copies are
+  // removed on success; user edits are not retained as preservation backups.
+  const staging = path.join(
+    path.dirname(dest),
+    `.${path.basename(dest)}.review-staging`,
+  );
+  const backup = path.join(
+    path.dirname(dest),
+    `.${path.basename(dest)}.review-previous`,
+  );
+  // A terminated process may have moved the previous directory but not yet
+  // promoted staging. Recover it before attempting another copy.
+  try {
+    await lstat(dest);
+    await rm(backup, { recursive: true, force: true });
+  } catch (error) {
+    if (!(error instanceof Error && "code" in error && error.code === "ENOENT"))
+      throw error;
+    try {
+      await renameDirectory(backup, dest);
+    } catch (restoreError) {
+      if (
+        !(
+          restoreError instanceof Error &&
+          "code" in restoreError &&
+          restoreError.code === "ENOENT"
+        )
+      )
+        throw restoreError;
+    }
+  }
+  await rm(staging, { recursive: true, force: true });
+  try {
+    await cp(src, staging, { recursive: true });
+    let movedExisting = false;
+    try {
+      await renameDirectory(dest, backup);
+      movedExisting = true;
+    } catch (error) {
+      if (
+        !(error instanceof Error && "code" in error && error.code === "ENOENT")
+      )
+        throw error;
+    }
+    try {
+      await renameDirectory(staging, dest);
+    } catch (error) {
+      if (movedExisting) {
+        try {
+          await renameDirectory(backup, dest);
+        } catch (restoreError) {
+          throw new AggregateError(
+            [error, restoreError],
+            `Could not restore ${dest}. The previous skill remains at ${backup}.`,
+          );
+        }
+      }
+      throw error;
+    }
+    if (movedExisting) await rm(backup, { recursive: true, force: true });
+  } finally {
+    await rm(staging, { recursive: true, force: true });
+  }
+}

--- a/packages/progressive-review/src/install-rollback.test.ts
+++ b/packages/progressive-review/src/install-rollback.test.ts
@@ -1,0 +1,58 @@
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, expect, it } from "vitest";
+
+import { installDirectory } from "./install-directory";
+
+let root: string | undefined;
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+it.each(["existing", "interrupted"])(
+  "restores the complete %s skill when the staged replacement cannot be renamed",
+  async (state) => {
+    root = await mkdtemp(path.join(tmpdir(), "review-skill-rollback-"));
+    const source = path.join(root, "runtime", "dev-review");
+    const old = path.join(root, "skills", "dev-review");
+    await mkdir(source, { recursive: true });
+    await writeFile(path.join(source, "SKILL.md"), "new content");
+    await mkdir(old, { recursive: true });
+    await writeFile(path.join(old, "SKILL.md"), "old content");
+    await writeFile(path.join(old, "reference.txt"), "old reference");
+    if (state === "interrupted")
+      await rename(
+        old,
+        path.join(path.dirname(old), ".dev-review.review-previous"),
+      );
+    const failPromotion: typeof rename = async (from, to) => {
+      if (to === old && String(from).endsWith(".review-staging"))
+        throw new Error("Injected replacement failure");
+      await rename(from, to);
+    };
+    await expect(installDirectory(source, old, failPromotion)).rejects.toThrow(
+      "Injected replacement failure",
+    );
+    expect(await readFile(path.join(old, "SKILL.md"), "utf8")).toBe(
+      "old content",
+    );
+    expect(await readFile(path.join(old, "reference.txt"), "utf8")).toBe(
+      "old reference",
+    );
+    expect(await readdir(path.dirname(old))).toEqual(["dev-review"]);
+    await installDirectory(source, old);
+    expect(await readFile(path.join(old, "SKILL.md"), "utf8")).toBe(
+      "new content",
+    );
+  },
+);

--- a/packages/progressive-review/src/install.ts
+++ b/packages/progressive-review/src/install.ts
@@ -1,6 +1,5 @@
 import {
   copyFile,
-  cp,
   lstat,
   mkdir,
   readFile,
@@ -15,6 +14,7 @@ import type { Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
 
 import { ensureNotesConfig, gitCommonDir } from "@dev.fast/local-vcs";
+import { valid as validVersion } from "semver";
 
 import { installFffForTargets, isFffTarget } from "./agent-fff";
 import {
@@ -25,6 +25,8 @@ import {
 } from "./agent-trace-hooks";
 import { emitJsonEvent, failWithJsonError, humanStream } from "./cli-output";
 import { isDirectory, isFile } from "./fs-utils";
+import { installDirectory } from "./install-directory";
+import { withSkillInstallLock } from "./skill-install-lock";
 import {
   type TraceCredentialsInput,
   configureTraceMachine,
@@ -72,6 +74,8 @@ export interface RunInstallInput {
   packageRoot?: string;
   env?: NodeJS.ProcessEnv;
   fff?: boolean;
+  /** Desktop reconciliation skips skills already at the bundled release. */
+  skipCurrentSkills?: boolean;
   reviewCommand?: string;
   trace?: {
     credentials?: TraceCredentialsInput;
@@ -83,6 +87,10 @@ export interface RunInstallInput {
 }
 
 export async function runInstall(input: RunInstallInput): Promise<number> {
+  return withSkillInstallLock(input.homeDir, () => runInstallUnlocked(input));
+}
+
+async function runInstallUnlocked(input: RunInstallInput): Promise<number> {
   const homeDir = input.homeDir ?? os.homedir();
   const packageRoot = input.packageRoot ?? defaultPackageRoot();
   const env = input.env ?? process.env;
@@ -160,17 +168,38 @@ export async function runInstall(input: RunInstallInput): Promise<number> {
     traceEnabled || (await traceMachineEnabled({ homeDir, env }));
 
   const installed: InstalledItem[] = [];
+  const visitedRoots = new Set<string>();
   for (const target of input.targets) {
     const destRoot = skillsDestRoot(homeDir, target);
-    await removeStaleSkills(destRoot);
-    for (const skillDir of skillDirs) {
-      const skillDest = path.join(destRoot, skillDir.name);
-      if (isTraceSkill(skillDir.name) && !installTraceHooks) {
-        await rm(skillDest, { recursive: true, force: true });
-        continue;
+    if (!visitedRoots.has(destRoot)) {
+      visitedRoots.add(destRoot);
+      await removeStaleSkills(destRoot);
+      for (const skillDir of skillDirs) {
+        const skillDest = path.join(destRoot, skillDir.name);
+        if (isTraceSkill(skillDir.name) && !installTraceHooks) {
+          await rm(skillDest, { recursive: true, force: true });
+          continue;
+        }
+        if (input.skipCurrentSkills) {
+          const bundled = await readSkillVersion(
+            path.join(skillDir.src, "SKILL.md"),
+            skillDir.name,
+          );
+          if (!bundled)
+            throw new Error(
+              `Bundled skill ${skillDir.name} has no release version. Reinstall Review Desktop.`,
+            );
+          if (
+            (await readSkillVersion(
+              path.join(skillDest, "SKILL.md"),
+              skillDir.name,
+            )) === bundled
+          )
+            continue;
+        }
+        await installDirectory(skillDir.src, skillDest);
+        installed.push({ kind: "skill", dest: skillDest });
       }
-      await installDirectory(skillDir.src, skillDest);
-      installed.push({ kind: "skill", dest: skillDest });
     }
     if (target === "opencode") {
       const pluginDest = openCodePluginPath(homeDir);
@@ -259,6 +288,15 @@ export async function removeInstalledSkills(
   target: InstallTarget,
   homeDir = os.homedir(),
 ): Promise<void> {
+  return withSkillInstallLock(homeDir, () =>
+    removeInstalledSkillsUnlocked(target, homeDir),
+  );
+}
+
+async function removeInstalledSkillsUnlocked(
+  target: InstallTarget,
+  homeDir: string,
+): Promise<void> {
   const destRoot = skillsDestRoot(homeDir, target);
   for (const name of [
     ...REQUIRED_SKILL_NAMES,
@@ -278,6 +316,15 @@ export async function removeInstalledSkills(
 export async function removeTraceSkills(
   target: InstallTarget,
   homeDir = os.homedir(),
+): Promise<void> {
+  return withSkillInstallLock(homeDir, () =>
+    removeTraceSkillsUnlocked(target, homeDir),
+  );
+}
+
+async function removeTraceSkillsUnlocked(
+  target: InstallTarget,
+  homeDir: string,
 ): Promise<void> {
   const destRoot = skillsDestRoot(homeDir, target);
   for (const name of TRACE_SKILL_NAMES) {
@@ -322,6 +369,82 @@ export async function detectInstalledTargets(
   return installed;
 }
 
+export interface InstalledSkillStatus {
+  target: InstallTarget;
+  name: string;
+  installedVersion: string | null;
+  bundledVersion: string | null;
+  stale: boolean;
+  error?: string;
+}
+
+/** Missing or malformed generated metadata is an unstamped legacy install. */
+export async function readSkillVersion(
+  file: string,
+  name: string,
+): Promise<string | null> {
+  try {
+    if (!(await hasValidSkillFile(file, name))) return null;
+    const source = await readFile(file, "utf8");
+    const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(source)?.[1];
+    const metadata = frontmatter?.match(
+      /^metadata:\r?\n((?:[ \t]+[^\n]*(?:\n|$))*)/m,
+    )?.[1];
+    if (
+      !metadata ||
+      !/^  review-managed-by: "Review Desktop"\r?$/m.test(metadata) ||
+      !/^  review-generated: "[^"\r\n]+"\r?$/m.test(metadata)
+    )
+      return null;
+    const version = metadata.match(
+      /^  review-version: "([^"\r\n]+)"\r?$/m,
+    )?.[1];
+    return version && (version === "development" || validVersion(version))
+      ? version
+      : null;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT")
+      return null;
+    throw error;
+  }
+}
+
+export async function resolveInstalledSkills(input: {
+  packageRoot: string;
+  homeDir: string;
+  targets: InstallTarget[];
+  traceEnabled: boolean;
+}): Promise<InstalledSkillStatus[]> {
+  const names: readonly string[] = input.traceEnabled
+    ? [...REQUIRED_SKILL_NAMES, ...TRACE_SKILL_NAMES]
+    : REQUIRED_SKILL_NAMES;
+  return Promise.all(
+    input.targets.flatMap((target) =>
+      names.map(async (name) => {
+        const bundledVersion = await readSkillVersion(
+          path.join(input.packageRoot, "skills", name, "SKILL.md"),
+          name,
+        );
+        const installedVersion = await readSkillVersion(
+          path.join(skillsDestRoot(input.homeDir, target), name, "SKILL.md"),
+          name,
+        );
+        const status: InstalledSkillStatus = {
+          target,
+          name,
+          bundledVersion,
+          installedVersion,
+          stale: !bundledVersion || installedVersion !== bundledVersion,
+        };
+        if (!bundledVersion) {
+          status.error = `Bundled skill ${name} has no release version. Reinstall Review Desktop.`;
+        }
+        return status;
+      }),
+    ),
+  );
+}
+
 function skillsDestRoot(homeDir: string, target: InstallTarget): string {
   if (target === "claude") return path.join(homeDir, ".claude", "skills");
   if (target === "cursor") return path.join(homeDir, ".cursor", "skills");
@@ -358,36 +481,6 @@ async function listSkillDirs(
     .filter((entry) => entry.hasSkillFile)
     .map(({ name, src }) => ({ name, src }))
     .sort((a, b) => a.name.localeCompare(b.name));
-}
-
-async function installDirectory(src: string, dest: string): Promise<void> {
-  await mkdir(path.dirname(dest), { recursive: true });
-  // Stage into a sibling temp dir, then swap into place with renames so an
-  // interruption mid-install never leaves the user with a half-removed skill.
-  // The temp dirs are siblings of dest, so the renames stay on one filesystem.
-  const staging = `${dest}.tmp-${process.pid}`;
-  const backup = `${dest}.bak-${process.pid}`;
-  await rm(staging, { recursive: true, force: true });
-  await rm(backup, { recursive: true, force: true });
-  await cp(src, staging, { recursive: true });
-  let movedExisting = false;
-  try {
-    await rename(dest, backup);
-    movedExisting = true;
-  } catch (error) {
-    if (
-      !(error instanceof Error && "code" in error && error.code === "ENOENT")
-    ) {
-      throw error;
-    }
-  }
-  try {
-    await rename(staging, dest);
-  } catch (error) {
-    if (movedExisting) await rename(backup, dest).catch(() => {});
-    throw error;
-  }
-  if (movedExisting) await rm(backup, { recursive: true, force: true });
 }
 
 async function installFile(src: string, dest: string): Promise<void> {

--- a/packages/progressive-review/src/server/cli-install.ts
+++ b/packages/progressive-review/src/server/cli-install.ts
@@ -44,6 +44,7 @@ import {
   detectInstalledTargets,
   removeInstalledSkills,
   removeTraceSkills,
+  resolveInstalledSkills,
   runInstall,
 } from "../install";
 import { readProgressiveReviewPackageVersion } from "../package-paths";
@@ -53,7 +54,10 @@ import {
   traceMachineStatus,
 } from "../trace-machine-setup";
 import { disableAllTraceRepositories } from "../trace-repository-hooks";
+import { withFileLock } from "../with-file-lock";
 import { reviewDesktopStateDir, writePrivateJsonAtomic } from "./desktop-paths";
+
+const installErrors = new Map<string, string>();
 
 const AGENT_HOME_DIR: Record<InstallTarget, string> = {
   claude: ".claude",
@@ -119,6 +123,17 @@ export async function resolveCliInstallStatus(input: {
     traceMachineStatus({ homeDir, env }),
   ]);
   const { agents, stamp } = agentStatus;
+  const managedTargets =
+    stamp?.consent === "granted"
+      ? (stamp.targets ??
+        agents.filter((agent) => agent.installed).map((agent) => agent.target))
+      : [];
+  const skills = await resolveInstalledSkills({
+    packageRoot: input.packageRoot,
+    homeDir,
+    targets: managedTargets,
+    traceEnabled: trace.enabled,
+  });
   const shimPath = pathShimPath(homeDir);
   const cliPath = path.join(input.packageRoot, "dist", "cli.js");
   const fffBinary = fffBinaryPath(homeDir);
@@ -140,11 +155,15 @@ export async function resolveCliInstallStatus(input: {
       };
     }),
   );
-  return {
+  const status: ReviewCliInstallStatus = {
     agents,
     fingerprint,
     stamp,
-    stale: stamp?.consent === "granted" && stamp.fingerprint !== fingerprint,
+    stale:
+      stamp?.consent === "granted" &&
+      (stamp.fingerprint !== fingerprint ||
+        skills.some((skill) => skill.stale)),
+    skills,
     shim: {
       path: shimPath,
       installed: await isOwnedShim(shimPath),
@@ -167,19 +186,83 @@ export async function resolveCliInstallStatus(input: {
         }
       : null,
   };
+  const error = installErrors.get(homeDir);
+  if (error) status.error = error;
+  return status;
 }
 
-export async function applyCliInstall(input: {
+interface ApplyCliInstallInput {
   packageRoot: string;
   targets: InstallTarget[];
   shim?: boolean;
   fff?: boolean;
+  autoUpdate?: boolean;
   trace?: true | TraceCredentialsInput;
   cliPath?: string;
   cliRuntimePath?: string;
   homeDir?: string;
   env?: NodeJS.ProcessEnv;
-}): Promise<{ code: number; output: string; shimPath?: string }> {
+}
+
+export async function applyCliInstall(
+  input: ApplyCliInstallInput,
+): Promise<{ code: number; output: string; shimPath?: string }> {
+  const homeDir = input.homeDir ?? os.homedir();
+  try {
+    const result = await withDesktopInstallLock(input.env, async () => {
+      if (input.autoUpdate) {
+        // Re-read consent under the mutation lock: a stale UI snapshot must
+        // never reinstall a target the user has since removed or declined.
+        const status = await resolveCliInstallStatus(input);
+        const stamp = status.stamp;
+        if (stamp?.consent !== "granted" || !status.stale)
+          return { code: 0, output: "" };
+        const targets =
+          stamp.targets ??
+          status.agents
+            .filter((agent) => agent.installed)
+            .map((agent) => agent.target);
+        if (targets.length === 0 && !stamp.shimPath)
+          return { code: 0, output: "" };
+        return applyCliInstallUnlocked({
+          ...input,
+          targets,
+          shim: Boolean(stamp.shimPath),
+          fff: false,
+          trace: undefined,
+        });
+      }
+      return applyCliInstallUnlocked(input);
+    });
+    if (result.code === 0) installErrors.delete(homeDir);
+    else installErrors.set(homeDir, result.output);
+    return result;
+  } catch (error) {
+    const output = error instanceof Error ? error.message : String(error);
+    installErrors.set(homeDir, output);
+    return { code: 1, output };
+  }
+}
+
+async function withDesktopInstallLock<T>(
+  env: NodeJS.ProcessEnv = process.env,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const outcome = await withFileLock(
+    `${cliInstallStampPath(env)}.lock`,
+    { retryMs: 50, timeoutMs: 30_000, staleMs: 300_000, unownedGraceMs: 5_000 },
+    operation,
+  );
+  if (!outcome.acquired)
+    throw new Error(
+      "Another Review setup operation is running. Retry shortly.",
+    );
+  return outcome.result;
+}
+
+async function applyCliInstallUnlocked(
+  input: ApplyCliInstallInput,
+): Promise<{ code: number; output: string; shimPath?: string }> {
   const homeDir = input.homeDir ?? os.homedir();
   const env = input.env ?? process.env;
   const wantShim = input.shim ?? input.targets.length > 0;
@@ -204,6 +287,7 @@ export async function applyCliInstall(input: {
       packageRoot: input.packageRoot,
       env,
       fff: input.fff,
+      skipCurrentSkills: input.autoUpdate,
       reviewCommand:
         wantShim || (await isFile(pathShimPath(homeDir)))
           ? pathShimPath(homeDir)
@@ -297,38 +381,56 @@ export async function applyCliInstall(input: {
 export async function declineCliInstall(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<void> {
-  await writePrivateJsonAtomic(cliInstallStampPath(env), {
-    consent: "declined",
-    updatedAt: new Date().toISOString(),
-  } satisfies ReviewCliInstallStamp);
+  await withDesktopInstallLock(env, () =>
+    writePrivateJsonAtomic(cliInstallStampPath(env), {
+      consent: "declined",
+      updatedAt: new Date().toISOString(),
+    } satisfies ReviewCliInstallStamp),
+  );
 }
 
 export async function skipCliInstall(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<void> {
-  const stampPath = cliInstallStampPath(env);
-  if (await readCliInstallStamp(stampPath)) return;
-  await writePrivateJsonAtomic(stampPath, {
-    consent: "skipped",
-    updatedAt: new Date().toISOString(),
-  } satisfies ReviewCliInstallStamp);
+  await withDesktopInstallLock(env, async () => {
+    const stampPath = cliInstallStampPath(env);
+    if (await readCliInstallStamp(stampPath)) return;
+    await writePrivateJsonAtomic(stampPath, {
+      consent: "skipped",
+      updatedAt: new Date().toISOString(),
+    } satisfies ReviewCliInstallStamp);
+  });
 }
 
 /** Removes the stamp entirely, so the next app launch prompts again. */
 export async function resetCliInstall(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<void> {
-  await rm(cliInstallStampPath(env), { force: true });
+  await withDesktopInstallLock(env, () =>
+    rm(cliInstallStampPath(env), { force: true }),
+  );
 }
 
-export async function removeCliInstall(input: {
+interface RemoveCliInstallInput {
   targets: InstallTarget[];
   shim?: boolean;
   fff?: boolean;
   trace?: boolean;
   homeDir?: string;
   env?: NodeJS.ProcessEnv;
-}): Promise<{ output: string }> {
+}
+
+export async function removeCliInstall(
+  input: RemoveCliInstallInput,
+): Promise<{ output: string }> {
+  return withDesktopInstallLock(input.env, () =>
+    removeCliInstallUnlocked(input),
+  );
+}
+
+async function removeCliInstallUnlocked(
+  input: RemoveCliInstallInput,
+): Promise<{ output: string }> {
   const homeDir = input.homeDir ?? os.homedir();
   const env = input.env ?? process.env;
   const chunks: string[] = [];
@@ -430,8 +532,8 @@ export async function removeCliInstall(input: {
 }
 
 /**
- * Fingerprint of everything the app distributes: the package version, the
- * built CLI, skill sources, and agent integrations. Content-based so it works
+ * Fingerprint of the CLI and agent integrations. Skills are compared
+ * independently through their release versions. Content-based so it works
  * identically in a dev checkout and a packaged review-runtime, with no
  * build-time stamping.
  */
@@ -441,13 +543,6 @@ export async function installFingerprint(packageRoot: string): Promise<string> {
   const cliPath = path.join(packageRoot, "dist", "cli.js");
   hash.update("dist/cli.js\0");
   hash.update(await readTextIfExists(cliPath));
-  for (const file of await listFilesRecursive(
-    path.join(packageRoot, "skills"),
-  )) {
-    hash.update(`${file.relPath}\0`);
-    hash.update(await readFile(file.absPath));
-    hash.update("\0");
-  }
   for (const file of await listFilesRecursive(
     path.join(packageRoot, "plugins"),
   )) {

--- a/packages/progressive-review/src/server/desktop-server.ts
+++ b/packages/progressive-review/src/server/desktop-server.ts
@@ -816,6 +816,7 @@ export function createGlobalReviewServer(
       targets: request.targets,
     };
     if (request.shim !== undefined) applyInput.shim = request.shim;
+    if (request.autoUpdate) applyInput.autoUpdate = true;
     if (request.fff) applyInput.fff = true;
     if (request.trace !== undefined) applyInput.trace = request.trace;
     if (discovery.cliPath) applyInput.cliPath = discovery.cliPath;

--- a/packages/progressive-review/src/server/skill-updates.test.ts
+++ b/packages/progressive-review/src/server/skill-updates.test.ts
@@ -1,0 +1,311 @@
+import { execFile } from "node:child_process";
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { reviewCliInstallResyncRequest } from "../../../../apps/review-desktop/code-oss/src/vs/review/common/reviewCliInstall";
+import { collectingWritable } from "../cli-output";
+import { readSkillVersion, runInstall } from "../install";
+import {
+  applyCliInstall,
+  cliInstallStampPath,
+  installFingerprint,
+  resolveCliInstallStatus,
+} from "./cli-install";
+import { writePrivateJsonAtomic } from "./desktop-paths";
+
+const execFileAsync = promisify(execFile);
+const roots: string[] = [];
+const workspace = path.resolve(import.meta.dirname, "../../../..");
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function fixture() {
+  const root = await mkdtemp(path.join(tmpdir(), "review-skill-upgrade-"));
+  roots.push(root);
+  const homeDir = path.join(root, "home");
+  await mkdir(homeDir);
+  const env = {
+    DEV_REVIEW_HOME: path.join(homeDir, ".dev"),
+    PATH: "",
+    TRACE_R2_MODE: "mock",
+  };
+  const packageRoot = path.join(root, "runtime");
+  await cp(
+    path.join(workspace, "packages/progressive-review/skills"),
+    path.join(packageRoot, "skills"),
+    { recursive: true },
+  );
+  await cp(
+    path.join(workspace, "packages/progressive-review/plugins"),
+    path.join(packageRoot, "plugins"),
+    { recursive: true },
+  );
+  await writeFile(
+    path.join(packageRoot, "package.json"),
+    '{"version":"0.0.1"}',
+  );
+  const stampVersion = async (version: string) => {
+    await execFileAsync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        'import { stampReviewSkills } from "./apps/review-desktop/scripts/stage-review-runtime.mjs"; await stampReviewSkills(process.argv[1], process.argv[2]);',
+        packageRoot,
+        version,
+      ],
+      { cwd: workspace },
+    );
+  };
+  await stampVersion("1.0.0");
+  const input = { homeDir, env, packageRoot, shim: false };
+  const skill = (name = "dev-review", rootName = ".agents") =>
+    path.join(homeDir, rootName, "skills", name, "SKILL.md");
+  const launch = async () => {
+    const status = await resolveCliInstallStatus(input);
+    const request = status.stale
+      ? reviewCliInstallResyncRequest(status)
+      : undefined;
+    if (!request) return;
+    return applyCliInstall({
+      ...input,
+      ...request,
+      targets: [...request.targets],
+    });
+  };
+  return { ...input, input, skill, stampVersion, launch };
+}
+
+describe("packaged skill updates", () => {
+  it("upgrades generated directories, removes local edits, and performs no writes on a second launch", async () => {
+    const f = await fixture();
+    expect(
+      (await applyCliInstall({ ...f.input, targets: ["codex", "pi"] })).code,
+    ).toBe(0);
+    const supporting = path.join(path.dirname(f.skill()), "local.txt");
+    await writeFile(supporting, "local edits");
+    await writeFile(
+      f.skill(),
+      (await readFile(f.skill(), "utf8")) + "\nlocal edit\n",
+    );
+    await f.stampVersion("1.1.0");
+    expect((await f.launch())?.code).toBe(0);
+    expect(await readSkillVersion(f.skill(), "dev-review")).toBe("1.1.0");
+    expect(await readFile(f.skill(), "utf8")).not.toContain("local edit");
+    await expect(stat(supporting)).rejects.toMatchObject({ code: "ENOENT" });
+    const before = await stat(f.skill());
+    const stampBefore = await readFile(cliInstallStampPath(f.env), "utf8");
+    expect(await f.launch()).toBeUndefined();
+    expect((await stat(f.skill())).mtimeMs).toBe(before.mtimeMs);
+    expect(await readFile(cliInstallStampPath(f.env), "utf8")).toBe(
+      stampBefore,
+    );
+    expect((await resolveCliInstallStatus(f.input)).skills).toHaveLength(4);
+  });
+
+  it("does not let a one-agent install hide another agent's old skills", async () => {
+    const f = await fixture();
+    await applyCliInstall({ ...f.input, targets: ["codex", "claude"] });
+    const fingerprint = await installFingerprint(f.packageRoot);
+    await f.stampVersion("2.0.0");
+    expect(await installFingerprint(f.packageRoot)).toBe(fingerprint);
+    await applyCliInstall({ ...f.input, targets: ["codex"] });
+    const before = await stat(f.skill());
+    expect((await resolveCliInstallStatus(f.input)).stale).toBe(true);
+    expect((await f.launch())?.code).toBe(0);
+    expect(
+      await readSkillVersion(f.skill("dev-review", ".claude"), "dev-review"),
+    ).toBe("2.0.0");
+    expect((await stat(f.skill())).mtimeMs).toBe(before.mtimeMs);
+  });
+
+  it("migrates legacy metadata, repairs missing skills, and supports rollbacks", async () => {
+    const f = await fixture();
+    await applyCliInstall({ ...f.input, targets: ["codex"] });
+    await writeFile(
+      f.skill(),
+      "---\nname: dev-review\ndescription: legacy\n---\nlegacy",
+    );
+    await rm(path.dirname(f.skill("dev-review-map")), { recursive: true });
+    expect((await f.launch())?.code).toBe(0);
+    expect(
+      await readSkillVersion(f.skill("dev-review-map"), "dev-review-map"),
+    ).toBe("1.0.0");
+    await f.stampVersion("0.9.0");
+    expect((await f.launch())?.code).toBe(0);
+    expect(await readSkillVersion(f.skill(), "dev-review")).toBe("0.9.0");
+  });
+
+  it.each(["declined", "skipped", "absent"])(
+    "does not enroll terminal installs with %s Desktop consent",
+    async (consent) => {
+      const f = await fixture();
+      const sink = collectingWritable([]);
+      await runInstall({
+        ...f.input,
+        targets: ["codex"],
+        stdout: sink,
+        stderr: sink,
+      });
+      if (consent !== "absent")
+        await writePrivateJsonAtomic(cliInstallStampPath(f.env), {
+          consent,
+          updatedAt: new Date().toISOString(),
+        });
+      await f.stampVersion("2.0.0");
+      expect(await f.launch()).toBeUndefined();
+      // Even a stale startup request cannot override the current consent.
+      await applyCliInstall({
+        ...f.input,
+        targets: ["codex"],
+        autoUpdate: true,
+      });
+      expect(await readSkillVersion(f.skill(), "dev-review")).toBe("1.0.0");
+    },
+  );
+
+  it("respects an explicit empty target list and legacy consent without targets", async () => {
+    const f = await fixture();
+    await applyCliInstall({ ...f.input, targets: ["codex"] });
+    await f.stampVersion("2.0.0");
+    const stamp = { consent: "granted", updatedAt: new Date().toISOString() };
+    await writePrivateJsonAtomic(cliInstallStampPath(f.env), {
+      ...stamp,
+      targets: [],
+    });
+    expect(await f.launch()).toBeUndefined();
+    await writePrivateJsonAtomic(cliInstallStampPath(f.env), stamp);
+    expect((await f.launch())?.code).toBe(0);
+    expect(await readSkillVersion(f.skill(), "dev-review")).toBe("2.0.0");
+  });
+
+  it("retries a failed destination without marking it current", async () => {
+    const f = await fixture();
+    await applyCliInstall({ ...f.input, targets: ["codex", "claude"] });
+    await f.stampVersion("2.0.0");
+    const claudeRoot = path.join(f.homeDir, ".claude", "skills");
+    await rm(claudeRoot, { recursive: true });
+    await writeFile(claudeRoot, "blocked destination");
+    expect((await f.launch())?.code).toBe(1);
+    const failed = await resolveCliInstallStatus(f.input);
+    expect(failed.stale).toBe(true);
+    expect(failed.error).toBeTruthy();
+    expect(await readSkillVersion(f.skill(), "dev-review")).toBe("2.0.0");
+    await rm(claudeRoot);
+    expect((await f.launch())?.code).toBe(0);
+    expect((await resolveCliInstallStatus(f.input)).error).toBeUndefined();
+    expect(
+      await readSkillVersion(f.skill("dev-review", ".claude"), "dev-review"),
+    ).toBe("2.0.0");
+  });
+
+  it("serializes concurrent installs without losing selected agents", async () => {
+    const f = await fixture();
+    const results = await Promise.all([
+      applyCliInstall({ ...f.input, targets: ["codex"] }),
+      applyCliInstall({ ...f.input, targets: ["claude"] }),
+    ]);
+    expect(results.map((result) => result.code)).toEqual([0, 0]);
+    expect(
+      (await resolveCliInstallStatus(f.input)).stamp?.targets?.sort(),
+    ).toEqual(["claude", "codex"]);
+  });
+  it("serializes independent installer processes", async () => {
+    const f = await fixture();
+    const code = `import { applyCliInstall } from "./packages/progressive-review/src/server/cli-install.ts";
+      const result = await applyCliInstall({ homeDir: process.argv[1], packageRoot: process.argv[2], env: { DEV_REVIEW_HOME: process.argv[3], PATH: "" }, targets: [process.argv[4]], shim: false });
+      if (result.code !== 0) throw new Error(result.output);`;
+    await Promise.all(
+      ["codex", "claude"].map((target) =>
+        execFileAsync(
+          process.execPath,
+          [
+            "--import",
+            "tsx",
+            "--input-type=module",
+            "-e",
+            code,
+            f.homeDir,
+            f.packageRoot,
+            f.env.DEV_REVIEW_HOME,
+            target,
+          ],
+          { cwd: workspace },
+        ),
+      ),
+    );
+    expect(
+      (await resolveCliInstallStatus(f.input)).stamp?.targets?.sort(),
+    ).toEqual(["claude", "codex"]);
+  });
+
+  it("reports invalid bundled metadata without replacing the installed skill", async () => {
+    const f = await fixture();
+    await applyCliInstall({ ...f.input, targets: ["codex"] });
+    const source = path.join(f.packageRoot, "skills", "dev-review", "SKILL.md");
+    await writeFile(
+      source,
+      (await readFile(source, "utf8")).replace(
+        'review-version: "1.0.0"',
+        'review-version: "broken"',
+      ),
+    );
+    expect((await f.launch())?.code).toBe(1);
+    expect(await readSkillVersion(f.skill(), "dev-review")).toBe("1.0.0");
+    expect(
+      (await resolveCliInstallStatus(f.input)).skills?.find(
+        (skill) => skill.name === "dev-review",
+      )?.error,
+    ).toContain("no release version");
+  });
+
+  it("updates OpenCode and trace skills only for already enabled integrations", async () => {
+    const f = await fixture();
+    const installed = await applyCliInstall({
+      ...f.input,
+      targets: ["opencode"],
+      trace: {
+        endpoint: "mock://endpoint",
+        bucket: "mock-bucket",
+        key: "mock-key",
+        secret: "mock-secret",
+      },
+    });
+    expect(installed).toMatchObject({ code: 0 });
+    const settingsPath = (await resolveCliInstallStatus(f.input)).trace
+      .settingsPath;
+    const traceBefore = await readFile(settingsPath, "utf8");
+    await f.stampVersion("2.0.0");
+    expect((await f.launch())?.code).toBe(0);
+    const traceSkill = path.join(
+      f.homeDir,
+      ".config",
+      "opencode",
+      "skills",
+      "trace-archaeology",
+      "SKILL.md",
+    );
+    expect(await readSkillVersion(traceSkill, "trace-archaeology")).toBe(
+      "2.0.0",
+    );
+    expect(await readFile(settingsPath, "utf8")).toBe(traceBefore);
+    expect(
+      (await resolveCliInstallStatus(f.input)).stamp?.fffRegistrations,
+    ).toBeUndefined();
+  });
+});

--- a/packages/progressive-review/src/skill-install-lock.ts
+++ b/packages/progressive-review/src/skill-install-lock.ts
@@ -1,0 +1,21 @@
+import os from "node:os";
+import path from "node:path";
+
+import { withFileLock } from "./with-file-lock";
+
+/** Shared by terminal installs, Desktop updates, and removals, across processes. */
+export async function withSkillInstallLock<T>(
+  homeDir: string = os.homedir(),
+  operation: () => Promise<T>,
+): Promise<T> {
+  const outcome = await withFileLock(
+    path.join(homeDir, ".dev", "skill-install.lock"),
+    { retryMs: 50, timeoutMs: 30_000, staleMs: 300_000, unownedGraceMs: 5_000 },
+    operation,
+  );
+  if (!outcome.acquired)
+    throw new Error(
+      "Another Review skill installation is running. Retry shortly.",
+    );
+  return outcome.result;
+}

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -1401,6 +1401,19 @@ export const ReviewCliInstallStatusSchema = z.strictObject({
   fingerprint: requiredString,
   stamp: ReviewCliInstallStampSchema.nullable(),
   stale: z.boolean(),
+  skills: z
+    .array(
+      z.strictObject({
+        target: ReviewCliInstallTargetSchema,
+        name: requiredString,
+        installedVersion: requiredString.nullable(),
+        bundledVersion: requiredString.nullable(),
+        stale: z.boolean(),
+        error: requiredString.optional(),
+      }),
+    )
+    .optional(),
+  error: requiredString.optional(),
   shim: z.strictObject({
     path: requiredString,
     installed: z.boolean(),
@@ -1449,6 +1462,7 @@ export const ReviewCliInstallApplyRequestSchema = z
   .strictObject({
     targets: z.array(ReviewCliInstallTargetSchema),
     shim: z.boolean().optional(),
+    autoUpdate: z.boolean().optional(),
     fff: z.boolean().optional(),
     trace: z
       .union([


### PR DESCRIPTION
Review Desktop now stamps bundled skills with its release version and a generated-file notice, then automatically replaces older Desktop-managed skills on startup. Current versions are skipped; local edits are overwritten on upgrade, and terminal-only installs are not automatically enrolled.

Updates compare each installed skill independently, deduplicate shared destinations, and preserve existing trace/optional integration settings. Serialized installs and staged directory replacement allow failed or interrupted updates to retry without losing the previous complete skill.

Validation: 65 focused installer, packaging, and native-client tests; runtime build, typecheck, lint, and formatting checks. A staged production runtime passed HTTP install, upgrade, local-edit overwrite, restart, and duplicate-request no-op checks in a disposable home.
