### PR TITLE
Allow Codex Ask sessions to reach Review through the sandbox proxy

### DIFF
--- a/packages/progressive-review/src/native-agent/codex-app-server.ts
+++ b/packages/progressive-review/src/native-agent/codex-app-server.ts
@@ -383,7 +383,12 @@ export async function startCodexThread(input: {
 
 export async function forkThread(
   client: CodexAppServerClient,
-  input: { sourceThreadId: string; cwd: string; config?: JsonObject },
+  input: {
+    sourceThreadId: string;
+    cwd: string;
+    config?: JsonObject;
+    permissions?: string;
+  },
 ): Promise<string> {
   const params: JsonObject = {
     threadId: input.sourceThreadId,
@@ -392,15 +397,17 @@ export async function forkThread(
     excludeTurns: true,
   };
   if (input.config !== undefined) params.config = input.config;
+  if (input.permissions !== undefined) params.permissions = input.permissions;
   return threadId(await client.request("thread/fork", params), "forked");
 }
 
 export async function startThread(
   client: CodexAppServerClient,
-  input: { cwd: string; config?: JsonObject },
+  input: { cwd: string; config?: JsonObject; permissions?: string },
 ): Promise<string> {
   const params: JsonObject = { cwd: input.cwd, ephemeral: false };
   if (input.config !== undefined) params.config = input.config;
+  if (input.permissions !== undefined) params.permissions = input.permissions;
   return threadId(await client.request("thread/start", params), "new");
 }
 

--- a/packages/progressive-review/src/native-agent/codex.ts
+++ b/packages/progressive-review/src/native-agent/codex.ts
@@ -1,4 +1,5 @@
 import {
+  type JsonObject,
   type JsonValue,
   jsonArray,
   jsonNumber,
@@ -30,6 +31,7 @@ import {
 } from "./terminal-command";
 
 const MATERIALIZE_TIMEOUT_MS = 60_000;
+const ASK_PERMISSIONS = "review-ask";
 
 interface NativeToolEnvironment {
   [name: string]: string;
@@ -91,19 +93,45 @@ export class CodexAgentServer implements AgentServer {
       [DEV_REVIEW_HOME_ENV]: devReviewHome(),
     };
     if (pathValue) env.PATH = pathValue;
-    const config = { "shell_environment_policy.set": env };
+    // Ask sessions read a frozen checkout and fetch their thread from Desktop.
+    // Enable the proxy as well as networking: domain rules alone do not prevent
+    // unrestricted direct connections. Ephemeral ports avoid proxy collisions
+    // between simultaneous Ask sessions.
+    const config: JsonObject = {
+      "shell_environment_policy.set": env,
+      default_permissions: ASK_PERMISSIONS,
+      "features.network_proxy": true,
+      [`permissions.${ASK_PERMISSIONS}.extends`]: ":read-only",
+      [`permissions.${ASK_PERMISSIONS}.network.enabled`]: true,
+      [`permissions.${ASK_PERMISSIONS}.network.domains`]: {
+        [new URL(this.#desktop.baseUrl).hostname]: "allow",
+      },
+      [`permissions.${ASK_PERMISSIONS}.network.proxy_url`]:
+        "http://127.0.0.1:0",
+      [`permissions.${ASK_PERMISSIONS}.network.socks_url`]:
+        "http://127.0.0.1:0",
+    };
     let threadId: string;
     if (!input.session) {
-      threadId = await startThread(client, { cwd: input.cwd, config });
+      threadId = await startThread(client, {
+        cwd: input.cwd,
+        config,
+        permissions: ASK_PERMISSIONS,
+      });
     } else if ("forkOf" in input.session) {
       threadId = await forkThread(client, {
         config,
+        permissions: ASK_PERMISSIONS,
         sourceThreadId: input.session.forkOf,
         cwd: input.cwd,
       });
     } else {
       threadId = input.session.resume;
-      await client.request("thread/resume", { threadId, config });
+      await client.request("thread/resume", {
+        threadId,
+        config,
+        permissions: ASK_PERMISSIONS,
+      });
       this.#thread(threadId).subscribed = true;
     }
     // Threads created on this connection already stream to it.
@@ -124,6 +152,7 @@ export class CodexAgentServer implements AgentServer {
         result = await client.request("turn/start", {
           threadId,
           cwd: input.cwd,
+          permissions: ASK_PERMISSIONS,
           input: [{ type: "text", text: input.prompt.text, text_elements: [] }],
         });
       } catch (error) {
@@ -152,6 +181,10 @@ export class CodexAgentServer implements AgentServer {
     }
     const url = await this.#host.url();
     const args = ["--remote", url];
+    for (const [name, value] of Object.entries(config)) {
+      if (name === "shell_environment_policy.set") continue;
+      args.push("-c", `${name}=${tomlInline(value)}`);
+    }
     for (const [name, value] of Object.entries(env)) {
       args.push(
         "-c",

--- a/packages/progressive-review/src/threads-cli.test.ts
+++ b/packages/progressive-review/src/threads-cli.test.ts
@@ -1,6 +1,8 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough, type Writable } from "node:stream";
@@ -16,6 +18,7 @@ import {
   reviewThreadDbPath,
 } from "./review-thread-store-backend";
 import {
+  runReviewThreadsGet,
   runReviewThreadsList,
   runReviewThreadsReply,
   runReviewThreadsResolve,
@@ -34,6 +37,61 @@ afterEach(async () => {
 });
 
 describe("review threads CLI", () => {
+  it("reads the attached thread through the sandbox proxy", async () => {
+    const payload = {
+      review: "review-proxy",
+      state: "draft",
+      comment: {
+        threadId: "thread-proxy",
+        target: { kind: "document" },
+        status: "open",
+        messages: [],
+      },
+    };
+    let destination: string | undefined;
+    let request = "";
+    const proxy = createServer();
+    proxy.on("connect", (incoming, socket) => {
+      destination = incoming.url;
+      socket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      socket.on("data", (chunk) => {
+        request += chunk.toString();
+        if (!request.includes("\r\n\r\n")) return;
+        const body = JSON.stringify(payload);
+        socket.end(
+          `HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${Buffer.byteLength(body)}\r\nConnection: close\r\n\r\n${body}`,
+        );
+      });
+    });
+    await new Promise<void>((resolve) => proxy.listen(0, "127.0.0.1", resolve));
+    try {
+      // listen above binds a TCP port and has completed successfully.
+      const address = proxy.address() as AddressInfo;
+      const output = await captureOutput((stdout) =>
+        runReviewThreadsGet({
+          cwd: process.cwd(),
+          threadId: "thread-proxy",
+          stdout,
+          env: {
+            DEV_FAST_REVIEW_AGENT_THREAD_URL:
+              "http://review.invalid:12345/agent-threads",
+            DEV_FAST_REVIEW_AGENT_THREAD_TOKEN: "proxy-test-token",
+            HTTP_PROXY: `http://127.0.0.1:${address.port}`,
+            NO_PROXY: "",
+          },
+        }),
+      );
+      expect(JSON.parse(output)).toEqual(payload);
+      expect(destination).toBe("review.invalid:12345");
+      expect(request).toContain("GET /agent-threads/thread-proxy HTTP/1.1");
+      expect(request).toContain("x-review-token: proxy-test-token");
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        proxy.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
   it("lists, replies to, and resolves comment threads", async () => {
     const { root, review, document } = await makeReview();
 

--- a/packages/progressive-review/src/threads-cli.ts
+++ b/packages/progressive-review/src/threads-cli.ts
@@ -7,6 +7,7 @@ import {
   isJsonObject,
   jsonString,
 } from "@dev.fast/review-protocol";
+import { EnvHttpProxyAgent } from "undici";
 
 import {
   REVIEW_AGENT_THREAD_TOKEN_ENV,
@@ -76,42 +77,56 @@ async function readAttachedReviewThread(input: {
       "review threads get requires an attached Review Desktop server.",
     );
   }
-  let response: Response;
+  // Node fetch does not automatically use the proxy supplied by Codex's
+  // network sandbox. Keep this dispatcher local to the attached-thread read.
+  const dispatcher = new EnvHttpProxyAgent({
+    httpProxy: env.http_proxy ?? env.HTTP_PROXY,
+    httpsProxy: env.https_proxy ?? env.HTTPS_PROXY,
+    noProxy: env.no_proxy ?? env.NO_PROXY,
+  });
+  const requestOptions = { dispatcher };
   try {
-    response = await fetch(
-      `${baseUrl.replace(/\/$/u, "")}/${encodeURIComponent(input.threadId)}`,
-      { headers: { "x-review-token": token } },
-    );
-  } catch (error) {
-    throw new Error("Review Desktop could not read the thread.", {
-      cause: error,
-    });
+    let response: Response;
+    try {
+      response = await fetch(
+        `${baseUrl.replace(/\/$/u, "")}/${encodeURIComponent(input.threadId)}`,
+        { headers: { "x-review-token": token }, ...requestOptions },
+      );
+    } catch (error) {
+      throw new Error("Review Desktop could not read the thread.", {
+        cause: error,
+      });
+    }
+    if (response.status === 404) {
+      await response.body?.cancel();
+      throw new Error(`Comment thread not found: ${input.threadId}`);
+    }
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new Error(
+        `Review Desktop could not read the thread (${response.status}).`,
+      );
+    }
+    const record: unknown = await response.json();
+    if (!isJsonObject(record)) {
+      throw new Error("Review Desktop returned an invalid thread response.");
+    }
+    const review = jsonString(record.review);
+    const state = record.state;
+    if (review === undefined || (state !== "draft" && state !== "submitted")) {
+      throw new Error("Review Desktop returned an invalid thread response.");
+    }
+    if (input.reviewUuid && input.reviewUuid !== review) {
+      throw new Error(`Review not found: ${input.reviewUuid}`);
+    }
+    return {
+      review,
+      state,
+      comment: ReviewCommentThreadRecordSchema.parse(record.comment),
+    };
+  } finally {
+    await dispatcher.close();
   }
-  if (response.status === 404) {
-    throw new Error(`Comment thread not found: ${input.threadId}`);
-  }
-  if (!response.ok) {
-    throw new Error(
-      `Review Desktop could not read the thread (${response.status}).`,
-    );
-  }
-  const record: unknown = await response.json();
-  if (!isJsonObject(record)) {
-    throw new Error("Review Desktop returned an invalid thread response.");
-  }
-  const review = jsonString(record.review);
-  const state = record.state;
-  if (review === undefined || (state !== "draft" && state !== "submitted")) {
-    throw new Error("Review Desktop returned an invalid thread response.");
-  }
-  if (input.reviewUuid && input.reviewUuid !== review) {
-    throw new Error(`Review not found: ${input.reviewUuid}`);
-  }
-  return {
-    review,
-    state,
-    comment: ReviewCommentThreadRecordSchema.parse(record.comment),
-  };
 }
 
 export async function runReviewThreadsResolve(


### PR DESCRIPTION
Codex “Ask now” sessions could fail to retrieve their Review thread with `connect EPERM 127.0.0.1:<port>`. Review supplied the endpoint and token but inherited a sandbox policy that could block the connection before authentication.

This change selects a read-only `review-ask` permission profile for new, forked, and resumed Ask sessions and enables Codex's network proxy with an allow rule for the Desktop host. The terminal receives the same configuration. Proxy listeners use dynamically allocated ports so simultaneous sessions do not collide.

The attached-thread CLI lookup now uses an environment-aware proxy dispatcher; allowing the host alone would not fix Node fetch attempting a direct connection. A regression test retrieves an authenticated thread through a local proxy using an otherwise unresolvable destination.

Codex's allow rules apply to hosts, not individual ports: the normal Desktop endpoint therefore allows the loopback host. The profile retains read-only filesystem access. This uses Codex permission profiles and was validated with Codex CLI 0.153.4.

Validation:
- Full local `pnpm run ci`: Desktop build, tutorial validation, lint, formatting, workspace typechecks, and tests.
- Actual Codex sandbox: the updated thread lookup reached a local endpoint through the proxy; an unrelated public host was rejected with HTTP 403.
