### PR TITLE
Fix Codex Ask Now follow-up permission reloads

### DIFF
--- a/packages/progressive-review/src/native-agent/codex-app-server.ts
+++ b/packages/progressive-review/src/native-agent/codex-app-server.ts
@@ -297,9 +297,16 @@ export class CodexAppServerHost {
     const { child, client } = await started;
     await client.close();
     if (child.exitCode === null && child.signalCode === null) {
-      const closed = once(child, "close");
-      child.kill("SIGTERM");
-      await closed;
+      const exited = once(child, "exit");
+      // Codex may keep running while shutting down plugins. Bound graceful
+      // shutdown so closing Review cannot hang, then wait for actual exit.
+      const timer = setTimeout(() => child.kill("SIGKILL"), 2_000);
+      try {
+        child.kill("SIGTERM");
+        await exited;
+      } finally {
+        clearTimeout(timer);
+      }
     }
   }
 

--- a/packages/progressive-review/src/native-agent/codex-app-server.ts
+++ b/packages/progressive-review/src/native-agent/codex-app-server.ts
@@ -17,6 +17,7 @@ import {
 } from "@dev.fast/review-protocol";
 import { WebSocket } from "undici";
 
+import { tomlInline } from "./terminal-command";
 import { isJsonRecord } from "./transcript-json";
 
 interface PendingRequest {
@@ -273,6 +274,8 @@ interface StartedHost {
 export class CodexAppServerHost {
   #started: Promise<StartedHost> | undefined;
 
+  constructor(private readonly config: JsonObject = {}) {}
+
   /** WebSocket URL of the shared server. */
   async url(): Promise<string> {
     return (await this.#start()).url;
@@ -293,7 +296,11 @@ export class CodexAppServerHost {
     this.#started = undefined;
     const { child, client } = await started;
     await client.close();
-    if (child.exitCode === null) child.kill("SIGTERM");
+    if (child.exitCode === null && child.signalCode === null) {
+      const closed = once(child, "close");
+      child.kill("SIGTERM");
+      await closed;
+    }
   }
 
   #start(): Promise<StartedHost> {
@@ -301,7 +308,18 @@ export class CodexAppServerHost {
     const started = (async (): Promise<StartedHost> => {
       const child: ListeningChild = spawn(
         "codex",
-        ["app-server", "--listen", "ws://127.0.0.1:0"],
+        [
+          "app-server",
+          "--listen",
+          "ws://127.0.0.1:0",
+          // TUI follow-ups select the thread's named permission profile again.
+          // Codex reloads server config for that selection, without the config
+          // overrides supplied to thread/start or thread/fork.
+          ...Object.entries(this.config).flatMap(([name, value]) => [
+            "-c",
+            `${name}=${tomlInline(value)}`,
+          ]),
+        ],
         {
           cwd: "/",
           env: process.env,

--- a/packages/progressive-review/src/native-agent/codex.integration.test.ts
+++ b/packages/progressive-review/src/native-agent/codex.integration.test.ts
@@ -1,0 +1,47 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { jsonObject, jsonString } from "@dev.fast/review-protocol";
+import { expect, it, vi } from "vitest";
+
+import { server } from "./codex";
+import { CodexAppServerClient } from "./codex-app-server";
+
+// Run against the installed Codex with REVIEW_CODEX_INTEGRATION=1. An isolated
+// home keeps this independent of user profiles, credentials, and saved threads.
+it.runIf(process.env.REVIEW_CODEX_INTEGRATION === "1")(
+  "accepts a terminal follow-up selecting the Ask permission profile",
+  async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "review-codex-live-"));
+    vi.stubEnv("CODEX_HOME", directory);
+    const agent = server({
+      runtimeDirectory: directory,
+      desktopEndpoint: { baseUrl: "http://127.0.0.1:4000", token: "test" },
+    });
+    let terminal: CodexAppServerClient | undefined;
+    try {
+      const launch = await agent.launch({ cwd: directory });
+      const remoteIndex = launch.command.args.indexOf("--remote");
+      terminal = await CodexAppServerClient.connectWebSocket(
+        launch.command.args[remoteIndex + 1]!,
+      );
+      // Unlike Review's initial submission, the TUI explicitly re-selects the
+      // active profile. This causes Codex to reload the server configuration.
+      const result = await terminal.request("turn/start", {
+        threadId: launch.sessionId,
+        permissions: "review-ask",
+        input: [],
+      });
+      const turn = jsonObject(jsonObject(result)?.turn);
+      expect(jsonString(turn?.id)).toBeTruthy();
+      expect(turn?.error).toBeNull();
+    } finally {
+      await terminal?.close();
+      await agent.close();
+      vi.unstubAllEnvs();
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+  30_000,
+);

--- a/packages/progressive-review/src/native-agent/codex.ts
+++ b/packages/progressive-review/src/native-agent/codex.ts
@@ -33,6 +33,23 @@ import {
 const MATERIALIZE_TIMEOUT_MS = 60_000;
 const ASK_PERMISSIONS = "review-ask";
 
+function askPermissionsConfig(baseUrl: string): JsonObject {
+  // Enable the proxy as well as networking: domain rules alone do not prevent
+  // unrestricted direct connections. Ephemeral ports avoid proxy collisions
+  // between simultaneous Ask sessions.
+  return {
+    default_permissions: ASK_PERMISSIONS,
+    "features.network_proxy": true,
+    [`permissions.${ASK_PERMISSIONS}.extends`]: ":read-only",
+    [`permissions.${ASK_PERMISSIONS}.network.enabled`]: true,
+    [`permissions.${ASK_PERMISSIONS}.network.domains`]: {
+      [new URL(baseUrl).hostname]: "allow",
+    },
+    [`permissions.${ASK_PERMISSIONS}.network.proxy_url`]: "http://127.0.0.1:0",
+    [`permissions.${ASK_PERMISSIONS}.network.socks_url`]: "http://127.0.0.1:0",
+  };
+}
+
 interface NativeToolEnvironment {
   [name: string]: string;
 }
@@ -94,22 +111,9 @@ export class CodexAgentServer implements AgentServer {
     };
     if (pathValue) env.PATH = pathValue;
     // Ask sessions read a frozen checkout and fetch their thread from Desktop.
-    // Enable the proxy as well as networking: domain rules alone do not prevent
-    // unrestricted direct connections. Ephemeral ports avoid proxy collisions
-    // between simultaneous Ask sessions.
     const config: JsonObject = {
+      ...askPermissionsConfig(this.#desktop.baseUrl),
       "shell_environment_policy.set": env,
-      default_permissions: ASK_PERMISSIONS,
-      "features.network_proxy": true,
-      [`permissions.${ASK_PERMISSIONS}.extends`]: ":read-only",
-      [`permissions.${ASK_PERMISSIONS}.network.enabled`]: true,
-      [`permissions.${ASK_PERMISSIONS}.network.domains`]: {
-        [new URL(this.#desktop.baseUrl).hostname]: "allow",
-      },
-      [`permissions.${ASK_PERMISSIONS}.network.proxy_url`]:
-        "http://127.0.0.1:0",
-      [`permissions.${ASK_PERMISSIONS}.network.socks_url`]:
-        "http://127.0.0.1:0",
     };
     let threadId: string;
     if (!input.session) {
@@ -424,6 +428,9 @@ export function server(
 ): AgentServer {
   return new CodexAgentServer(
     options,
-    options.host ?? new CodexAppServerHost(),
+    options.host ??
+      new CodexAppServerHost(
+        askPermissionsConfig(options.desktopEndpoint.baseUrl),
+      ),
   );
 }


### PR DESCRIPTION
Codex terminal follow-ups in Ask Now failed with `default_permissions requires a [permissions] table`: selecting the active `review-ask` profile reloads server configuration without the per-thread overrides used for the initial turn.

Register the same read-only permission profile and Review network proxy settings when starting the shared Codex app-server, so follow-ups can resolve the profile. Shutdown waits for process exit, allowing deterministic cleanup without retries; if graceful termination stalls, the owned process is force-stopped after two seconds.

Includes an opt-in regression test against the installed Codex using an isolated home and a separate terminal connection. Reproduced the original error on Codex 0.153.4 and verified the fixed request succeeds.

Validation:

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm desktop:build`
- `pnpm --filter @dev.fast/review check:tutorial`
- 15 Codex and tutorial tests, including the live regression test with `REVIEW_CODEX_INTEGRATION=1`
- `pnpm --filter @dev.fast/review-desktop test` (237 tests)
- The full `pnpm test` run passed the root, local-vcs, and protocol tests, plus 1,226 Review tests, but exposed four tutorial shutdown timeouts. After fixing shutdown, all nine tutorial tests and six Codex tests passed on rerun. The entire suite was not repeated after that correction.
