### PR TITLE
Stop registering the unreachable browser automation surface

### DIFF
--- a/apps/review-desktop/UPSTREAM
+++ b/apps/review-desktop/UPSTREAM
@@ -256,7 +256,11 @@ one of these entries:
 - `scripts/notarize-macos.sh` (fork-owned): accepts `APPLE_SIGN_IDENTITY` as an
   alias for the `CODESIGN_IDENTITY` that upstream's `sign.ts` reads, so the
   signing identity can live with the rest of the Apple credentials.
-- `build/.moduleignore`
+- `build/.moduleignore`: also drops `playwright-core` from packaged builds. It is
+  a production dependency (~12 MB) loaded only by
+  `src/vs/platform/browserView/node/playwrightService.ts` through a dynamic
+  import, on a path nothing constructs once the `playwright` channel is
+  unregistered.
 - `build/darwin/create-universal-app.ts`
 - `build/darwin/verify-macho.ts`
 - `build/lib/i18n.resources.json`
@@ -327,6 +331,20 @@ one of these entries:
   menu on window focus and count changes), and `ReviewUpdateDialog` replaces
   `NotAvailableUpdateDialog` (the stock dialog defers to a workbench
   `UpdateContribution` that Review does not load).
+  Finally, it does not register `IAgentNetworkFilterService`,
+  `IWebContentExtractorService`, or the `webContentExtractor` IPC channel. No
+  Review surface reaches them, and leaving the channel registered exposes a
+  service with no consumer.
+- `src/vs/code/electron-utility/sharedProcess/sharedProcessMain.ts`: does not
+  register `ISharedWebContentExtractorService`, the `sharedWebContentExtractor`
+  channel, or the `playwright` channel and the network filter it is constructed
+  with. The only consumers of the shared web content extractor are three chat
+  renderer classes (`chatDragAndDrop`, `chatInputPart`, `chatAttachmentModel`)
+  that Review never instantiates, and nothing binds the service in Review's
+  renderer either. The browser-view stack behind the `playwright` channel is
+  reachable from no Review surface: Review registers no chat, browser-view, or
+  agent contributions, and the extension-host `browser` API is gated on a
+  proposed API that `product.json` does not enable.
 - `src/vs/workbench/contrib/webview/browser/pre/index.html`: guard a transient
   missing iframe body while polling active webview focus.
 - `src/vs/workbench/electron-browser/parts/dialogs/dialog.contribution.ts`:

--- a/apps/review-desktop/code-oss/build/.moduleignore
+++ b/apps/review-desktop/code-oss/build/.moduleignore
@@ -225,3 +225,8 @@ zone.js/dist/**
 # in websocket's browser.js inside a try/catch with a globalThis fallback,
 # so it is unnecessary in the browsers/runtimes VS Code supports.
 es5-ext/**
+
+# playwright-core backs the browser-view automation stack. Review registers
+# neither its services nor its IPC channels, so nothing constructs
+# PlaywrightService and its dynamic import never runs. See UPSTREAM.
+playwright-core/**

--- a/apps/review-desktop/code-oss/src/vs/code/electron-main/app.ts
+++ b/apps/review-desktop/code-oss/src/vs/code/electron-main/app.ts
@@ -139,9 +139,6 @@ import { NativeMcpDiscoveryHelperService } from '../../platform/mcp/node/nativeM
 import { IMcpGatewayService, McpGatewayChannelName } from '../../platform/mcp/common/mcpGateway.js';
 import { McpGatewayService } from '../../platform/mcp/node/mcpGatewayService.js';
 import { McpGatewayChannel } from '../../platform/mcp/node/mcpGatewayChannel.js';
-import { IWebContentExtractorService } from '../../platform/webContentExtractor/common/webContentExtractor.js';
-import { NativeWebContentExtractorService } from '../../platform/webContentExtractor/electron-main/webContentExtractorService.js';
-import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../platform/networkFilter/common/networkFilterService.js';
 import { ITerminalSandboxService, NullTerminalSandboxService } from '../../platform/sandbox/common/terminalSandboxService.js';
 import ErrorTelemetry from '../../platform/telemetry/electron-main/errorTelemetry.js';
 import { ReviewDesktopHost } from '../../review/electron-main/reviewDesktopHost.js';
@@ -1150,10 +1147,8 @@ export class CodeApplication extends Disposable {
 		const meteredConnectionService = new MeteredConnectionMainService(this.configurationService);
 		services.set(IMeteredConnectionService, meteredConnectionService);
 
-		// Web Contents Extractor
+		// Terminal Sandbox
 		services.set(ITerminalSandboxService, new SyncDescriptor(NullTerminalSandboxService));
-		services.set(IAgentNetworkFilterService, new SyncDescriptor(AgentNetworkFilterService, undefined, true));
-		services.set(IWebContentExtractorService, new SyncDescriptor(NativeWebContentExtractorService, undefined, false /* proxied to other processes */));
 
 		// Webview Manager
 		services.set(IWebviewManagerService, new SyncDescriptor(WebviewMainService));
@@ -1349,10 +1344,6 @@ export class CodeApplication extends Disposable {
 		});
 		mainProcessElectronServer.registerChannel('nativeHost', nativeHostChannel);
 		sharedProcessClient.then(client => client.registerChannel('nativeHost', nativeHostChannel));
-
-		// Web Content Extractor
-		const webContentExtractorChannel = ProxyChannel.fromService(accessor.get(IWebContentExtractorService), disposables);
-		mainProcessElectronServer.registerChannel('webContentExtractor', webContentExtractorChannel);
 
 		// Workspaces
 		const workspacesChannel = ProxyChannel.fromService(accessor.get(IWorkspacesService), disposables);

--- a/apps/review-desktop/code-oss/src/vs/code/electron-utility/sharedProcess/sharedProcessMain.ts
+++ b/apps/review-desktop/code-oss/src/vs/code/electron-utility/sharedProcess/sharedProcessMain.ts
@@ -129,8 +129,6 @@ import { DefaultExtensionsInitializer } from './contrib/defaultExtensionsInitial
 import { AllowedExtensionsService } from '../../../platform/extensionManagement/common/allowedExtensionsService.js';
 import { IExtensionGalleryManifestService } from '../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { ExtensionGalleryManifestIPCService } from '../../../platform/extensionManagement/common/extensionGalleryManifestServiceIpc.js';
-import { ISharedWebContentExtractorService } from '../../../platform/webContentExtractor/common/webContentExtractor.js';
-import { SharedWebContentExtractorService } from '../../../platform/webContentExtractor/node/sharedWebContentExtractorService.js';
 import { McpManagementService } from '../../../platform/mcp/node/mcpManagementService.js';
 import { IAllowedMcpServersService, IMcpGalleryService, IMcpManagementService } from '../../../platform/mcp/common/mcpManagement.js';
 import { IMcpResourceScannerService, McpResourceScannerService } from '../../../platform/mcp/common/mcpResourceScannerService.js';
@@ -141,8 +139,6 @@ import { IMcpGalleryManifestService } from '../../../platform/mcp/common/mcpGall
 import { McpGalleryManifestIPCService } from '../../../platform/mcp/common/mcpGalleryManifestServiceIpc.js';
 import { IMeteredConnectionService } from '../../../platform/meteredConnection/common/meteredConnection.js';
 import { MeteredConnectionChannelClient, METERED_CONNECTION_CHANNEL } from '../../../platform/meteredConnection/common/meteredConnectionIpc.js';
-import { PlaywrightChannel } from '../../../platform/browserView/node/playwrightChannel.js';
-import { AgentNetworkFilterService } from '../../../platform/networkFilter/common/networkFilterService.js';
 import { ILocalGitService } from '../../../platform/git/common/localGitService.js';
 import { LocalGitService } from '../../../platform/git/node/localGitService.js';
 
@@ -412,9 +408,6 @@ class SharedProcessMain extends Disposable implements IClientConnectionFilter {
 		// Remote Tunnel
 		services.set(IRemoteTunnelService, new SyncDescriptor(RemoteTunnelService));
 
-		// Web Content Extractor
-		services.set(ISharedWebContentExtractorService, new SyncDescriptor(SharedWebContentExtractorService));
-
 		// Local Git
 		services.set(ILocalGitService, new SyncDescriptor(LocalGitService, undefined, false /* proxied to other processes */));
 
@@ -492,15 +485,6 @@ class SharedProcessMain extends Disposable implements IClientConnectionFilter {
 		// Remote Tunnel
 		const remoteTunnelChannel = ProxyChannel.fromService(accessor.get(IRemoteTunnelService), this._store);
 		this.server.registerChannel('remoteTunnel', remoteTunnelChannel);
-
-		// Web Content Extractor
-		const webContentExtractorChannel = ProxyChannel.fromService(accessor.get(ISharedWebContentExtractorService), this._store);
-		this.server.registerChannel('sharedWebContentExtractor', webContentExtractorChannel);
-
-		// Playwright
-		const agentNetworkFilterService = this._register(new AgentNetworkFilterService(accessor.get(IConfigurationService)));
-		const playwrightChannel = this._register(new PlaywrightChannel(this.server, accessor.get(IMainProcessService), accessor.get(ILogService), agentNetworkFilterService, accessor.get(ITelemetryService)));
-		this.server.registerChannel('playwright', playwrightChannel);
 
 		// Local Git
 		const localGitChannel = ProxyChannel.fromService(accessor.get(ILocalGitService), this._store);

--- a/apps/review-desktop/scripts/vendor-integrity.test.mjs
+++ b/apps/review-desktop/scripts/vendor-integrity.test.mjs
@@ -58,3 +58,51 @@ test("postinstall does not install unused remote and upstream test packages", ()
 
   assert.deepEqual(unusedTargets, []);
 });
+
+test("does not register the unreachable browser automation surface", async () => {
+  const codeOss = new URL("../code-oss/", import.meta.url);
+  const app = await readFile(
+    new URL("src/vs/code/electron-main/app.ts", codeOss),
+    "utf8",
+  );
+  const sharedProcess = await readFile(
+    new URL(
+      "src/vs/code/electron-utility/sharedProcess/sharedProcessMain.ts",
+      codeOss,
+    ),
+    "utf8",
+  );
+  const moduleIgnore = await readFile(
+    new URL("build/.moduleignore", codeOss),
+    "utf8",
+  );
+
+  // No Review surface drives the agent network filter, the web content
+  // extractor, or the Playwright browser view. Registering their channels
+  // would expose services with no consumer. See UPSTREAM.
+  for (const channel of [
+    "webContentExtractor",
+    "sharedWebContentExtractor",
+    "playwright",
+  ]) {
+    assert.doesNotMatch(app, new RegExp(`registerChannel\\('${channel}'`));
+    assert.doesNotMatch(
+      sharedProcess,
+      new RegExp(`registerChannel\\('${channel}'`),
+    );
+  }
+
+  for (const service of [
+    "IAgentNetworkFilterService",
+    "IWebContentExtractorService",
+    "ISharedWebContentExtractorService",
+  ]) {
+    assert.doesNotMatch(app, new RegExp(`services\\.set\\(${service},`));
+    assert.doesNotMatch(
+      sharedProcess,
+      new RegExp(`services\\.set\\(${service},`),
+    );
+  }
+
+  assert.match(moduleIgnore, /^playwright-core\/\*\*$/m);
+});


### PR DESCRIPTION
Stacked on #243.

Review ships three services and three IPC channels for agent browser automation that nothing in the product calls. That residual surface is what made the three Agent Network Filter advisories a question at all — with no registration, there is nothing behind those channels to bypass.

## What changes

- `app.ts` — stops registering `IAgentNetworkFilterService`, `IWebContentExtractorService`, and the `webContentExtractor` channel.
- `sharedProcessMain.ts` — stops registering `ISharedWebContentExtractorService`, the `sharedWebContentExtractor` channel, and the `playwright` channel with the network filter it was constructed with.
- `build/.moduleignore` — drops `playwright-core` (~12 MB **production** dependency) from packaged builds.

## Why deregister rather than delete

Deleting the 42 files across `networkFilter/`, `browserView/`, and `webContentExtractor/` cascades into 6 chat attachment/widget files (real value imports of `BrowserEditorInput`, `IBrowserViewWorkbenchService`, `BrowserViewSharingState`), 3 extension-host files including `extHost.protocol.ts`, and `auth.ts` — turning ten pristine upstream files permanently divergent and forcing every future refresh to re-apply the deletions.

Deregistering touches three files, two of which **already diverge and are already enumerated in `UPSTREAM`**:

| File | Before this PR |
|---|---|
| `src/vs/code/electron-main/app.ts` | already divergent, `UPSTREAM` listed |
| `build/.moduleignore` | already divergent, `UPSTREAM` listed |
| `sharedProcessMain.ts` | pristine — the one newly divergent file |

Same surface removed, a tenth of the drift. The modules stay in the tree and keep absorbing upstream refreshes cleanly.

## Nothing that worked is removed

- The only consumers of the shared web content extractor are three chat renderer classes (`chatDragAndDrop`, `chatInputPart`, `chatAttachmentModel`) that Review never instantiates — and **no renderer-side registration for either extractor service exists in the tree at all**, so those injection sites could never have resolved.
- No code requests any of the three channels by name (`getChannel('webContentExtractor'|'sharedWebContentExtractor'|'playwright')` — zero hits).
- `platform/native/electron-main/auth.ts` is untouched; its `BrowserSession.isBrowserViewWebContents` guard keeps working because the browser-view module stays.
- Three orphaned upstream comments are cleaned up, and the `// Web Contents Extractor` heading is retitled `// Terminal Sandbox` to match what it now actually heads.

## Verification

- `pnpm lint`, `format:check`, `typecheck`, `test` — all green.
- Packaged build + `smoke-launch-packaged.mjs` — renderer + Review server ready in 7.1s. A missing service registration would surface here as a startup DI failure.
- `playwright-core` confirmed absent from the packaged bundle with no remnants; the app's `node_modules` is now 3.8 MB total.
- New `vendor-integrity.test.mjs` tripwire asserts the three channels stay unregistered and `playwright-core/**` stays ignored.