### PR TITLE
Make Ask Agent tab bars consistent with review tabs

### DIFF
--- a/apps/review-desktop/code-oss/src/vs/review/browser/media/review.css
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/media/review.css
@@ -101,10 +101,10 @@
   .part.editor
   .editor-group-container
   > .title
-  > .tabs-and-actions-container.review-chrome-inset {
+  > .tabs-and-actions-container.review-chrome-tab-strip {
   box-sizing: border-box;
-  padding-left: calc(var(--review-chrome-left-width, 0px) + 6px);
-  padding-right: calc(var(--review-chrome-right-width, 0px) + 6px);
+  padding-left: 6px;
+  padding-right: 6px;
   user-select: none;
   -webkit-app-region: drag;
 }
@@ -113,22 +113,31 @@
   .part.editor
   .editor-group-container
   > .title
-  > .tabs-and-actions-container.review-chrome-inset {
+  > .tabs-and-actions-container.review-chrome-tab-strip {
   -webkit-app-region: no-drag;
 }
 
 .monaco-workbench
   .part.editor
-  .tabs-and-actions-container.review-chrome-inset
+  .tabs-and-actions-container.review-chrome-tab-strip
   .tabs-container {
   -webkit-app-region: drag;
 }
 
 .monaco-workbench.review-tab-dragging
   .part.editor
-  .tabs-and-actions-container.review-chrome-inset
+  .tabs-and-actions-container.review-chrome-tab-strip
   .tabs-container {
   -webkit-app-region: no-drag;
+}
+
+.monaco-workbench
+  .part.editor
+  .editor-group-container
+  > .title
+  > .tabs-and-actions-container.review-chrome-inset {
+  padding-left: calc(var(--review-chrome-left-width, 0px) + 6px);
+  padding-right: calc(var(--review-chrome-right-width, 0px) + 6px);
 }
 
 .monaco-workbench .part.editor .tabs-container > .tab,
@@ -141,6 +150,14 @@
   > .monaco-scrollable-element
   > .scrollbar {
   -webkit-app-region: no-drag;
+}
+
+/* Ask Agent keeps native tabs without the terminal creation, group lock, or
+   overflow controls. Removing their boxes leaves the strip available to drag. */
+.monaco-workbench.review-workbench .part.editor
+  .review-agent-terminal-tabs > .tabs-and-actions-container
+  > :is(.editor-actions, .editor-layout-actions, .editor-actions-separator) {
+  display: none;
 }
 
 /* ---------------------------------------------------------------------------

--- a/apps/review-desktop/code-oss/src/vs/review/browser/workbench.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/browser/workbench.ts
@@ -304,7 +304,7 @@ export class ReviewWorkbench extends Disposable implements IAgentWorkbenchLayout
 	private _restoreAttachedEditorMaximizedOnShow = false;
 	protected _editorPartAutoVisibilitySuppressionCount = 0;
 	protected _hasAppliedInitialEditorSplit = false;
-	private reviewChromeInsetElement: HTMLElement | undefined;
+	private readonly reviewChromeTabStrips: HTMLElement[] = [];
 	private readonly reviewChromeDragListeners = this._register(new DisposableStore());
 	private readonly reviewChromeInsetScheduler = this._register(new RunOnceScheduler(() => this.updateReviewChromeInset(), 0));
 
@@ -1142,8 +1142,10 @@ export class ReviewWorkbench extends Disposable implements IAgentWorkbenchLayout
 	private updateReviewChromeInset(): void {
 		this.reviewChromeDragListeners.clear();
 		this.mainContainer.classList.remove('review-tab-dragging');
-		this.reviewChromeInsetElement?.classList.remove('review-chrome-inset');
-		this.reviewChromeInsetElement = undefined;
+		for (const tabStrip of this.reviewChromeTabStrips) {
+			tabStrip.classList.remove('review-chrome-tab-strip', 'review-chrome-inset');
+		}
+		this.reviewChromeTabStrips.length = 0;
 
 		const editorPartContainer = this._editorPartContainer;
 		if (!editorPartContainer) {
@@ -1152,6 +1154,7 @@ export class ReviewWorkbench extends Disposable implements IAgentWorkbenchLayout
 
 		let topLeftGroup: HTMLElement | undefined;
 		let topLeftRect: DOMRect | undefined;
+		const visibleGroups: { group: HTMLElement; rect: DOMRect }[] = [];
 		const groups = editorPartContainer.getElementsByClassName('editor-group-container');
 		for (let index = 0; index < groups.length; index++) {
 			const group = groups[index];
@@ -1164,28 +1167,40 @@ export class ReviewWorkbench extends Disposable implements IAgentWorkbenchLayout
 				continue;
 			}
 
+			visibleGroups.push({ group, rect });
+
 			if (!topLeftRect || rect.top < topLeftRect.top - 1 || (Math.abs(rect.top - topLeftRect.top) <= 1 && rect.left < topLeftRect.left)) {
 				topLeftGroup = group;
 				topLeftRect = rect;
 			}
 		}
 
-		if (!topLeftGroup) {
+		if (!topLeftGroup || !topLeftRect) {
 			return;
 		}
 
-		const tabStrips = topLeftGroup.getElementsByClassName('tabs-and-actions-container');
-		for (let index = 0; index < tabStrips.length; index++) {
-			const tabStrip = tabStrips[index];
-			if (isHTMLElement(tabStrip)) {
-				this.reviewChromeInsetElement = tabStrip;
-				tabStrip.classList.add('review-chrome-inset');
-				this.reviewChromeDragListeners.add(addDisposableListener(tabStrip, 'dragstart', () => this.mainContainer.classList.add('review-tab-dragging')));
-				const finishTabDrag = () => this.mainContainer.classList.remove('review-tab-dragging');
-				this.reviewChromeDragListeners.add(addDisposableListener(tabStrip, 'dragend', finishTabDrag));
-				this.reviewChromeDragListeners.add(addDisposableListener(tabStrip, 'drop', finishTabDrag));
-				break;
+		const finishTabDrag = () => this.mainContainer.classList.remove('review-tab-dragging');
+
+		// Every top-row group shares window dragging, including Ask Agent's
+		// terminal group. Only the leftmost group needs the navigation inset.
+		for (const { group, rect } of visibleGroups) {
+			if (Math.abs(rect.top - topLeftRect.top) > 1) {
+				continue;
 			}
+
+			const tabStrip = group.querySelector(':scope > .title > .tabs-and-actions-container');
+			if (!isHTMLElement(tabStrip)) {
+				continue;
+			}
+
+			this.reviewChromeTabStrips.push(tabStrip);
+			tabStrip.classList.add('review-chrome-tab-strip');
+			if (group === topLeftGroup) {
+				tabStrip.classList.add('review-chrome-inset');
+			}
+			this.reviewChromeDragListeners.add(addDisposableListener(tabStrip, 'dragstart', () => this.mainContainer.classList.add('review-tab-dragging')));
+			this.reviewChromeDragListeners.add(addDisposableListener(tabStrip, 'dragend', finishTabDrag));
+			this.reviewChromeDragListeners.add(addDisposableListener(tabStrip, 'drop', finishTabDrag));
 		}
 	}
 

--- a/apps/review-desktop/code-oss/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/apps/review-desktop/code-oss/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -40,6 +40,7 @@ import { IEditorTitleControlDimensions } from './editorTitleControl.js';
 import { IReadonlyEditorGroupModel } from '../../../common/editor/editorGroupModel.js';
 import { EDITOR_CORE_NAVIGATION_COMMANDS } from './editorCommands.js';
 import { IAuxiliaryEditorPart, MergeGroupMode } from '../../../services/editor/common/editorGroupsService.js';
+import { Schemas } from '../../../../base/common/network.js';
 import { isMacintosh } from '../../../../base/common/platform.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
@@ -340,6 +341,12 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 	}
 
 	protected updateEditorActionsToolbar(): void {
+		// Ask Agent uses native terminal editors, but needs no terminal-management
+		// toolbar. Keep this scoped to the active terminal so file/diff actions return.
+		this.parent.classList.toggle('review-agent-terminal-tabs',
+			!!IsReviewWindowContext.getValue(this.contextKeyService) &&
+			this.groupView.activeEditor?.resource?.scheme === Schemas.vscodeTerminal);
+
 		if (!this.editorActionsEnabled) {
 			return;
 		}


### PR DESCRIPTION
Ask Agent tabs now use the same 6px gutter and empty-space window dragging as the review tab bar. All top-row editor groups share the existing drag handling; only the leftmost group reserves navigation/window-control space, and lower groups remain outside the window-drag region.

Hide the new-terminal, lock, and overflow controls while a Review terminal editor is active. File and diff editor actions remain available. Cleanup uses one collection for all chrome tab strips.

Validation:
- Desktop client typecheck passed.
- Desktop tests: 233 passed, 1 skipped, 0 failures.
- Local Desktop build launched; user approved the appearance.
- Native window movement was not independently verified by automation.
