### PR TITLE
Keep Fedora package validation in publish workflows

### DIFF
--- a/.github/workflows/review-desktop-ci.yml
+++ b/.github/workflows/review-desktop-ci.yml
@@ -20,11 +20,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  linux-packages:
-    uses: ./.github/workflows/review-linux-build.yml
-    with:
-      commit: ${{ github.sha }}
-
   review-desktop:
     name: Review Desktop
     runs-on: ubuntu-latest


### PR DESCRIPTION
Every pull request and push to main currently launches the full Fedora package build and validation pipeline. Remove that caller from Review Desktop CI so these checks run through the existing stable, preview, and manual Linux publish workflows, including their dry runs. Stable publication still requires Fedora validation to pass.

Validation: actionlint passed for the CI, reusable Fedora, stable release, preview, and manual Linux workflows; git diff --check passed. The required PR check remains Review Desktop.
