### PR TITLE
Fix Codex Ask permission inheritance

### DIFF
--- a/packages/progressive-review/src/native-agent/codex.ts
+++ b/packages/progressive-review/src/native-agent/codex.ts
@@ -152,7 +152,6 @@ export class CodexAgentServer implements AgentServer {
         result = await client.request("turn/start", {
           threadId,
           cwd: input.cwd,
-          permissions: ASK_PERMISSIONS,
           input: [{ type: "text", text: input.prompt.text, text_elements: [] }],
         });
       } catch (error) {
@@ -180,11 +179,9 @@ export class CodexAgentServer implements AgentServer {
       await accepted;
     }
     const url = await this.#host.url();
+    // Remote resume inherits the server thread's permissions; the TUI rejects
+    // permission overrides when attaching to an existing remote thread.
     const args = ["--remote", url];
-    for (const [name, value] of Object.entries(config)) {
-      if (name === "shell_environment_policy.set") continue;
-      args.push("-c", `${name}=${tomlInline(value)}`);
-    }
     for (const [name, value] of Object.entries(env)) {
       args.push(
         "-c",


### PR DESCRIPTION
Ask Now could fail when starting its first message (`default_permissions requires a [permissions] table`) or close its terminal immediately with `Permission overrides are not supported when resuming a remote task`.

Let turns and remote terminals inherit the server thread's permissions. Keep the read-only Review permission profile and proxy configuration on thread creation, fork, and resume.

Validation: reproduced the first failure with Codex 0.154.0 and confirmed the request succeeds without the turn override; both existing Codex session tests pass; `pnpm dev` rebuilt and launched. Full interactive Ask Now verification is pending.
