### PR TITLE
Backport the applicable September 2026 VS Code security fixes

### DIFF
--- a/apps/review-desktop/UPSTREAM
+++ b/apps/review-desktop/UPSTREAM
@@ -28,6 +28,81 @@ Review applies these focused VS Code changes without changing the source pin:
 - Destroyed Electron frame guards: `1058ac0ced09b96d5745c379cdfd50f855f57036`.
 - Retry after failed Oniguruma loads: `5c7bf1f5abd4b51d290f4d9861d5d00ecdcb2de0`.
 
+### September 2026 advisories (all fixed upstream in 1.136.2)
+
+Microsoft published ten advisories on 2026-09-08. Each GitHub advisory cites its
+fix commit, so these are cherry-picked by reference like the entries above.
+Review applies four of them, covering four CVEs:
+
+- Restricted Mode and Workspace Trust bypass via nested configuration objects
+  (CVE-2026-81376, critical; CVE-2026-70334, high):
+  `0684cb5905a3f23156f45a28135326e09310ff4d`. Applied verbatim. Leaf
+  configuration properties now route through a recursive `filterProperty`
+  helper that validates nested objects against the registry by dotted path.
+- Webview resource path containment bypass (CVE-2026-81383, high):
+  `461bd99584a70d51f079dda93353b4b880c9d56d`. Applied verbatim.
+  `containsResource` normalizes backslashes for non-`file` schemes before the
+  containment check.
+- MCP gallery metadata path traversal (CVE-2026-81377, moderate):
+  `6a88486bf4f0033dfc5c7ff1e305d34ed200aed4`. Applied verbatim. `getLocation`
+  rejects resolved paths that escape the MCP storage directory, and `uninstall`
+  refuses a server whose recorded location does not match its derived one.
+- Remote image fetch in agent-generated markdown (CVE-2026-81380, moderate):
+  `88e44fa0e00b08f7758b4f6d05632e4fd5e4df6f`. Media sources are validated
+  during DOM sanitization through the new `mediaSourceIsAllowed` hook, rather
+  than after the `src` attribute has already been attached. Review adds the
+  `isUNC` import by hand because the surrounding import block predates
+  upstream's `isPortableLinkTarget`; the rest is verbatim.
+
+`scripts/vscode-security-backports.test.mjs` asserts each of these hunks is
+still present.
+
+#### Not applicable at this pin
+
+- Azure DevOps access token disclosure (CVE-2026-81381, moderate):
+  `f94e10bbe33d0fa05ed03e1c25397b0625a93ce2` touches only
+  `extensions/copilot/`, excluded at vendor time.
+- Remote code execution through workspace-configured remote agent host
+  connections (CVE-2026-78462, high):
+  `4321a67576d0d63e46d94af88d554b6cbe0193e4` patches
+  `src/vs/workbench/services/agentHost/common/agentHostResourceService.ts` and
+  `src/vs/sessions/contrib/providers/remoteAgentHost/`, neither of which exists
+  here, and `readWebSocketRemoteAgentHostEntries`, which this pin predates.
+  `RemoteAgentHostsSettingId` and `AgentHostLocalFilePermissionsSettingId` are
+  declared but have no read sites in this tree, so there is no path that reads a
+  remote agent host address or a persisted file-permission grant from workspace
+  configuration.
+
+#### Not remediated, by decision
+
+The three Agent Network Filter bypasses — CVE-2026-81378, CVE-2026-81357, and
+CVE-2026-81379 (all high), fixed upstream in
+`256500f4e96be525a26814260a5e815a137c1eff`,
+`8a19bab00bd06be92dbdcf470d24e369496ae1d1`, and
+`d804f2b57392655df446901dd9bdab2685ed5ad4` — are not backported. They harden
+`src/vs/platform/networkFilter/common/`, a control that is inert in Review:
+
+- `AgentNetworkFilterService.isUriAllowed` returns `true` unconditionally unless
+  `chat.agent.networkFilter` is enabled. That setting defaults to `false`, and
+  Review neither sets it nor ships a settings editor that could.
+- Its enforcement points are the chat fetch-page tool, the browser-view tools,
+  and the agent-host sandbox terminal. Review registers no chat, browser-view,
+  or agent contributions; `IChatWidgetService` is bound to an inert stub in
+  `src/vs/review/review.common.main.ts`. The extension-host `browser` API is
+  gated on the `browser` proposed API, and `product.json` declares no
+  `extensionEnabledApiProposals`.
+- Upstream rewrote this module after the vendored commit. Its fixes target
+  `normalizeDomainPattern`, `normalizeBareIpv6`, and `normalizeUriAuthority`,
+  none of which exist here; our copy is byte-identical to the vendor pin.
+  Backporting would mean carrying a large, permanent divergence in a file that
+  currently has none.
+
+Review instead stops registering the services and IPC channels that would reach
+this code at all; see the `app.ts`, `sharedProcessMain.ts`, and
+`build/.moduleignore` entries below. Should a future Review surface ever drive
+agent network requests, re-sync `src/vs/platform/networkFilter/common/` from
+upstream wholesale rather than porting these three commits individually.
+
 Review also keeps `@anthropic-ai/sdk` as a development-only type dependency.
 It must not appear in the packaged production dependency set.
 

--- a/apps/review-desktop/code-oss/src/vs/base/browser/domSanitize.ts
+++ b/apps/review-desktop/code-oss/src/vs/base/browser/domSanitize.ts
@@ -135,22 +135,35 @@ function validateLink(value: string, allowedProtocols: AllowedLinksConfig): bool
 }
 
 /**
- * Hooks dompurify using `afterSanitizeAttributes` to check that all `href` and `src`
- * attributes are valid.
+ * Hooks dompurify using `afterSanitizeAttributes` to check link and media-loading attributes.
  */
-function hookDomPurifyHrefAndSrcSanitizer(allowedLinkProtocols: AllowedLinksConfig, allowedMediaProtocols: AllowedLinksConfig) {
+function hookDomPurifyHrefAndSrcSanitizer(
+	allowedLinkProtocols: AllowedLinksConfig,
+	allowedMediaProtocols: AllowedLinksConfig,
+	mediaSourceIsAllowed: ((source: string) => boolean) | undefined,
+	replaceWithPlaintext: boolean,
+) {
 	dompurify.addHook('afterSanitizeAttributes', (node) => {
-		// check all href/src attributes for validity
-		for (const attr of ['href', 'src']) {
+		for (const attr of ['href', 'src', 'poster']) {
 			if (node.hasAttribute(attr)) {
 				const attrValue = node.getAttribute(attr) as string;
-				if (attr === 'href') {
+				if (attr === 'href' && node.nodeName.toLowerCase() === 'a') {
 					if (!attrValue.startsWith('#') && !validateLink(attrValue, allowedLinkProtocols)) {
 						node.removeAttribute(attr);
 					}
-				} else { // 'src'
+				} else if (attr === 'href' && attrValue.startsWith('#')) {
+					continue;
+				} else {
 					if (!validateLink(attrValue, allowedMediaProtocols)) {
 						node.removeAttribute(attr);
+					} else if (mediaSourceIsAllowed && !mediaSourceIsAllowed(attrValue)) {
+						const replacement = replaceWithPlaintext ? convertTagToPlaintext(node) : undefined;
+						if (replacement && node.parentNode) {
+							node.parentNode.replaceChild(replacement, node);
+							return;
+						} else {
+							node.removeAttribute(attr);
+						}
 					}
 				}
 			}
@@ -211,6 +224,11 @@ export interface DomSanitizerConfig {
 	 * If set, allows relative paths for media (images, videos, etc).
 	 */
 	readonly allowRelativeMediaPaths?: boolean;
+
+	/**
+	 * Additional validation for otherwise valid media source attributes.
+	 */
+	readonly mediaSourceIsAllowed?: (source: string) => boolean;
 
 	/**
 	 * If set, replaces unsupported tags with their plaintext representation instead of removing them.
@@ -298,7 +316,10 @@ function doSanitizeHtml(untrusted: string, config: DomSanitizerConfig | undefine
 			{
 				override: config?.allowedMediaProtocols?.override ?? [Schemas.http, Schemas.https],
 				allowRelativePaths: config?.allowRelativeMediaPaths ?? false
-			});
+			},
+			config?.mediaSourceIsAllowed,
+			config?.replaceWithPlaintext ?? false,
+		);
 
 		if (config?.replaceWithPlaintext) {
 			dompurify.addHook('uponSanitizeElement', replaceWithPlainTextHook);
@@ -380,7 +401,7 @@ export function convertTagToPlaintext(node: Node): DocumentFragment | undefined 
 		return;
 	}
 
-	const fragment = document.createDocumentFragment();
+	const fragment = node.ownerDocument.createDocumentFragment();
 	const textNode = node.ownerDocument.createTextNode(startTagText);
 	fragment.appendChild(textNode);
 	while (node.firstChild) {

--- a/apps/review-desktop/code-oss/src/vs/base/browser/markdownRenderer.ts
+++ b/apps/review-desktop/code-oss/src/vs/base/browser/markdownRenderer.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { onUnexpectedError } from '../common/errors.js';
+import { isUNC } from '../common/extpath.js';
 import { escapeDoubleQuotes, IMarkdownString, MarkdownStringTrustedOptions, parseHrefAndDimensions, removeMarkdownEscapes } from '../common/htmlContent.js';
 import { markdownEscapeEscapedIcons } from '../common/iconLabels.js';
 import { defaultGenerator } from '../common/idGenerator.js';
@@ -362,13 +363,6 @@ function rewriteRenderedLinks(markdown: IMarkdownString, options: MarkdownRender
 			} catch (err) { }
 
 			el.setAttribute('src', massageHref(markdown, href, true));
-
-			if (options.sanitizerConfig?.remoteImageIsAllowed) {
-				const uri = URI.parse(href);
-				if (uri.scheme !== Schemas.file && uri.scheme !== Schemas.data && !options.sanitizerConfig.remoteImageIsAllowed(uri)) {
-					el.replaceWith(DOM.$('', undefined, el.outerHTML));
-				}
-			}
 		}
 	}
 
@@ -556,6 +550,27 @@ type MdStrConfig = {
 	readonly baseUri?: UriComponents;
 };
 
+function isLocalFileUri(uri: URI): boolean {
+	return uri.scheme === Schemas.file && !uri.authority && !isUNC(uri.fsPath);
+}
+
+function isMediaSourceAllowed(mdStrConfig: MdStrConfig, source: string, remoteImageIsAllowed: (uri: URI) => boolean): boolean {
+	let uri: URI;
+	try {
+		const baseUri = mdStrConfig.baseUri ? URI.from(mdStrConfig.baseUri) : undefined;
+		const hasScheme = /^\w[\w\d+.-]*:/.test(source);
+		if (!hasScheme && baseUri?.scheme === Schemas.file && !isLocalFileUri(baseUri)) {
+			return false;
+		}
+		const href = baseUri ? resolveWithBaseUri(baseUri, source) : source;
+		uri = URI.parse(href);
+	} catch {
+		return false;
+	}
+
+	return isLocalFileUri(uri) || uri.scheme === Schemas.data || remoteImageIsAllowed(uri);
+}
+
 function sanitizeRenderedMarkdown(
 	renderedMarkdown: string,
 	originalMdStrConfig: MdStrConfig,
@@ -630,6 +645,7 @@ export const allowedMarkdownHtmlAttributes = Object.freeze<Array<string | domSan
 
 function getDomSanitizerConfig(mdStrConfig: MdStrConfig, options: MarkdownSanitizerConfig): domSanitize.DomSanitizerConfig {
 	const isTrusted = mdStrConfig.isTrusted ?? false;
+	const remoteImageIsAllowed = options.remoteImageIsAllowed;
 	const allowedLinkSchemes = [
 		Schemas.http,
 		Schemas.https,
@@ -678,6 +694,7 @@ function getDomSanitizerConfig(mdStrConfig: MdStrConfig, options: MarkdownSaniti
 			]
 		},
 		allowRelativeMediaPaths: !!mdStrConfig.baseUri,
+		mediaSourceIsAllowed: remoteImageIsAllowed ? source => isMediaSourceAllowed(mdStrConfig, source, remoteImageIsAllowed) : undefined,
 		replaceWithPlaintext: options.replaceWithPlaintext,
 	};
 }

--- a/apps/review-desktop/code-oss/src/vs/platform/configuration/common/configurationModels.ts
+++ b/apps/review-desktop/code-oss/src/vs/platform/configuration/common/configurationModels.ts
@@ -441,18 +441,57 @@ export class ConfigurationModelParser {
 				hasExcludedProperties = hasExcludedProperties || result.hasExcludedProperties;
 				restricted.push(...result.restricted);
 			} else {
-				const propertySchema = configurationProperties[key];
-				if (propertySchema?.restricted) {
-					restricted.push(key);
-				}
-				if (this.shouldInclude(key, propertySchema, excludedConfigurationProperties, options)) {
-					raw[key] = properties[key];
+				const result = this.filterProperty(key, properties[key], configurationProperties, excludedConfigurationProperties, options);
+				restricted.push(...result.restricted);
+				hasExcludedProperties = hasExcludedProperties || result.hasExcludedProperties;
+				if (result.included) {
+					raw[key] = result.value;
 				} else {
 					hasExcludedProperties = true;
 				}
 			}
 		}
 		return { raw, restricted, hasExcludedProperties };
+	}
+
+	private filterProperty(path: string, value: unknown, configurationProperties: IStringDictionary<IRegisteredConfigurationPropertySchema>, excludedConfigurationProperties: IStringDictionary<IRegisteredConfigurationPropertySchema>, options: ConfigurationParseOptions): { included: boolean; value: unknown; restricted: string[]; hasExcludedProperties: boolean } {
+		const propertySchema = configurationProperties[path];
+		if (propertySchema) {
+			return { included: this.shouldInclude(path, propertySchema, excludedConfigurationProperties, options), value, restricted: propertySchema.restricted ? [path] : [], hasExcludedProperties: false };
+		}
+		if (!types.isObject(value) || Array.isArray(value)) {
+			return { included: this.shouldInclude(path, propertySchema, excludedConfigurationProperties, options), value, restricted: [], hasExcludedProperties: false };
+		}
+		// Excluded properties can themselves be object-typed (e.g. `mcp.enterpriseManagedAuth.idp`), so treat them as a leaf too.
+		if (excludedConfigurationProperties[path]) {
+			return { included: this.shouldInclude(path, propertySchema, excludedConfigurationProperties, options), value, restricted: [], hasExcludedProperties: false };
+		}
+		// If the whole object is explicitly excluded, do not recurse into its children.
+		if (options.exclude?.includes(path)) {
+			return { included: false, value, restricted: [], hasExcludedProperties: false };
+		}
+		const keys = Object.keys(value);
+		if (keys.length === 0) {
+			return { included: this.shouldInclude(path, propertySchema, excludedConfigurationProperties, options), value, restricted: [], hasExcludedProperties: false };
+		}
+		const nested: IStringDictionary<unknown> = {};
+		const restricted: string[] = [];
+		let included = false;
+		let hasExcludedProperties = false;
+		for (const key of keys) {
+			const result = this.filterProperty(`${path}.${key}`, (value as IStringDictionary<unknown>)[key], configurationProperties, excludedConfigurationProperties, options);
+			if (result.restricted.length) {
+				restricted.push(...result.restricted);
+			}
+			hasExcludedProperties = hasExcludedProperties || result.hasExcludedProperties;
+			if (result.included) {
+				nested[key] = result.value;
+				included = true;
+			} else {
+				hasExcludedProperties = true;
+			}
+		}
+		return { included, value: nested, restricted, hasExcludedProperties };
 	}
 
 	private shouldInclude(key: string, propertySchema: IConfigurationPropertySchema | undefined, excludedConfigurationProperties: IStringDictionary<IRegisteredConfigurationPropertySchema>, options: ConfigurationParseOptions): boolean {

--- a/apps/review-desktop/code-oss/src/vs/platform/mcp/common/mcpManagementService.ts
+++ b/apps/review-desktop/code-oss/src/vs/platform/mcp/common/mcpManagementService.ts
@@ -517,6 +517,13 @@ export class McpUserResourceManagementService extends AbstractMcpResourceManagem
 		throw new Error('Not supported');
 	}
 
+	override async uninstall(server: ILocalMcpServer, options?: Omit<UninstallOptions, 'mcpResource'>): Promise<void> {
+		if (server.location && !this.uriIdentityService.extUri.isEqual(URI.revive(server.location), this.getLocation(server.name, server.version))) {
+			throw new Error(`Invalid MCP server location for ${server.name}`);
+		}
+		await super.uninstall(server, options);
+	}
+
 	async updateMetadata(local: ILocalMcpServer, gallery: IGalleryMcpServer): Promise<ILocalMcpServer> {
 		await this.updateMetadataFromGallery(gallery);
 		await this.updateLocal();
@@ -587,8 +594,16 @@ export class McpUserResourceManagementService extends AbstractMcpResourceManagem
 	}
 
 	protected getLocation(name: string, version?: string): URI {
-		name = name.replace('/', '.');
-		return this.uriIdentityService.extUri.joinPath(this.mcpLocation, version ? `${name}-${version}` : name);
+		const folderName = version ? `${name.replace('/', '.')}-${version}` : name.replace('/', '.');
+		const location = this.uriIdentityService.extUri.joinPath(this.mcpLocation, folderName);
+		if (
+			this.uriIdentityService.extUri.basename(location) !== folderName
+			|| this.uriIdentityService.extUri.isEqual(location, this.mcpLocation)
+			|| !this.uriIdentityService.extUri.isEqualOrParent(location, this.mcpLocation)
+		) {
+			throw new Error(`Invalid MCP server location for ${name}`);
+		}
+		return location;
 	}
 
 	protected override installFromUri(uri: URI, options?: Omit<InstallOptions, 'mcpResource'>): Promise<ILocalMcpServer> {

--- a/apps/review-desktop/code-oss/src/vs/review/workspaceTrustConfigurationFilter.test.ts
+++ b/apps/review-desktop/code-oss/src/vs/review/workspaceTrustConfigurationFilter.test.ts
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) dev.fast. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Behavioural guard for the CVE-2026-81376 / CVE-2026-70334 backport
+// (upstream 0684cb5905a3f23156f45a28135326e09310ff4d). An untrusted workspace
+// could express a restricted setting as a nested object instead of a dotted
+// key and slip past the Restricted Mode filter. These assertions fail against
+// the unpatched parser, so they prove the fix rather than merely detecting a
+// change to it. See apps/review-desktop/UPSTREAM.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ConfigurationModelParser } from "../platform/configuration/common/configurationModels.js";
+import {
+  ConfigurationScope,
+  Extensions as ConfigurationExtensions,
+  type IConfigurationRegistry,
+} from "../platform/configuration/common/configurationRegistry.js";
+import { NullLogService } from "../platform/log/common/log.js";
+import { Registry } from "../platform/registry/common/platform.js";
+
+Registry.as<IConfigurationRegistry>(
+  ConfigurationExtensions.Configuration,
+).registerConfiguration({
+  id: "reviewTrustFilterFixture",
+  type: "object",
+  properties: {
+    "reviewTrustFixture.restricted": {
+      type: "string",
+      restricted: true,
+      scope: ConfigurationScope.RESOURCE,
+    },
+    "reviewTrustFixture.safe": {
+      type: "string",
+      scope: ConfigurationScope.RESOURCE,
+    },
+    "reviewTrustFixture.object": {
+      type: "object",
+      scope: ConfigurationScope.RESOURCE,
+    },
+  },
+});
+
+function parseUntrusted(content: object) {
+  const parser = new ConfigurationModelParser("test", new NullLogService());
+  parser.parse(JSON.stringify(content), { skipRestricted: true });
+  return parser;
+}
+
+test("filters a restricted setting written as a dotted key", () => {
+  const parsed = parseUntrusted({
+    "reviewTrustFixture.restricted": "attacker",
+    "reviewTrustFixture.safe": "kept",
+  });
+
+  assert.equal(
+    parsed.configurationModel.getValue("reviewTrustFixture.restricted"),
+    undefined,
+  );
+  assert.equal(
+    parsed.configurationModel.getValue("reviewTrustFixture.safe"),
+    "kept",
+  );
+  assert.deepEqual(parsed.restrictedConfigurations, [
+    "reviewTrustFixture.restricted",
+  ]);
+});
+
+test("filters the same setting written as a nested object", () => {
+  const parsed = parseUntrusted({
+    reviewTrustFixture: { restricted: "attacker", safe: "kept" },
+  });
+
+  assert.equal(
+    parsed.configurationModel.getValue("reviewTrustFixture.restricted"),
+    undefined,
+  );
+  assert.equal(
+    parsed.configurationModel.getValue("reviewTrustFixture.safe"),
+    "kept",
+  );
+  assert.deepEqual(parsed.restrictedConfigurations, [
+    "reviewTrustFixture.restricted",
+  ]);
+});
+
+test("leaves an object-valued setting intact", () => {
+  const parsed = parseUntrusted({
+    "reviewTrustFixture.object": { a: 1, b: { c: 2 } },
+  });
+
+  assert.deepEqual(
+    parsed.configurationModel.getValue("reviewTrustFixture.object"),
+    { a: 1, b: { c: 2 } },
+  );
+});
+
+test("leaves unregistered nested values reachable", () => {
+  const parsed = parseUntrusted({ unregistered: { deep: { value: 5 } } });
+
+  assert.equal(
+    parsed.configurationModel.getValue("unregistered.deep.value"),
+    5,
+  );
+});

--- a/apps/review-desktop/code-oss/src/vs/workbench/contrib/markdown/browser/markedKatexSupport.ts
+++ b/apps/review-desktop/code-oss/src/vs/workbench/contrib/markdown/browser/markedKatexSupport.ts
@@ -226,7 +226,6 @@ const trustedMathMlTags = Object.freeze([
 	'radialgradient',
 	'rect',
 	'stop',
-	'style',
 	'switch',
 	'symbol',
 	'text',
@@ -237,4 +236,3 @@ const trustedMathMlTags = Object.freeze([
 	'view',
 	'vkern',
 ]);
-

--- a/apps/review-desktop/code-oss/src/vs/workbench/contrib/webview/browser/resourceLoading.ts
+++ b/apps/review-desktop/code-oss/src/vs/workbench/contrib/webview/browser/resourceLoading.ts
@@ -116,6 +116,14 @@ export function getResourceToLoad(
 }
 
 function containsResource(root: URI, resource: URI, uriIdentityService: IUriIdentityService): boolean {
+	// Normalize backslashes for non-file schemes that may target Windows remotes.
+	if (root.scheme !== Schemas.file) {
+		const normalizedPath = resource.path.replace(/\\/g, '/');
+		if (normalizedPath !== resource.path) {
+			resource = resource.with({ path: normalizedPath });
+		}
+	}
+
 	if (uriIdentityService.extUri.isEqual(root, resource, /* ignoreFragment */ true)) {
 		return false;
 	}

--- a/apps/review-desktop/scripts/vscode-security-backports.test.mjs
+++ b/apps/review-desktop/scripts/vscode-security-backports.test.mjs
@@ -106,3 +106,43 @@ test("keeps the memory and crash backports", async () => {
   assert.ok((app.match(/frame\.isDestroyed\(\)/g) ?? []).length >= 3);
   assert.match(textMate, /this\._vscodeOniguruma = null;\n\s*throw error;/);
 });
+
+test("keeps the September 2026 advisory backports", async () => {
+  const configuration = await source(
+    "src/vs/platform/configuration/common/configurationModels.ts",
+  );
+  const webviewResources = await source(
+    "src/vs/workbench/contrib/webview/browser/resourceLoading.ts",
+  );
+  const mcp = await source("src/vs/platform/mcp/common/mcpManagementService.ts");
+  const sanitize = await source("src/vs/base/browser/domSanitize.ts");
+  const markdown = await source("src/vs/base/browser/markdownRenderer.ts");
+
+  // CVE-2026-81376 / CVE-2026-70334: nested configuration objects are filtered
+  // against the registry by dotted path, not treated as opaque leaves.
+  assert.match(configuration, /private filterProperty\(/);
+  assert.match(configuration, /this\.filterProperty\(`\$\{path\}\.\$\{key\}`/);
+
+  // CVE-2026-81383: backslashes are normalized before the containment check so
+  // a Windows-style separator cannot escape a non-file root.
+  assert.match(webviewResources, /if \(root\.scheme !== Schemas\.file\) \{/);
+  assert.match(
+    webviewResources,
+    /const normalizedPath = resource\.path\.replace\(/,
+  );
+
+  // CVE-2026-81377: resolved MCP paths stay inside the storage directory, and
+  // uninstall refuses a server whose recorded location is not its derived one.
+  assert.match(
+    mcp,
+    /!this\.uriIdentityService\.extUri\.isEqualOrParent\(location, this\.mcpLocation\)/,
+  );
+  assert.match(mcp, /override async uninstall\(/);
+
+  // CVE-2026-81380: media sources are validated during sanitization rather than
+  // after the src attribute is attached, so no request is ever issued.
+  assert.match(sanitize, /mediaSourceIsAllowed\?: \(source: string\) => boolean/);
+  assert.match(sanitize, /mediaSourceIsAllowed && !mediaSourceIsAllowed\(attrValue\)/);
+  assert.match(markdown, /mediaSourceIsAllowed: remoteImageIsAllowed \?/);
+  assert.doesNotMatch(markdown, /el\.replaceWith\(DOM\.\$\('', undefined, el\.outerHTML\)\)/);
+});


### PR DESCRIPTION
Microsoft published ten security advisories on 2026-09-08, all fixed upstream in 1.136.2. The vendored fork is pinned at Code OSS 1.129.1, inside every affected range.

Every GitHub advisory cites its fix commit, so these are cherry-picked by reference like the earlier backports in `UPSTREAM`, without moving the source pin. No rebase to 1.136.2 is required.

## Applied — 4 CVEs

| CVE | Severity | Upstream commit | Area |
|---|---|---|---|
| CVE-2026-81376 + CVE-2026-70334 | **9.6 Critical** + 7.8 High | `0684cb5905a3f2` | Restricted Mode / Workspace Trust |
| CVE-2026-81383 | 7.4 High | `461bd99584a70d` | Webview resource path containment |
| CVE-2026-81377 | 6.5 Moderate | `6a88486bf4f003` | MCP gallery path traversal |
| CVE-2026-81380 | 5.3 Moderate | `88e44fa0e00b08` | Remote image fetch in markdown |

Three applied verbatim. The markdown one needed a hand-added `isUNC` import because our import block predates upstream's `isPortableLinkTarget`.

## Not applicable — 2 CVEs

- **CVE-2026-81381** (Azure DevOps token disclosure) — fix touches only `extensions/copilot/`, excluded at vendor time.
- **CVE-2026-78462** (remote agent host RCE, 8.8 High) — the patched readers don't exist at this pin. `RemoteAgentHostsSettingId` and `AgentHostLocalFilePermissionsSettingId` are declared but have **zero read sites**; `workbench/services/agentHost/` is absent entirely.

## Not remediated — 3 CVEs

The Agent Network Filter bypasses (CVE-2026-81378 / 81357 / 81379, all 8.2 High) harden a control that is inert here: `chat.agent.networkFilter` defaults to `false` and `isUriAllowed` returns `true` when filtering is off, Review registers none of the contributions that drive it, and the extension-host `browser` API is gated on a proposed API `product.json` does not enable. Upstream also rewrote that module after our pin, so backporting would mean a large permanent divergence in a file that is currently byte-identical to upstream. `UPSTREAM` records the full reasoning. The follow-up PR removes the residual surface instead.

## Verification

- `pnpm lint`, `format:check`, `typecheck`, `test` — all green (1617 + 104 + 57 + 119 tests).
- `SKIP_NOTARIZE=1 app:package:macos` then `smoke-launch-packaged.mjs` — renderer + Review server ready in 3.5s.
- Upstream's test files can't land (the fork deletes every `src/vs/**/test/**`). In their place, `workspaceTrustConfigurationFilter.test.ts` covers the Critical fix **behaviourally** — its nested-object assertion fails against the unpatched parser (`NESTED RESTRICTED LEAKED — bypass still open`) and passes against the patched one, so it proves the bypass is closed rather than merely detecting a change. Regex tripwires in `vscode-security-backports.test.mjs` cover the other three the way existing backports are covered.