### PR TITLE
wip: diffs internally.

### DIFF
--- a/STRUCTURAL-DIFF.md
+++ b/STRUCTURAL-DIFF.md
@@ -65,8 +65,11 @@ coordinates, and carrying collapse state between layouts.
 - Older wire without `aligned_rows` uses hunk alignment. Omitted gaps
   are filled positionally for expansion only; use the newer `aligned_rows` wire
   field for authoritative full-file alignment.
-- The CLI stream is consumed incrementally, but this first bridge collects a
-  comparison before mounting the native view (64 MiB / 120-second limits).
+- The CLI stream is forwarded as NDJSON. The file tree appears before diffs
+  arrive, with loading indicators and per-file errors. Ready files are inserted
+  in tree order without replacing the existing editors; selecting a pending
+  file reveals it when ready. Disposing the review cancels the subprocess.
+- Comparisons retain the 64 MiB / 120-second limits and are not yet cached.
 - This is not a large-file performance benchmark or a complete validation of
   comments, nested partial folds, Unicode wrapping, added/deleted files, or jj.
 
@@ -87,5 +90,5 @@ kept replaying file-stream chunks after reloads. Cleanup now waits until event
 delivery finishes. After three reloads, the sampled file stream delivered one
 copy and scrolling crossed file boundaries in both layouts.
 
-Initial mounting still waits for the full subprocess result; this PR does not
-claim progressive rendering or a comprehensive performance benchmark.
+Structural results now render progressively; the large comparison is still
+useful for exercising files that finish at different times.

--- a/STRUCTURAL-DIFF.md
+++ b/STRUCTURAL-DIFF.md
@@ -1,0 +1,84 @@
+# Native structural diff experiment
+
+This branch replaces the Files view's diff computation with `diffr` when
+`REVIEW_DIFFR_BINARY` names an executable. Without it, Review uses its existing
+native diff provider. It does not require a diffr server or CodeMirror.
+
+```sh
+REVIEW_DESKTOP_DEV_FAST=1 DEV_REVIEW_EXTENSIONS=none pnpm desktop:build
+REVIEW_DIFFR_BINARY=/absolute/path/to/diffr \
+  DEV_REVIEW_HOME=/tmp/review-structural-home \
+  DEV_REVIEW_EXTENSIONS=none pnpm desktop:run
+```
+
+Use the same `DEV_REVIEW_HOME` with this checkout's `review` CLI when opening a
+Review in this isolated app.
+
+## Implemented
+
+- Review invokes the CLI for its resolved repository comparison and reads v1
+  NDJSON from stdout. Nonzero exit, cancellation, incomplete streams and
+  per-file errors are surfaced. The executable is host configuration.
+- Native Monaco models display the exact source snapshots carried by the wire.
+  Base/head comparisons use pinned file URIs so existing language services can
+  attach. Revision-only virtual resources retain their existing language-service
+  limitations. The sidebar uses ReviewChangedFilesTree (the native Workbench tree).
+- Complete `aligned_rows` from the TUI wire drives split alignment when supplied;
+  older wire continues to use hunk pairings. Folding hides source rows;
+  wrapping and external editor view zones contribute height; only unequal
+  segments create alignment spacers. The diff is not recomputed on folding.
+- Whole-line fold controls use the supplied fold ranges. Paired ranges share
+  collapse state. Unified view filters folded original lines out of its deleted
+  code view zones, and restores them on expansion.
+- Review's native language tokenization and theme color the source rows. Change paint uses
+  the hunks’ `novel_lhs` / `novel_rhs` lists for light whole-line backgrounds and
+  `Novel` / `NovelWord` spans for darker token highlights in both layouts. Textual
+  replacement groups control layout but never imply red/green backgrounds.
+- Unchanged tokens stay neutral regardless of their position or indentation.
+- Only `hunks[].lines` are initially visible. Omitted source ranges use native
+  expandable context gaps; full models remain intact for language services.
+  Structural folds within the visible hunks initially expand. Fold state survives split/unified switches
+  while the Files view remains mounted.
+
+## Verified
+
+Both native and server TypeScript checks; six alignment/coordinate tests; four
+subprocess protocol tests; native app build. A real two-commit TypeScript fixture
+was opened in the isolated app. Mouse checks cover paired collapse/expansion in
+both layouts, unequal fold lengths, preserved alignment, unchanged toggle
+coordinates, and carrying collapse state between layouts.
+
+## First-pass limits
+
+- Native folding is a whole-line approximation: inline folds and the wire's
+  custom placeholder strings are not yet rendered. Native controls retain the
+  first source line and show the editor's normal collapsed indicator.
+- Fold state is not yet persisted across unmounting the Files view. Defaults
+  do not yet specialize by file class or fold tag.
+- Older wire without `aligned_rows` uses hunk alignment. Omitted gaps
+  are filled positionally for expansion only; use the newer `aligned_rows` wire
+  field for authoritative full-file alignment.
+- The CLI stream is consumed incrementally, but this first bridge collects a
+  comparison before mounting the native view (64 MiB / 120-second limits).
+- This is not a large-file performance benchmark or a complete validation of
+  comments, nested partial folds, Unicode wrapping, added/deleted files, or jj.
+
+## Larger manual exercise
+
+Review PR #108 was loaded at its original comparison commits:
+- Base: `de8ebb1b1fd5786577a68b70c80b0ab8f5bb83b4`
+- Head: `f00d6a8b3cbe1b85f1deddbb9a016450003bb8a3`
+
+This covers 30 files, roughly 30,600 aligned rows, and a 32 MB NDJSON payload.
+Manual checks covered every file-tree entry, split/unified switching, paired
+fold toggles, context expansion, and scrolling between files. Initial visibility
+was also checked against the hunk row sets across all 30 files.
+
+The exercise exposed a renderer-reconnect bug: disposing the disconnect emitter
+inside its first listener suppressed later cleanup, so old IPC channel servers
+kept replaying file-stream chunks after reloads. Cleanup now waits until event
+delivery finishes. After three reloads, the sampled file stream delivered one
+copy and scrolling crossed file boundaries in both layouts.
+
+Initial mounting still waits for the full subprocess result; this PR does not
+claim progressive rendering or a comprehensive performance benchmark.

--- a/STRUCTURAL-DIFF.md
+++ b/STRUCTURAL-DIFF.md
@@ -1,8 +1,15 @@
 # Native structural diff experiment
 
-This branch replaces the Files view's diff computation with `diffr` when
-`REVIEW_DIFFR_BINARY` names an executable. Without it, Review uses its existing
-native diff provider. It does not require a diffr server or CodeMirror.
+Enable **Settings → Experimental Features → Structural Diffs** to replace the
+standard Diff view with the structural viewer. The setting is saved as
+`review.experimental.structuralDiff.enabled`, defaults to off, and remounts open
+review views when changed. Turning it off restores the standard provider without
+requesting structural diffs.
+
+The Review host runs `diffr` from PATH, or the executable named by
+`REVIEW_DIFFR_BINARY`. The environment variable selects the executable; it does not
+enable the feature. Missing or incompatible executables surface an error in the
+Diff view. A diffr server and CodeMirror are not required.
 
 ```sh
 REVIEW_DESKTOP_DEV_FAST=1 DEV_REVIEW_EXTENSIONS=none pnpm desktop:build

--- a/apps/review-desktop/code-oss/src/vs/base/parts/ipc/electron-main/ipc.electron.ts
+++ b/apps/review-desktop/code-oss/src/vs/base/parts/ipc/electron-main/ipc.electron.ts
@@ -52,7 +52,10 @@ export class Server extends IPCServer {
 					Server.Clients.delete(id);
 				}
 
-				onDidClientReconnect.dispose();
+				// Let every disconnect listener run before disposing the emitter.
+				// Disposing during fire clears its delivery queue, leaving the old
+				// channel server subscribed after a renderer reload.
+				queueMicrotask(() => onDidClientReconnect.dispose());
 			});
 			const protocol = new ElectronProtocol(webContents, onMessage);
 

--- a/apps/review-desktop/code-oss/src/vs/editor/browser/widget/diffEditor/components/diffEditorDecorations.ts
+++ b/apps/review-desktop/code-oss/src/vs/editor/browser/widget/diffEditor/components/diffEditorDecorations.ts
@@ -41,6 +41,17 @@ export class DiffEditorDecorations extends Disposable {
 
 		const originalDecorations: IModelDeltaDecoration[] = [];
 		const modifiedDecorations: IModelDeltaDecoration[] = [];
+		if (diff.changeHighlights) {
+			for (const line of diff.changeHighlights.originalLines ?? []) {
+				originalDecorations.push({ range: { startLineNumber: line, startColumn: 1, endLineNumber: line, endColumn: 1 }, options: diffLineDeleteDecorationBackground });
+			}
+			for (const line of diff.changeHighlights.modifiedLines ?? []) {
+				modifiedDecorations.push({ range: { startLineNumber: line, startColumn: 1, endLineNumber: line, endColumn: 1 }, options: diffLineAddDecorationBackground });
+			}
+			for (const range of diff.changeHighlights.original) originalDecorations.push({ range, options: diffDeleteDecoration });
+			for (const range of diff.changeHighlights.modified) modifiedDecorations.push({ range, options: diffAddDecoration });
+			return { originalDecorations, modifiedDecorations };
+		}
 		if (!movedTextToCompare) {
 			for (const m of diff.mappings) {
 				if (!m.lineRangeMapping.original.isEmpty) {

--- a/apps/review-desktop/code-oss/src/vs/editor/browser/widget/diffEditor/components/diffEditorEditors.ts
+++ b/apps/review-desktop/code-oss/src/vs/editor/browser/widget/diffEditor/components/diffEditorEditors.ts
@@ -190,7 +190,7 @@ export class DiffEditorEditors extends Disposable {
 
 		// Clone scrollbar options before changing them
 		clonedOptions.scrollbar = { ...(clonedOptions.scrollbar || {}) };
-		clonedOptions.folding = false;
+		clonedOptions.folding = this._options.editorOptions.get().experimentalDiffFolding === true;
 		clonedOptions.codeLens = this._options.diffCodeLens.get();
 		clonedOptions.fixedOverflowWidgets = true;
 

--- a/apps/review-desktop/code-oss/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/diffEditorViewZones.ts
+++ b/apps/review-desktop/code-oss/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/diffEditorViewZones.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { projectSourceAlignment } from "../../../../../common/diff/sourceLineAlignment.js";
 import { $, addDisposableListener } from '../../../../../../base/browser/dom.js';
 import { ArrayQueue } from '../../../../../../base/common/arrays.js';
 import { RunOnceScheduler } from '../../../../../../base/common/async.js';
@@ -81,6 +82,8 @@ export class DiffEditorViewZones extends Disposable {
 
 		this._register(this._editors.original.onDidChangeViewZones((_args) => { if (!this._canIgnoreViewZoneUpdateEvent()) { updateImmediately.schedule(); } }));
 		this._register(this._editors.modified.onDidChangeViewZones((_args) => { if (!this._canIgnoreViewZoneUpdateEvent()) { updateImmediately.schedule(); } }));
+		this._register(this._editors.original.onDidChangeHiddenAreas(() => updateImmediately.schedule()));
+		this._register(this._editors.modified.onDidChangeHiddenAreas(() => updateImmediately.schedule()));
 		this._register(this._editors.original.onDidChangeConfiguration((args) => {
 			if (args.hasChanged(EditorOption.wrappingInfo) || args.hasChanged(EditorOption.lineHeight)) { updateImmediately.schedule(); }
 		}));
@@ -100,6 +103,9 @@ export class DiffEditorViewZones extends Disposable {
 			state.read(reader);
 			const renderSideBySide = this._options.renderSideBySide.read(reader);
 			const innerHunkAlignment = renderSideBySide;
+			if (renderSideBySide && diff.sourceLineAlignment) {
+				return computeSourceAlignment(this._editors.original, this._editors.modified, diff.sourceLineAlignment, this._origViewZonesToIgnore, this._modViewZonesToIgnore);
+			}
 			return computeRangeAlignment(
 				this._editors.original,
 				this._editors.modified,
@@ -184,7 +190,7 @@ export class DiffEditorViewZones extends Disposable {
 							if (i > originalModel.getLineCount()) {
 								return { orig: origViewZones, mod: modViewZones };
 							}
-							deletedCodeLineBreaksComputer?.addRequest(i, null);
+							if (this._editors.original._getViewModel()!.coordinatesConverter.getModelLineViewLineCount(i) > 0) deletedCodeLineBreaksComputer?.addRequest(i, null);
 						}
 					}
 				}
@@ -201,13 +207,15 @@ export class DiffEditorViewZones extends Disposable {
 			const mightContainRTL = this._editors.original.getModel()?.mightContainRTL() ?? false;
 			const renderOptions = RenderOptions.fromEditor(this._editors.modified);
 
+			const changeHighlights = this._diffModel.read(reader)?.diff.read(reader)?.changeHighlights;
 			for (const a of alignmentsVal) {
 				if (a.diff && !renderSideBySide && (!this._options.useTrueInlineDiffRendering.read(reader) || !allowsTrueInlineDiffRendering(a.diff))) {
-					if (!a.originalRange.isEmpty) {
+					if (!a.originalRange.isEmpty && a.originalRange.mapToLineArray(l => this._editors.original._getViewModel()!.coordinatesConverter.getModelLineViewLineCount(l)).some(height => height > 0)) {
 						originalModelTokenizationCompleted.read(reader); // Update view-zones once tokenization completes
 
 						const deletedCodeDomNode = document.createElement('div');
-						deletedCodeDomNode.classList.add('view-lines', 'line-delete', 'line-delete-selectable', 'monaco-mouse-cursor-text');
+						deletedCodeDomNode.classList.add('view-lines', 'line-delete-selectable', 'monaco-mouse-cursor-text');
+						if (!changeHighlights) deletedCodeDomNode.classList.add('line-delete');
 						const originalModel = this._editors.original.getModel()!;
 						// `a.originalRange` can be out of bound when the diff has not been updated yet.
 						// In this case, we do an early return.
@@ -215,27 +223,50 @@ export class DiffEditorViewZones extends Disposable {
 						if (a.originalRange.endLineNumberExclusive - 1 > originalModel.getLineCount()) {
 							return { orig: origViewZones, mod: modViewZones };
 						}
+						const visibleOriginalLines = a.originalRange.mapToLineArray(l => l).filter(l => this._editors.original._getViewModel()!.coordinatesConverter.getModelLineViewLineCount(l) > 0);
 						const source = new LineSource(
-							a.originalRange.mapToLineArray(l => originalModel.tokenization.getLineTokens(l)),
-							a.originalRange.mapToLineArray(_ => lineBreakData[lineBreakDataIdx++]),
+							visibleOriginalLines.map(l => originalModel.tokenization.getLineTokens(l)),
+							visibleOriginalLines.map(_ => lineBreakData[lineBreakDataIdx++]),
 							mightContainNonBasicASCII,
 							mightContainRTL,
 						);
 						const decorations: InlineDecoration[] = [];
-						for (const i of a.diff.innerChanges || []) {
-							decorations.push(new InlineDecoration(
-								i.originalRange.delta(-(a.diff.original.startLineNumber - 1)),
-								diffDeleteDecoration.className!,
-								InlineDecorationType.Regular
-							));
+						if (changeHighlights) {
+							// Source lines can be hidden by folds. Map paint into the compact
+							// deleted-code buffer rather than treating it as contiguous source.
+							const visibleRows = new Map(visibleOriginalLines.map((line, i) => [line, i + 1]));
+							for (const highlight of changeHighlights.original) {
+								for (let line = highlight.startLineNumber; line <= highlight.endLineNumber; line++) {
+									const row = visibleRows.get(line);
+									if (row === undefined) continue;
+									const start = line === highlight.startLineNumber ? highlight.startColumn : 1;
+									const end = line === highlight.endLineNumber ? highlight.endColumn : originalModel.getLineMaxColumn(line);
+									if (end > start) decorations.push(new InlineDecoration(new Range(row, start, row, end), diffDeleteDecoration.className!, InlineDecorationType.Regular));
+								}
+							}
+						} else {
+							for (const i of a.diff.innerChanges || []) {
+								decorations.push(new InlineDecoration(i.originalRange.delta(-(a.diff.original.startLineNumber - 1)), diffDeleteDecoration.className!, InlineDecorationType.Regular));
+							}
 						}
-						const result = renderLines(source, renderOptions, decorations, deletedCodeDomNode);
+						const result = renderLines(source, renderOptions, decorations, deletedCodeDomNode, false, changeHighlights !== undefined);
+						if (changeHighlights) {
+							const novelLines = new Set(changeHighlights.originalLines);
+							const viewLines = deletedCodeDomNode.querySelectorAll('.view-line');
+							let viewRow = 0;
+							for (let i = 0; i < visibleOriginalLines.length; i++) {
+								for (let wrappedRow = 0; wrappedRow < result.viewLineCounts[i]; wrappedRow++, viewRow++) {
+									if (novelLines.has(visibleOriginalLines[i])) viewLines[viewRow].classList.add('line-delete');
+
+								}
+							}
+						}
 
 						const marginDomNode = document.createElement('div');
-						marginDomNode.className = 'inline-deleted-margin-view-zone';
+						marginDomNode.className = changeHighlights ? 'inline-original-margin-view-zone' : 'inline-deleted-margin-view-zone';
 						applyFontInfo(marginDomNode, renderOptions.fontInfo);
 
-						if (this._options.renderIndicators.read(reader)) {
+						if (!changeHighlights && this._options.renderIndicators.read(reader)) {
 							for (let i = 0; i < result.heightInLines; i++) {
 								const marginElement = document.createElement('div');
 								marginElement.className = `delete-sign ${ThemeIcon.asClassName(diffRemoveIcon)}`;
@@ -257,6 +288,7 @@ export class DiffEditorViewZones extends Disposable {
 								this._editors.original.getModel()!,
 								this._contextMenuService,
 								this._clipboardService,
+								visibleOriginalLines,
 							)
 						);
 
@@ -265,7 +297,7 @@ export class DiffEditorViewZones extends Disposable {
 							// Account for wrapped lines in the (collapsed) original editor (which doesn't wrap lines).
 							if (count > 1) {
 								origViewZones.push({
-									afterLineNumber: a.originalRange.startLineNumber + i,
+									afterLineNumber: visibleOriginalLines[i],
 									domNode: createFakeLinesDiv(),
 									heightInPx: (count - 1) * modLineHeight,
 									showInHiddenAreas: true,
@@ -287,7 +319,7 @@ export class DiffEditorViewZones extends Disposable {
 					}
 
 					const marginDomNode = document.createElement('div');
-					marginDomNode.className = 'gutter-delete';
+					marginDomNode.className = changeHighlights ? '' : 'gutter-delete';
 
 					origViewZones.push({
 						afterLineNumber: a.originalRange.endLineNumberExclusive - 1,
@@ -656,4 +688,18 @@ export function allowsTrueInlineDiffRendering(mapping: DetailedLineRangeMapping)
 
 export function rangeIsSingleLine(range: Range): boolean {
 	return range.startLineNumber === range.endLineNumber;
+}
+
+/** Project existing correspondence through folding and wrapping, without rematching. */
+function computeSourceAlignment(original: CodeEditorWidget, modified: CodeEditorWidget, rows: readonly (readonly [number | null, number | null])[], originalZonesToIgnore: ReadonlySet<string>, modifiedZonesToIgnore: ReadonlySet<string>): ILineRangeAlignment[] {
+	const leftView = original._getViewModel()!.coordinatesConverter;
+	const rightView = modified._getViewModel()!.coordinatesConverter;
+	const leftHeight = original.getOption(EditorOption.lineHeight);
+	const rightHeight = modified.getOption(EditorOption.lineHeight);
+	const leftExtra = new Map(getAdditionalLineHeights(original, originalZonesToIgnore).map(info => [info.lineNumber, info.heightInPx]));
+	const rightExtra = new Map(getAdditionalLineHeights(modified, modifiedZonesToIgnore).map(info => [info.lineNumber, info.heightInPx]));
+	return projectSourceAlignment(rows,
+		l => leftView.getModelLineViewLineCount(l + 1) === 0 ? 0 : leftHeight + (leftExtra.get(l + 1) ?? 0),
+		r => rightView.getModelLineViewLineCount(r + 1) === 0 ? 0 : rightHeight + (rightExtra.get(r + 1) ?? 0),
+	).filter(s => s.leftHeight !== s.rightHeight).map(s => ({ originalRange: new LineRange(s.leftStart + 1, s.leftEnd + 1), modifiedRange: new LineRange(s.rightStart + 1, s.rightEnd + 1), originalHeightInPx: s.leftHeight, modifiedHeightInPx: s.rightHeight, diff: undefined }));
 }

--- a/apps/review-desktop/code-oss/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/inlineDiffDeletedCodeMargin.ts
+++ b/apps/review-desktop/code-oss/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/inlineDiffDeletedCodeMargin.ts
@@ -48,6 +48,7 @@ export class InlineDiffDeletedCodeMargin extends Disposable {
 		private readonly _originalTextModel: ITextModel,
 		private readonly _contextMenuService: IContextMenuService,
 		private readonly _clipboardService: IClipboardService,
+		private readonly _originalLineNumbers?: readonly number[],
 	) {
 		super();
 
@@ -171,7 +172,7 @@ export class InlineDiffDeletedCodeMargin extends Disposable {
 			for (let i = 0; i < this._renderLinesResult.viewLineCounts.length; i++) {
 				acc += this._renderLinesResult.viewLineCounts[i];
 				if (lineNumberOffset < acc) {
-					return i;
+					return this._originalLineNumbers ? this._originalLineNumbers[i] - this._diff.original.startLineNumber : i;
 				}
 			}
 		}

--- a/apps/review-desktop/code-oss/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/renderLines.ts
+++ b/apps/review-desktop/code-oss/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/renderLines.ts
@@ -20,10 +20,11 @@ import { getColumnOfNodeOffset } from '../../../../viewParts/viewLines/viewLine.
 
 const ttPolicy = createTrustedTypesPolicy('diffEditorWidget', { createHTML: value => value });
 
-export function renderLines(source: LineSource, options: RenderOptions, decorations: InlineDecoration[], domNode: HTMLElement, noExtra = false): RenderLinesResult {
+export function renderLines(source: LineSource, options: RenderOptions, decorations: InlineDecoration[], domNode: HTMLElement, noExtra = false, explicitChangeHighlights = false): RenderLinesResult {
 	applyFontInfo(domNode, options.fontInfo);
 
-	const hasCharChanges = (decorations.length > 0);
+	// An explicit empty highlight set means unchanged, not a whole-line deletion.
+	const hasCharChanges = explicitChangeHighlights || (decorations.length > 0);
 
 	const sb = new StringBuilder(10000);
 	let maxCharsPerLine = 0;

--- a/apps/review-desktop/code-oss/src/vs/editor/browser/widget/diffEditor/diffEditorViewModel.ts
+++ b/apps/review-desktop/code-oss/src/vs/editor/browser/widget/diffEditor/diffEditorViewModel.ts
@@ -94,7 +94,7 @@ export class DiffEditorViewModel extends Disposable implements IDiffEditorViewMo
 			/** @description collapse touching unchanged ranges */
 
 			const lastUnchangedRegions = this._unchangedRegions.read(reader);
-			if (!lastUnchangedRegions || lastUnchangedRegions.regions.some(r => r.isDragged.read(reader))) {
+			if (!lastUnchangedRegions || lastUnchangedRegions.regions.some(r => r instanceof SuppliedContextGap) || lastUnchangedRegions.regions.some(r => r.isDragged.read(reader))) {
 				return;
 			}
 
@@ -151,6 +151,19 @@ export class DiffEditorViewModel extends Disposable implements IDiffEditorViewMo
 		}));
 
 		const updateUnchangedRegions = (result: IDocumentDiff, tx: ITransaction, reader?: IReader) => {
+			if (result.contextGaps) {
+				const previous = this._unchangedRegions.get();
+				const regions = result.contextGaps.map(gap => {
+					const region = new SuppliedContextGap(gap);
+					const old = previous?.regions.find(r => r.originalLineNumber === gap.originalStart && r.modifiedLineNumber === gap.modifiedStart && r.lineCount === region.lineCount);
+					if (old) region.setState(old.visibleLineCountTop.get(), old.visibleLineCountBottom.get(), tx);
+					return region;
+				});
+				model.original.deltaDecorations(previous?.originalDecorationIds ?? [], []);
+				model.modified.deltaDecorations(previous?.modifiedDecorationIds ?? [], []);
+				this._unchangedRegions.set({ regions, originalDecorationIds: [], modifiedDecorationIds: [] }, tx);
+				return;
+			}
 			const newUnchangedRegions = UnchangedRegion.fromDiffs(
 				result.changes,
 				model.original.getLineCount(),
@@ -380,6 +393,9 @@ export class DiffEditorViewModel extends Disposable implements IDiffEditorViewMo
 
 function normalizeDocumentDiff(diff: IDocumentDiff, original: ITextModel, modified: ITextModel): IDocumentDiff {
 	return {
+		sourceLineAlignment: diff.sourceLineAlignment,
+	contextGaps: diff.contextGaps,
+		changeHighlights: diff.changeHighlights,
 		changes: diff.changes.map(c => new DetailedLineRangeMapping(
 			c.original,
 			c.modified,
@@ -419,6 +435,8 @@ export class DiffState {
 			result.moves || [],
 			result.identical,
 			result.quitEarly,
+			result.sourceLineAlignment,
+			result.changeHighlights,
 		);
 	}
 
@@ -427,6 +445,8 @@ export class DiffState {
 		public readonly movedTexts: readonly MovedText[],
 		public readonly identical: boolean,
 		public readonly quitEarly: boolean,
+		public readonly sourceLineAlignment?: IDocumentDiff["sourceLineAlignment"],
+		public readonly changeHighlights?: IDocumentDiff["changeHighlights"],
 	) { }
 }
 
@@ -640,6 +660,22 @@ export class UnchangedRegion {
 		this._visibleLineCountTop.set(visibleLineCountTop, tx);
 		this._visibleLineCountBottom.set(visibleLineCountBottom, tx);
 	}
+}
+
+/** Native expansion controls over the exact omitted ranges supplied by the provider. */
+class SuppliedContextGap extends UnchangedRegion {
+	constructor(private readonly gap: NonNullable<IDocumentDiff['contextGaps']>[number]) {
+		super(gap.originalStart, gap.modifiedStart, Math.max(gap.originalCount, gap.modifiedCount), 0, 0);
+	}
+	override get originalUnchangedRange(): LineRange { return LineRange.ofLength(this.gap.originalStart, this.gap.originalCount); }
+	override get modifiedUnchangedRange(): LineRange { return LineRange.ofLength(this.gap.modifiedStart, this.gap.modifiedCount); }
+	private hidden(start: number, count: number, reader: IReader | undefined): LineRange {
+		const top = Math.min(count, this.visibleLineCountTop.read(reader));
+		const bottom = Math.min(count - top, this.visibleLineCountBottom.read(reader));
+		return LineRange.ofLength(start + top, count - top - bottom);
+	}
+	override getHiddenOriginalRange(reader: IReader | undefined): LineRange { return this.hidden(this.gap.originalStart, this.gap.originalCount, reader); }
+	override getHiddenModifiedRange(reader: IReader | undefined): LineRange { return this.hidden(this.gap.modifiedStart, this.gap.modifiedCount, reader); }
 }
 
 export const enum RevealPreference {

--- a/apps/review-desktop/code-oss/src/vs/editor/browser/widget/diffEditor/style.css
+++ b/apps/review-desktop/code-oss/src/vs/editor/browser/widget/diffEditor/style.css
@@ -217,6 +217,7 @@
 	opacity: 1;
 }
 
+.monaco-editor .inline-original-margin-view-zone,
 .monaco-editor .inline-deleted-margin-view-zone {
 	text-align: right;
 }

--- a/apps/review-desktop/code-oss/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
+++ b/apps/review-desktop/code-oss/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
@@ -9,7 +9,7 @@ import { compareBy, numberComparator } from '../../../../base/common/arrays.js';
 import { findFirstMax } from '../../../../base/common/arraysFind.js';
 import { BugIndicatingError } from '../../../../base/common/errors.js';
 import { Disposable, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
-import { IObservable, IReader, ITransaction, autorun, autorunWithStore, derived, disposableObservableValue, globalTransaction, observableFromEvent, observableValue, transaction } from '../../../../base/common/observable.js';
+import { IObservable, IReader, ITransaction, autorun, autorunWithStore, mapObservableArrayCached, derived, disposableObservableValue, globalTransaction, observableFromEvent, observableValue, transaction } from '../../../../base/common/observable.js';
 import { Scrollable, ScrollbarVisibility } from '../../../../base/common/scrollable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
@@ -130,30 +130,20 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 		}));
 		this.scrollTop = observableFromEvent(this, this._scrollableElement.onScroll, () => /** @description scrollTop */ this._scrollableElement.getScrollPosition().scrollTop);
 		this.scrollLeft = observableFromEvent(this, this._scrollableElement.onScroll, () => /** @description scrollLeft */ this._scrollableElement.getScrollPosition().scrollLeft);
-		this._viewItemsInfo = derived<{ items: readonly VirtualizedViewItem[]; getItem: (viewModel: DocumentDiffItemViewModel) => VirtualizedViewItem }>(this,
-			(reader) => {
-				const vm = this._viewModel.read(reader);
-				if (!vm) {
-					return { items: [], getItem: _d => { throw new BugIndicatingError(); } };
-				}
-				const viewModels = vm.items.read(reader);
-				const map = new Map<DocumentDiffItemViewModel, VirtualizedViewItem>();
-				const items = viewModels.map(d => {
-					const item = reader.store.add(new VirtualizedViewItem(d, this._objectPool, this.scrollLeft, delta => {
-						this._scrollableElement.setScrollPosition({ scrollTop: this._scrollableElement.getScrollPosition().scrollTop + delta });
-					}));
-					const data = this._lastDocStates?.[item.getKey()];
-					if (data) {
-						transaction(tx => {
-							item.setViewState(data, tx);
-						});
-					}
-					map.set(d, item);
-					return item;
-				});
-				return { items, getItem: d => map.get(d)! };
-			}
-		);
+		const viewModels = derived(this, reader => this._viewModel.read(reader)?.items.read(reader) ?? []);
+		const virtualItems = mapObservableArrayCached(this, viewModels, (d, store) => {
+			const item = store.add(new VirtualizedViewItem(d, this._objectPool, this.scrollLeft, delta => {
+				this._scrollableElement.setScrollPosition({ scrollTop: this._scrollableElement.getScrollPosition().scrollTop + delta });
+			}));
+			const data = this._lastDocStates?.[item.getKey()];
+			if (data) transaction(tx => item.setViewState(data, tx));
+			return item;
+		});
+		this._viewItemsInfo = derived(this, reader => {
+			const items = virtualItems.read(reader);
+			const map = new Map(items.map(item => [item.viewModel, item]));
+			return { items, getItem: (d: DocumentDiffItemViewModel) => map.get(d)! };
+		});
 		this._viewItems = this._viewItemsInfo.map(this, items => items.items);
 		this._spaceBetweenPx = 0;
 		this.contentHeight = this._viewItems.map(this, (items, reader) => items.reduce((r, i) => r + i.contentHeight.read(reader) + this._spaceBetweenPx, 0));
@@ -224,6 +214,9 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 
 		this._scrollableElements.content.style.position = 'relative';
 
+		let previousItems: readonly VirtualizedViewItem[] = [];
+		let previousHeights: number[] = [];
+		let previousModel: MultiDiffEditorViewModel | undefined;
 		this._register(autorun((reader) => {
 			/** @description Update scroll dimensions */
 			const height = this._sizeObserver.height.read(reader);
@@ -235,6 +228,29 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 
 			let scrollWidth = width;
 			const viewItems = this._viewItems.read(reader);
+			const model = this._viewModel.read(reader);
+			let anchoredScrollTop: number | undefined;
+			// Streaming inserts files before the viewport, then their measured
+			// heights replace estimates. Anchor both updates to the same existing
+			// file and pixel offset; preserving only insertions still causes jumps.
+			if (model === previousModel) {
+				const oldTop = this._scrollableElement.getScrollPosition().scrollTop + this._scrollStart();
+				let before = 0;
+				for (let i = 0; i < previousItems.length; i++) {
+					if (oldTop < before + previousHeights[i]) {
+						const index = viewItems.indexOf(previousItems[i]);
+						if (index >= 0) {
+							const newBefore = viewItems.slice(0, index).reduce((sum, item) => sum + item.contentHeight.get() + this._spaceBetweenPx, 0);
+							anchoredScrollTop = newBefore + oldTop - before - this._scrollStart();
+						}
+						break;
+					}
+					before += previousHeights[i];
+				}
+			}
+			previousItems = viewItems;
+			previousHeights = viewItems.map(item => item.contentHeight.read(reader) + this._spaceBetweenPx);
+			previousModel = model;
 			const max = findFirstMax(viewItems, compareBy(i => i.maxScroll.read(reader).maxScroll, numberComparator));
 			if (max) {
 				const maxScroll = max.maxScroll.read(reader);
@@ -252,6 +268,10 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 					: totalHeight,
 				scrollWidth,
 			});
+
+			if (anchoredScrollTop !== undefined && anchoredScrollTop !== this._scrollableElement.getScrollPosition().scrollTop) {
+				this._scrollableElement.setScrollPosition({ scrollTop: anchoredScrollTop });
+			}
 
 			// A restored scroll offset applied before the model updated these
 			// dimensions would be clamped against a stale (often 0) scrollHeight, so

--- a/apps/review-desktop/code-oss/src/vs/editor/common/config/editorOptions.ts
+++ b/apps/review-desktop/code-oss/src/vs/editor/common/config/editorOptions.ts
@@ -51,6 +51,8 @@ export const enum EditorAutoIndentStrategy {
  * Configuration options for the editor.
  */
 export interface IEditorOptions {
+	/** @internal Enables folding in the structural diff experiment only. */
+	experimentalDiffFolding?: boolean;
 	/**
 	 * This editor is used inside a diff editor.
 	 */

--- a/apps/review-desktop/code-oss/src/vs/editor/common/diff/documentDiffProvider.ts
+++ b/apps/review-desktop/code-oss/src/vs/editor/common/diff/documentDiffProvider.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken } from '../../../base/common/cancellation.js';
+import { IRange } from '../core/range.js';
 import { Event } from '../../../base/common/event.js';
 import { MovedText } from './linesDiffComputer.js';
 import { DetailedLineRangeMapping } from './rangeMapping.js';
@@ -54,6 +55,18 @@ export interface IDocumentDiffProviderOptions {
  * @internal
  */
 export interface IDocumentDiff {
+	/** Authoritative change paint, independent of replacement ranges used for layout.
+	 * When present (even empty), replaces inferred line and character highlighting. */
+	readonly changeHighlights?: {
+		readonly original: readonly IRange[];
+		readonly modified: readonly IRange[];
+		/** One-based source lines receiving a lighter whole-line background. */
+		readonly originalLines?: readonly number[];
+		readonly modifiedLines?: readonly number[];
+	};
+	/** Optional authoritative zero-based source row correspondence. Null denotes padding. */
+	readonly contextGaps?: readonly { originalStart: number; modifiedStart: number; originalCount: number; modifiedCount: number }[];
+	readonly sourceLineAlignment?: readonly (readonly [number | null, number | null])[];
 	/**
 	 * If true, both text models are identical (byte-wise).
 	 */

--- a/apps/review-desktop/code-oss/src/vs/editor/common/diff/sourceLineAlignment.ts
+++ b/apps/review-desktop/code-oss/src/vs/editor/common/diff/sourceLineAlignment.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface SourceAlignmentSegment {
+	leftStart: number;
+	leftEnd: number;
+	rightStart: number;
+	rightEnd: number;
+	leftHeight: number;
+	rightHeight: number;
+}
+
+/** Heights are zero for folded lines. Only visible paired lines remain anchors. */
+export function projectSourceAlignment(
+	rows: readonly (readonly [number | null, number | null])[],
+	leftHeight: (line: number) => number,
+	rightHeight: (line: number) => number,
+): SourceAlignmentSegment[] {
+	const result: SourceAlignmentSegment[] = [];
+	let left = 0, right = 0, startLeft = 0, startRight = 0, heightLeft = 0, heightRight = 0;
+	const flush = () => {
+		if (left === startLeft && right === startRight) return;
+		result.push({ leftStart: startLeft, leftEnd: left, rightStart: startRight, rightEnd: right, leftHeight: heightLeft, rightHeight: heightRight });
+		startLeft = left; startRight = right; heightLeft = heightRight = 0;
+	};
+	for (const [l, r] of rows) {
+		const lh = l === null ? 0 : leftHeight(l);
+		const rh = r === null ? 0 : rightHeight(r);
+		if (l !== null && r !== null && lh > 0 && rh > 0) flush();
+		if (l !== null) left = l + 1;
+		if (r !== null) right = r + 1;
+		heightLeft += lh; heightRight += rh;
+	}
+	flush();
+	return result;
+}

--- a/apps/review-desktop/code-oss/src/vs/review/browser/media/review.css
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/media/review.css
@@ -1767,3 +1767,14 @@ body
   background: var(--review-comment-accent) !important;
   color: #fff !important;
 }
+
+/* Give commenting and folding separate hit targets in the Files view. */
+.review-files-editor .monaco-editor .margin-view-overlays .cldr:is(
+  .codicon-folding-expanded,
+  .codicon-folding-collapsed,
+  .codicon-folding-manual-expanded,
+  .codicon-folding-manual-collapsed
+) {
+  margin-left: 30px;
+  width: 20px !important;
+}

--- a/apps/review-desktop/code-oss/src/vs/review/browser/media/review.css
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/media/review.css
@@ -1778,3 +1778,31 @@ body
   margin-left: 30px;
   width: 20px !important;
 }
+
+.review-files-editor-diffs { position: relative; }
+.review-structural-stream-status:not([hidden]) {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 24px;
+  color: var(--vscode-descriptionForeground);
+  background: var(--vscode-editor-background);
+}
+.review-structural-stream-status.loading::before {
+  content: "";
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: review-structural-loading 1s linear infinite;
+}
+@keyframes review-structural-loading { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .review-structural-stream-status.loading::before { animation: none; }
+}

--- a/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/parts/canvas/reviewCanvasPart.ts
@@ -91,6 +91,7 @@ import type {
 import {
 	REVIEW_KEYMAP_SETTING,
 	REVIEW_SOFTWARE_MAP_SETTING,
+	REVIEW_STRUCTURAL_DIFF_SETTING,
 	REVIEW_TELEMETRY_SETTING,
 } from "../../../common/reviewConfigurationDefaults.js";
 import {
@@ -309,7 +310,8 @@ export class ReviewCanvasEditorPane extends EditorPane {
 		);
 		this._register(
 			configurationService.onDidChangeConfiguration((event) => {
-				if (!event.affectsConfiguration(REVIEW_SOFTWARE_MAP_SETTING)) return;
+				if (!event.affectsConfiguration(REVIEW_SOFTWARE_MAP_SETTING) &&
+					!event.affectsConfiguration(REVIEW_STRUCTURAL_DIFF_SETTING)) return;
 				const input = this.renderedInput;
 				const model = this.renderedModel;
 				if (!input || !model || model.state !== "active") return;
@@ -928,6 +930,13 @@ export class ReviewCanvasEditorPane extends EditorPane {
 				);
 				return this.currentSoftwareMapEnabled();
 			},
+			structuralDiffEnabled: this.currentStructuralDiffEnabled(),
+			setStructuralDiffEnabled: async (enabled) => {
+				await this.configurationService.updateValue(
+					REVIEW_STRUCTURAL_DIFF_SETTING, enabled, ConfigurationTarget.USER,
+				);
+				return this.currentStructuralDiffEnabled();
+			},
 			manageExtensions: () =>
 				void this.commandService.executeCommand("review.manageExtensions"),
 		};
@@ -955,6 +964,10 @@ export class ReviewCanvasEditorPane extends EditorPane {
 				REVIEW_KEYMAP_SETTING,
 			) ?? "none"
 		);
+	}
+
+	private currentStructuralDiffEnabled(): boolean {
+		return this.configurationService.getValue<boolean>(REVIEW_STRUCTURAL_DIFF_SETTING) === true;
 	}
 
 	private currentSoftwareMapEnabled(): boolean {
@@ -1245,6 +1258,7 @@ export class ReviewCanvasEditorPane extends EditorPane {
 					document,
 					softwareMap,
 					softwareMapEnabled,
+					structuralDiffEnabled: this.currentStructuralDiffEnabled(),
 					reviewErrors: this.sessionService.reviewErrors,
 					commits: model.session.review.commits ?? [],
 					range: {
@@ -1590,6 +1604,7 @@ export class ReviewCanvasEditorPane extends EditorPane {
 				document: documentPromise,
 				softwareMap: softwareMapPromise,
 				softwareMapEnabled: true,
+				structuralDiffEnabled: this.currentStructuralDiffEnabled(),
 				reviewErrors: this.sessionService.reviewErrors,
 				commits: session.review.commits ?? [],
 				range: {

--- a/apps/review-desktop/code-oss/src/vs/review/browser/reviewChangedFilesTree.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/reviewChangedFilesTree.ts
@@ -128,6 +128,8 @@ class ChangedFilesTreeRenderer
   static readonly TEMPLATE_ID = "review.changedFiles.entry";
   readonly templateId = ChangedFilesTreeRenderer.TEMPLATE_ID;
 
+  constructor(private readonly states: Map<string, { status: "loading" | "error"; message?: string }>) {}
+
   renderTemplate(container: HTMLElement): ChangedFilesTreeTemplate {
     const row = append(container, $(".review-changed-files-row"));
     const icon = append(row, $("span.review-changed-files-icon"));
@@ -166,6 +168,10 @@ class ChangedFilesTreeRenderer
     template.icon.className = isFile
       ? `review-changed-files-icon review-changed-files-icon-${element.file.status} ${ThemeIcon.asClassName(fileStatusIcon(element.file.status))}`
       : "review-changed-files-icon";
+    const state = isFile ? this.states.get(element.file.path) : undefined;
+    if (state) template.icon.className = `review-changed-files-icon codicon codicon-${state.status === "loading" ? "loading codicon-modifier-spin" : "error"}`;
+    template.row.title = state?.message ?? (state?.status === "loading" ? "Loading diff…" : "");
+    template.row.setAttribute("aria-busy", String(state?.status === "loading"));
     template.label.textContent = isFile
       ? element.name
       : elements.map((item) => item.name).join("/");
@@ -186,6 +192,7 @@ export class ReviewChangedFilesTree extends Disposable {
   >;
   private readonly fileElements = new Map<string, ChangedFileElement>();
   private files: readonly ReviewDiffFileWire[] = [];
+  private readonly states = new Map<string, { status: "loading" | "error"; message?: string }>();
   private activePath: string | undefined;
   private syncingActiveFile = false;
 
@@ -199,7 +206,7 @@ export class ReviewChangedFilesTree extends Disposable {
       container,
       $(".review-changed-files-tree"),
     );
-    const renderer = new ChangedFilesTreeRenderer();
+    const renderer = new ChangedFilesTreeRenderer(this.states);
     this.tree = this._register(
       instantiationService.createInstance(
         WorkbenchCompressibleObjectTree<ChangedTreeElement, void>,
@@ -254,9 +261,17 @@ export class ReviewChangedFilesTree extends Disposable {
     this.refresh(selectedPath);
   }
 
-  setActiveFile(path: string | undefined): void {
+  setFileState(path: string, status: "loading" | "error" | undefined, message?: string): void {
+    if (status) this.states.set(path, { status, message });
+    else this.states.delete(path);
+    const element = this.fileElements.get(path);
+    if (element) this.tree.rerender(element);
+  }
+
+  setActiveFile(path: string | undefined, reveal = true): void {
+    if (!reveal && this.activePath === path) return;
     this.activePath = path;
-    this.syncSelection(path);
+    this.syncSelection(path, reveal);
   }
 
   layout(height: number, width: number): void {
@@ -271,13 +286,13 @@ export class ReviewChangedFilesTree extends Disposable {
     this.syncSelection(this.activePath ?? selectedPath);
   }
 
-  private syncSelection(path: string | undefined): void {
+  private syncSelection(path: string | undefined, reveal = true): void {
     const element = path ? this.fileElements.get(path) : undefined;
     this.syncingActiveFile = true;
     try {
       this.tree.setSelection(element ? [element] : []);
       this.tree.setFocus(element ? [element] : []);
-      if (element) this.tree.reveal(element);
+      if (element && reveal) this.tree.reveal(element);
     } finally {
       this.syncingActiveFile = false;
     }

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewConfiguration.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewConfiguration.ts
@@ -20,7 +20,7 @@
 import { localize } from '../../nls.js';
 import { Registry } from '../../platform/registry/common/platform.js';
 import { ConfigurationScope, Extensions, type IConfigurationRegistry } from '../../platform/configuration/common/configurationRegistry.js';
-import { REVIEW_KEYMAPS, REVIEW_KEYMAP_SETTING, REVIEW_SOFTWARE_MAP_SETTING, REVIEW_TELEMETRY_SETTING, curatedExtensionConfigurationDefaults, reviewConfigurationDefaults } from './reviewConfigurationDefaults.js';
+import { REVIEW_KEYMAPS, REVIEW_KEYMAP_SETTING, REVIEW_SOFTWARE_MAP_SETTING, REVIEW_STRUCTURAL_DIFF_SETTING, REVIEW_TELEMETRY_SETTING, curatedExtensionConfigurationDefaults, reviewConfigurationDefaults } from './reviewConfigurationDefaults.js';
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
 
@@ -40,6 +40,11 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			default: true,
 			description: localize('review.telemetry.enabled', "Send anonymous Review usage data."),
+		},
+		[REVIEW_STRUCTURAL_DIFF_SETTING]: {
+			type: 'boolean',
+			default: false,
+			description: localize('review.experimental.structuralDiff.enabled', "Replace the standard diff view with structural diffs from diffr. Requires the diffr CLI."),
 		},
 		[REVIEW_SOFTWARE_MAP_SETTING]: {
 			type: 'boolean',

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewConfigurationDefaults.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewConfigurationDefaults.ts
@@ -24,12 +24,14 @@
 
 export const REVIEW_KEYMAP_SETTING = 'review.keymap';
 export const REVIEW_TELEMETRY_SETTING = 'review.telemetry.enabled';
+export const REVIEW_STRUCTURAL_DIFF_SETTING = 'review.experimental.structuralDiff.enabled';
 export const REVIEW_SOFTWARE_MAP_SETTING = 'review.experimental.softwareMap.enabled';
 export const REVIEW_KEYMAPS = ['none', 'vim', 'emacs'] as const;
 export type ReviewKeymap = typeof REVIEW_KEYMAPS[number];
 
 export const reviewConfigurationDefaults = {
 	[REVIEW_SOFTWARE_MAP_SETTING]: false,
+	[REVIEW_STRUCTURAL_DIFF_SETTING]: false,
 	[REVIEW_TELEMETRY_SETTING]: true,
 	'telemetry.telemetryLevel': 'off',
 	'telemetry.enableTelemetry': false,

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewStructuralDiff.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewStructuralDiff.test.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { projectSourceAlignment } from "../../editor/common/diff/sourceLineAlignment.js";
+import {
+  nativeFoldRange,
+  structuralRows,
+  utf16Column,
+  type StructuralDiff,
+} from "./reviewStructuralDiff.js";
+
+test("paired collapse removes hidden height without leaving padding for hidden anchors", () => {
+  const rows: [number | null, number | null][] = [
+    [0, 0],
+    [1, 1],
+    [null, 2],
+    [2, 3],
+    [3, 4],
+  ];
+  const segments = projectSourceAlignment(
+    rows,
+    (l) => (l === 1 || l === 2 ? 0 : 20),
+    (r) => (r >= 1 && r <= 3 ? 0 : 20),
+  );
+  assert.deepEqual(
+    segments.map((s) => [s.leftEnd, s.rightEnd, s.rightHeight - s.leftHeight]),
+    [
+      [3, 4, 0],
+      [4, 5, 0],
+    ],
+  );
+});
+
+test("one-sided collapse pads before the next surviving anchor", () => {
+  const segments = projectSourceAlignment(
+    [
+      [0, 0],
+      [1, 1],
+      [2, 2],
+    ],
+    (l) => (l === 1 ? 0 : 20),
+    () => 20,
+  );
+  assert.equal(segments[0].rightHeight - segments[0].leftHeight, 20);
+  assert.equal(segments[1].leftStart, 2);
+  assert.equal(segments[1].rightStart, 2);
+});
+
+test("wrapping contributes height without changing correspondence", () => {
+  const segments = projectSourceAlignment(
+    [
+      [0, 0],
+      [1, 1],
+    ],
+    () => 20,
+    (r) => (r === 0 ? 60 : 20),
+  );
+  assert.equal(segments[0].rightHeight - segments[0].leftHeight, 40);
+  assert.equal(segments[1].leftStart, 1);
+});
+
+test("hunk alignment survives context overlap and fills omitted context", () => {
+  const diff = {
+    lhs_src: { Text: "a\nb\nc\nd\n" },
+    rhs_src: { Text: "a\nx\nb\nc\nd\n" },
+    hunks: [
+      {
+        lines: [
+          [0, 0],
+          [null, 1],
+          [1, 2],
+        ],
+      },
+      {
+        lines: [
+          [1, 2],
+          [2, 3],
+        ],
+      },
+    ],
+  } as StructuralDiff;
+  assert.deepEqual(structuralRows(diff), [
+    [0, 0],
+    [null, 1],
+    [1, 2],
+    [2, 3],
+    [3, 4],
+    [4, 5],
+  ]);
+});
+
+test("fold endpoints are exclusive and inline ranges cannot become native line folds", () => {
+  assert.deepEqual(
+    nativeFoldRange({ start: { line: 2, byte_column: 0 }, end: { line: 5, byte_column: 0 } }),
+    { start: 3, end: 5 },
+  );
+  assert.equal(
+    nativeFoldRange({ start: { line: 2, byte_column: 1 }, end: { line: 2, byte_column: 8 } }),
+    undefined,
+  );
+});
+
+test("Tree-sitter byte offsets convert to Monaco UTF-16 columns", () => {
+  assert.equal(utf16Column("a😀éz", 7), 5);
+  assert.throws(() => utf16Column("a😀éz", 2), /UTF-8 boundary/);
+});

--- a/apps/review-desktop/code-oss/src/vs/review/common/reviewStructuralDiff.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/common/reviewStructuralDiff.ts
@@ -1,0 +1,138 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/** Lossless subset of diffr's v1 domain wire used by the native experiment. */
+export interface StructuralRange {
+  start: { line: number; byte_column: number };
+  end: { line: number; byte_column: number };
+}
+export interface StructuralFold {
+  range: StructuralRange;
+  tags: string[];
+  placeholder: string;
+  match_kind: "Novel" | { Unchanged: { opposite: StructuralRange } };
+}
+export interface StructuralPosition {
+  pos: { line: number; start_col: number; end_col: number };
+  kind: Record<string, { highlight: unknown }>;
+}
+export interface StructuralDiff {
+  lhs_src: { Text: string } | "Binary";
+  rhs_src: { Text: string } | "Binary";
+  hunks: { lines: [number | null, number | null][]; novel_lhs: number[]; novel_rhs: number[] }[];
+  aligned_rows?: [number | null, number | null][];
+  lhs_folds: StructuralFold[];
+  rhs_folds: StructuralFold[];
+  lhs_positions: StructuralPosition[];
+  rhs_positions: StructuralPosition[];
+}
+export interface StructuralFileEvent {
+  type: "file";
+  file: { old_path: string | null; new_path: string | null };
+  diff: StructuralDiff;
+}
+
+/** Monaco keeps a final empty line after a newline; the wire need not mention it. */
+export function structuralRows(diff: StructuralDiff): [number | null, number | null][] {
+  if (diff.lhs_src === "Binary" || diff.rhs_src === "Binary") return [];
+  const leftCount = diff.lhs_src.Text.split("\n").length;
+  const rightCount = diff.rhs_src.Text.split("\n").length;
+  const result: [number | null, number | null][] = [];
+  let left = 0,
+    right = 0;
+  function gap(leftEnd: number, rightEnd: number) {
+    while (left < leftEnd || right < rightEnd) {
+      result.push([left < leftEnd ? left++ : null, right < rightEnd ? right++ : null]);
+    }
+  }
+  for (const lines of diff.aligned_rows ? [diff.aligned_rows] : diff.hunks.map(hunk => hunk.lines)) {
+    for (const [l, r] of lines) {
+      // Context in neighboring hunks can overlap. Consumed rows must agree.
+      if ((l === null || l < left) && (r === null || r < right)) continue;
+      if ((l !== null && l < left) || (r !== null && r < right)) {
+        throw new Error("diffr supplied conflicting hunk alignment.");
+      }
+      if ((l !== null && l >= leftCount) || (r !== null && r >= rightCount)) {
+        throw new Error("diffr alignment exceeds the source.");
+      }
+      gap(l ?? left, r ?? right);
+      result.push([l, r]);
+      if (l !== null) left = l + 1;
+      if (r !== null) right = r + 1;
+    }
+  }
+  gap(leftCount, rightCount);
+  return result;
+}
+
+/** Native folding retains the first source line and hides following whole lines. */
+export function nativeFoldRange(
+  range: StructuralRange,
+): { start: number; end: number } | undefined {
+  const start = range.start.line + 1;
+  const end = range.end.line + (range.end.byte_column === 0 ? 0 : 1);
+  return end > start ? { start, end } : undefined;
+}
+
+export function utf16Column(text: string, byteColumn: number): number {
+  let bytes = 0,
+    units = 0;
+  for (const character of text) {
+    if (bytes >= byteColumn) break;
+    bytes += new TextEncoder().encode(character).length;
+    units += character.length;
+  }
+  if (bytes !== byteColumn) throw new Error("diffr position is not on a UTF-8 boundary.");
+  return units + 1;
+}
+
+/** Only engine-classified novel lines and spans receive change paint. Text inequality is layout-only. */
+export function structuralHighlights(diff: StructuralDiff) {
+  function side(source: StructuralDiff["lhs_src"], positions: StructuralPosition[]) {
+    if (source === "Binary") return [];
+    const lines = source.Text.replace(/\r\n/g, "\n").split("\n");
+    return positions.filter(p => "Novel" in p.kind || "NovelWord" in p.kind).map(({ pos }) => ({
+      startLineNumber: pos.line + 1,
+      startColumn: utf16Column(lines[pos.line], pos.start_col),
+      endLineNumber: pos.line + 1,
+      endColumn: utf16Column(lines[pos.line], pos.end_col),
+    }));
+  }
+  return {
+    original: side(diff.lhs_src, diff.lhs_positions),
+    modified: side(diff.rhs_src, diff.rhs_positions),
+    originalLines: [...new Set(diff.hunks.flatMap(hunk => hunk.novel_lhs))].map(line => line + 1),
+    modifiedLines: [...new Set(diff.hunks.flatMap(hunk => hunk.novel_rhs))].map(line => line + 1),
+  };
+}
+
+/** Omitted hunk rows remain available for explicit context expansion. */
+export function structuralContextGaps(diff: StructuralDiff) {
+  const selected = [new Set<number>(), new Set<number>()];
+  for (const hunk of diff.hunks) for (const row of hunk.lines)
+    row.forEach((line, side) => { if (line !== null) selected[side].add(line); });
+  const gaps: { originalStart: number; modifiedStart: number; originalCount: number; modifiedCount: number }[] = [];
+  let original = 1, modified = 1;
+  let gap: typeof gaps[number] | undefined;
+  let mask = "";
+  for (const [lhs, rhs] of structuralRows(diff)) {
+    const hideLeft = lhs !== null && !selected[0].has(lhs);
+    const hideRight = rhs !== null && !selected[1].has(rhs);
+    const nextMask = `${hideLeft}:${hideRight}`;
+    if (!hideLeft && !hideRight) { gap = undefined; mask = ""; }
+    else {
+      if (!gap || mask !== nextMask) {
+        gap = { originalStart: original, modifiedStart: modified, originalCount: 0, modifiedCount: 0 };
+        gaps.push(gap);
+        mask = nextMask;
+      }
+      if (hideLeft) gap.originalCount++;
+      if (hideRight) gap.modifiedCount++;
+    }
+    if (lhs !== null) original = lhs + 2;
+    if (rhs !== null) modified = rhs + 2;
+  }
+  return gaps;
+}

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffViewService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffViewService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { prepareStructuralReview } from "./reviewStructuralDiff.js";
 import { Emitter } from "../../base/common/event.js";
 import {
   Disposable,
@@ -152,17 +153,20 @@ class DiffViewHandle extends Disposable implements ReviewDiffViewHandle {
       );
       if (this.disposed) return;
       const store = this._register(new DisposableStore());
+      const structural = await prepareStructuralReview(this.instantiationService, entries, this.spec.scope, store);
+      if (this.disposed) return;
       // The input owns the text-model references its view model resolves, so
       // this handle disposes it alongside the view.
       const input = store.add(
-        this.instantiationService.createInstance(
+        structural.instantiation.createInstance(
           ReviewFilesEditorInput,
           reviewFilesSourceUri(session, this.spec.scope),
-          entries,
+          structural.entries,
+          structural.enabled,
         ),
       );
       const view = store.add(
-        this.instantiationService.createInstance(
+        structural.instantiation.createInstance(
           ReviewFilesDiffView,
           this.spec.container,
           this.overflowWidgetsDomNode,

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffViewService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffViewService.ts
@@ -160,7 +160,7 @@ class DiffViewHandle extends Disposable implements ReviewDiffViewHandle {
       const store = this._register(new DisposableStore());
       const structural = structuralEnabled
         ? await prepareStructuralReview(this.instantiationService, entries, this.spec.scope, store)
-        : { instantiation: this.instantiationService, entries, enabled: false };
+        : { instantiation: this.instantiationService, entries, enabled: false, load: undefined };
       if (this.disposed) return;
       // The input owns the text-model references its view model resolves, so
       // this handle disposes it alongside the view.
@@ -180,12 +180,21 @@ class DiffViewHandle extends Disposable implements ReviewDiffViewHandle {
         ),
       );
       this.view = view;
+      if (structural.enabled) view.startLoading(structural.entries);
       store.add(
         view.onDidChangeActiveControl(() => this.bindActiveControl(view)),
       );
-      await view.setInput(input, this.viewStates.get(this.viewStateKey));
+      // A saved whole-list offset cannot be restored into a partial streamed list.
+      await view.setInput(input, structural.enabled ? undefined : this.viewStates.get(this.viewStateKey));
       if (this.disposed) return;
       this.bindActiveControl(view);
+      if (structural.load) {
+        void structural.load((path, error) => {
+          if (!this.disposed) view.fileLoaded(path, error);
+        }).catch(error => {
+          if (!this.disposed) view.loadingFailed(error instanceof Error ? error.message : String(error));
+        });
+      }
     } catch (error) {
       if (this.disposed) return;
       this._onDidError.fire(

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffViewService.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewDiffViewService.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IConfigurationService } from "../../platform/configuration/common/configuration.js";
+import { REVIEW_STRUCTURAL_DIFF_SETTING } from "../common/reviewConfigurationDefaults.js";
 import { prepareStructuralReview } from "./reviewStructuralDiff.js";
 import { Emitter } from "../../base/common/event.js";
 import {
@@ -146,14 +148,19 @@ class DiffViewHandle extends Disposable implements ReviewDiffViewHandle {
     try {
       const session = this.sessionModelService.activeModel?.session;
       if (!session) throw new Error("No active Review Desktop session.");
-      this.viewStateKey = `${session.session.sessionId}:${session.session.routePath ?? "/"}:${this.spec.scope?.commit ?? "full"}`;
+      const structuralEnabled = this.instantiationService.invokeFunction((a) =>
+        a.get(IConfigurationService).getValue<boolean>(REVIEW_STRUCTURAL_DIFF_SETTING) === true,
+      );
+      this.viewStateKey = `${session.session.sessionId}:${session.session.routePath ?? "/"}:${this.spec.scope?.commit ?? "full"}:${structuralEnabled}`;
       const entries = await buildReviewFilesEntries(
         this.codeResources,
         this.spec.scope,
       );
       if (this.disposed) return;
       const store = this._register(new DisposableStore());
-      const structural = await prepareStructuralReview(this.instantiationService, entries, this.spec.scope, store);
+      const structural = structuralEnabled
+        ? await prepareStructuralReview(this.instantiationService, entries, this.spec.scope, store)
+        : { instantiation: this.instantiationService, entries, enabled: false };
       if (this.disposed) return;
       // The input owns the text-model references its view model resolves, so
       // this handle disposes it alongside the view.

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewFilesDiffView.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewFilesDiffView.ts
@@ -121,6 +121,7 @@ export class ReviewFilesEditorInput extends MultiDiffEditorInput {
   constructor(
     source: URI,
     readonly entries: readonly ReviewFilesEditorEntry[],
+    structural: boolean,
     @ITextModelService textModelService: ITextModelService,
     @ITextResourceConfigurationService
     textResourceConfigurationService: ITextResourceConfigurationService,
@@ -141,7 +142,7 @@ export class ReviewFilesEditorInput extends MultiDiffEditorInput {
             undefined,
             undefined,
             reviewMultiDiffLabelUris(entry.file),
-            REVIEW_FILES_DIFF_EDITOR_OPTIONS,
+            structural ? { ...REVIEW_FILES_DIFF_EDITOR_OPTIONS, hideUnchangedRegions: { enabled: true }, folding: true, lineDecorationsWidth: 40, experimentalDiffFolding: true, showFoldingControls: "always", experimental: { useTrueInlineView: false } } : REVIEW_FILES_DIFF_EDITOR_OPTIONS,
           ),
       ),
       true,

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewFilesDiffView.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewFilesDiffView.ts
@@ -14,6 +14,7 @@ import {
   Orientation,
   SplitView,
 } from "../../base/browser/ui/splitview/splitview.js";
+import { autorun } from "../../base/common/observable.js";
 import { Emitter, Event } from "../../base/common/event.js";
 import { Disposable, toDisposable } from "../../base/common/lifecycle.js";
 import { isEqual } from "../../base/common/resources.js";
@@ -118,6 +119,10 @@ export class ReviewFilesEditorInput extends MultiDiffEditorInput {
   static override readonly ID = "workbench.input.devfast.reviewFiles";
   static readonly EDITOR_ID = "workbench.editor.devfast.reviewFiles";
 
+  private readonly updateResources: (paths: ReadonlySet<string>) => void;
+
+  setReadyFiles(paths: ReadonlySet<string>): void { this.updateResources(paths); }
+
   constructor(
     source: URI,
     readonly entries: readonly ReviewFilesEditorEntry[],
@@ -130,10 +135,7 @@ export class ReviewFilesEditorInput extends MultiDiffEditorInput {
     multiDiffSourceResolverService: IMultiDiffSourceResolverService,
     @ITextFileService textFileService: ITextFileService,
   ) {
-    super(
-      source,
-      "Files",
-      entries.map(
+    const items = entries.map(
         (entry) =>
           new MultiDiffEditorItem(
             entry.original,
@@ -144,14 +146,30 @@ export class ReviewFilesEditorInput extends MultiDiffEditorInput {
             reviewMultiDiffLabelUris(entry.file),
             structural ? { ...REVIEW_FILES_DIFF_EDITOR_OPTIONS, hideUnchangedRegions: { enabled: true }, folding: true, lineDecorationsWidth: 40, experimentalDiffFolding: true, showFoldingControls: "always", experimental: { useTrueInlineView: false } } : REVIEW_FILES_DIFF_EDITOR_OPTIONS,
           ),
-      ),
+      );
+    const changes = new Emitter<void>();
+    let current: readonly MultiDiffEditorItem[] = [];
+    const streamSource = { resources: { get value() { return current; }, onDidChange: changes.event } };
+    super(
+      source,
+      "Files",
+      structural ? undefined : items,
       true,
       textModelService,
       textResourceConfigurationService,
       instantiationService,
-      multiDiffSourceResolverService,
+      structural ? {
+        _serviceBrand: undefined,
+        registerResolver: resolver => multiDiffSourceResolverService.registerResolver(resolver),
+        resolve: async () => streamSource,
+      } : multiDiffSourceResolverService,
       textFileService,
     );
+    this._register(changes);
+    this.updateResources = paths => {
+      current = items.filter((_, index) => paths.has(entries[index].file.path));
+      changes.fire();
+    };
   }
 
   override get typeId(): string {
@@ -183,6 +201,10 @@ export class ReviewFilesDiffView extends Disposable {
   private viewModel: MultiDiffEditorViewModel | undefined;
   private input: ReviewFilesEditorInput | undefined;
   private inlineCommentOpen = false;
+  private readonly readyFiles = new Set<string>();
+  private readonly fileStates = new Map<string, string>();
+  private pendingPath: string | undefined;
+  private readonly streamStatus: HTMLElement;
 
   constructor(
     private readonly container: HTMLElement,
@@ -235,6 +257,9 @@ export class ReviewFilesDiffView extends Disposable {
         undefined,
       ),
     );
+    this.streamStatus = append(diffContainer, $(".review-structural-stream-status"));
+    this.streamStatus.setAttribute("role", "status");
+    this.streamStatus.hidden = true;
     this._register(
       this.widget.onDidChangeActiveControl(() =>
         this._onDidChangeActiveControl.fire(),
@@ -273,6 +298,13 @@ export class ReviewFilesDiffView extends Disposable {
           (entry) => entry.file.path === file.path,
         );
         if (!element) return;
+        if (this.fileStates.has(file.path)) {
+          this.pendingPath = file.path;
+          this.showStreamStatus();
+          return;
+        }
+        this.pendingPath = undefined;
+        this.showStreamStatus();
         this.reveal({
           original: element.original,
           modified: element.modified,
@@ -328,6 +360,7 @@ export class ReviewFilesDiffView extends Disposable {
     viewState: IMultiDiffEditorViewState | undefined,
   ): Promise<void> {
     this.input = input;
+    this.changedFilesTree.setFiles(input.entries.map(entry => entry.file));
     const viewModel = await input.getViewModel();
     if (this._store.isDisposed) return;
     this.viewModel = viewModel;
@@ -336,6 +369,51 @@ export class ReviewFilesDiffView extends Disposable {
     this.widget.setViewModel(viewModel, { preserveFocus: true, viewState });
     this.changedFilesTree.setFiles(input.entries.map((entry) => entry.file));
     this.syncFileSelectionFromWidget();
+    this._register(autorun(reader => {
+      const items = viewModel.items.read(reader);
+      const entry = this.input?.entries.find(e => e.file.path === this.pendingPath);
+      if (!entry || !this.readyFiles.has(entry.file.path)) return;
+      if (!items.some(item => sameResource(item.originalUri, entry.original) && sameResource(item.modifiedUri, entry.modified))) return;
+      this.pendingPath = undefined;
+      this.showStreamStatus();
+      queueMicrotask(() => { if (!this._store.isDisposed) this.reveal(entry); });
+    }));
+  }
+
+  startLoading(entries: readonly ReviewFilesEditorEntry[]): void {
+    this.changedFilesTree.setFiles(entries.map(e => e.file));
+    for (const entry of entries) {
+      this.fileStates.set(entry.file.path, "Loading diff…");
+      this.changedFilesTree.setFileState(entry.file.path, "loading");
+    }
+    this.showStreamStatus();
+  }
+
+  fileLoaded(path: string, error?: string): void {
+    if (error) {
+      this.fileStates.set(path, error);
+      this.changedFilesTree.setFileState(path, "error", error);
+    } else {
+      this.fileStates.delete(path);
+      this.readyFiles.add(path);
+      this.changedFilesTree.setFileState(path, undefined);
+      this.input?.setReadyFiles(this.readyFiles);
+    }
+    this.showStreamStatus();
+  }
+
+  loadingFailed(message: string): void {
+    for (const [path, state] of this.fileStates) if (state === "Loading diff…") this.fileLoaded(path, message);
+    this.showStreamStatus();
+  }
+
+  private showStreamStatus(): void {
+    const message = this.pendingPath ? this.fileStates.get(this.pendingPath) : undefined;
+    this.streamStatus.hidden = !message && this.readyFiles.size > 0 || this.fileStates.size === 0;
+    this.streamStatus.textContent = message
+      ? `${this.pendingPath}: ${message}`
+      : this.readyFiles.size === 0 ? [...this.fileStates.values()][0] ?? "" : "";
+    this.streamStatus.classList.toggle("loading", [...this.fileStates.values()].some(s => s === "Loading diff…"));
   }
 
   getViewState(): IMultiDiffEditorViewState | undefined {
@@ -388,14 +466,15 @@ export class ReviewFilesDiffView extends Disposable {
   private syncFileSelectionFromWidget(): void {
     const resource = this.widget.getActiveItem();
     const input = this.input;
-    if (!resource || !input) return;
+    if (!resource || !input || this.pendingPath) return;
     const index = input.entries.findIndex(
       (entry) =>
         sameResource(entry.original, resource.original) &&
         sameResource(entry.modified, resource.modified),
     );
     if (index === -1) return;
-    this.changedFilesTree.setActiveFile(input.entries[index].file.path);
+    // Passive editor updates must not move a sidebar the reader scrolled independently.
+    this.changedFilesTree.setActiveFile(input.entries[index].file.path, false);
   }
 }
 function sameResource(left: URI | undefined, right: URI | undefined): boolean {

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewStructuralDiff.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewStructuralDiff.ts
@@ -7,7 +7,7 @@ import { IModelService } from "../../editor/common/services/model.js";
 import { ITextModelService } from "../../editor/common/services/resolverService.js";
 import { ILanguageService } from "../../editor/common/languages/language.js";
 import { reviewVirtualUri } from "../common/reviewCodeResources.js";
-import { Event } from "../../base/common/event.js";
+import { Emitter, Event } from "../../base/common/event.js";
 import { DisposableStore, toDisposable } from "../../base/common/lifecycle.js";
 import { CancellationError } from "../../base/common/errors.js";
 import { IInstantiationService } from "../../platform/instantiation/common/instantiation.js";
@@ -20,7 +20,7 @@ import { LineRange } from "../../editor/common/core/ranges/lineRange.js";
 import { DetailedLineRangeMapping } from "../../editor/common/diff/rangeMapping.js";
 import { FoldingController } from "../../editor/contrib/folding/browser/folding.js";
 import type { FoldingModel } from "../../editor/contrib/folding/browser/foldingModel.js";
-import { FoldingRangeKind } from "../../editor/common/languages.js";
+import { FoldingRangeKind, type FoldingRangeProvider } from "../../editor/common/languages.js";
 import { IReviewSessionModelService } from "./reviewSessionModelService.js";
 import { reviewDiffFilesUrl } from "../common/reviewReveal.js";
 import {
@@ -44,80 +44,111 @@ export async function prepareStructuralReview(
   instantiation: IInstantiationService;
   enabled: boolean;
   entries: readonly ReviewFilesEditorEntry[];
+  load(onFile: (path: string, error?: string) => void): Promise<void>;
 }> {
   const sessionModel = instantiation.invokeFunction((a) =>
     a.get(IReviewSessionModelService),
   ).activeModel;
   if (!sessionModel) throw new Error("Review session is unavailable.");
-  const abort = new AbortController();
-  lifetime.add(toDisposable(() => abort.abort()));
   const session = sessionModel.session;
-  const url = reviewDiffFilesUrl(session.sessionUrl, session.session.routePath ?? "/");
-  url.pathname = url.pathname.replace(/diff-files$/, "structural-diff");
-  const response = await sessionModel.request(String(url), {
-    method: "POST",
-    headers: { "x-review-token": session.token, "content-type": "application/json" },
-    body: JSON.stringify({ commit: scope?.commit }),
-    signal: abort.signal,
-  });
-  const body = await response.json();
-  if (!response.ok || !body.ok) throw new Error(body.error ?? "Structural diff request failed.");
-  if (lifetime.isDisposed) throw new CancellationError();
-  if (!body.enabled) throw new Error("This Review server does not have structural diffs enabled. Configure diffr on the host and restart Review.");
   const files = new Map<string, StructuralDiff>();
-  for (const event of body.events as StructuralFileEvent[]) {
-    if (event.type === "file") files.set(event.file.new_path ?? event.file.old_path!, event.diff);
-  }
+  const changed = lifetime.add(new Emitter<void>());
   // Use pinned checkout resources so native language providers see real project files.
   // Revision-only resources retain their virtual snapshot identity.
   const modelService = instantiation.invokeFunction((a) => a.get(IModelService));
   const resolver = instantiation.invokeFunction((a) => a.get(ITextModelService));
   const languages = instantiation.invokeFunction((a) => a.get(ILanguageService));
-  entries = await Promise.all(
-    entries.map(async (entry) => {
-      const diff = files.get(entry.file.path);
-      if (!diff || diff.lhs_src === "Binary" || diff.rhs_src === "Binary") return entry;
-      const original = entry.original.scheme === "file" ? entry.original : reviewVirtualUri(
-        "base",
-        entry.file.previousPath ?? entry.file.path,
-        entry.file.path,
-        session.session.sessionId,
-        scope?.commit,
-      );
-      const modified = entry.modified.scheme === "file" ? entry.modified : reviewVirtualUri(
-        "head",
-        entry.file.path,
-        entry.file.path,
-        session.session.sessionId,
-        scope?.commit,
-      );
-      for (const [uri, text] of [
-        [original, diff.lhs_src.Text],
-        [modified, diff.rhs_src.Text],
-      ] as const) {
-        if (uri.scheme === "file") {
-          const reference = lifetime.add(await resolver.createModelReference(uri));
-          if (reference.object.textEditorModel.getValue().replace(/\r\n/g, "\n") !== text.replace(/\r\n/g, "\n"))
-            throw new Error("Pinned checkout differs from diffr's source snapshot; reload the review.");
-          continue;
-        }
-        const existing = modelService.getModel(uri);
-        if (existing && existing.getValue().replace(/\r\n/g, "\n") !== text.replace(/\r\n/g, "\n"))
-          throw new Error("Structural snapshot changed; reload the review.");
-        if (!existing)
+  entries = entries.map(entry => ({
+    ...entry,
+    original: entry.original.scheme === "file" ? entry.original : reviewVirtualUri(
+      "base", entry.file.previousPath ?? entry.file.path, entry.file.path,
+      session.session.sessionId, scope?.commit,
+    ),
+    modified: entry.modified.scheme === "file" ? entry.modified : reviewVirtualUri(
+      "head", entry.file.path, entry.file.path, session.session.sessionId, scope?.commit,
+    ),
+  }));
+  const pairs = new Map(entries.map(e => [e.original.toString() + "\n" + e.modified.toString(), e.file.path]));
+  async function accept(event: StructuralFileEvent): Promise<string> {
+    const path = event.file.new_path ?? event.file.old_path!;
+    const entry = entries.find(e => e.file.path === path);
+    if (!entry) throw new Error(`diffr returned an unexpected file: ${path}`);
+    const diff = event.diff;
+    if (diff.lhs_src !== "Binary" && diff.rhs_src !== "Binary") {
+      for (const [uri, text] of [[entry.original, diff.lhs_src.Text], [entry.modified, diff.rhs_src.Text]] as const) {
+        if (uri.scheme !== "file" && !modelService.getModel(uri))
           modelService.createModel(text, languages.createByFilepathOrFirstLine(uri), uri);
-        lifetime.add(await resolver.createModelReference(uri));
+        const reference = lifetime.add(await resolver.createModelReference(uri));
+        if (reference.object.textEditorModel.getValue().replace(/\r\n/g, "\n") !== text.replace(/\r\n/g, "\n"))
+          throw new Error("Pinned checkout differs from diffr's source snapshot; reload the review.");
       }
-      return { ...entry, original, modified };
-    }),
-  );
-  if (lifetime.isDisposed) throw new CancellationError();
-  const pairs = new Map(
-    entries.map((e) => [
-      e.original.toString() + "\n" + e.modified.toString(),
-      files.get(e.file.path),
-    ]),
-  );
+    }
+    if (lifetime.isDisposed) throw new CancellationError();
+    files.set(path, diff);
+    changed.fire();
+    return path;
+  }
+  async function load(onFile: (path: string, error?: string) => void): Promise<void> {
+    const abort = new AbortController();
+    lifetime.add(toDisposable(() => abort.abort()));
+    const url = reviewDiffFilesUrl(session.sessionUrl, session.session.routePath ?? "/");
+    url.pathname = url.pathname.replace(/diff-files$/, "structural-diff");
+    const response = await sessionModel!.request(String(url), {
+      method: "POST",
+      headers: { "x-review-token": session.token, "content-type": "application/json" },
+      body: JSON.stringify({ commit: scope?.commit }), signal: abort.signal,
+    });
+    if (!response.ok) throw new Error((await response.json()).error ?? "Structural diff request failed.");
+    if (!response.body || !response.headers.get("content-type")?.includes("ndjson"))
+      throw new Error("The Review host must be updated to stream structural diffs.");
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "", started = false, complete = false;
+    const seen = new Set<string>();
+    async function line(text: string) {
+      if (!text.trim()) return;
+      const event = JSON.parse(text);
+      if (complete) throw new Error("diffr emitted data after completion.");
+      if (!started) {
+        if (event.type === "error") throw new Error(event.message);
+        if (event.type !== "start" || event.version !== 1) throw new Error("Unsupported diffr stream protocol.");
+        started = true;
+      } else if (event.type === "file" || event.type === "file_error") {
+        const path = event.file.new_path ?? event.file.old_path;
+        if (seen.has(path)) throw new Error(`diffr returned a duplicate file: ${path}`);
+        seen.add(path);
+        if (event.type === "file_error") onFile(path, event.message);
+        else {
+          try { onFile(await accept(event)); }
+          catch (error) {
+            if (lifetime.isDisposed) throw error;
+            onFile(path, error instanceof Error ? error.message : String(error));
+          }
+        }
+      } else if (event.type === "complete") complete = true;
+      else throw new Error(event.message ?? `Unexpected diffr event: ${event.type}`);
+    }
+    try {
+      while (true) {
+        const chunk = await reader.read();
+        buffer += decoder.decode(chunk.value, { stream: !chunk.done });
+        let end: number;
+        while ((end = buffer.indexOf("\n")) >= 0) {
+          const text = buffer.slice(0, end); buffer = buffer.slice(end + 1);
+          await line(text);
+        }
+        if (chunk.done) break;
+      }
+      await line(buffer);
+      if (!complete) throw new Error("diffr stream ended before completion.");
+      for (const entry of entries) if (!seen.has(entry.file.path))
+        onFile(entry.file.path, "diffr did not supply a result for this file.");
+    } finally {
+      await reader.cancel().catch(() => {});
+      reader.releaseLock();
+      abort.abort();
+    }
+  }
   const factory: IDiffProviderFactoryService = {
     _serviceBrand: undefined,
     createDiffProvider() {
@@ -125,7 +156,8 @@ export async function prepareStructuralReview(
         onDidChange: Event.None,
         async computeDiff(original, modified, _options, token) {
           if (token.isCancellationRequested) throw new CancellationError();
-          const diff = pairs.get(original.uri.toString() + "\n" + modified.uri.toString());
+          const path = pairs.get(original.uri.toString() + "\n" + modified.uri.toString());
+          const diff = path === undefined ? undefined : files.get(path);
           if (!diff) throw new Error("diffr did not supply a result for this file.");
           if (diff.lhs_src === "Binary" || diff.rhs_src === "Binary") {
             return { changes: [], moves: [], identical: false, quitEarly: false, changeHighlights: { original: [], modified: [] } };
@@ -182,8 +214,8 @@ export async function prepareStructuralReview(
   const child = lifetime.add(
     instantiation.createChild(new ServiceCollection([IDiffProviderFactoryService, factory])),
   );
-  attachStructuralEditors(instantiation, entries, files, lifetime);
-  return { instantiation: child, enabled: true, entries };
+  attachStructuralEditors(instantiation, entries, files, lifetime, changed.event);
+  return { instantiation: child, enabled: true, entries, load };
 }
 
 function attachStructuralEditors(
@@ -191,16 +223,39 @@ function attachStructuralEditors(
   entries: readonly ReviewFilesEditorEntry[],
   files: Map<string, StructuralDiff>,
   lifetime: DisposableStore,
+  onDidLoad: Event<void>,
 ): void {
   const features = instantiation.invokeFunction((a) => a.get(ILanguageFeaturesService));
   const editors = instantiation.invokeFunction((a) => a.get(ICodeEditorService));
-  const sources = new Map<string, { diff: StructuralDiff; side: 0 | 1; pair: string }>();
+  const sources = new Map<string, { side: 0 | 1; pair: string }>();
   for (const entry of entries) {
-    const diff = files.get(entry.file.path);
-    if (!diff || diff.lhs_src === "Binary" || diff.rhs_src === "Binary") continue;
-    sources.set(entry.original.toString(), { diff, side: 0, pair: entry.file.path });
-    sources.set(entry.modified.toString(), { diff, side: 1, pair: entry.file.path });
+    sources.set(entry.original.toString(), { side: 0, pair: entry.file.path });
+    sources.set(entry.modified.toString(), { side: 1, pair: entry.file.path });
   }
+  const provider: FoldingRangeProvider = {
+    id: "review-diffr",
+    onDidChange: Event.map(onDidLoad, () => provider),
+    provideFoldingRanges(model) {
+      const source = sources.get(model.uri.toString());
+      const diff = source && files.get(source.pair);
+      if (!source || !diff) return null;
+      return (source.side === 0 ? diff.lhs_folds : diff.rhs_folds).flatMap(
+        (fold) => {
+          const range = nativeFoldRange(fold.range);
+          return range
+            ? [
+                {
+                  ...range,
+                  kind: fold.tags.includes("imports")
+                    ? FoldingRangeKind.Imports
+                    : FoldingRangeKind.Region,
+                },
+              ]
+            : [];
+        },
+      );
+    },
+  };
   lifetime.add(
     features.foldingRangeProvider.register(
       entries
@@ -210,28 +265,7 @@ function attachStructuralEditors(
           pattern: uri.path.replace(/[\[\]*?{}]/g, (character) => `[${character}]`),
           exclusive: true,
         })),
-      {
-        id: "review-diffr",
-        provideFoldingRanges(model) {
-          const source = sources.get(model.uri.toString());
-          if (!source) return null;
-          return (source.side === 0 ? source.diff.lhs_folds : source.diff.rhs_folds).flatMap(
-            (fold) => {
-              const range = nativeFoldRange(fold.range);
-              return range
-                ? [
-                    {
-                      ...range,
-                      kind: fold.tags.includes("imports")
-                        ? FoldingRangeKind.Imports
-                        : FoldingRangeKind.Region,
-                    },
-                  ]
-                : [];
-            },
-          );
-        },
-      },
+      provider,
     ),
   );
   const models = new Map<string, Set<FoldingModel>>();
@@ -248,8 +282,9 @@ function attachStructuralEditors(
       binding.clear();
       const model = editor.getModel();
       const source = model && sources.get(model.uri.toString());
-      if (!model || !source) return;
-      const folds = source.side === 0 ? source.diff.lhs_folds : source.diff.rhs_folds;
+      const diff = source && files.get(source.pair);
+      if (!model || !source || !diff) return;
+      const folds = source.side === 0 ? diff.lhs_folds : diff.rhs_folds;
       const folding = await FoldingController.get(editor)?.getFoldingModel();
       if (!folding || binding.isDisposed || current !== generation || editor.getModel() !== model)
         return;
@@ -314,6 +349,7 @@ function attachStructuralEditors(
     const update = () => {
       void bind().catch((error) => console.error("Structural editor binding failed", error));
     };
+    store.add(onDidLoad(update));
     store.add(editor.onDidChangeModel(update));
     store.add(editor.onDidChangeConfiguration(update));
     store.add(editor.onDidDispose(() => store.dispose()));

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewStructuralDiff.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewStructuralDiff.ts
@@ -63,7 +63,7 @@ export async function prepareStructuralReview(
   const body = await response.json();
   if (!response.ok || !body.ok) throw new Error(body.error ?? "Structural diff request failed.");
   if (lifetime.isDisposed) throw new CancellationError();
-  if (!body.enabled) return { instantiation, enabled: false, entries };
+  if (!body.enabled) throw new Error("This Review server does not have structural diffs enabled. Configure diffr on the host and restart Review.");
   const files = new Map<string, StructuralDiff>();
   for (const event of body.events as StructuralFileEvent[]) {
     if (event.type === "file") files.set(event.file.new_path ?? event.file.old_path!, event.diff);

--- a/apps/review-desktop/code-oss/src/vs/review/services/reviewStructuralDiff.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/services/reviewStructuralDiff.ts
@@ -1,0 +1,324 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IModelService } from "../../editor/common/services/model.js";
+import { ITextModelService } from "../../editor/common/services/resolverService.js";
+import { ILanguageService } from "../../editor/common/languages/language.js";
+import { reviewVirtualUri } from "../common/reviewCodeResources.js";
+import { Event } from "../../base/common/event.js";
+import { DisposableStore, toDisposable } from "../../base/common/lifecycle.js";
+import { CancellationError } from "../../base/common/errors.js";
+import { IInstantiationService } from "../../platform/instantiation/common/instantiation.js";
+import { ServiceCollection } from "../../platform/instantiation/common/serviceCollection.js";
+import { IDiffProviderFactoryService } from "../../editor/browser/widget/diffEditor/diffProviderFactoryService.js";
+import { ICodeEditorService } from "../../editor/browser/services/codeEditorService.js";
+import type { ICodeEditor } from "../../editor/browser/editorBrowser.js";
+import { ILanguageFeaturesService } from "../../editor/common/services/languageFeatures.js";
+import { LineRange } from "../../editor/common/core/ranges/lineRange.js";
+import { DetailedLineRangeMapping } from "../../editor/common/diff/rangeMapping.js";
+import { FoldingController } from "../../editor/contrib/folding/browser/folding.js";
+import type { FoldingModel } from "../../editor/contrib/folding/browser/foldingModel.js";
+import { FoldingRangeKind } from "../../editor/common/languages.js";
+import { IReviewSessionModelService } from "./reviewSessionModelService.js";
+import { reviewDiffFilesUrl } from "../common/reviewReveal.js";
+import {
+  nativeFoldRange,
+  structuralRows,
+  structuralHighlights,
+  structuralContextGaps,
+  type StructuralDiff,
+  type StructuralFileEvent,
+} from "../common/reviewStructuralDiff.js";
+import type { ReviewCommitScope } from "../common/reviewProtocol.js";
+import type { ReviewFilesEditorEntry } from "./reviewFilesDiffView.js";
+
+/** Owned by one Files view, including provider registrations and fold listeners. */
+export async function prepareStructuralReview(
+  instantiation: IInstantiationService,
+  entries: readonly ReviewFilesEditorEntry[],
+  scope: ReviewCommitScope | undefined,
+  lifetime: DisposableStore,
+): Promise<{
+  instantiation: IInstantiationService;
+  enabled: boolean;
+  entries: readonly ReviewFilesEditorEntry[];
+}> {
+  const sessionModel = instantiation.invokeFunction((a) =>
+    a.get(IReviewSessionModelService),
+  ).activeModel;
+  if (!sessionModel) throw new Error("Review session is unavailable.");
+  const abort = new AbortController();
+  lifetime.add(toDisposable(() => abort.abort()));
+  const session = sessionModel.session;
+  const url = reviewDiffFilesUrl(session.sessionUrl, session.session.routePath ?? "/");
+  url.pathname = url.pathname.replace(/diff-files$/, "structural-diff");
+  const response = await sessionModel.request(String(url), {
+    method: "POST",
+    headers: { "x-review-token": session.token, "content-type": "application/json" },
+    body: JSON.stringify({ commit: scope?.commit }),
+    signal: abort.signal,
+  });
+  const body = await response.json();
+  if (!response.ok || !body.ok) throw new Error(body.error ?? "Structural diff request failed.");
+  if (lifetime.isDisposed) throw new CancellationError();
+  if (!body.enabled) return { instantiation, enabled: false, entries };
+  const files = new Map<string, StructuralDiff>();
+  for (const event of body.events as StructuralFileEvent[]) {
+    if (event.type === "file") files.set(event.file.new_path ?? event.file.old_path!, event.diff);
+  }
+  // Use pinned checkout resources so native language providers see real project files.
+  // Revision-only resources retain their virtual snapshot identity.
+  const modelService = instantiation.invokeFunction((a) => a.get(IModelService));
+  const resolver = instantiation.invokeFunction((a) => a.get(ITextModelService));
+  const languages = instantiation.invokeFunction((a) => a.get(ILanguageService));
+  entries = await Promise.all(
+    entries.map(async (entry) => {
+      const diff = files.get(entry.file.path);
+      if (!diff || diff.lhs_src === "Binary" || diff.rhs_src === "Binary") return entry;
+      const original = entry.original.scheme === "file" ? entry.original : reviewVirtualUri(
+        "base",
+        entry.file.previousPath ?? entry.file.path,
+        entry.file.path,
+        session.session.sessionId,
+        scope?.commit,
+      );
+      const modified = entry.modified.scheme === "file" ? entry.modified : reviewVirtualUri(
+        "head",
+        entry.file.path,
+        entry.file.path,
+        session.session.sessionId,
+        scope?.commit,
+      );
+      for (const [uri, text] of [
+        [original, diff.lhs_src.Text],
+        [modified, diff.rhs_src.Text],
+      ] as const) {
+        if (uri.scheme === "file") {
+          const reference = lifetime.add(await resolver.createModelReference(uri));
+          if (reference.object.textEditorModel.getValue().replace(/\r\n/g, "\n") !== text.replace(/\r\n/g, "\n"))
+            throw new Error("Pinned checkout differs from diffr's source snapshot; reload the review.");
+          continue;
+        }
+        const existing = modelService.getModel(uri);
+        if (existing && existing.getValue().replace(/\r\n/g, "\n") !== text.replace(/\r\n/g, "\n"))
+          throw new Error("Structural snapshot changed; reload the review.");
+        if (!existing)
+          modelService.createModel(text, languages.createByFilepathOrFirstLine(uri), uri);
+        lifetime.add(await resolver.createModelReference(uri));
+      }
+      return { ...entry, original, modified };
+    }),
+  );
+  if (lifetime.isDisposed) throw new CancellationError();
+  const pairs = new Map(
+    entries.map((e) => [
+      e.original.toString() + "\n" + e.modified.toString(),
+      files.get(e.file.path),
+    ]),
+  );
+  const factory: IDiffProviderFactoryService = {
+    _serviceBrand: undefined,
+    createDiffProvider() {
+      return {
+        onDidChange: Event.None,
+        async computeDiff(original, modified, _options, token) {
+          if (token.isCancellationRequested) throw new CancellationError();
+          const diff = pairs.get(original.uri.toString() + "\n" + modified.uri.toString());
+          if (!diff) throw new Error("diffr did not supply a result for this file.");
+          if (diff.lhs_src === "Binary" || diff.rhs_src === "Binary") {
+            return { changes: [], moves: [], identical: false, quitEarly: false, changeHighlights: { original: [], modified: [] } };
+          }
+          const left = diff.lhs_src.Text.replace(/\r\n/g, "\n");
+          const right = diff.rhs_src.Text.replace(/\r\n/g, "\n");
+          if (
+            original.getLinesContent().join("\n") !== left ||
+            modified.getLinesContent().join("\n") !== right
+          ) {
+            throw new Error(
+              "diffr sources differ from Review's editor snapshots; reload the review.",
+            );
+          }
+          const rows = structuralRows(diff);
+          const changes: DetailedLineRangeMapping[] = [];
+          let l = 0,
+            r = 0;
+          let start: [number, number] | undefined;
+          const flush = () => {
+            if (start)
+              changes.push(
+                new DetailedLineRangeMapping(
+                  new LineRange(start[0] + 1, l + 1),
+                  new LineRange(start[1] + 1, r + 1),
+                  undefined,
+                ),
+              );
+            start = undefined;
+          };
+          const ls = left.split("\n"),
+            rs = right.split("\n");
+          for (const [a, b] of rows) {
+            const changed = a === null || b === null || ls[a] !== rs[b];
+            if (changed) start ??= [l, r];
+            else flush();
+            if (a !== null) l = a + 1;
+            if (b !== null) r = b + 1;
+          }
+          flush();
+          return {
+            changes,
+            moves: [],
+            identical: left === right,
+            quitEarly: false,
+            sourceLineAlignment: rows,
+            contextGaps: structuralContextGaps(diff),
+            changeHighlights: structuralHighlights(diff),
+          };
+        },
+      };
+    },
+  };
+  const child = lifetime.add(
+    instantiation.createChild(new ServiceCollection([IDiffProviderFactoryService, factory])),
+  );
+  attachStructuralEditors(instantiation, entries, files, lifetime);
+  return { instantiation: child, enabled: true, entries };
+}
+
+function attachStructuralEditors(
+  instantiation: IInstantiationService,
+  entries: readonly ReviewFilesEditorEntry[],
+  files: Map<string, StructuralDiff>,
+  lifetime: DisposableStore,
+): void {
+  const features = instantiation.invokeFunction((a) => a.get(ILanguageFeaturesService));
+  const editors = instantiation.invokeFunction((a) => a.get(ICodeEditorService));
+  const sources = new Map<string, { diff: StructuralDiff; side: 0 | 1; pair: string }>();
+  for (const entry of entries) {
+    const diff = files.get(entry.file.path);
+    if (!diff || diff.lhs_src === "Binary" || diff.rhs_src === "Binary") continue;
+    sources.set(entry.original.toString(), { diff, side: 0, pair: entry.file.path });
+    sources.set(entry.modified.toString(), { diff, side: 1, pair: entry.file.path });
+  }
+  lifetime.add(
+    features.foldingRangeProvider.register(
+      entries
+        .flatMap((entry) => [entry.original, entry.modified])
+        .map((uri) => ({
+          scheme: uri.scheme,
+          pattern: uri.path.replace(/[\[\]*?{}]/g, (character) => `[${character}]`),
+          exclusive: true,
+        })),
+      {
+        id: "review-diffr",
+        provideFoldingRanges(model) {
+          const source = sources.get(model.uri.toString());
+          if (!source) return null;
+          return (source.side === 0 ? source.diff.lhs_folds : source.diff.rhs_folds).flatMap(
+            (fold) => {
+              const range = nativeFoldRange(fold.range);
+              return range
+                ? [
+                    {
+                      ...range,
+                      kind: fold.tags.includes("imports")
+                        ? FoldingRangeKind.Imports
+                        : FoldingRangeKind.Region,
+                    },
+                  ]
+                : [];
+            },
+          );
+        },
+      },
+    ),
+  );
+  const models = new Map<string, Set<FoldingModel>>();
+  const collapsed = new Map<string, boolean>();
+  let synchronizing = false;
+  function watch(editor: ICodeEditor) {
+    const store = lifetime.add(new DisposableStore());
+    const binding = store.add(new DisposableStore());
+    let generation = 0;
+    const bind = async () => {
+      const current = ++generation;
+      await Promise.resolve();
+      if (store.isDisposed || current !== generation) return;
+      binding.clear();
+      const model = editor.getModel();
+      const source = model && sources.get(model.uri.toString());
+      if (!model || !source) return;
+      const folds = source.side === 0 ? source.diff.lhs_folds : source.diff.rhs_folds;
+      const folding = await FoldingController.get(editor)?.getFoldingModel();
+      if (!folding || binding.isDisposed || current !== generation || editor.getModel() !== model)
+        return;
+      const modelKey = `${source.pair}:${source.side}`;
+      const members = models.get(modelKey) ?? new Set<FoldingModel>();
+      members.add(folding);
+      models.set(modelKey, members);
+      binding.add(toDisposable(() => members.delete(folding)));
+      const keyFor = (fold: (typeof folds)[number]) => {
+        const range =
+          source.side === 1 && fold.match_kind !== "Novel"
+            ? fold.match_kind.Unchanged.opposite
+            : fold.range;
+        const side = fold.match_kind === "Novel" ? source.side : 0;
+        return `${source.pair}:${side}:${JSON.stringify(range)}`;
+      };
+      const restore = () => {
+        const toggle = [];
+        for (const fold of folds) {
+          const range = nativeFoldRange(fold.range);
+          if (!range) continue;
+          const region = folding.getRegionAtLine(range.start);
+          if (region?.startLineNumber !== range.start || region.endLineNumber !== range.end)
+            continue;
+          if (region.isCollapsed !== (collapsed.get(keyFor(fold)) ?? false)) toggle.push(region);
+        }
+        if (toggle.length) folding.toggleCollapseState(toggle);
+      };
+      binding.add(
+        folding.onDidChange((event) => {
+          if (synchronizing) return;
+          synchronizing = true;
+          try {
+            for (const region of event.collapseStateChanged ?? []) {
+              const fold = folds.find((f) => {
+                const r = nativeFoldRange(f.range);
+                return r?.start === region.startLineNumber && r.end === region.endLineNumber;
+              });
+              if (!fold) continue;
+              collapsed.set(keyFor(fold), region.isCollapsed);
+              if (fold.match_kind === "Novel") continue;
+              const opposite = nativeFoldRange(fold.match_kind.Unchanged.opposite);
+              if (!opposite) continue;
+              for (const other of models.get(`${source.pair}:${1 - source.side}`) ?? []) {
+                const target = other.getRegionAtLine(opposite.start);
+                if (
+                  target?.startLineNumber === opposite.start &&
+                  target.endLineNumber === opposite.end &&
+                  target.isCollapsed !== region.isCollapsed
+                )
+                  other.toggleCollapseState([target]);
+              }
+            }
+            if (!event.collapseStateChanged) restore();
+          } finally {
+            synchronizing = false;
+          }
+        }),
+      );
+      restore();
+    };
+    const update = () => {
+      void bind().catch((error) => console.error("Structural editor binding failed", error));
+    };
+    store.add(editor.onDidChangeModel(update));
+    store.add(editor.onDidChangeConfiguration(update));
+    store.add(editor.onDidDispose(() => store.dispose()));
+    update();
+  }
+  lifetime.add(editors.onCodeEditorAdd(watch));
+  for (const editor of editors.listCodeEditors()) watch(editor);
+}

--- a/packages/progressive-review/app/src/desktop-entry.tsx
+++ b/packages/progressive-review/app/src/desktop-entry.tsx
@@ -159,7 +159,7 @@ function ReviewCanvas({
   if (content.kind === "session") {
     return (
       <DesktopReviewApp
-        key={content.bridge.config.sessionId}
+        key={`${content.bridge.config.sessionId}:${content.structuralDiffEnabled}`}
         documentBundle={content.document}
         softwareMapBundle={content.softwareMap}
         softwareMapEnabled={content.softwareMapEnabled}

--- a/packages/progressive-review/app/src/settings-page.tsx
+++ b/packages/progressive-review/app/src/settings-page.tsx
@@ -72,6 +72,9 @@ export function SettingsPage({
   const [softwareMapEnabled, setSoftwareMapEnabled] = useState(
     settings.softwareMapEnabled,
   );
+  const [structuralDiffEnabled, setStructuralDiffEnabled] = useState(
+    settings.structuralDiffEnabled,
+  );
   const [installStatus, setInstallStatus] = useState<
     ReviewCliInstallStatus | undefined
   >(settings.install?.status);
@@ -222,6 +225,28 @@ export function SettingsPage({
           </Section>
 
           <Section label="Experimental Features">
+            <Row
+              label="Structural Diffs"
+              description="Replace the standard diff view with syntax-aware diffs and linked folds. Requires the diffr CLI."
+            >
+              <label className="review-settings-toggle">
+                <input
+                  type="checkbox"
+                  aria-label="Structural Diffs"
+                  checked={structuralDiffEnabled}
+                  disabled={busy !== null}
+                  onChange={(event) => {
+                    const enabled = event.target.checked;
+                    void run(
+                      "structural-diff",
+                      () => settings.setStructuralDiffEnabled(enabled),
+                      setStructuralDiffEnabled,
+                    );
+                  }}
+                />
+                <span>{structuralDiffEnabled ? "On" : "Off"}</span>
+              </label>
+            </Row>
             <Row
               label="Software Map"
               description="Show the experimental Software Map view in reviews."

--- a/packages/progressive-review/src/server/review-api.ts
+++ b/packages/progressive-review/src/server/review-api.ts
@@ -96,6 +96,7 @@ import {
   parseUpdateReviewCommentInput,
   requestJsonErrorStatus,
 } from "./review-api-parsers";
+import { structuralDiff } from "./structural-diff";
 
 const REVIEW_SUBMIT_HOOK_ENV = "DEV_FAST_REVIEW_SUBMIT_HOOK";
 export const TUTORIAL_QUESTION_SOURCE_WAIT_MS = 5_000;
@@ -391,6 +392,7 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
   app.get("/document-meta", route(documentMeta));
   app.get("/stack", route(reviewStack));
   app.post("/diff-files", route(diffFiles));
+  app.post("/structural-diff", route(structuralDiffRequest));
   app.get("/file-content", route(fileContent));
   app.get("/agent-traces", route(agentTraces));
   app.get("/agent-traces/:sessionId", route(agentTraceDetail));
@@ -967,6 +969,22 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     return reviewApiJsonResponse(200, {
       layers: await resolveReviewStackLayers(current, reviews),
     });
+  }
+
+  async function structuralDiffRequest(
+    context: Context<ReviewHonoEnv>,
+  ): Promise<Response> {
+    const body = parseReviewDiffFilesInput(await readJson(context.req.raw));
+    const target = await resolveScopedDiffTarget(
+      new URL(context.req.url),
+      body.commit,
+    );
+    const result = await structuralDiff({
+      ...target,
+      paths: body.paths,
+      signal: context.req.raw.signal,
+    });
+    return reviewApiJsonResponse(200, { ok: true, ...result });
   }
 
   async function diffFiles(context: Context<ReviewHonoEnv>): Promise<Response> {

--- a/packages/progressive-review/src/server/review-api.ts
+++ b/packages/progressive-review/src/server/review-api.ts
@@ -979,12 +979,31 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
       new URL(context.req.url),
       body.commit,
     );
-    const result = await structuralDiff({
-      ...target,
-      paths: body.paths,
-      signal: context.req.raw.signal,
+    const abort = new AbortController();
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        const send = (event: unknown) => {
+          if (!abort.signal.aborted) controller.enqueue(encoder.encode(JSON.stringify(event) + "\n"));
+        };
+        try {
+          await structuralDiff({
+            ...target,
+            paths: body.paths,
+            signal: AbortSignal.any([context.req.raw.signal, abort.signal]),
+            onEvent: send,
+          });
+        } catch (error) {
+          send({ type: "error", message: error instanceof Error ? error.message : String(error) });
+        } finally {
+          if (!abort.signal.aborted) controller.close();
+        }
+      },
+      cancel() { abort.abort(); },
     });
-    return reviewApiJsonResponse(200, { ok: true, ...result });
+    return new Response(stream, {
+      headers: { "content-type": "application/x-ndjson", "cache-control": "no-store" },
+    });
   }
 
   async function diffFiles(context: Context<ReviewHonoEnv>): Promise<Response> {

--- a/packages/progressive-review/src/server/structural-diff.test.ts
+++ b/packages/progressive-review/src/server/structural-diff.test.ts
@@ -1,0 +1,81 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, expect, test, vi } from "vitest";
+
+import { structuralDiff } from "./structural-diff";
+
+const roots: string[] = [];
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function executable(script: string) {
+  const root = await mkdtemp(path.join(tmpdir(), "review-diffr-test-"));
+  roots.push(root);
+  const file = path.join(root, "diffr");
+  await writeFile(file, `#!${process.execPath}\n${script}`, { mode: 0o755 });
+  vi.stubEnv("REVIEW_DIFFR_BINARY", file);
+  return root;
+}
+
+test("reads chunked NDJSON and sends Review's merge-base comparison as one argument", async () => {
+  const root = await executable(`
+    process.stdout.write('{"type":"start","version":1}\\n{"type":"fi');
+    setTimeout(() => {
+      process.stdout.write('le","args":' + JSON.stringify(process.argv.slice(2)) + '}\\n');
+      process.stdout.write('{"type":"complete","succeeded":1,"failed":0}\\n');
+    }, 5);
+  `);
+  const result = await structuralDiff({
+    rootPath: root,
+    baseRef: "base",
+    headRef: "head",
+    paths: ["space name.ts"],
+  });
+  expect(result.events[1]).toEqual({
+    type: "file",
+    args: [
+      "--repo",
+      root,
+      "--format",
+      "ndjson",
+      "base...head",
+      "--",
+      "space name.ts",
+    ],
+  });
+});
+
+test("rejects a successful process that truncates its stream", async () => {
+  const root = await executable(
+    `console.log(JSON.stringify({ type: "start", version: 1 }));`,
+  );
+  await expect(
+    structuralDiff({ rootPath: root, baseRef: "base" }),
+  ).rejects.toThrow("before completion");
+});
+
+test("propagates per-file errors instead of silently showing a different diff", async () => {
+  const root = await executable(
+    `console.log('{"type":"start","version":1}\\n{"type":"file_error","message":"parse failed"}');`,
+  );
+  await expect(
+    structuralDiff({ rootPath: root, baseRef: "base" }),
+  ).rejects.toThrow("parse failed");
+});
+
+test("cancellation terminates the subprocess", async () => {
+  const root = await executable(`setInterval(() => {}, 1000);`);
+  await expect(
+    structuralDiff({
+      rootPath: root,
+      baseRef: "base",
+      signal: AbortSignal.timeout(50),
+    }),
+  ).rejects.toThrow();
+});

--- a/packages/progressive-review/src/server/structural-diff.ts
+++ b/packages/progressive-review/src/server/structural-diff.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
 
-/** The experiment is opt-in: the host selects the executable, never the request. */
+/** The frontend setting opts in; the host selects the executable, never the request. */
 export async function structuralDiff(input: {
   rootPath: string;
   baseRef?: string;
@@ -9,8 +9,7 @@ export async function structuralDiff(input: {
   paths?: readonly string[];
   signal?: AbortSignal;
 }): Promise<{ enabled: boolean; events: unknown[] }> {
-  const executable = process.env.REVIEW_DIFFR_BINARY;
-  if (!executable) return { enabled: false, events: [] };
+  const executable = process.env.REVIEW_DIFFR_BINARY || "diffr";
   if (!input.baseRef)
     throw new Error("Structural review requires a base revision.");
   const args = ["--repo", input.rootPath, "--format", "ndjson"];
@@ -34,7 +33,11 @@ export async function structuralDiff(input: {
     stderr = (stderr + chunk).slice(-16_384);
   });
   const exited = new Promise<void>((resolve, reject) => {
-    child.once("error", reject);
+    child.once("error", (error: NodeJS.ErrnoException) => {
+      reject(error.code === "ENOENT"
+        ? new Error("Cannot find diffr. Install it on the Review host PATH or set REVIEW_DIFFR_BINARY to its executable, then restart Review.")
+        : error);
+    });
     child.once("close", (code) => {
       if (code === 0) resolve();
       else reject(new Error(`diffr exited with ${code}: ${stderr}`));

--- a/packages/progressive-review/src/server/structural-diff.ts
+++ b/packages/progressive-review/src/server/structural-diff.ts
@@ -1,0 +1,80 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+
+/** The experiment is opt-in: the host selects the executable, never the request. */
+export async function structuralDiff(input: {
+  rootPath: string;
+  baseRef?: string;
+  headRef?: string;
+  paths?: readonly string[];
+  signal?: AbortSignal;
+}): Promise<{ enabled: boolean; events: unknown[] }> {
+  const executable = process.env.REVIEW_DIFFR_BINARY;
+  if (!executable) return { enabled: false, events: [] };
+  if (!input.baseRef)
+    throw new Error("Structural review requires a base revision.");
+  const args = ["--repo", input.rootPath, "--format", "ndjson"];
+  // Match Review's merge-base-to-head comparison, including commit scopes.
+  args.push(
+    input.headRef ? `${input.baseRef}...${input.headRef}` : input.baseRef,
+  );
+  args.push("--", ...(input.paths ?? []));
+  const signal = AbortSignal.any([
+    AbortSignal.timeout(120_000),
+    ...(input.signal ? [input.signal] : []),
+  ]);
+  const child = spawn(executable, args, {
+    cwd: input.rootPath,
+    stdio: ["ignore", "pipe", "pipe"],
+    signal,
+  });
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr = (stderr + chunk).slice(-16_384);
+  });
+  const exited = new Promise<void>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`diffr exited with ${code}: ${stderr}`));
+    });
+  });
+  // Observe process errors immediately, including before stdout closes.
+  void exited.catch(() => {});
+  const events: unknown[] = [];
+  let bytes = 0;
+  let started = false;
+  let completed = false;
+  const lines = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  try {
+    for await (const line of lines) {
+      bytes += Buffer.byteLength(line);
+      if (bytes > 64 * 1024 * 1024)
+        throw new Error("Structural diff exceeded 64 MiB.");
+      if (!line.trim()) continue;
+      const event = JSON.parse(line);
+      if (completed) throw new Error("diffr emitted data after completion.");
+      if (!started) {
+        if (event.type !== "start" || event.version !== 1) {
+          throw new Error("Unsupported diffr stream protocol.");
+        }
+        started = true;
+      } else if (event.type === "complete") {
+        completed = true;
+      } else if (event.type === "file_error") {
+        throw new Error(`diffr: ${event.message}`);
+      } else if (event.type !== "file") {
+        throw new Error(`Unexpected diffr event: ${event.type}`);
+      }
+      events.push(event);
+    }
+    await exited;
+    if (!completed) throw new Error("diffr stream ended before completion.");
+    return { enabled: true, events };
+  } finally {
+    lines.close();
+    if (child.exitCode === null) child.kill();
+    await exited.catch(() => {});
+  }
+}

--- a/packages/progressive-review/src/server/structural-diff.ts
+++ b/packages/progressive-review/src/server/structural-diff.ts
@@ -8,6 +8,7 @@ export async function structuralDiff(input: {
   headRef?: string;
   paths?: readonly string[];
   signal?: AbortSignal;
+  onEvent?: (event: unknown) => void;
 }): Promise<{ enabled: boolean; events: unknown[] }> {
   const executable = process.env.REVIEW_DIFFR_BINARY || "diffr";
   if (!input.baseRef)
@@ -66,11 +67,12 @@ export async function structuralDiff(input: {
       } else if (event.type === "complete") {
         completed = true;
       } else if (event.type === "file_error") {
-        throw new Error(`diffr: ${event.message}`);
+        if (!input.onEvent) throw new Error(`diffr: ${event.message}`);
       } else if (event.type !== "file") {
         throw new Error(`Unexpected diffr event: ${event.type}`);
       }
-      events.push(event);
+      if (input.onEvent) input.onEvent(event);
+      else events.push(event);
     }
     await exited;
     if (!completed) throw new Error("diffr stream ended before completion.");

--- a/packages/review-protocol/src/contracts.ts
+++ b/packages/review-protocol/src/contracts.ts
@@ -977,6 +977,8 @@ export interface ReviewCanvasSettingsContent {
   setDismissedRetentionDays(days: number | null): Promise<number | null>;
   softwareMapEnabled: boolean;
   setSoftwareMapEnabled(enabled: boolean): Promise<boolean>;
+  structuralDiffEnabled: boolean;
+  setStructuralDiffEnabled(enabled: boolean): Promise<boolean>;
   manageExtensions(): void;
   // Agent installs are managed here too, so they stay reachable once Home
   // has reviews and no longer shows the Welcome rail. Absent when the
@@ -1050,6 +1052,7 @@ export type ReviewCanvasContent =
       document: Promise<unknown>;
       softwareMap: Promise<unknown | null>;
       softwareMapEnabled: boolean;
+      structuralDiffEnabled: boolean;
       reviewErrors: readonly ReviewListError[];
       range: ReviewCanvasRange;
       commits: readonly ReviewCommitSummary[];


### PR DESCRIPTION
Prototype replacing native diff computation with diffr's NDJSON output when `REVIEW_DIFFR_BINARY` is configured. The Files view initially shows only diffr's hunk rows, with expandable context gaps and paired structural folds. Full source models remain available for language services; native syntax colors are preserved, with light novel-line backgrounds and stronger changed-token highlights.

The adapter uses supplied correspondence for split alignment and filters folded original rows in unified view. It keeps unchanged content neutral. Pinned base/head resources use native file models; individual-commit virtual resources still have language-service limitations.

Stress testing the complete 30-file Review PR #108 exposed duplicate file-stream delivery after renderer reloads. Defer reconnect-emitter disposal until all disconnect listeners run, allowing old IPC channel servers to clean up and preventing inflated source models and scroll ranges.

Validation: native build and client TypeScript check passed. Manually exercised all 30 file-tree entries, split/unified layouts, paired fold toggles, context expansion, and scrolling across files. Checked initial visibility against the hunk row sets across the full comparison; after three reloads, a sampled file stream delivered exactly one copy. Earlier prototype checks cover alignment/coordinates and subprocess protocol handling.

Draft limitations: full comparison is collected before mounting (64 MiB / 120 seconds); whole-line folding only; custom fold placeholders and persistent fold state are not implemented. See `STRUCTURAL-DIFF.md` for setup and the original stress-test comparison commits.
