### PR TITLE
Show the spinner instead of loading text while a review loads

### DIFF
--- a/packages/progressive-review/app/src/App.tsx
+++ b/packages/progressive-review/app/src/App.tsx
@@ -44,6 +44,7 @@ import {
   ThreadsIcon,
 } from "./icons";
 import { repairInstruction } from "./repair-instruction";
+import { ReviewCanvasLoading } from "./review-canvas-loading";
 import { ReviewPanelHost } from "./review-components";
 import {
   ReviewProvider,
@@ -819,9 +820,7 @@ function ReviewDocumentLoadState({
 }): ReactElement {
   switch (state.state) {
     case "loading":
-      return (
-        <ReviewUnavailable role="status" message="Still loading this review…" />
-      );
+      return <ReviewCanvasLoading />;
     case "needs-republish":
       return (
         <ReviewUnavailable
@@ -860,9 +859,7 @@ function ReviewSoftwareMapLoadState({
 }): ReactElement {
   switch (state.state) {
     case "loading":
-      return (
-        <ReviewUnavailable role="status" message="Loading software map…" />
-      );
+      return <ReviewCanvasLoading />;
     case "needs-republish":
       return (
         <ReviewUnavailable

--- a/packages/progressive-review/app/src/desktop-entry.tsx
+++ b/packages/progressive-review/app/src/desktop-entry.tsx
@@ -335,7 +335,7 @@ function ReviewCanvas({
       </CanvasShell>
     );
   }
-  return <ReviewCanvasLoading page note="Preparing the selected review…" />;
+  return <ReviewCanvasLoading page />;
 }
 
 function Home({


### PR DESCRIPTION
## What

While a review or its software map loads, the canvas rendered a plain text line — "Still loading this review…" / "Loading software map…" — via `ReviewUnavailable`. On a slow load that text is all you get.

`ReviewCanvasLoading` is the app's one loading affordance and already handles the spinner, the polite live region, `aria-busy`, and `prefers-reduced-motion`. Both loading states now use it, so a load is a bare spinner with no status text.

Also drops the delayed "Preparing the selected review…" note in the desktop entry, so a long wait stays a bare spinner rather than revealing text after ~10s.

## Not changed

`ReviewDocumentBoundary` keeps its `message`/`note` ("Your coding agent is writing the canvas now…"). That path is a canvas-render failure — diagnostic text, not a plain loading state — and `review-document-boundary.test.tsx` asserts on it.

`ReviewUnavailable`'s `role="status"` variant stays: `ReviewCommitsView` still uses it.

## Verification

- `pnpm test` in `packages/progressive-review`: 1534 passed, 2 skipped. (One unhandled rejection surfaced from `desktop-server-repair.test.ts` — an `EINVAL` on a temp path under parallel run; that file passes in isolation on clean `main`, so it is a pre-existing flake unrelated to this change.)
- `pnpm format:check` clean; `pnpm lint` shows no new errors.
- `pnpm typecheck` reports the same three pre-existing `reviewCliInstall.ts` errors on clean `main` as with this change — no new type errors.
- Not yet checked visually in the running desktop app.