### PR TITLE
Resolve the live-session source target once per session

### DIFF
--- a/packages/progressive-review/src/server/review-api.ts
+++ b/packages/progressive-review/src/server/review-api.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { statSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 
 import {
@@ -68,6 +68,7 @@ import {
 } from "../review-thread-store-backend";
 import { ReviewThreadsService } from "../review-threads-service";
 import {
+  type ReviewSourceTarget,
   readReviewStoreRecord,
   resolveReviewRepoRootFromStore,
   resolveReviewSessionBaseCommit,
@@ -203,7 +204,7 @@ export async function captureSanitizedUiTelemetry(
   }
 }
 
-interface ReviewApiOptions {
+export interface ReviewApiOptions {
   mode: ReviewSessionMode;
   readOnlyThreadsPath?: string;
   sourceUnavailable?: string;
@@ -224,6 +225,11 @@ interface ReviewApiOptions {
     error?: string,
   ) => void;
   runReviewThreadMutation?: <T>(operation: () => T | Promise<T>) => Promise<T>;
+  /** Resolves the pinned head/base worktrees for a live session. Tests
+   * inject a stub; production uses `resolveReviewSourceTarget`. */
+  resolveSourceTarget?: (input: {
+    reviewRootPath: string;
+  }) => Promise<ReviewSourceTarget>;
   reviewToken: string;
   agentServer: (harness: ReviewAgentHarness) => AgentServer;
   openNativeAgentTerminal: (
@@ -1132,8 +1138,30 @@ export function createReviewApi(options: ReviewApiOptions): ReviewApi {
     };
   }
 
-  async function requestSourceTarget() {
-    if (!readOnlyReview) return resolveRequestSourceTarget({ reviewRootPath });
+  const resolveSourceTarget =
+    options.resolveSourceTarget ?? resolveReviewSourceTarget;
+  // Resolving the pinned checkouts costs several git subprocesses. A session
+  // serves one revision, so one resolution serves every request until a
+  // checkout root disappears from disk; the desktop host applies the same
+  // existence test to its own checkout-root cache.
+  let liveSourceTarget: Promise<ReviewSourceTarget> | null = null;
+  const sourceTargetRootsExist = (target: ReviewSourceTarget): boolean =>
+    existsSync(target.sourceRootPath) &&
+    (!target.preparedBase || existsSync(target.preparedBase.sourceRootPath));
+
+  async function requestSourceTarget(): Promise<ReviewSourceTarget> {
+    if (!readOnlyReview) {
+      const cached = liveSourceTarget;
+      if (cached) {
+        const target = await cached.catch(() => null);
+        if (target && sourceTargetRootsExist(target)) return target;
+        // Another request already replaced a failed or stale entry.
+        if (liveSourceTarget !== cached) return requestSourceTarget();
+      }
+      const pending = resolveSourceTarget({ reviewRootPath });
+      liveSourceTarget = pending;
+      return pending;
+    }
     if (options.sourceUnavailable) throw new Error(options.sourceUnavailable);
     if (!session.headRootPath || !session.baseRootPath)
       throw new Error("The pinned source worktrees are unavailable.");
@@ -1534,12 +1562,6 @@ async function rematerializeReviewSoftwareMapArtifacts(input: {
   return { status: "rematerialized", headCommit, artifactPath };
 }
 
-async function resolveRequestSourceTarget(input: { reviewRootPath: string }) {
-  return resolveReviewSourceTarget({
-    reviewRootPath: input.reviewRootPath,
-  });
-}
-
 interface CodePeekDiffResponse {
   baseRef?: string;
   headRef?: string;
@@ -1558,7 +1580,7 @@ interface CodePeekDiffFile {
 
 async function resolveCodePeekDiff(input: {
   snapshot: SourceSnapshot;
-  sourceTarget: Awaited<ReturnType<typeof resolveRequestSourceTarget>>;
+  sourceTarget: ReviewSourceTarget;
   graph: "head" | "base";
   includePatch: boolean;
 }): Promise<CodePeekDiffResponse | undefined> {
@@ -1644,7 +1666,7 @@ function codePeekDiffRangeFiles(
 }
 
 async function buildSoftwareMapResolvedData(input: {
-  sourceTarget: Awaited<ReturnType<typeof resolveRequestSourceTarget>>;
+  sourceTarget: ReviewSourceTarget;
   codeElements: ReturnType<typeof parseSoftwareMapCodeElements>;
   coverageClaims: ReturnType<typeof parseSoftwareMapCoverageClaims>;
 }): Promise<SoftwareMapResolvedDataResponse> {

--- a/packages/progressive-review/src/server/session-handler.test.ts
+++ b/packages/progressive-review/src/server/session-handler.test.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import {
@@ -490,6 +490,79 @@ describe("createReviewSessionHandler", () => {
         ok: true,
         hook: { configured: true },
       });
+    } finally {
+      await handler.close();
+    }
+  });
+
+  it("resolves the live source target once per session and again when a checkout root disappears", async () => {
+    const rootPath = await tempDir("review-live-source-target-");
+    const reviewPath = path.join(rootPath, "review.mdx");
+    await writeFile(reviewPath, "# Review");
+    // Two stand-in "pinned checkouts". The fake resolver hands out the next
+    // one on every call, so a re-resolution is observable both by count and
+    // by which root served the peek.
+    const roots = [path.join(rootPath, "head-1"), path.join(rootPath, "head-2")];
+    for (const root of roots) {
+      await mkdir(root);
+      await writeFile(path.join(root, "src.ts"), "line 1\nline 2\nline 3\n");
+    }
+    let resolutions = 0;
+    const handler = await createReviewSessionHandler({
+      ...unusedAgentServices,
+      rootPath,
+      toolingRoot: rootPath,
+      reviewPath,
+      routePath: "/",
+      token: "secret",
+      reviewUuid: "11111111-1111-4111-8111-111111111111",
+      resolveSourceTarget: async () => {
+        const sourceRootPath = roots[resolutions]!;
+        resolutions += 1;
+        return { repoRoot: rootPath, sourceRootPath, diffRootPath: rootPath };
+      },
+      session: {
+        rootPath,
+        baseRef: "HEAD",
+        appUrl: "http://127.0.0.1:5570",
+        reviewPath,
+        startedAt: Date.now(),
+      },
+    });
+    const resolvePeek = () =>
+      handler.handle(
+        new Request(
+          "http://127.0.0.1:5570/__progressive-review/code-peek/resolve",
+          {
+            method: "POST",
+            headers: {
+              "x-review-token": "secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              root: { kind: "range", file: "src.ts", fromLine: 1, toLine: 2 },
+              graph: "head",
+              includeDiff: false,
+              includeDiffSummary: false,
+            }),
+          },
+        ),
+      );
+    try {
+      const responses = await Promise.all(
+        Array.from({ length: 5 }, () => resolvePeek()),
+      );
+      for (const response of responses) {
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({ ok: true });
+      }
+      expect(resolutions).toBe(1);
+
+      await rm(roots[0]!, { recursive: true, force: true });
+      const afterRemoval = await resolvePeek();
+      expect(afterRemoval.status).toBe(200);
+      expect(await afterRemoval.json()).toMatchObject({ ok: true });
+      expect(resolutions).toBe(2);
     } finally {
       await handler.close();
     }

--- a/packages/progressive-review/src/server/session-handler.test.ts
+++ b/packages/progressive-review/src/server/session-handler.test.ts
@@ -502,7 +502,10 @@ describe("createReviewSessionHandler", () => {
     // Two stand-in "pinned checkouts". The fake resolver hands out the next
     // one on every call, so a re-resolution is observable both by count and
     // by which root served the peek.
-    const roots = [path.join(rootPath, "head-1"), path.join(rootPath, "head-2")];
+    const roots = [
+      path.join(rootPath, "head-1"),
+      path.join(rootPath, "head-2"),
+    ];
     for (const root of roots) {
       await mkdir(root);
       await writeFile(path.join(root, "src.ts"), "line 1\nline 2\nline 3\n");
@@ -562,6 +565,76 @@ describe("createReviewSessionHandler", () => {
       const afterRemoval = await resolvePeek();
       expect(afterRemoval.status).toBe(200);
       expect(await afterRemoval.json()).toMatchObject({ ok: true });
+      expect(resolutions).toBe(2);
+    } finally {
+      await handler.close();
+    }
+  });
+
+  it("retries live source target resolution after a failed attempt", async () => {
+    const rootPath = await tempDir("review-live-source-target-retry-");
+    const reviewPath = path.join(rootPath, "review.mdx");
+    await writeFile(reviewPath, "# Review");
+    const headRoot = path.join(rootPath, "head");
+    await mkdir(headRoot);
+    await writeFile(path.join(headRoot, "src.ts"), "line 1\nline 2\n");
+    let resolutions = 0;
+    const handler = await createReviewSessionHandler({
+      ...unusedAgentServices,
+      rootPath,
+      toolingRoot: rootPath,
+      reviewPath,
+      routePath: "/",
+      token: "secret",
+      reviewUuid: "11111111-1111-4111-8111-111111111111",
+      resolveSourceTarget: async () => {
+        resolutions += 1;
+        if (resolutions === 1) throw new Error("git is busy");
+        return {
+          repoRoot: rootPath,
+          sourceRootPath: headRoot,
+          diffRootPath: rootPath,
+        };
+      },
+      session: {
+        rootPath,
+        baseRef: "HEAD",
+        appUrl: "http://127.0.0.1:5570",
+        reviewPath,
+        startedAt: Date.now(),
+      },
+    });
+    const resolvePeek = () =>
+      handler.handle(
+        new Request(
+          "http://127.0.0.1:5570/__progressive-review/code-peek/resolve",
+          {
+            method: "POST",
+            headers: {
+              "x-review-token": "secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              root: { kind: "range", file: "src.ts", fromLine: 1, toLine: 1 },
+              graph: "head",
+              includeDiff: false,
+              includeDiffSummary: false,
+            }),
+          },
+        ),
+      );
+    try {
+      const failed = await resolvePeek();
+      expect(failed.status).not.toBe(200);
+      expect(await failed.json()).toMatchObject({
+        ok: false,
+        error: "git is busy",
+      });
+      const retried = await resolvePeek();
+      expect(retried.status).toBe(200);
+      expect(resolutions).toBe(2);
+      const cached = await resolvePeek();
+      expect(cached.status).toBe(200);
       expect(resolutions).toBe(2);
     } finally {
       await handler.close();

--- a/packages/progressive-review/src/server/session-handler.ts
+++ b/packages/progressive-review/src/server/session-handler.ts
@@ -40,7 +40,11 @@ import {
   isAuthorizedRequest,
   jsonResponse,
 } from "./hono-http";
-import { type ReviewApi, createReviewApi } from "./review-api";
+import {
+  type ReviewApi,
+  type ReviewApiOptions,
+  createReviewApi,
+} from "./review-api";
 import {
   LIVE_REVIEW_SESSION_MODE,
   type ReviewSessionArtifacts,
@@ -92,6 +96,8 @@ export interface ReviewSessionHandlerInput {
     error?: string,
   ) => void;
   runReviewThreadMutation?: <T>(operation: () => T | Promise<T>) => Promise<T>;
+  /** Test seam for live-session worktree resolution; see `ReviewApiOptions`. */
+  resolveSourceTarget?: ReviewApiOptions["resolveSourceTarget"];
   agentServer: (harness: ReviewAgentHarness) => AgentServer;
   openNativeAgentTerminal: (
     input: Extract<
@@ -449,6 +455,7 @@ export async function createReviewSessionHandler(
       input.onReviewThreadsCommit?.(commit);
     },
     runReviewThreadMutation: input.runReviewThreadMutation,
+    resolveSourceTarget: input.resolveSourceTarget,
     reviewToken: token,
     agentServer: input.agentServer,
     openNativeAgentTerminal: input.openNativeAgentTerminal,


### PR DESCRIPTION
Live Review Desktop sessions re-resolved the pinned head/base checkouts on every `/code-peek/resolve` and `/software-map/resolved-data` request. Each resolution runs several git subprocesses, so a review with 30 peeks spent about 1.9 seconds in peek resolution on open. Historical and repair sessions already reuse roots resolved at registration.

`createReviewApi` now resolves the live source target once per session and reuses it while both checkout roots still exist on disk. A rejected resolution is retried on the next request. `resolveSourceTarget` is an optional injection seam on `ReviewApiOptions` / `ReviewSessionHandlerInput`, allowing the behavior to be unit-tested without git.

No change to `resolveReviewSourceTarget`, the prepare lock, or the renderer.

## Performance

Measured with standalone Desktop hosts on separate copies of the Review home, the same 30-peek review, and renderer concurrency of 8:

| | total | median per peek |
|---|---:|---:|
| `main` | 1858 ms | 401 ms |
| this branch | 359 ms | 35 ms |

That is a 5.18x reduction in total wall time. At concurrency 1, median latency dropped from 241 ms to 24 ms. Every replay completed with `fails=0`.

## Compatibility

- Dumped all 30 code-peek responses from both hosts; recursive diff was empty.
- Concurrent first requests share one resolution.
- Missing checkout roots trigger re-resolution.
- Failed resolution retries on the next request and caches the successful retry.
- Historical and repair-validation behavior remains unchanged.

## Validation

- `pnpm --filter @dev.fast/review exec vitest run src/server` (23 files, 182 tests)
- `pnpm --filter @dev.fast/review typecheck`
- `pnpm lint` (zero errors)
- `pnpm format:check`
